### PR TITLE
docs: update resource requirements recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-Expression ((New-Object
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) (Windows / macOS)
 - [Docker Engine](https://docs.docker.com/engine/install/) (Linux) or [Podman Desktop](https://podman-desktop.io/) (alternative)
 
-**Resource requirements**: The Docker VM needs at least 2 CPU cores and 4 GB RAM. In Docker Desktop, go to Settings → Resources to adjust.
+**Resource requirements**: Minimum 2 CPU cores and 4 GB RAM. If you want to deploy multiple Workers for a more powerful Agent Teams experience, **4 CPU cores and 8 GB RAM are recommended** — OpenClaw's memory usage is relatively high. In Docker Desktop, go to Settings → Resources to adjust.
 
 ### Upgrade
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,7 +60,7 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-Expression ((New-Object
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/)（Windows / macOS）
 - [Docker Engine](https://docs.docker.com/engine/install/)（Linux）或 [Podman Desktop](https://podman-desktop.io/)（替代方案）
 
-**资源需求**：Docker 虚拟机至少需要分配 2 核 CPU 和 4 GB 内存。Docker Desktop 用户可在 Settings → Resources 中调整。
+**资源需求**：最低 2 核 CPU 和 4 GB 内存。如果希望部署较多 Worker 体验更强大的 Agent Teams 能力，**建议 4 核 8 GB 内存** —— 目前 OpenClaw 内存占用较高。Docker Desktop 用户可在 Settings → Resources 中调整。
 
 ### 升级
 


### PR DESCRIPTION
- Minimum requirements remain 2c4g
- Recommend 4c8g for deploying multiple Workers for better Agent Teams experience
- Reason: OpenClaw has relatively high memory usage