### PR TITLE
fix: use 'latest' as version for non-tag builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
             echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
             echo "is_tag=true" >> $GITHUB_OUTPUT
           else
-            echo "version=${SHA_SHORT}" >> $GITHUB_OUTPUT
+            echo "version=latest" >> $GITHUB_OUTPUT
             echo "is_tag=false" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
## Summary

When building images without a version tag (e.g. manual workflow dispatch), use `latest` as the version instead of commit SHA.

## Changes

- Modified `.github/workflows/build.yml` `Extract metadata` step
- Non-tag builds now set `version=latest` instead of `version=${SHA_SHORT}`

## Rationale

Users were confused when checking `.builtin-version` and seeing a commit SHA like `d259177` instead of a meaningful version identifier. 

After this change:
- **Tag builds** (v1.0.3) → `.builtin-version` = `v1.0.3`
- **Non-tag builds** → `.builtin-version` = `latest`

This is more consistent and easier for users to understand.

## Related

- #102 - User reported seeing commit SHA instead of version