### PR TITLE
Improve install script with Quick Start mode and better UX

### DIFF
--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -144,6 +144,78 @@ wait_manager_ready() {
 }
 
 # ============================================================
+# Create OpenAI-compatible provider via Higress Console API
+# ============================================================
+
+create_openai_compat_provider() {
+    local base_url="${HICLAW_OPENAI_BASE_URL}"
+    local api_key="${HICLAW_LLM_API_KEY}"
+    local console_port="${HICLAW_PORT_CONSOLE:-18001}"
+    local console_url="http://localhost:${console_port}"
+    
+    if [ -z "${base_url}" ] || [ -z "${api_key}" ]; then
+        log "WARNING: OpenAI Base URL or API Key not set, skipping provider creation"
+        return 1
+    fi
+    
+    # Parse base URL to extract domain and port
+    local domain=""
+    local port="443"
+    local protocol="https"
+    
+    # Remove protocol prefix
+    local url_without_proto="${base_url#https://}"
+    url_without_proto="${url_without_proto#http://}"
+    
+    # Detect protocol
+    if [[ "${base_url}" == http://* ]]; then
+        protocol="http"
+        port="80"
+    fi
+    
+    # Extract domain (first part before /)
+    domain="${url_without_proto%%/*}"
+    
+    # Check for explicit port in domain
+    if [[ "${domain}" == *:* ]]; then
+        port="${domain##*:}"
+        domain="${domain%:*}"
+    fi
+    
+    log "Creating OpenAI-compatible provider..."
+    log "  Domain: ${domain}"
+    log "  Port: ${port}"
+    log "  Protocol: ${protocol}"
+    
+    # Create DNS service source
+    local service_name="openai-compat"
+    local create_service_resp
+    create_service_resp=$(curl -sf -X POST "${console_url}/v1/service-sources" \
+        -H 'Accept: application/json' \
+        -H 'Content-Type: application/json' \
+        -d "{\"type\":\"dns\",\"name\":\"${service_name}\",\"port\":\"${port}\",\"protocol\":\"${protocol}\",\"proxyName\":\"\",\"domain\":\"${domain}\"}" 2>/dev/null) || {
+        log "WARNING: Failed to create DNS service source (may already exist)"
+    }
+    
+    # Wait a moment for service to be created
+    sleep 2
+    
+    # Create AI provider
+    local provider_name="openai-compat"
+    local create_provider_resp
+    create_provider_resp=$(curl -sf -X POST "${console_url}/v1/ai/providers" \
+        -H 'Accept: application/json' \
+        -H 'Content-Type: application/json' \
+        -d "{\"type\":\"openai\",\"name\":\"${provider_name}\",\"tokens\":[\"${api_key}\"],\"version\":0,\"protocol\":\"openai/v1\",\"tokenFailoverConfig\":{\"enabled\":false},\"rawConfigs\":{\"openaiCustomUrl\":\"${base_url}\",\"openaiCustomServiceName\":\"${service_name}.dns\",\"openaiCustomServicePort\":${port}}}" 2>/dev/null) || {
+        log "WARNING: Failed to create AI provider (may already exist)"
+        return 1
+    }
+    
+    log "OpenAI-compatible provider created successfully"
+    return 0
+}
+
+# ============================================================
 # Send welcome message to Manager
 # ============================================================
 
@@ -355,23 +427,27 @@ install_manager() {
         log "--- Onboarding Mode ---"
         echo ""
         echo "Choose your installation mode:"
-        echo "  1) Quick Start  - Fast installation with all default values (recommended)"
-        echo "  2) Manual       - Customize each option step by step"
+        echo "  1) Quick Start  - Fast installation with Alibaba Cloud (recommended)"
+        echo "  2) Manual       - Choose LLM provider and customize options"
         echo ""
         read -p "Enter choice [1/2]: " ONBOARDING_CHOICE
         ONBOARDING_CHOICE="${ONBOARDING_CHOICE:-1}"
         
         case "${ONBOARDING_CHOICE}" in
             1|quick|quickstart)
-                log "Quick Start mode selected - using all default values"
-                HICLAW_NON_INTERACTIVE=1
+                log "Quick Start mode selected - using Alibaba Cloud Bailian"
+                HICLAW_LLM_PROVIDER="qwen"
+                HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
+                HICLAW_QUICKSTART=1
                 ;;
             2|manual)
-                log "Manual mode selected - you will be prompted for each option"
+                log "Manual mode selected - you will choose LLM provider and customize options"
                 ;;
             *)
                 log "Invalid choice, defaulting to Quick Start mode"
