### PR TITLE
Extract openclaw-build into shared openclaw-base image to avoid ~900M…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,10 +69,12 @@ jobs:
 
       - name: Summary
         env:
+          OPENCLAW_BASE_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/openclaw-base
           MANAGER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-manager
           WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-worker
         run: |
           echo "### Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "- OpenClaw Base: \`${OPENCLAW_BASE_IMAGE}:${{ steps.meta.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Manager: \`${MANAGER_IMAGE}:${{ steps.meta.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Worker: \`${WORKER_IMAGE}:${{ steps.meta.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Platforms: \`linux/amd64, linux/arm64\`" >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,18 @@ VERSION        ?= latest
 REGISTRY       ?= higress-registry.cn-hangzhou.cr.aliyuncs.com
 REPO           ?= higress
 
-MANAGER_IMAGE  ?= $(REGISTRY)/$(REPO)/hiclaw-manager
-WORKER_IMAGE   ?= $(REGISTRY)/$(REPO)/hiclaw-worker
+MANAGER_IMAGE       ?= $(REGISTRY)/$(REPO)/hiclaw-manager
+WORKER_IMAGE        ?= $(REGISTRY)/$(REPO)/hiclaw-worker
+OPENCLAW_BASE_IMAGE ?= $(REGISTRY)/$(REPO)/openclaw-base
 
 MANAGER_TAG    ?= $(MANAGER_IMAGE):$(VERSION)
 WORKER_TAG     ?= $(WORKER_IMAGE):$(VERSION)
+OPENCLAW_BASE_TAG ?= $(OPENCLAW_BASE_IMAGE):$(VERSION)
 
 # Local image names (no registry prefix, used by tests and install script)
-LOCAL_MANAGER  = hiclaw/manager-agent:$(VERSION)
-LOCAL_WORKER   = hiclaw/worker-agent:$(VERSION)
+LOCAL_MANAGER       = hiclaw/manager-agent:$(VERSION)
+LOCAL_WORKER        = hiclaw/worker-agent:$(VERSION)
+LOCAL_OPENCLAW_BASE = hiclaw/openclaw-base:$(VERSION)
 
 # Higress base image registry (regional mirrors auto-synced from cn-hangzhou primary)
 #   China (default): higress-registry.cn-hangzhou.cr.aliyuncs.com
@@ -65,8 +68,8 @@ TEST_FILTER    ?=
 
 # ---------- Phony targets ----------
 
-.PHONY: all build build-manager build-worker \
-        tag push push-manager push-worker \
+.PHONY: all build build-openclaw-base build-manager build-worker \
+        tag push push-openclaw-base push-manager push-worker \
         push-native push-native-manager push-native-worker \
         buildx-setup \
         test test-quick test-installed \
@@ -79,17 +82,25 @@ all: build
 
 # ---------- Build ----------
 
-build: build-manager build-worker ## Build all images
+build: build-openclaw-base build-manager build-worker ## Build all images
+
+build-openclaw-base: ## Build OpenClaw base image
+	@echo "==> Building OpenClaw base image: $(LOCAL_OPENCLAW_BASE) (registry: $(HIGRESS_REGISTRY))"
+	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(DOCKER_BUILD_ARGS) \
+		-t $(LOCAL_OPENCLAW_BASE) \
+		./openclaw-base/
+
+OPENCLAW_BASE_BUILD_ARG = --build-arg OPENCLAW_BASE_TAG=$(VERSION)
 
 build-manager: ## Build Manager image
 	@echo "==> Building Manager image: $(LOCAL_MANAGER) (registry: $(HIGRESS_REGISTRY))"
-	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(BUILTIN_VERSION_ARG) $(DOCKER_BUILD_ARGS) \
+	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(BUILTIN_VERSION_ARG) $(OPENCLAW_BASE_BUILD_ARG) $(DOCKER_BUILD_ARGS) \
 		-t $(LOCAL_MANAGER) \
 		./manager/
 
 build-worker: ## Build Worker image
 	@echo "==> Building Worker image: $(LOCAL_WORKER) (registry: $(HIGRESS_REGISTRY))"
-	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(DOCKER_BUILD_ARGS) \
+	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(OPENCLAW_BASE_BUILD_ARG) $(DOCKER_BUILD_ARGS) \
 		-t $(LOCAL_WORKER) \
 		./worker/
 
@@ -128,7 +139,32 @@ else
 	fi
 endif
 
-push: push-manager push-worker ## Build + push multi-arch images (amd64 + arm64)
+push: push-openclaw-base push-manager push-worker ## Build + push multi-arch images (amd64 + arm64)
+
+push-openclaw-base: buildx-setup ## Build + push multi-arch OpenClaw base image
+	@echo "==> Building + pushing multi-arch OpenClaw base: $(OPENCLAW_BASE_TAG) [$(MULTIARCH_PLATFORMS)]"
+ifeq ($(IS_PODMAN),1)
+	@# Podman: build each platform into a manifest list, then push
+	-podman manifest rm $(OPENCLAW_BASE_TAG) 2>/dev/null
+	$(foreach plat,$(subst $(comma), ,$(MULTIARCH_PLATFORMS)), \
+		echo "  -> Building OpenClaw base for $(plat)..." && \
+		podman build --platform $(plat) \
+			$(REGISTRY_ARG) $(DOCKER_BUILD_ARGS) \
+			--manifest $(OPENCLAW_BASE_TAG) \
+			./openclaw-base/ && ) true
+	podman manifest push --all $(OPENCLAW_BASE_TAG) docker://$(OPENCLAW_BASE_TAG)
+	$(if $(filter-out latest,$(VERSION)), \
+		podman manifest push --all $(OPENCLAW_BASE_TAG) docker://$(OPENCLAW_BASE_IMAGE):latest)
+else
+	docker buildx build \
+		--builder $(BUILDX_BUILDER) \
+		--platform $(MULTIARCH_PLATFORMS) \
+		$(REGISTRY_ARG) $(DOCKER_BUILD_ARGS) \
+		-t $(OPENCLAW_BASE_TAG) \
+		$(if $(filter-out latest,$(VERSION)),-t $(OPENCLAW_BASE_IMAGE):latest) \
+		--push \
+		./openclaw-base/
+endif
 
 push-manager: buildx-setup ## Build + push multi-arch Manager image
 	@echo "==> Building + pushing multi-arch Manager: $(MANAGER_TAG) [$(MULTIARCH_PLATFORMS)]"
@@ -138,7 +174,7 @@ ifeq ($(IS_PODMAN),1)
 	$(foreach plat,$(subst $(comma), ,$(MULTIARCH_PLATFORMS)), \
 		echo "  -> Building Manager for $(plat)..." && \
 		podman build --platform $(plat) \
-			$(REGISTRY_ARG) $(BUILTIN_VERSION_ARG) $(DOCKER_BUILD_ARGS) \
+			$(REGISTRY_ARG) $(BUILTIN_VERSION_ARG) $(OPENCLAW_BASE_BUILD_ARG) $(DOCKER_BUILD_ARGS) \
 			--manifest $(MANAGER_TAG) \
 			./manager/ && ) true
 	podman manifest push --all $(MANAGER_TAG) docker://$(MANAGER_TAG)
@@ -148,7 +184,7 @@ else
 	docker buildx build \
 		--builder $(BUILDX_BUILDER) \
 		--platform $(MULTIARCH_PLATFORMS) \
-		$(REGISTRY_ARG) $(BUILTIN_VERSION_ARG) $(DOCKER_BUILD_ARGS) \
+		$(REGISTRY_ARG) $(BUILTIN_VERSION_ARG) $(OPENCLAW_BASE_BUILD_ARG) $(DOCKER_BUILD_ARGS) \
 		-t $(MANAGER_TAG) \
 		$(if $(filter-out latest,$(VERSION)),-t $(MANAGER_IMAGE):latest) \
 		--push \
@@ -163,7 +199,7 @@ ifeq ($(IS_PODMAN),1)
 	$(foreach plat,$(subst $(comma), ,$(MULTIARCH_PLATFORMS)), \
 		echo "  -> Building Worker for $(plat)..." && \
 		podman build --platform $(plat) \
-			$(REGISTRY_ARG) $(DOCKER_BUILD_ARGS) \
+			$(REGISTRY_ARG) $(OPENCLAW_BASE_BUILD_ARG) $(DOCKER_BUILD_ARGS) \
 			--manifest $(WORKER_TAG) \
 			./worker/ && ) true
 	podman manifest push --all $(WORKER_TAG) docker://$(WORKER_TAG)
@@ -173,7 +209,7 @@ else
 	docker buildx build \
 		--builder $(BUILDX_BUILDER) \
 		--platform $(MULTIARCH_PLATFORMS) \
-		$(REGISTRY_ARG) $(DOCKER_BUILD_ARGS) \
+		$(REGISTRY_ARG) $(OPENCLAW_BASE_BUILD_ARG) $(DOCKER_BUILD_ARGS) \
 		-t $(WORKER_TAG) \
 		$(if $(filter-out latest,$(VERSION)),-t $(WORKER_IMAGE):latest) \
 		--push \
@@ -321,6 +357,7 @@ clean: ## Remove local images and test containers
 	@echo "==> Removing local images..."
 	-docker rmi $(LOCAL_MANAGER) 2>/dev/null
 	-docker rmi $(LOCAL_WORKER) 2>/dev/null
+	-docker rmi $(LOCAL_OPENCLAW_BASE) 2>/dev/null
 	@echo "==> Clean complete"
 
 # ---------- Help ----------

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -23,37 +23,9 @@ FROM ${HIGRESS_REGISTRY}/higress/mc:20260216 AS mc
 # ============ Stage 4: Element Web ============
 FROM ${HIGRESS_REGISTRY}/higress/element-web:20260216 AS element-web
 
-# ============ Stage 5: OpenClaw + mcporter ============
-FROM ${HIGRESS_REGISTRY}/higress/node:20-slim AS openclaw-build
-
-# Build args (must be declared BEFORE any RUN that uses them)
-ARG APT_MIRROR=mirrors.aliyun.com
-ARG HTTP_PROXY
-ARG HTTPS_PROXY
-ARG http_proxy
-ARG https_proxy
-ARG NPM_REGISTRY=https://registry.npmjs.org/
-
-# Set proxy as environment variables to ensure all tools can use them
-ENV HTTP_PROXY=${HTTP_PROXY} \
-    HTTPS_PROXY=${HTTPS_PROXY} \
-    http_proxy=${http_proxy} \
-    https_proxy=${https_proxy}
-
-RUN if [ -n "${APT_MIRROR}" ]; then \
-        sed -i "s|deb.debian.org|${APT_MIRROR}|g" /etc/apt/sources.list.d/debian.sources 2>/dev/null || \
-        sed -i "s|deb.debian.org|${APT_MIRROR}|g" /etc/apt/sources.list 2>/dev/null || true; \
-    fi && \
-    apt-get update && apt-get install -y git python3 make g++ curl && \
-    npm install -g pnpm n && n 22 && \
-    hash -r && node --version
-
-RUN git clone https://github.com/johnlanni/openclaw.git /opt/openclaw && \
-    cd /opt/openclaw && git checkout 837631055cf89b9cf5cece8ee07405b910173a38
-
-RUN cd /opt/openclaw && pnpm config set registry ${NPM_REGISTRY} && pnpm install && pnpm build
-
-RUN npm install -g mcporter
+# ============ Stage 5: OpenClaw + mcporter (shared base image) ============
+ARG OPENCLAW_BASE_TAG=latest
+FROM ${HIGRESS_REGISTRY}/higress/openclaw-base:${OPENCLAW_BASE_TAG} AS openclaw-build
 
 # Install AI coding CLI tools here (npm works correctly in this stage)
 RUN npm install -g @google/gemini-cli @anthropic-ai/claude-code

--- a/openclaw-base/Dockerfile
+++ b/openclaw-base/Dockerfile
@@ -1,0 +1,43 @@
+# ============================================================
+# OpenClaw Base Image - Shared build for Manager and Worker
+# ============================================================
+# Pre-compiles OpenClaw + mcporter so that Manager and Worker
+# can share the same base layer, avoiding ~900MB duplicate downloads.
+#
+# Build args:
+#   HIGRESS_REGISTRY  - base image registry (default: cn-hangzhou)
+#   APT_MIRROR        - APT mirror host (default: mirrors.aliyun.com, set to empty to use official)
+# ============================================================
+
+ARG HIGRESS_REGISTRY=higress-registry.cn-hangzhou.cr.aliyuncs.com
+
+FROM ${HIGRESS_REGISTRY}/higress/node:20-slim
+
+# Build args (must be declared BEFORE any RUN that uses them)
+ARG APT_MIRROR=mirrors.aliyun.com
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG http_proxy
+ARG https_proxy
+ARG NPM_REGISTRY=https://registry.npmjs.org/
+
+# Set proxy as environment variables to ensure all tools can use them
+ENV HTTP_PROXY=${HTTP_PROXY} \
+    HTTPS_PROXY=${HTTPS_PROXY} \
+    http_proxy=${http_proxy} \
+    https_proxy=${https_proxy}
+
+RUN if [ -n "${APT_MIRROR}" ]; then \
+        sed -i "s|deb.debian.org|${APT_MIRROR}|g" /etc/apt/sources.list.d/debian.sources 2>/dev/null || \
+        sed -i "s|deb.debian.org|${APT_MIRROR}|g" /etc/apt/sources.list 2>/dev/null || true; \
+    fi && \
+    apt-get update && apt-get install -y git python3 make g++ curl && \
+    npm install -g pnpm n && n 22 && \
+    hash -r && node --version
+
+RUN git clone https://github.com/johnlanni/openclaw.git /opt/openclaw && \
+    cd /opt/openclaw && git checkout 1021357a54537a205770238240f06978436062ff
+
+RUN cd /opt/openclaw && pnpm config set registry ${NPM_REGISTRY} && pnpm install && pnpm build
+
+RUN npm install -g mcporter

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -14,37 +14,9 @@ ARG HIGRESS_REGISTRY=higress-registry.cn-hangzhou.cr.aliyuncs.com
 # ============ Stage 1: mc (MinIO Client) ============
 FROM ${HIGRESS_REGISTRY}/higress/mc:20260216 AS mc
 
-# ============ Stage 2: OpenClaw + mcporter build ============
-FROM ${HIGRESS_REGISTRY}/higress/node:20-slim AS openclaw-build
-
-# Build args (must be declared BEFORE any RUN that uses them)
-ARG APT_MIRROR=mirrors.aliyun.com
-ARG HTTP_PROXY
-ARG HTTPS_PROXY
-ARG http_proxy
-ARG https_proxy
-ARG NPM_REGISTRY=https://registry.npmjs.org/
-
-# Set proxy as environment variables to ensure all tools can use them
-ENV HTTP_PROXY=${HTTP_PROXY} \
-    HTTPS_PROXY=${HTTPS_PROXY} \
-    http_proxy=${http_proxy} \
-    https_proxy=${https_proxy}
-
-RUN if [ -n "${APT_MIRROR}" ]; then \
-        sed -i "s|deb.debian.org|${APT_MIRROR}|g" /etc/apt/sources.list.d/debian.sources 2>/dev/null || \
-        sed -i "s|deb.debian.org|${APT_MIRROR}|g" /etc/apt/sources.list 2>/dev/null || true; \
-    fi && \
-    apt-get update && apt-get install -y git python3 make g++ curl && \
-    npm install -g pnpm n && n 22 && \
-    hash -r && node --version
-
-RUN git clone https://github.com/johnlanni/openclaw.git /opt/openclaw && \
-    cd /opt/openclaw && git checkout 837631055cf89b9cf5cece8ee07405b910173a38
-
-RUN cd /opt/openclaw && pnpm config set registry ${NPM_REGISTRY} && pnpm install && pnpm build
-
-RUN npm install -g mcporter
+# ============ Stage 2: OpenClaw + mcporter (shared base image) ============
+ARG OPENCLAW_BASE_TAG=latest
+FROM ${HIGRESS_REGISTRY}/higress/openclaw-base:${OPENCLAW_BASE_TAG} AS openclaw-build
 
 # ============ Final Image ============
 FROM ${HIGRESS_REGISTRY}/higress/ubuntu:24.04


### PR DESCRIPTION
…B duplicate layers

Worker and Manager each had an identical openclaw-build stage (~900MB) that produced different layer digests due to independent builds. This extracts the shared build (node:20-slim + openclaw + mcporter) into openclaw-base/Dockerfile, so both images FROM the same base and share layers when pulled.

Also updates openclaw pinned commit 