### PR TITLE
docs: add FAQ for Bailian Coding Plan 401 error

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,6 +12,7 @@
 - [Does HiClaw support sending and receiving files](#does-hiclaw-support-sending-and-receiving-files)
 - [Why does Manager/Worker keep showing "typing"](#why-does-managerworker-keep-showing-typing)
 - [Manager not responding or returning error status codes](#manager-not-responding-or-returning-error-status-codes)
+- [HTTP 401: invalid access token or token expired](#http-401-invalid-access-token-or-token-expired)
 
 ---
 
@@ -169,6 +170,20 @@ Search the log for the relevant status code. Common causes:
 - **404**: The model name is probably wrong.
 
 To determine whether the error came from the backend or from a Higress misconfiguration, check the `upstream_host` field in the log entry. If `upstream_host` has a value, the request reached the backend and the error was returned by the upstream service. If it's empty, Higress itself couldn't route the request.
+
+---
+
+## HTTP 401: invalid access token or token expired
+
+If you see this error when Manager or Worker tries to call the LLM, check whether you selected **Bailian Coding Plan** during installation but haven't activated it yet.
+
+Bailian Coding Plan is a free trial program from Alibaba Cloud. To use it, you need to activate it first:
+
+1. Visit: https://www.aliyun.com/benefit/scene/codingplan
+2. Log in with your Alibaba Cloud account
+3. Follow the instructions to activate the Coding Plan
+
+After activation, re-run the installation or restart the Manager container. The token should work immediately.
 
 ---
 

--- a/docs/zh-cn/faq.md
+++ b/docs/zh-cn/faq.md
@@ -12,6 +12,7 @@
 - [HiClaw 支持发送和接收文件吗](#hiclaw-支持发送和接收文件吗)
 - [为什么 Manager/Worker 一直显示"输入中"](#为什么-managerworker-一直显示输入中)
 - [在房间里和 Manager 聊天没有响应或返回错误状态码](#在房间里和-manager-聊天没有响应或返回错误状态码)
+- [HTTP 401: invalid access token or token expired](#http-401-invalid-access-token-or-token-expired)
 
 ---
 
@@ -169,6 +170,20 @@ docker exec -it hiclaw-manager cat /var/log/hiclaw/higress-gateway.log
 - **404**：模型名称填写有误。
 
 要判断是后端服务出错还是 Higress 自身配置问题，查看日志中的 `upstream_host` 字段：如果该字段有值，说明请求已到达后端，异常状态码是由上游服务返回的；如果为空，说明 Higress 本身无法路由该请求。
+
+---
+
+## HTTP 401: invalid access token or token expired
+
+如果 Manager 或 Worker 调用 LLM 时出现这个错误，检查一下是否在安装时选择了**百炼 Coding Plan**，但还没有去开通。
+
+百炼 Coding Plan 是阿里云提供的免费试用计划，需要先激活才能使用：
+
+1. 访问：https://www.aliyun.com/benefit/scene/codingplan
+2. 使用阿里云账号登录
+3. 按照指引完成激活
+
+激活后重新执行安装或重启 Manager 容器即可正常使用。
 
 ---
 


### PR DESCRIPTION
## 新增 FAQ：HTTP 401: invalid access token or token expired

### 问题描述
用户在安装时选择了百炼 Coding Plan，但还没有去开通，导致 Manager 或 Worker 调用 LLM 时返回 401 错误。

### 解决方案
1. 访问：https://www.aliyun.com/benefit/scene/codingplan
2. 使用阿里云账号登录
3. 按照指引完成激活

激活后重新执行安装或重启 Manager 容器即可正常使用。

### 文档更新
- 英文版和中文版 FAQ 都已添加新条目