-                HICLAW_NON_INTERACTIVE=1
+                HICLAW_LLM_PROVIDER="qwen"
+                HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
+                HICLAW_QUICKSTART=1
                 ;;
         esac
         log ""
@@ -545,58 +621,71 @@ install_manager() {
 
     # LLM Configuration
     log "--- LLM Configuration ---"
-    if [ "${HICLAW_NON_INTERACTIVE}" = "1" ]; then
-        # Quick Start mode: use default provider
-        HICLAW_LLM_PROVIDER="${HICLAW_LLM_PROVIDER:-alibaba-cloud}"
-        HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
-        log "  Provider: ${HICLAW_LLM_PROVIDER} (default)"
-        log "  Model: ${HICLAW_DEFAULT_MODEL} (default)"
-    else
-        # Manual mode: show options
-        echo ""
-        echo "Available LLM Providers:"
-        echo "  1) alibaba-cloud  - Alibaba Cloud Bailian (default, recommended for Chinese users)"
-        echo "  2) openai         - OpenAI"
-        echo "  3) anthropic      - Anthropic Claude"
-        echo "  4) other          - Other providers (manual configuration)"
-        echo ""
-        read -p "Select provider [1/2/3/4]: " PROVIDER_CHOICE
-        PROVIDER_CHOICE="${PROVIDER_CHOICE:-1}"
-        
-        case "${PROVIDER_CHOICE}" in
-            1|alibaba-cloud)
-                HICLAW_LLM_PROVIDER="alibaba-cloud"
-                HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
-                ;;
-            2|openai)
-                HICLAW_LLM_PROVIDER="openai"
-                HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-gpt-4o}"
-                ;;
-            3|anthropic)
-                HICLAW_LLM_PROVIDER="anthropic"
-                HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-claude-sonnet-4-20250514}"
-                ;;
-            4|other)
-                read -p "Enter provider name: " HICLAW_LLM_PROVIDER
-                read -p "Enter default model ID: " HICLAW_DEFAULT_MODEL
-                ;;
-            *)
-                HICLAW_LLM_PROVIDER="alibaba-cloud"
-                HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
-                ;;
-        esac
-        log "  Provider: ${HICLAW_LLM_PROVIDER}"
-        log "  Model: ${HICLAW_DEFAULT_MODEL}"
-    fi
     
-    # Prompt for API Key with helpful message
-    if [ "${HICLAW_LLM_PROVIDER}" = "alibaba-cloud" ] || [ "${HICLAW_LLM_PROVIDER}" = "qwen" ]; then
+    if [ "${HICLAW_QUICKSTART}" = "1" ]; then
+        # Quick Start mode: use Alibaba Cloud Bailian
+        log "  Provider: qwen (Alibaba Cloud Bailian)"
+        log "  Model: ${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
         log ""
         log "  💡 Get your Alibaba Cloud Bailian API Key from:"
         log "     https://www.aliyun.com/product/bailian"
         log ""
