### PR TITLE
fix: align test flow with install script conventions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -330,13 +330,15 @@ uninstall: ## Stop and remove Manager + all Worker containers
 		docker rm -f "$$c" 2>/dev/null || true; \
 	done
 	-docker volume rm hiclaw-data 2>/dev/null && echo "  Removed volume: hiclaw-data" || true
-	@if [ -f ./hiclaw-manager.env ]; then \
-		DATA_DIR=$$(grep '^HICLAW_DATA_DIR=' ./hiclaw-manager.env 2>/dev/null | cut -d= -f2-); \
+	@ENV_FILE="$${HICLAW_ENV_FILE:-$${HOME}/hiclaw-manager.env}"; \
+	[ -f "$$ENV_FILE" ] || ENV_FILE="./hiclaw-manager.env"; \
+	if [ -f "$$ENV_FILE" ]; then \
+		DATA_DIR=$$(grep '^HICLAW_DATA_DIR=' "$$ENV_FILE" 2>/dev/null | cut -d= -f2-); \
 		if [ -n "$$DATA_DIR" ] && [ -d "$$DATA_DIR" ]; then \
 			echo "  External data directory preserved: $$DATA_DIR"; \
 			echo "  To delete: rm -rf $$DATA_DIR"; \
 		fi; \
-		WORKSPACE_DIR=$$(grep '^HICLAW_WORKSPACE_DIR=' ./hiclaw-manager.env 2>/dev/null | cut -d= -f2-); \
+		WORKSPACE_DIR=$$(grep '^HICLAW_WORKSPACE_DIR=' "$$ENV_FILE" 2>/dev/null | cut -d= -f2-); \
 		if [ -n "$$WORKSPACE_DIR" ] && [ -d "$$WORKSPACE_DIR" ]; then \
 			PARENT=$$(dirname "$$WORKSPACE_DIR"); \
 			BASE=$$(basename "$$WORKSPACE_DIR"); \

--- a/tests/lib/matrix-client.sh
+++ b/tests/lib/matrix-client.sh
@@ -60,6 +60,11 @@ matrix_joined_rooms() {
         -H "Authorization: Bearer ${token}"
 }
 
+# URL-encode a room ID for use in URL paths (! -> %21)
+_encode_room_id() {
+    echo "${1//!/%21}"
+}
+
 # ============================================================
 # Messaging
 # ============================================================
