### PR TITLE
docs: add FAQ entry for checking current HiClaw version

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,6 @@
 # FAQ
 
+- [How to check the current HiClaw version](#how-to-check-the-current-hiclaw-version)
 - [Installation script exits immediately on Windows](#installation-script-exits-immediately-on-windows)
 - [Manager Agent startup timeout](#manager-agent-startup-timeout)
 - [Accessing the web UI from other devices on the LAN](#accessing-the-web-ui-from-other-devices-on-the-lan)
@@ -10,6 +11,22 @@
 - [Does HiClaw support sending and receiving files](#does-hiclaw-support-sending-and-receiving-files)
 - [Why does Manager/Worker keep showing "typing"](#why-does-managerworker-keep-showing-typing)
 - [Manager not responding or returning error status codes](#manager-not-responding-or-returning-error-status-codes)
+
+---
+
+## How to check the current HiClaw version
+
+Run the following command to see the installed version:
+
+```bash
+docker exec hiclaw-manager cat /opt/hiclaw/agent/.builtin-version
+```
+
+To install a specific version, use the `HICLAW_VERSION` environment variable during installation:
+
+```bash
+HICLAW_VERSION=0.1.0 bash <(curl -sSL https://higress.ai/hiclaw/install.sh)
+```
 
 ---
 

--- a/docs/zh-cn/faq.md
+++ b/docs/zh-cn/faq.md
@@ -1,5 +1,6 @@
 # 常见问题
 
+- [如何查看当前 HiClaw 版本](#如何查看当前-hiclaw-版本)
 - [Windows 下执行安装脚本闪退](#windows-下执行安装脚本闪退)
 - [Manager Agent 启动超时](#manager-agent-启动超时)
 - [局域网其他电脑如何访问 Web 端](#局域网其他电脑如何访问-web-端)
@@ -10,6 +11,22 @@
 - [HiClaw 支持发送和接收文件吗](#hiclaw-支持发送和接收文件吗)
 - [为什么 Manager/Worker 一直显示"输入中"](#为什么-managerworker-一直显示输入中)
 - [在房间里和 Manager 聊天没有响应或返回错误状态码](#在房间里和-manager-聊天没有响应或返回错误状态码)
+
+---
+
+## 如何查看当前 HiClaw 版本
+
+执行以下命令查看已安装的版本：
+
+```bash
+docker exec hiclaw-manager cat /opt/hiclaw/agent/.builtin-version
+```
+
+安装时指定版本：
+
+```bash
+HICLAW_VERSION=0.1.0 bash <(curl -sSL https://higress.ai/hiclaw/install.sh)
+```
 
 ---
 


### PR DESCRIPTION
## 新增 FAQ：如何查看当前 HiClaw 版本

### 查看已安装版本
```bash
docker exec hiclaw-manager cat /opt/hiclaw/agent/.builtin-version
```

### 查看镜像 tag（如果显示 latest）
```bash
docker inspect hiclaw-manager --format '{{.Config.Image}}'
```

### 安装时指定版本
```bash
HICLAW_VERSION=0.1.0 bash <(curl -sSL https://higress.ai/hiclaw/install.sh)
```

同时更新了英文和中文 FAQ 文档。