### PR TITLE
feat: skip :latest tag for pre-release versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,13 @@ MULTIARCH_PLATFORMS ?= linux/amd64,linux/arm64
 # Buildx builder name (auto-created if not exists)
 BUILDX_BUILDER     ?= hiclaw-multiarch
 
+# Pre-release version detection
+# Pre-release versions (containing -rc, -beta, -alpha, etc.) should NOT push :latest tag
+# This allows testing specific versions without affecting the latest stable image
+IS_PRERELEASE := $(shell echo "$(VERSION)" | grep -qiE -- '-(rc|beta|alpha|pre|preview|dev|snapshot)(\.[0-9]+)?$$' && echo 1 || echo 0)
+# Whether to push :latest tag (push for stable releases, skip for latest and pre-releases)
+PUSH_LATEST := $(if $(filter latest,$(VERSION)),,$(if $(filter 1,$(IS_PRERELEASE)),,yes))
+
 # Test flags
 SKIP_BUILD     ?=
 TEST_FILTER    ?=
@@ -109,12 +116,12 @@ build-worker: ## Build Worker image
 tag: build ## Tag images for registry push
 	docker tag $(LOCAL_MANAGER) $(MANAGER_TAG)
 	docker tag $(LOCAL_WORKER) $(WORKER_TAG)
-ifeq ($(VERSION),latest)
-	@echo "==> Images tagged as $(VERSION)"
-else
+ifeq ($(PUSH_LATEST),yes)
 	docker tag $(LOCAL_MANAGER) $(MANAGER_IMAGE):latest
 	docker tag $(LOCAL_WORKER) $(WORKER_IMAGE):latest
 	@echo "==> Images tagged as $(VERSION) and latest"
+else
+	@echo "==> Images tagged as $(VERSION) (latest not pushed for pre-release)"
 endif
 
 # ---------- Push (multi-arch, default) ----------
@@ -153,15 +160,16 @@ ifeq ($(IS_PODMAN),1)
 			--manifest $(OPENCLAW_BASE_TAG) \
 			./openclaw-base/ && ) true
 	podman manifest push --all $(OPENCLAW_BASE_TAG) docker://$(OPENCLAW_BASE_TAG)
-	$(if $(filter-out latest,$(VERSION)), \
-		podman manifest push --all $(OPENCLAW_BASE_TAG) docker://$(OPENCLAW_BASE_IMAGE):latest)
+	$(if $(PUSH_LATEST), \
+		podman manifest push --all $(OPENCLAW_BASE_TAG) docker://$(OPENCLAW_BASE_IMAGE):latest && \
+		echo "  -> Also pushed :latest tag")
 else
 	docker buildx build \
 		--builder $(BUILDX_BUILDER) \
 		--platform $(MULTIARCH_PLATFORMS) \
 		$(REGISTRY_ARG) $(DOCKER_BUILD_ARGS) \
 		-t $(OPENCLAW_BASE_TAG) \
-		$(if $(filter-out latest,$(VERSION)),-t $(OPENCLAW_BASE_IMAGE):latest) \
+		$(if $(PUSH_LATEST),-t $(OPENCLAW_BASE_IMAGE):latest) \
 		--push \
 		./openclaw-base/
 endif
@@ -178,15 +186,16 @@ ifeq ($(IS_PODMAN),1)
 			--manifest $(MANAGER_TAG) \
 			./manager/ && ) true
 	podman manifest push --all $(MANAGER_TAG) docker://$(MANAGER_TAG)
