### PR TITLE
fix: use exec_in_manager for DM room creation in test-02

### DIFF
--- a/tests/test-02-create-worker.sh
+++ b/tests/test-02-create-worker.sh
@@ -31,14 +31,7 @@ DM_ROOM=$(matrix_find_dm_room "${ADMIN_TOKEN}" "${MANAGER_USER}" 2>/dev/null || 
 
 if [ -z "${DM_ROOM}" ]; then
     log_info "Creating DM room with Manager..."
-    DM_ROOM=$(curl -sf -X POST "${TEST_MATRIX_DIRECT_URL}/_matrix/client/v3/createRoom" \
-        -H "Authorization: Bearer ${ADMIN_TOKEN}" \
-        -H 'Content-Type: application/json' \
-        -d '{
-            "invite": ["'"${MANAGER_USER}"'"],
-            "is_direct": true,
-            "preset": "trusted_private_chat"
-        }' | jq -r '.room_id')
+    DM_ROOM=$(matrix_create_dm_room "${ADMIN_TOKEN}" "${MANAGER_USER}")
     sleep 5
 fi
 


### PR DESCRIPTION
## Problem

In CI, `test-02-create-worker.sh` always fails when no pre-existing DM room exists (e.g., fresh install, or test run standalone without test-01). The fallback room creation used a raw `curl`:

```bash
DM_ROOM=$(curl -sf -X POST "${TEST_MATRIX_DIRECT_URL}/_matrix/client/v3/createRoom" ...)
```

`TEST_MATRIX_DIRECT_URL` is `http://127.0.0.1:6167` — the Matrix internal port that is **not exposed to the CI host**. The curl silently fails, `DM_ROOM` is empty, and all 6 assertions in the test fail.

## Fix

Replace the raw curl with the existing `matrix_create_dm_room()` helper, which routes through `docker exec` (same as all other Matrix API calls in the test library):

```bash
DM_ROOM=$(matrix_create_dm_room "${ADMIN_TOKEN}" "${MANAGER_USER}")
```

## Impact

This fixes the CI for all PRs that modify `manager/` code, including PR #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)