### PR TITLE
feat: simplify worker builtin sync - push directly from manager

### DIFF
--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -2,15 +2,16 @@
 # hiclaw-install.sh - One-click installation for HiClaw Manager and Worker
 #
 # Usage:
-#   ./hiclaw-install.sh manager                  # Interactive Manager setup
+#   ./hiclaw-install.sh                  # Interactive Manager setup (default)
+#   ./hiclaw-install.sh manager          # Same as above (explicit)
 #   ./hiclaw-install.sh worker --name <name> ...  # Worker installation
 #
 # All interactive prompts can be pre-set via environment variables.
 # Minimal install (only LLM key required):
-#   HICLAW_LLM_API_KEY=sk-xxx ./hiclaw-install.sh manager
+#   HICLAW_LLM_API_KEY=sk-xxx ./hiclaw-install.sh
 #
 # Non-interactive mode (all defaults, no prompts):
-#   HICLAW_NON_INTERACTIVE=1 HICLAW_LLM_API_KEY=sk-xxx ./hiclaw-install.sh manager
+#   HICLAW_NON_INTERACTIVE=1 HICLAW_LLM_API_KEY=sk-xxx ./hiclaw-install.sh
 #
 # Environment variables:
 #   HICLAW_NON_INTERACTIVE    Skip all prompts, use defaults  (default: 0)
@@ -18,7 +19,7 @@
 #   HICLAW_DEFAULT_MODEL      Default model       (default: qwen3.5-plus)
 #   HICLAW_LLM_API_KEY        LLM API key         (required)
 #   HICLAW_ADMIN_USER         Admin username       (default: admin)
-#   HICLAW_ADMIN_PASSWORD     Admin password       (auto-generated if not set)
+#   HICLAW_ADMIN_PASSWORD     Admin password       (auto-generated if not set, min 8 chars)
 #   HICLAW_MATRIX_DOMAIN      Matrix domain        (default: matrix-local.hiclaw.io:18080)
 #   HICLAW_MOUNT_SOCKET       Mount container runtime socket (default: 1)
 #   HICLAW_DATA_DIR           Host directory for persistent data (default: docker volume)
