### PR TITLE
docs: add roadmap for lightweight workers and team management center

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,16 @@ A built-in dashboard for observing and controlling your Agent Teams:
 
 Goal: Make Agent Teams as observable and controllable as human teams — no black boxes.
 
+### Universal MCP Service Support
+
+Currently, Workers access GitHub via Higress MCP Gateway + mcporter, using only a Higress-issued token — real GitHub PATs never leave the gateway. This secure pattern works for any MCP server:
+
+- **Pre-built MCP connectors**: GitHub, Slack, Notion, Linear, and more
+- **Custom MCP integration**: Bring your own MCP server, let Higress handle auth
+- **Per-Worker access control**: Manager grants/revokes MCP access per Worker
+
+Goal: Any tool that speaks MCP can be safely exposed to Workers without credential leakage.
+
 ---
 
 ## Documentation

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -209,6 +209,16 @@ docker exec -it hiclaw-manager cat /var/log/hiclaw/manager-agent.log
 
 目标：让 Agent Teams 像人类团队一样透明可控——没有黑盒。
 
+### 通用 MCP 服务支持
+
+目前 Worker 通过 Higress MCP 网关 + mcporter 访问 GitHub，只需使用 Higress 签发的 token，真实的 GitHub PAT 永远不会暴露给 Worker。这个安全的模式可以扩展到任意 MCP 服务：
+
+- **预置 MCP 连接器**：GitHub、Slack、Notion、Linear 等常用服务
+- **自定义 MCP 集成**：接入自己的 MCP 服务，由 Higress 统一管理认证
+- **细粒度权限控制**：Manager 可按 Worker 授予/撤销 MCP 服务访问权限
+
+目标：任何支持 MCP 协议的工具都能安全地暴露给 Worker，凭证零泄露。
+
 ---
 
 ## 文档


### PR DESCRIPTION
## 新增 Roadmap 章节

### 1. 轻量级 Worker 运行时
目前 Worker 基于 OpenClaw 运行，内存占用较高（约 500MB+）。计划支持更轻量的运行时：
- **Copaw** —— 适合简单任务的轻量 Agent
- **Zeroclaw** —— 零依赖，适合资源受限环境
- **Nanoclaw** —— 超轻量，适合边缘部署

目标：单 Worker 内存占用从 ~500MB 降至 <100MB

### 2. Team 管理中心
开箱即用的可视化控制台：
- **实时观测**：每个 Agent 的思考过程、工具调用、决策过程可视化
- **主动打断**：随时暂停或停止任何 Agent 的工作
- **任务时间线**：完整的历史记录
- **资源监控**：CPU/内存使用情况

目标：让 Agent Teams 像人类团队一样透明可控