@@ -72,12 +77,14 @@ matrix_send_message() {
     local room_id="$2"
     local body="$3"
     local txn_id="$(date +%s%N)"
+    local room_enc
+    room_enc="$(_encode_room_id "${room_id}")"
 
     # Escape newlines and special chars for JSON
     local escaped_body
     escaped_body=$(echo "$body" | jq -Rs '.' | sed 's/^"//;s/"$//')
 
-    exec_in_manager curl -sf -X PUT "${TEST_MATRIX_DIRECT_URL}/_matrix/client/v3/rooms/${room_id}/send/m.room.message/${txn_id}" \
+    exec_in_manager curl -sf -X PUT "${TEST_MATRIX_DIRECT_URL}/_matrix/client/v3/rooms/${room_enc}/send/m.room.message/${txn_id}" \
         -H "Authorization: Bearer ${token}" \
         -H 'Content-Type: application/json' \
         -d '{
@@ -93,8 +100,10 @@ matrix_read_messages() {
     local token="$1"
     local room_id="$2"
     local limit="${3:-20}"
+    local room_enc
+    room_enc="$(_encode_room_id "${room_id}")"
 
-    exec_in_manager curl -sf "${TEST_MATRIX_DIRECT_URL}/_matrix/client/v3/rooms/${room_id}/messages?dir=b&limit=${limit}" \
+    exec_in_manager curl -sf "${TEST_MATRIX_DIRECT_URL}/_matrix/client/v3/rooms/${room_enc}/messages?dir=b&limit=${limit}" \
         -H "Authorization: Bearer ${token}"
 }
 
@@ -174,8 +183,9 @@ matrix_find_dm_room() {
     rooms=$(matrix_joined_rooms "${token}" | jq -r '.joined_rooms[]')
 
     for room_id in ${rooms}; do
-        local members
-        members=$(exec_in_manager curl -sf "${TEST_MATRIX_DIRECT_URL}/_matrix/client/v3/rooms/${room_id}/members" \
+        local room_enc members
+        room_enc="$(_encode_room_id "${room_id}")"
+        members=$(exec_in_manager curl -sf "${TEST_MATRIX_DIRECT_URL}/_matrix/client/v3/rooms/${room_enc}/members" \
             -H "Authorization: Bearer ${token}" 2>/dev/null | jq -r '.chunk[].state_key' 2>/dev/null)
 
         if echo "${members}" | grep -q "${other_user}"; then

--- a/tests/lib/test-helpers.sh
+++ b/tests/lib/test-helpers.sh
@@ -12,11 +12,11 @@
 
 export TEST_MANAGER_HOST="${TEST_MANAGER_HOST:-127.0.0.1}"
 export TEST_MATRIX_PORT="${TEST_MATRIX_PORT:-6167}"
-export TEST_GATEWAY_PORT="${TEST_GATEWAY_PORT:-8080}"
-export TEST_CONSOLE_PORT="${TEST_CONSOLE_PORT:-8001}"
+export TEST_GATEWAY_PORT="${TEST_GATEWAY_PORT:-18080}"
+export TEST_CONSOLE_PORT="${TEST_CONSOLE_PORT:-18001}"
 export TEST_MINIO_PORT="${TEST_MINIO_PORT:-9000}"
 export TEST_MINIO_CONSOLE_PORT="${TEST_MINIO_CONSOLE_PORT:-9001}"
-export TEST_ELEMENT_PORT="${TEST_ELEMENT_PORT:-8088}"
+export TEST_ELEMENT_PORT="${TEST_ELEMENT_PORT:-18088}"
 
 export TEST_MATRIX_URL="http://${TEST_MANAGER_HOST}:${TEST_GATEWAY_PORT}"
 export TEST_MATRIX_DIRECT_URL="${TEST_MATRIX_DIRECT_URL:-http://${TEST_MANAGER_HOST}:${TEST_MATRIX_PORT}}"
@@ -42,7 +42,7 @@ TEST_FAILURES=()
 # ============================================================
 
 log_info() {
-    echo -e "\033[36m[TEST INFO]\033[0m $1"
+    echo -e "\033[36m[TEST INFO]\033[0m $1" >&2
 }
 
 log_pass() {
@@ -202,12 +202,12 @@ wait_for_manager_agent_ready() {
         local manager_full_id="@${manager_user}:${matrix_domain}"
         local manager_joined=false
 
+        local room_enc="${room_id//!/%21}"
         while [ "${elapsed}" -lt "${timeout}" ]; do
             local members
-            members=$(curl -sf -X GET \
+            members=$(docker exec "${manager_container}" curl -sf -X GET \
                 -H "Authorization: Bearer ${access_token}" \
-                -H "Host: ${matrix_domain}" \
-                "http://${TEST_MANAGER_HOST}:${TEST_GATEWAY_PORT}/_matrix/client/v3/rooms/${room_id}/members" 2>/dev/null | \
+                "http://127.0.0.1:6167/_matrix/client/v3/rooms/${room_enc}/members" 2>/dev/null | \
                 jq -r '.chunk[].state_key' 2>/dev/null) || true
 
             if echo "${members}" | grep -q "${manager_full_id}"; then
@@ -255,7 +255,8 @@ detect_manager_config() {
     if [ -n "${detected_gateway_port}" ] && [ -z "${TEST_GATEWAY_PORT_SET:-}" ]; then
         export TEST_GATEWAY_PORT="${detected_gateway_port}"
         export TEST_MATRIX_URL="http://${TEST_MANAGER_HOST}:${TEST_GATEWAY_PORT}"
-        export TEST_MINIO_URL="http://${TEST_MANAGER_HOST}:${TEST_GATEWAY_PORT}"
+        # Note: TEST_MINIO_URL is NOT updated here. MinIO runs on the fixed internal port 9000
+        # inside the container; mc commands use exec_in_manager so no host port is needed.
     fi
     
     if [ -n "${detected_console_port}" ] && [ -z "${TEST_CONSOLE_PORT_SET:-}" ]; then

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -28,7 +28,7 @@ export TEST_ADMIN_PASSWORD="${TEST_ADMIN_PASSWORD:-testpassword123}"
 export TEST_MINIO_USER="${TEST_MINIO_USER:-${TEST_ADMIN_USER}}"
 export TEST_MINIO_PASSWORD="${TEST_MINIO_PASSWORD:-${TEST_ADMIN_PASSWORD}}"
 export TEST_REGISTRATION_TOKEN="${TEST_REGISTRATION_TOKEN:-test-reg-token-$(openssl rand -hex 8)}"
-export TEST_MATRIX_DOMAIN="${TEST_MATRIX_DOMAIN:-matrix-local.hiclaw.io:8080}"
+export TEST_MATRIX_DOMAIN="${TEST_MATRIX_DOMAIN:-matrix-local.hiclaw.io:18080}"
 export TEST_MANAGER_HOST="${TEST_MANAGER_HOST:-127.0.0.1}"
 export HICLAW_LLM_API_KEY="${HICLAW_LLM_API_KEY:-}"
 
@@ -42,29 +42,34 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# When using an existing installation, load credentials from env file
-if [ "${USE_EXISTING}" = true ]; then
-    ENV_FILE="${HICLAW_ENV_FILE:-${PROJECT_ROOT}/hiclaw-manager.env}"
-    if [ -f "${ENV_FILE}" ]; then
+# Load credentials from hiclaw-manager.env into TEST_* variables
+load_env_file() {
+    # Install script saves to ${HOME}/hiclaw-manager.env; fall back to project root for compat.
+    local env_file="${HICLAW_ENV_FILE:-${HOME}/hiclaw-manager.env}"
+    [ -f "${env_file}" ] || env_file="${PROJECT_ROOT}/hiclaw-manager.env"
+    if [ -f "${env_file}" ]; then
         while IFS='=' read -r key value; do
             [[ "${key}" =~ ^#.*$ || -z "${key}" ]] && continue
             key=$(echo "${key}" | xargs)
             case "${key}" in
-                HICLAW_ADMIN_USER)       export TEST_ADMIN_USER="${value}" ;;
-                HICLAW_ADMIN_PASSWORD)   export TEST_ADMIN_PASSWORD="${value}" ;;
-                HICLAW_MINIO_USER)       export TEST_MINIO_USER="${value}" ;;
-                HICLAW_MINIO_PASSWORD)   export TEST_MINIO_PASSWORD="${value}" ;;
-                HICLAW_REGISTRATION_TOKEN) export TEST_REGISTRATION_TOKEN="${value}" ;;
-                HICLAW_MATRIX_DOMAIN)    export TEST_MATRIX_DOMAIN="${value}" ;;
-                HICLAW_LLM_API_KEY)      [ -z "${HICLAW_LLM_API_KEY}" ] && export HICLAW_LLM_API_KEY="${value}" ;;
+                HICLAW_ADMIN_USER)          export TEST_ADMIN_USER="${value}" ;;
+                HICLAW_ADMIN_PASSWORD)      export TEST_ADMIN_PASSWORD="${value}" ;;
+                HICLAW_MINIO_USER)          export TEST_MINIO_USER="${value}" ;;
+                HICLAW_MINIO_PASSWORD)      export TEST_MINIO_PASSWORD="${value}" ;;
+                HICLAW_REGISTRATION_TOKEN)  export TEST_REGISTRATION_TOKEN="${value}" ;;
+                HICLAW_MATRIX_DOMAIN)       export TEST_MATRIX_DOMAIN="${value}" ;;
+                HICLAW_LLM_API_KEY)         [ -z "${HICLAW_LLM_API_KEY}" ] && export HICLAW_LLM_API_KEY="${value}" ;;
                 HICLAW_MANAGER_GATEWAY_KEY) export TEST_MANAGER_GATEWAY_KEY="${value}" ;;