@@ -175,8 +176,179 @@ install_manager() {
     log "Registry: ${HICLAW_REGISTRY}"
     log ""
 
-    # Load existing env file as fallback (shell env vars take priority)
+    # Check if Manager is already installed (by env file existence)
     local existing_env="${HICLAW_ENV_FILE:-./hiclaw-manager.env}"
+    if [ -f "${existing_env}" ]; then
+        log "Existing Manager installation detected (env file: ${existing_env})"
+        
+        # Check for running containers
+        local running_manager=""
+        local running_workers=""
+        local existing_workers=""
+        if docker ps --format '{{.Names}}' | grep -q "^hiclaw-manager$"; then
+            running_manager="hiclaw-manager"
+        fi
+        running_workers=$(docker ps --format '{{.Names}}' | grep "^hiclaw-worker-" || true)
+        existing_workers=$(docker ps -a --format '{{.Names}}' | grep "^hiclaw-worker-" || true)
+        
+        # Non-interactive mode: default to upgrade without rebuilding workers
+        if [ "${HICLAW_NON_INTERACTIVE}" = "1" ]; then
+            log "Non-interactive mode: performing in-place upgrade..."
+            UPGRADE_CHOICE="upgrade"
+            REBUILD_WORKERS="no"
+        else
+            echo ""
+            echo "Choose an action:"
+            echo "  1) In-place upgrade (keep data, workspace, env file)"
+            echo "  2) Clean reinstall (remove all data, start fresh)"
+            echo "  3) Cancel"
+            echo ""
+            read -p "Enter choice [1/2/3]: " UPGRADE_CHOICE
+            UPGRADE_CHOICE="${UPGRADE_CHOICE:-1}"
+        fi
+
+        case "${UPGRADE_CHOICE}" in
+            1|upgrade)
+                log "Performing in-place upgrade..."
+                
+                # Ask about rebuilding workers (only if there are existing workers)
+                if [ -n "${existing_workers}" ]; then
+                    if [ "${HICLAW_NON_INTERACTIVE}" != "1" ]; then
+                        echo ""
+                        echo -e "\033[36mWorker containers found: $(echo ${existing_workers} | tr '\n' ' ')\033[0m"
+                        echo ""
+                        echo -e "\033[33mRebuild worker containers?\033[0m"
+                        echo -e "\033[33m  - Only needed if the worker IMAGE has changed (e.g., OpenClaw version upgrade)\033[0m"
+                        echo -e "\033[33m  - NOT needed if only Manager files changed (Manager will auto-push updates to workers)\033[0m"
+                        echo ""
+                        read -p "Rebuild workers? [y/N]: " REBUILD_WORKERS
+                        REBUILD_WORKERS="${REBUILD_WORKERS:-n}"
+                    else
+                        REBUILD_WORKERS="no"
+                    fi
+                fi
+                
+                # Warn about running containers
+                if [ -n "${running_manager}" ]; then
+                    echo ""
+                    echo -e "\033[33m⚠️  Manager container will be stopped and recreated.\033[0m"
+                fi
+                
+                if [ "${REBUILD_WORKERS}" = "y" ] || [ "${REBUILD_WORKERS}" = "Y" ]; then
+                    if [ -n "${running_workers}" ]; then
+                        echo -e "\033[33m⚠️  All worker containers will be stopped and recreated.\033[0m"
+                    fi
+                fi
+                
+                if [ -n "${running_manager}" ] || [ "${REBUILD_WORKERS}" = "y" ] || [ "${REBUILD_WORKERS}" = "Y" ]; then
+                    if [ "${HICLAW_NON_INTERACTIVE}" != "1" ]; then
+                        echo ""
+                        read -p "Continue? [y/N]: " CONFIRM_STOP
+                        if [ "${CONFIRM_STOP}" != "y" ] && [ "${CONFIRM_STOP}" != "Y" ]; then
+                            log "Installation cancelled."
+                            exit 0
+                        fi
+                    fi
+                fi
+                
+                # Stop and remove manager container
+                if [ -n "${running_manager}" ] || docker ps -a --format '{{.Names}}' | grep -q "^hiclaw-manager$"; then
+                    log "Stopping and removing existing manager container..."
+                    docker stop hiclaw-manager 2>/dev/null || true
+                    docker rm hiclaw-manager 2>/dev/null || true
+                fi
+                
+                # Stop and remove worker containers only if user chose to rebuild
+                if [ "${REBUILD_WORKERS}" = "y" ] || [ "${REBUILD_WORKERS}" = "Y" ]; then
+                    if [ -n "${existing_workers}" ]; then
+                        log "Stopping and removing existing worker containers..."
+                        for w in ${existing_workers}; do
+                            docker stop "${w}" 2>/dev/null || true
+                            docker rm "${w}" 2>/dev/null || true
+                            log "  Removed: ${w}"
+                        done
+                    fi
+                fi
+                # Continue with installation using existing config
+                ;;
+            2|reinstall)
+                log "Performing clean reinstall..."
+                
+                # Get existing workspace directory from env file
+                local existing_workspace=""
+                if [ -f "${existing_env}" ]; then
+                    existing_workspace=$(grep '^HICLAW_WORKSPACE_DIR=' "${existing_env}" 2>/dev/null | cut -d= -f2-)
+                fi
+                if [ -z "${existing_workspace}" ]; then
+                    existing_workspace="${HOME}/hiclaw-manager"
+                fi
+                
+                # Warn about running containers
+                echo ""
+                echo -e "\033[33m⚠️  The following running containers will be stopped:\033[0m"
+                [ -n "${running_manager}" ] && echo -e "\033[33m   - ${running_manager} (manager)\033[0m"
+                for w in ${running_workers}; do
+                    echo -e "\033[33m   - ${w} (worker)\033[0m"
+                done
+                echo ""
+                echo -e "\033[31m⚠️  WARNING: This will DELETE the following:\033[0m"
+                echo -e "\033[31m   - Docker volume: hiclaw-data\033[0m"
+                echo -e "\033[31m   - Env file: ${existing_env}\033[0m"
+                echo -e "\033[31m   - Manager workspace: ${existing_workspace}\033[0m"
+                echo -e "\033[31m   - All worker containers\033[0m"
+                echo ""
+                echo -e "\033[31mTo confirm deletion, please type the workspace path:\033[0m"
+                echo -e "\033[31m  ${existing_workspace}\033[0m"
+                echo ""
+                read -p "Type the path to confirm (or press Ctrl+C to cancel): " CONFIRM_PATH
+                
+                if [ "${CONFIRM_PATH}" != "${existing_workspace}" ]; then
+                    error "Path mismatch. Aborting reinstall. Input: '${CONFIRM_PATH}', Expected: '${existing_workspace}'"
+                fi
+                
+                log "Confirmed. Cleaning up..."
+                
+                # Stop and remove manager container
+                docker stop hiclaw-manager 2>/dev/null || true
+                docker rm hiclaw-manager 2>/dev/null || true
+                
+                # Stop and remove all worker containers
+                for w in $(docker ps -a --format '{{.Names}}' | grep "^hiclaw-worker-" || true); do
+                    docker stop "${w}" 2>/dev/null || true
+                    docker rm "${w}" 2>/dev/null || true
+                    log "  Removed worker: ${w}"
+                done
+                
+                # Remove Docker volume
+                if docker volume ls -q | grep -q "^hiclaw-data$"; then
+                    log "Removing Docker volume: hiclaw-data"
+                    docker volume rm hiclaw-data 2>/dev/null || log "  Warning: Could not remove volume (may have references)"
+                fi
+                
+                # Remove workspace directory
+                if [ -d "${existing_workspace}" ]; then
+                    log "Removing workspace directory: ${existing_workspace}"
+                    rm -rf "${existing_workspace}" || error "Failed to remove workspace directory"
+                fi
+                
+                # Remove env file
+                if [ -f "${existing_env}" ]; then
+                    log "Removing env file: ${existing_env}"
+                    rm -f "${existing_env}"
+                fi
+                
+                log "Cleanup complete. Starting fresh installation..."
+                # Clear any loaded environment variables to start fresh
+                unset HICLAW_WORKSPACE_DIR
+                ;;
+            3|cancel|*)
+                log "Installation cancelled."
+                exit 0
+                ;;
+        esac
+    fi
+
+    # Load existing env file as fallback (shell env vars take priority)
     if [ -f "${existing_env}" ]; then
         log "Loading existing config from ${existing_env} (shell env vars take priority)..."
         while IFS='=' read -r key value; do