-	$(if $(filter-out latest,$(VERSION)), \
-		podman manifest push --all $(MANAGER_TAG) docker://$(MANAGER_IMAGE):latest)
+	$(if $(PUSH_LATEST), \
+		podman manifest push --all $(MANAGER_TAG) docker://$(MANAGER_IMAGE):latest && \
+		echo "  -> Also pushed :latest tag")
 else
 	docker buildx build \
 		--builder $(BUILDX_BUILDER) \
 		--platform $(MULTIARCH_PLATFORMS) \
 		$(REGISTRY_ARG) $(BUILTIN_VERSION_ARG) $(OPENCLAW_BASE_BUILD_ARG) $(DOCKER_BUILD_ARGS) \
 		-t $(MANAGER_TAG) \
-		$(if $(filter-out latest,$(VERSION)),-t $(MANAGER_IMAGE):latest) \
+		$(if $(PUSH_LATEST),-t $(MANAGER_IMAGE):latest) \
 		--push \
 		./manager/
 endif
@@ -203,15 +212,16 @@ ifeq ($(IS_PODMAN),1)
 			--manifest $(WORKER_TAG) \
 			./worker/ && ) true
 	podman manifest push --all $(WORKER_TAG) docker://$(WORKER_TAG)
-	$(if $(filter-out latest,$(VERSION)), \
-		podman manifest push --all $(WORKER_TAG) docker://$(WORKER_IMAGE):latest)
+	$(if $(PUSH_LATEST), \
+		podman manifest push --all $(WORKER_TAG) docker://$(WORKER_IMAGE):latest && \
+		echo "  -> Also pushed :latest tag")
 else
 	docker buildx build \
 		--builder $(BUILDX_BUILDER) \
 		--platform $(MULTIARCH_PLATFORMS) \
 		$(REGISTRY_ARG) $(OPENCLAW_BASE_BUILD_ARG) $(DOCKER_BUILD_ARGS) \
 		-t $(WORKER_TAG) \
-		$(if $(filter-out latest,$(VERSION)),-t $(WORKER_IMAGE):latest) \
+		$(if $(PUSH_LATEST),-t $(WORKER_IMAGE):latest) \
 		--push \
 		./worker/
 endif
@@ -226,7 +236,7 @@ push-native: tag ## Push native-arch images (dev only, overwrites multi-arch!)
 	docker push $(MANAGER_TAG)
 	@echo "==> Pushing Worker: $(WORKER_TAG)"
 	docker push $(WORKER_TAG)
-ifneq ($(VERSION),latest)
+ifeq ($(PUSH_LATEST),yes)
 	docker push $(MANAGER_IMAGE):latest
 	docker push $(WORKER_IMAGE):latest
 endif


### PR DESCRIPTION
## Summary

Pre-release versions (e.g., `v1.0.4-rc.1`, `v2.0.0-beta.2`) should not update the `:latest` tag. This allows testing specific versions without affecting the stable release channel.

## Changes

- Added `IS_PRERELEASE` detection using regex pattern matching
- Added `PUSH_LATEST` variable to control whether `:latest` tag should be pushed
- Updated all push targets (`push-openclaw-base`, `push-manager`, `push-worker`, `push-native`, `tag`) to use `PUSH_LATEST`

## Detection Logic

Matches versions with pre-release identifiers:
- `-rc`, `-beta`, `-alpha`, `-pre`, `-preview`, `-dev`, `-snapshot`
- Supports optional `.N` suffix (e.g., `-rc.1`, `-beta.2`)

| VERSION | IS_PRERELEASE | PUSH_LATEST | Behavior |
|---------|---------------|-------------|----------|
| `v1.0.4-rc.1` | 1 | (empty) | Only push `:v1.0.4-rc.1` |
| `v1.0.4` | 0 | yes | Push `:v1.0.4` AND `:latest` |
| `latest` | 0 | (empty) | Only push `:latest` |

## Use Case

When releasing RC versions for testing, you can now deploy with a specific version tag without worrying about affecting the `:latest` stable image:

```bash
# Cut RC tag
git tag v1.0.4-rc.1
git push origin v1.0.4-rc.1

# CI builds and pushes only :v1.0.4-rc.1 (NOT :latest)
# Testers can deploy with: hiclaw-install.sh --version v1.0.4-rc.1
```