### PR TITLE
feat: remove domain restriction from matrix homeserver route

### DIFF
--- a/manager/scripts/init/setup-higress.sh
+++ b/manager/scripts/init/setup-higress.sh
@@ -98,7 +98,7 @@ higress_api POST /v1/consumers "Creating Manager consumer" \
 # 2. Matrix Homeserver Route (no auth - public access)
 # ============================================================
 higress_api POST /v1/routes "Creating Matrix Homeserver route" \
-    '{"name":"matrix-homeserver","domains":["'"${MATRIX_DOMAIN%%:*}"'"],"path":{"matchType":"PRE","matchValue":"/_matrix"},"services":[{"name":"tuwunel.static","port":6167,"weight":100}]}'
+    '{"name":"matrix-homeserver","domains":[],"path":{"matchType":"PRE","matchValue":"/_matrix"},"services":[{"name":"tuwunel.static","port":6167,"weight":100}]}'
 
 # ============================================================
 # 3. Element Web Route (no auth - public access)


### PR DESCRIPTION
Use empty domains array so Matrix clients can connect directly via IP without requiring DNS configuration.