+        prompt HICLAW_LLM_API_KEY "LLM API Key" "" "true"
+    elif [ "${HICLAW_NON_INTERACTIVE}" = "1" ]; then
+        # Non-interactive mode: use defaults
+        HICLAW_LLM_PROVIDER="${HICLAW_LLM_PROVIDER:-qwen}"
+        HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
+        log "  Provider: ${HICLAW_LLM_PROVIDER} (default)"
+        log "  Model: ${HICLAW_DEFAULT_MODEL} (default)"
+        prompt HICLAW_LLM_API_KEY "LLM API Key" "" "true"
+    else
+        # Manual mode: only support Alibaba Cloud or OpenAI-compatible
+        echo ""
+        echo "Available LLM Providers:"
+        echo "  1) alibaba-cloud  - Alibaba Cloud Bailian (recommended for Chinese users)"
+        echo "  2) openai-compat  - OpenAI-compatible API (OpenAI, DeepSeek, etc.)"
+        echo ""
+        read -p "Select provider [1/2]: " PROVIDER_CHOICE
+        PROVIDER_CHOICE="${PROVIDER_CHOICE:-1}"
+        
+        case "${PROVIDER_CHOICE}" in
+            1|alibaba-cloud)
+                HICLAW_LLM_PROVIDER="qwen"
+                HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
+                log "  Provider: ${HICLAW_LLM_PROVIDER} (Alibaba Cloud Bailian)"
+                log "  Model: ${HICLAW_DEFAULT_MODEL}"
+                log ""
+                log "  💡 Get your Alibaba Cloud Bailian API Key from:"
+                log "     https://www.aliyun.com/product/bailian"
+                log ""
+                prompt HICLAW_LLM_API_KEY "LLM API Key" "" "true"
+                ;;
+            2|openai-compat)
+                HICLAW_LLM_PROVIDER="openai-compat"
+                log "  Provider: ${HICLAW_LLM_PROVIDER} (OpenAI-compatible)"
+                echo ""
+                read -p "Base URL (e.g., https://api.openai.com/v1): " HICLAW_OPENAI_BASE_URL
+                read -p "Default Model ID [gpt-4o]: " HICLAW_DEFAULT_MODEL
+                HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-gpt-4o}"
+                log "  Base URL: ${HICLAW_OPENAI_BASE_URL}"
+                log "  Model: ${HICLAW_DEFAULT_MODEL}"
+                log ""
+                prompt HICLAW_LLM_API_KEY "LLM API Key" "" "true"
+                ;;
+            *)
+                log "Invalid choice, defaulting to Alibaba Cloud"
+                HICLAW_LLM_PROVIDER="qwen"
+                HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
+                log "  Provider: ${HICLAW_LLM_PROVIDER}"
+                log "  Model: ${HICLAW_DEFAULT_MODEL}"
+                log ""
+                log "  💡 Get your Alibaba Cloud Bailian API Key from:"
+                log "     https://www.aliyun.com/product/bailian"
+                log ""
+                prompt HICLAW_LLM_API_KEY "LLM API Key" "" "true"
+                ;;
+        esac
     fi
-    prompt HICLAW_LLM_API_KEY "LLM API Key" "" "true"
 
     log ""
 
@@ -690,6 +779,7 @@ install_manager() {
 HICLAW_LLM_PROVIDER=${HICLAW_LLM_PROVIDER}
 HICLAW_DEFAULT_MODEL=${HICLAW_DEFAULT_MODEL}
 HICLAW_LLM_API_KEY=${HICLAW_LLM_API_KEY}
+HICLAW_OPENAI_BASE_URL=${HICLAW_OPENAI_BASE_URL:-}
 
 # Admin
 HICLAW_ADMIN_USER=${HICLAW_ADMIN_USER}
@@ -818,6 +908,11 @@ EOF
 
     # Wait for Manager agent to be ready
     wait_manager_ready "hiclaw-manager"
+
+    # Create OpenAI-compatible provider if needed
+    if [ "${HICLAW_LLM_PROVIDER}" = "openai-compat" ]; then
+        create_openai_compat_provider
+    fi
 
     # Send welcome message to Manager
     send_welcome_message


### PR DESCRIPTION
## 修改内容

### 1. 新增 Onboarding 模式选择

安装开始时让用户选择：
- **Quick Start**: 快速安装，使用所有默认值（推荐）
- **Manual**: 逐步自定义每个选项

### 2. 改进 LLM Provider 选择

- 默认 Provider 从 `qwen` 改为 `alibaba-cloud`，名称更清晰
- Manual 模式显示编号列表：
  - 1) alibaba-cloud - 阿里云百炼（默认，推荐国内用户）
  - 2) openai - OpenAI
  - 3) anthropic - Anthropic Claude
  - 4) other - 其他
- 添加阿里云百炼 API Key 获取链接：https://www.aliyun.com/product/bailian

### 3. 安装完成后增加模型切换提示



### 4. 更新帮助文本

简化 Usage 说明，突出 Quick Start 模式。

## 测试方式

```bash
# 测试 Quick Start 模式
./install/hiclaw-install.sh
# 选择 1

# 测试 Manual 模式
./install/hiclaw-install.sh
# 选择 2
```