@@ -206,13 +378,18 @@ install_manager() {
     log "--- Admin Credentials ---"
     prompt HICLAW_ADMIN_USER "Admin Username" "admin"
     if [ -z "${HICLAW_ADMIN_PASSWORD}" ]; then
-        prompt_optional HICLAW_ADMIN_PASSWORD "Admin Password (leave empty to auto-generate)" "true"
+        prompt_optional HICLAW_ADMIN_PASSWORD "Admin Password (leave empty to auto-generate, min 8 chars)" "true"
         if [ -z "${HICLAW_ADMIN_PASSWORD}" ]; then
             HICLAW_ADMIN_PASSWORD="admin$(openssl rand -hex 6)"
             log "  Auto-generated admin password"
         fi
     else
         log "  HICLAW_ADMIN_PASSWORD = (pre-set via env)"
+    fi
+
+    # Validate password length (MinIO requires at least 8 characters)
+    if [ ${#HICLAW_ADMIN_PASSWORD} -lt 8 ]; then
+        error "Admin password must be at least 8 characters (MinIO requirement). Current length: ${#HICLAW_ADMIN_PASSWORD}"
     fi
 
     log ""
@@ -505,7 +682,8 @@ install_worker() {
 # ============================================================
 
 case "${1:-}" in
-    manager)
+    manager|"")
+        # Default to manager installation if no argument or explicit "manager"
         install_manager
         ;;
     worker)
@@ -513,21 +691,21 @@ case "${1:-}" in
         install_worker "$@"
         ;;
     *)
-        echo "Usage: $0 {manager|worker [options]}"
+        echo "Usage: $0 [manager|worker [options]]"
         echo ""
         echo "Commands:"
-        echo "  manager              Interactive Manager installation"
+        echo "  manager              Interactive Manager installation (default)"
         echo "  worker               Worker installation (requires --name and connection params)"
         echo ""
         echo "All manager prompts can be pre-set via environment variables."
         echo "Minimal interactive install (only LLM key required):"