-                HICLAW_PORT_GATEWAY)     export TEST_GATEWAY_PORT="${value}" ;;
-                HICLAW_PORT_CONSOLE)     export TEST_CONSOLE_PORT="${value}" ;;
+                HICLAW_PORT_GATEWAY)        export TEST_GATEWAY_PORT="${value}" ;;
+                HICLAW_PORT_CONSOLE)        export TEST_CONSOLE_PORT="${value}" ;;
             esac
-        done < "${ENV_FILE}"
+        done < "${env_file}"
     fi
-    # Use the default container name
     export TEST_MANAGER_CONTAINER="hiclaw-manager"
+}
+
+if [ "${USE_EXISTING}" = true ]; then
+    load_env_file
 fi
 
 # ============================================================
@@ -136,89 +141,33 @@ if [ "${USE_EXISTING}" = true ]; then
         log "YOLO mode enabled (${TEST_MANAGER_CONTAINER})" || \
         log "WARNING: Could not enable YOLO mode (container may differ)"
 else
-    log "Starting Manager container..."
+    log "Installing Manager via install script..."
 
-    # Clean up any existing container
-    docker stop hiclaw-manager 2>/dev/null || true
-    docker rm hiclaw-manager 2>/dev/null || true
-
-    MANAGER_GATEWAY_KEY="$(openssl rand -hex 32)"
-
-    # Detect container runtime socket for direct Worker creation
-    CONTAINER_SOCK=""
-    SOCKET_MOUNT_ARGS=""
-    if [ -S "/run/podman/podman.sock" ]; then
-        CONTAINER_SOCK="/run/podman/podman.sock"
-    elif [ -S "/var/run/docker.sock" ]; then
-        CONTAINER_SOCK="/var/run/docker.sock"
-    fi
-
-    if [ -n "${CONTAINER_SOCK}" ]; then
-        log "Container runtime socket found: ${CONTAINER_SOCK} (direct Worker creation enabled)"
-        SOCKET_MOUNT_ARGS="-v ${CONTAINER_SOCK}:/var/run/docker.sock --security-opt label=disable"
-    else
-        log "No container runtime socket found (Worker creation will output commands)"
-    fi
-
-    export TEST_MANAGER_CONTAINER="hiclaw-manager"
-    docker run -d \
-        --name hiclaw-manager \
-        ${SOCKET_MOUNT_ARGS} \
-        -e "HICLAW_YOLO=1" \
-        -e "HICLAW_ADMIN_USER=${TEST_ADMIN_USER}" \
-        -e "HICLAW_ADMIN_PASSWORD=${TEST_ADMIN_PASSWORD}" \
-        -e "HICLAW_MANAGER_PASSWORD=$(openssl rand -hex 32)" \
-        -e "HICLAW_REGISTRATION_TOKEN=${TEST_REGISTRATION_TOKEN}" \
-        -e "HICLAW_MATRIX_DOMAIN=${TEST_MATRIX_DOMAIN}" \
-        -e "HICLAW_LLM_PROVIDER=${HICLAW_LLM_PROVIDER:-qwen}" \
-        -e "HICLAW_DEFAULT_MODEL=${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}" \
-        -e "HICLAW_LLM_API_KEY=${HICLAW_LLM_API_KEY}" \
-        -e "HICLAW_MINIO_USER=${TEST_MINIO_USER}" \
-        -e "HICLAW_MINIO_PASSWORD=${TEST_MINIO_PASSWORD}" \
-        -e "HICLAW_MANAGER_GATEWAY_KEY=${MANAGER_GATEWAY_KEY}" \
-        -e "HICLAW_WORKER_IMAGE=hiclaw/worker-agent:${HICLAW_VERSION}" \
-        -e "HICLAW_GITHUB_TOKEN=${HICLAW_GITHUB_TOKEN:-}" \
-        -p 8080:8080 \
-        -p 8001:8001 \
-        -p 8088:8088 \
-        "hiclaw/manager-agent:${HICLAW_VERSION}"
+    # Clean up any existing installation, then install fresh using hiclaw-install.sh.
+    # This ensures ports, domains, and all initialization (Higress routes, Matrix users)
+    # match exactly what users get in production.
+    make -C "${PROJECT_ROOT}" uninstall 2>/dev/null || true
+    HICLAW_NON_INTERACTIVE=1 HICLAW_YOLO=1 HICLAW_MOUNT_SOCKET=1 \
+        HICLAW_INSTALL_MANAGER_IMAGE="hiclaw/manager-agent:${HICLAW_VERSION}" \
+        HICLAW_INSTALL_WORKER_IMAGE="hiclaw/worker-agent:${HICLAW_VERSION}" \
+        make -C "${PROJECT_ROOT}" install SKIP_BUILD=1
 
     # ============================================================
