### PR TITLE
docs: add FAQ for connecting additional messaging channels

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,7 @@
 # FAQ
 
 - [How to check the current HiClaw version](#how-to-check-the-current-hiclaw-version)
+- [How to connect Feishu/DingTalk/WeCom/Discord/Telegram](#how-to-connect-feishudingtalkwecomdiscordtelegram)
 - [Installation script exits immediately on Windows](#installation-script-exits-immediately-on-windows)
 - [Manager Agent startup timeout](#manager-agent-startup-timeout)
 - [Accessing the web UI from other devices on the LAN](#accessing-the-web-ui-from-other-devices-on-the-lan)
@@ -168,3 +169,28 @@ Search the log for the relevant status code. Common causes:
 - **404**: The model name is probably wrong.
 
 To determine whether the error came from the backend or from a Higress misconfiguration, check the `upstream_host` field in the log entry. If `upstream_host` has a value, the request reached the backend and the error was returned by the upstream service. If it's empty, Higress itself couldn't route the request.
+
+---
+
+## How to connect Feishu/DingTalk/WeCom/Discord/Telegram
+
+HiClaw Manager is built on OpenClaw, which supports multiple messaging channels out of the box. To connect additional channels:
+
+**Method 1: Edit config directly**
+
+The Manager's working directory is `~/hiclaw-manager` (on your host). Edit `openclaw.json` in that directory to add channel configuration. Refer to [OpenClaw channel documentation](https://docs.openclaw.ai) for the specific config format for each platform.
+
+After editing, restart the Manager container for changes to take effect:
+
+```bash
+docker restart hiclaw-manager
+```
+
+**Method 2: Let Manager learn from your existing OpenClaw config**
+
+If you already use OpenClaw with other channels (e.g., in your personal setup), you can let Manager read your existing config:
+
+- **Tell Manager where the file is**: In Element Web, tell Manager the path to your OpenClaw config file (e.g., "My OpenClaw config is at `/home/user/my-openclaw.json`"). Manager will read it directly.
+- **Send the file as attachment**: In Element Web or any Matrix client, upload your config file as an attachment and send it to Manager. Manager will receive and read it.
+
+Then ask Manager to help configure the same channels in its own config.

--- a/docs/zh-cn/faq.md
+++ b/docs/zh-cn/faq.md
@@ -1,6 +1,7 @@
 # 常见问题
 
 - [如何查看当前 HiClaw 版本](#如何查看当前-hiclaw-版本)
+- [如何对接飞书/钉钉/企业微信/Discord/Telegram](#如何对接飞书钉钉企业微信discordtelegram)
 - [Windows 下执行安装脚本闪退](#windows-下执行安装脚本闪退)
 - [Manager Agent 启动超时](#manager-agent-启动超时)
 - [局域网其他电脑如何访问 Web 端](#局域网其他电脑如何访问-web-端)
@@ -168,3 +169,28 @@ docker exec -it hiclaw-manager cat /var/log/hiclaw/higress-gateway.log
 - **404**：模型名称填写有误。
 
 要判断是后端服务出错还是 Higress 自身配置问题，查看日志中的 `upstream_host` 字段：如果该字段有值，说明请求已到达后端，异常状态码是由上游服务返回的；如果为空，说明 Higress 本身无法路由该请求。
+
+---
+
+## 如何对接飞书/钉钉/企业微信/Discord/Telegram
+
+HiClaw Manager 基于 OpenClaw 构建，原生支持多种消息渠道。要对接其他渠道：
+
+**方法一：直接修改配置**
+
+Manager 的工作目录是宿主机上的 `~/hiclaw-manager`，里面的 `openclaw.json` 可以直接编辑。参照 [OpenClaw 渠道文档](https://docs.openclaw.ai) 中各平台的配置格式进行配置。
+
+修改后重启 Manager 容器使配置生效：
+
+```bash
+docker restart hiclaw-manager
+```
+
+**方法二：让 Manager 学习你现有的 OpenClaw 配置**
+
+如果你已经在其他地方使用 OpenClaw 接入了其他渠道，可以让 Manager 读取你现有的配置：
+
+- **告诉 Manager 文件位置**：在 Element Web 中告诉 Manager 你的 OpenClaw 配置文件路径（例如 "我的 OpenClaw 配置在 `/home/user/my-openclaw.json`"），Manager 会直接读取。
+- **通过附件发送**：在 Element Web 或其他 Matrix 客户端中，把配置文件作为附件上传发送给 Manager，Manager 会接收并读取。
+
+然后让 Manager 帮你在它的配置里添加相同的渠道。


### PR DESCRIPTION
## 新增 FAQ：如何对接飞书/钉钉/企业微信/Discord/Telegram

### 方法一：直接修改配置
Manager 的工作目录是 `~/hiclaw-manager`，直接编辑 `openclaw.json` 添加渠道配置。

### 方法二：让 Manager 学习现有配置
如果你已经有 OpenClaw 配置文件，可以复制到 Manager 工作目录，让 Manager 自己读取学习，然后更新配置。

### 文档更新
- 英文版和中文版 FAQ 都已添加新条目
- 提供具体的操作步骤和示例命令