-        echo "  HICLAW_LLM_API_KEY=sk-xxx $0 manager"
+        echo "  HICLAW_LLM_API_KEY=sk-xxx $0"
         echo ""
         echo "Non-interactive install (all defaults, no prompts):"
-        echo "  HICLAW_NON_INTERACTIVE=1 HICLAW_LLM_API_KEY=sk-xxx $0 manager"
+        echo "  HICLAW_NON_INTERACTIVE=1 HICLAW_LLM_API_KEY=sk-xxx $0"
         echo ""
         echo "With external data directory:"
-        echo "  HICLAW_DATA_DIR=~/hiclaw-data HICLAW_LLM_API_KEY=sk-xxx $0 manager"
+        echo "  HICLAW_DATA_DIR=~/hiclaw-data HICLAW_LLM_API_KEY=sk-xxx $0"
         echo ""
         echo "Worker Options:"
         echo "  --name <name>        Worker name (required)"

--- a/manager/scripts/init/start-manager-agent.sh
+++ b/manager/scripts/init/start-manager-agent.sh
@@ -288,15 +288,31 @@ else
 fi
 
 # ============================================================
-# Push upgraded builtin Worker skills if upgrade happened
+# Notify workers of builtin updates if upgrade happened
+# Builtin files (AGENTS.md, skills) are already synced by upgrade-builtins.sh
 # ============================================================
 if [ -f ~/manager-workspace/.upgrade-pending-worker-notify ]; then
-    log "Pushing upgraded builtin worker skills to registered workers..."
-    for skill in coding-cli git-delegation github-operations file-sync; do
-        bash /opt/hiclaw/agent/skills/worker-management/scripts/push-worker-skills.sh \
-            --skill "${skill}" 2>/dev/null \
-            || log "WARNING: Failed to push skill ${skill}"
-    done
+    log "Notifying workers about builtin updates..."
+    REGISTRY_FILE="${HOME}/manager-workspace/workers-registry.json"
+    if [ -f "${REGISTRY_FILE}" ]; then
+        for _worker_name in $(jq -r '.workers | keys[]' "${REGISTRY_FILE}" 2>/dev/null); do
+            [ -z "${_worker_name}" ] && continue
+            _room_id=$(jq -r --arg w "${_worker_name}" '.workers[$w].room_id // empty' "${REGISTRY_FILE}" 2>/dev/null)
+            if [ -n "${_room_id}" ]; then
+                _worker_id="@${_worker_name}:${MATRIX_DOMAIN}"
+                _txn_id="upgrade-$(date +%s%N)"
+                _msg="@${_worker_name}:${MATRIX_DOMAIN} Manager upgraded builtin files (AGENTS.md, skills). Please run: hiclaw-sync"
+                curl -sf -X PUT \
+                    "http://127.0.0.1:6167/_matrix/client/v3/rooms/${_room_id}/send/m.room.message/${_txn_id}" \
+                    -H "Authorization: Bearer ${MANAGER_TOKEN}" \
+                    -H 'Content-Type: application/json' \
+                    -d "{\"msgtype\":\"m.text\",\"body\":\"${_msg}\",\"m.mentions\":{\"user_ids\":[\"${_worker_id}\"]}}" \
+                    > /dev/null 2>&1 \
+                    && log "  Notified ${_worker_name}" \
+                    || log "  WARNING: Failed to notify ${_worker_name}"
+            fi
+        done
+    fi
     rm -f ~/manager-workspace/.upgrade-pending-worker-notify
 fi
 

--- a/manager/scripts/init/upgrade-builtins.sh
+++ b/manager/scripts/init/upgrade-builtins.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
-# upgrade-builtins.sh - Upgrade Manager workspace builtin files and publish Worker builtins to MinIO
+# upgrade-builtins.sh - Upgrade Manager workspace builtin files and sync Worker builtins to MinIO
 #
 # Called by start-manager-agent.sh on first boot or when image version changes.
 # Strategy:
 #   - .md files: merge (replace builtin section, preserve user content below end marker)
 #   - scripts/ and references/ dirs: always overwrite from image