-    # Step 3: Wait for Manager to be healthy
+    # Step 3: Wait for Manager to be healthy (via make wait-ready)
     # ============================================================
 
-    log "Waiting for Manager to become healthy..."
-    TIMEOUT=300
-    ELAPSED=0
+    make -C "${PROJECT_ROOT}" wait-ready
 
-    while [ "${ELAPSED}" -lt "${TIMEOUT}" ]; do
-        # Matrix and MinIO are not exposed to host; check via docker exec
-        MATRIX_OK=$(docker exec "${TEST_MANAGER_CONTAINER}" curl -s -o /dev/null -w '%{http_code}' \
-            "http://127.0.0.1:6167/_matrix/client/versions" 2>/dev/null) || true
-        MINIO_OK=$(docker exec "${TEST_MANAGER_CONTAINER}" curl -s -o /dev/null -w '%{http_code}' \
-            "http://127.0.0.1:9000/minio/health/live" 2>/dev/null) || true
-        CONSOLE_OK=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:8001/" 2>/dev/null) || true
+    # Load all configuration from the env file generated by the install script
+    load_env_file
+    log "  Admin user:     ${TEST_ADMIN_USER}"
+    log "  Matrix domain:  ${TEST_MATRIX_DOMAIN}"
+    log "  Gateway port:   ${TEST_GATEWAY_PORT}"
+    log "  Console port:   ${TEST_CONSOLE_PORT}"
 
