### PR TITLE
docs: add Mac M4 chip compatibility note for Manager Agent startup

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -3,7 +3,7 @@
 - [How to check the current HiClaw version](#how-to-check-the-current-hiclaw-version)
 - [How to connect Feishu/DingTalk/WeCom/Discord/Telegram](#how-to-connect-feishudingtalkwecomdiscordtelegram)
 - [Installation script exits immediately on Windows](#installation-script-exits-immediately-on-windows)
-- [Manager Agent startup timeout](#manager-agent-startup-timeout)
+- [Manager Agent startup timeout or failure](#manager-agent-startup-timeout-or-failure)
 - [Accessing the web UI from other devices on the LAN](#accessing-the-web-ui-from-other-devices-on-the-lan)
 - [Cannot connect to Matrix server locally](#cannot-connect-to-matrix-server-locally)
 - [How to talk to a Worker directly](#how-to-talk-to-a-worker-directly)
@@ -38,9 +38,11 @@ If the PowerShell installation script closes immediately after launching, first 
 
 ---
 
-## Manager Agent startup timeout
+## Manager Agent startup timeout or failure
 
-If the Manager Agent is unresponsive after installation, check the logs inside the container:
+If the Manager Agent is unresponsive after installation
+, or fails to start
+, check the logs inside the container:
 
 ```bash
 docker exec -it hiclaw-manager cat /var/log/hiclaw/manager-agent.log

--- a/docs/zh-cn/faq.md
+++ b/docs/zh-cn/faq.md
@@ -3,7 +3,7 @@
 - [如何查看当前 HiClaw 版本](#如何查看当前-hiclaw-版本)
 - [如何对接飞书/钉钉/企业微信/Discord/Telegram](#如何对接飞书钉钉企业微信discordtelegram)
 - [Windows 下执行安装脚本闪退](#windows-下执行安装脚本闪退)
-- [Manager Agent 启动超时](#manager-agent-启动超时)
+- [Manager Agent 启动超时或失败](#manager-agent-启动超时或失败)
 - [局域网其他电脑如何访问 Web 端](#局域网其他电脑如何访问-web-端)
 - [本地访问 Matrix 服务器不通](#本地访问-matrix-服务器不通)
 - [如何主动指挥 Worker](#如何主动指挥-worker)
@@ -38,11 +38,10 @@ HICLAW_VERSION=0.1.0 bash <(curl -sSL https://higress.ai/hiclaw/install.sh)
 
 ---
 
-## Manager Agent 启动超时
+## Manager Agent 启动超时或失败
 
-安装完成后如果 Manager Agent 迟迟没有响应，进容器查看日志：
-
-```bash
+安装完成后如果 Manager Agent 迟迟没有响应，或启动失败
+，进容器查看日志：```bash
 docker exec -it hiclaw-manager cat /var/log/hiclaw/manager-agent.log
 ```
 


### PR DESCRIPTION
## Summary

Add a known issue note in the FAQ documentation for users with Apple M4 chips. The Manager Agent may fail to start on M4 devices due to compatibility issues.

## Changes

- Updated `docs/zh-cn/faq.md`: Added "情况三：Mac M4 芯片设备" under "Manager Agent 启动超时"
- Updated `docs/faq.md`: Added "Case 3: Mac with M4 chip" under "Manager Agent startup timeout"

## Notes

- M4 chip support is being actively worked on
- This is a known compatibility issue that will be addressed in future releases