### PR TITLE
Fix typo: Chinese comma to English comma in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ All communication happens in Matrix Rooms. You see everything, and can intervene
 
 ## News
 
-- **2026-03-04**: We officially open source HiClaw，an Agent Teams System. Read more on our [blog](https://github.com/higress-group/hiclaw/blob/main/blog/hiclaw-announcement.md).
+- **2026-03-04**: We officially open source HiClaw, an Agent Teams System. Read more on our [blog](https://github.com/higress-group/hiclaw/blob/main/blog/hiclaw-announcement.md).
 
 
 ## Why HiClaw


### PR DESCRIPTION
Fixes a typo in README.md line 29 where a Chinese full-width comma (，) was used instead of an English comma in the English sentence: 'We officially open source HiClaw, an Agent Teams System.'