-        if [ "${MATRIX_OK}" = "200" ] && [ "${MINIO_OK}" = "200" ] && [ "${CONSOLE_OK}" = "200" ]; then
-            log "Manager is healthy (took ${ELAPSED}s)"
-            break
-        fi
-
-        sleep 10
-        ELAPSED=$((ELAPSED + 10))
-        log "Still waiting... (${ELAPSED}s) Matrix=${MATRIX_OK} MinIO=${MINIO_OK} Console=${CONSOLE_OK}"
-    done
-
-    if [ "${ELAPSED}" -ge "${TIMEOUT}" ]; then
-        error "Manager did not become healthy within ${TIMEOUT}s"
-        docker logs "${TEST_MANAGER_CONTAINER}" --tail 100
-        exit 1
-    fi
-
-    # Additional wait for Manager Agent to complete initialization
-    # Manager needs ~80s after services are up: register users, setup Higress, wait for auth plugin
-    log "Waiting additional 120s for Manager Agent initialization..."
-    sleep 120
+    # Enable YOLO mode for test run
+    docker exec "${TEST_MANAGER_CONTAINER}" touch /root/manager-workspace/yolo-mode 2>/dev/null && \
+        log "YOLO mode enabled (${TEST_MANAGER_CONTAINER})" || true
 fi
 
 # ============================================================

--- a/tests/test-02-create-worker.sh
+++ b/tests/test-02-create-worker.sh
@@ -93,7 +93,7 @@ ALICE_SOUL_EXISTS=$?
 assert_eq "0" "${ALICE_SOUL_EXISTS}" "Worker Alice SOUL.md exists in MinIO"
 
 ALICE_SOUL=$(minio_read_file "agents/alice/SOUL.md")
-assert_contains "${ALICE_SOUL}" "frontend" "Alice's SOUL.md mentions frontend"
+assert_contains_i "${ALICE_SOUL}" "frontend" "Alice's SOUL.md mentions frontend"
 
 log_section "Start Worker Container"
 


### PR DESCRIPTION
## Summary

- Fix port defaults in `test-helpers.sh` to match install script: 18080/18001/18088 (was 8080/8001/8088)
- Fix Matrix domain default in `run-all-tests.sh`: `matrix-local.hiclaw.io:18080`
- Replace raw `docker run` with `make install` + `make wait-ready` in the non-`--use-existing` path
- Load credentials from `~/hiclaw-manager.env` (install script output) with fallback to project root
- Remove erroneous `TEST_MINIO_URL` override in `detect_manager_config` (was using gateway port instead of MinIO port)
- Change `log_info()` to write to stderr so `$(...)` command substitution captures clean output only
- Add `_encode_room_id()` helper in `matrix-client.sh`; URL-encode `!` as `%21` in all room API paths (required by Tuwunel)
- Switch `wait_for_manager_agent_ready` Phase 2 room member check to `docker exec` (internal port 6167)
- Use `assert_contains_i` for SOUL.md frontend check (LLM-generated content may capitalize)

## Test plan

- [x] `test-01-manager-boot`: 12/12 pass
- [x] `test-02-create-worker`: 6/6 pass
- [x] `test-03-assign-task`: 3/3 pass
- [x] `test-04-human-intervene`: 3/3 pass
- [x] `test-05-heartbeat`: 1/1 pass
- [x] `test-06-multi-worker` and others: all pass
- [x] GitHub tests: skip gracefully without token (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)