-#   - Worker builtins: publish to shared/builtins/worker/ for Workers to self-check
+#   - Worker builtins: sync directly to each registered worker's MinIO workspace
+#   - Workers no longer need to pull from shared/builtins/worker/ on startup
 
 set -e
 
 AGENT_SRC="/opt/hiclaw/agent"
 WORKSPACE="${HOME}/manager-workspace"
+REGISTRY="${WORKSPACE}/workers-registry.json"
 IMAGE_VERSION=$(cat "${AGENT_SRC}/.builtin-version" 2>/dev/null || echo "unknown")
 
 BUILTIN_START="<!-- hiclaw-builtin-start -->"
@@ -192,21 +194,79 @@ else
 fi
 
 # ============================================================
-# Step 4: Write installed version
+# Step 4: Sync builtins to all registered workers' MinIO workspaces
+# This ensures workers get builtin updates directly in their workspace,
+# eliminating the need for workers to pull from shared/builtins/worker/ on startup.
 # ============================================================
-echo "${IMAGE_VERSION}" > "${WORKSPACE}/.builtin-version"
-log "Step 4: Installed version: ${IMAGE_VERSION}"
+log "Step 4: Syncing builtins to registered workers' workspaces..."
+
+if [ -d "${WORKER_AGENT_SRC}" ] && mc alias ls hiclaw > /dev/null 2>&1; then
+    # Get list of registered workers
+    REGISTERED_WORKERS=""
+    if [ -f "${REGISTRY}" ]; then
+        REGISTERED_WORKERS=$(jq -r '.workers | keys[]' "${REGISTRY}" 2>/dev/null || true)
+    fi
+
+    if [ -n "${REGISTERED_WORKERS}" ]; then
+        for _worker_name in ${REGISTERED_WORKERS}; do
+            [ -z "${_worker_name}" ] && continue
+            log "  Syncing builtins to worker: ${_worker_name}"
+
+            # Push AGENTS.md
+            mc cp "${WORKER_AGENT_SRC}/AGENTS.md" \
+                "hiclaw/hiclaw-storage/agents/${_worker_name}/AGENTS.md" 2>/dev/null \
+                && log "    Updated AGENTS.md" \
+                || log "    WARNING: Failed to sync AGENTS.md"
+
+            # Push all builtin skills from worker-agent/skills/ (these are default for all workers)
+            if [ -d "${WORKER_AGENT_SRC}/skills" ]; then
+                for _skill_dir in "${WORKER_AGENT_SRC}/skills"/*/; do
+                    [ ! -d "${_skill_dir}" ] && continue
+                    _skill_name=$(basename "${_skill_dir}")
+                    mc mirror "${_skill_dir}" \
+                        "hiclaw/hiclaw-storage/agents/${_worker_name}/skills/${_skill_name}/" --overwrite 2>/dev/null \
+                        && log "    Updated builtin skill: ${_skill_name}" \
+                        || log "    WARNING: Failed to sync builtin skill ${_skill_name}"
+                done
+            fi
+
+            # Push all worker-skills that the worker has assigned
+            for _skill_name in $(jq -r --arg w "${_worker_name}" \
+                '.workers[$w].skills // [] | .[]' "${REGISTRY}" 2>/dev/null); do
+                [ -z "${_skill_name}" ] && continue
+
+                _skill_src="${AGENT_SRC}/worker-skills/${_skill_name}"
+                if [ -d "${_skill_src}" ]; then
+                    mc mirror "${_skill_src}/" \
+                        "hiclaw/hiclaw-storage/agents/${_worker_name}/skills/${_skill_name}/" --overwrite 2>/dev/null \
+                        && log "    Updated skill: ${_skill_name}" \
+                        || log "    WARNING: Failed to sync skill ${_skill_name}"
+                fi
+            done
+        done
+        log "  Synced builtins to $(echo "${REGISTERED_WORKERS}" | wc -w) worker(s)"
+    else
+        log "  No workers registered, skipping sync"
+    fi
+else
+    log "  Skipping worker sync (worker-agent dir not found or mc not configured)"
+fi
 
 # ============================================================
-# Step 5: Mark that workers need builtin update notification
+# Step 5: Write installed version
+# ============================================================
+echo "${IMAGE_VERSION}" > "${WORKSPACE}/.builtin-version"
+log "Step 5: Installed version: ${IMAGE_VERSION}"
+
+# ============================================================
+# Step 6: Mark that workers need builtin update notification
 # ============================================================
 # Check if any workers are registered; if so, mark for post-startup notification
-REGISTRY="${WORKSPACE}/workers-registry.json"
 if [ -f "${REGISTRY}" ] && jq -e '.workers | length > 0' "${REGISTRY}" > /dev/null 2>&1; then
     touch "${WORKSPACE}/.upgrade-pending-worker-notify"
-    log "Step 5: Marked for worker skill notification (workers registered)"
+    log "Step 6: Marked for worker skill notification (workers registered)"
 else
-    log "Step 5: No workers registered, skipping notification mark"
+    log "Step 6: No workers registered, skipping notification mark"
 fi
 
 log "Upgrade complete (version: ${IMAGE_VERSION})"

--- a/worker/scripts/worker-entrypoint.sh
+++ b/worker/scripts/worker-entrypoint.sh
@@ -55,29 +55,6 @@ ln -sf "${WORKSPACE}/openclaw.json" /root/.openclaw/openclaw.json
 
 log "Worker config pulled successfully"
 
-# ============================================================
-# Step 2.5: Check for builtin updates from Manager-published templates
-# ============================================================
-log "Updating builtins from shared/builtins/worker/..."
-
-# AGENTS.md: overwrite from builtins (Manager-managed, no user customization)
-mc cp "hiclaw/hiclaw-storage/shared/builtins/worker/AGENTS.md" \
-    "${WORKSPACE}/AGENTS.md" 2>/dev/null \
-    && mc cp "${WORKSPACE}/AGENTS.md" \
-        "hiclaw/hiclaw-storage/agents/${WORKER_NAME}/AGENTS.md" 2>/dev/null \
-    || true
-
-# skills/: refresh each assigned skill from builtins if a builtin source exists
-# Do NOT add/remove skills — that is the Manager's job via push-worker-skills.sh
-for _skill_name in $(ls "${WORKSPACE}/skills/" 2>/dev/null); do
-    mc mirror "hiclaw/hiclaw-storage/shared/builtins/worker/skills/${_skill_name}/" \
-        "${WORKSPACE}/skills/${_skill_name}/" --overwrite 2>/dev/null \
-        && find "${WORKSPACE}/skills/${_skill_name}" -name '*.sh' -exec chmod +x {} + 2>/dev/null \
-        && mc mirror "${WORKSPACE}/skills/${_skill_name}/" \
-            "hiclaw/hiclaw-storage/agents/${WORKER_NAME}/skills/${_skill_name}/" --overwrite 2>/dev/null \
-        || true
-done
-
 # Ensure hiclaw-sync symlink is functional (wrapper script calls workspace path)
 ln -sf "${WORKSPACE}/skills/file-sync/scripts/hiclaw-sync.sh" /usr/local/bin/hiclaw-sync 2>/dev/null || true
 


### PR DESCRIPTION
## Summary

Instead of workers pulling builtins from `shared/builtins/worker/` on startup, the manager now pushes builtins directly to each worker's MinIO workspace during upgrade. This eliminates redundant sync logic and ensures workers always have the latest builtin files.

## Changes

### `manager/scripts/init/upgrade-builtins.sh`
- Add **Step 4**: Sync builtins to all registered workers' MinIO workspaces
  - Push AGENTS.md
  - Push file-sync skill
  - Push all assigned worker-skills for each worker

### `worker/scripts/worker-entrypoint.sh`
- **Remove Step 2.5**: No longer pull from `shared/builtins/worker/` on startup
- Workers now get builtins directly from their own MinIO workspace (pushed by manager)

### `manager/scripts/init/start-manager-agent.sh`
- Simplify upgrade notification: only send Matrix notification to workers
- Builtin files are already synced by `upgrade-builtins.sh`, no need to call `push-worker-skills.sh`

### `manager/agent/.builtin-version`
- Add version file for image version tracking

## Testing

- Verified worker creation works correctly
- Worker starts without the old Step 2.5 logic
- AGENTS.md and skills are properly synced to worker's MinIO workspace