### PR TITLE
feat: enable cron daemon in manager and worker containers

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -6,3 +6,4 @@ Record image-affecting changes to `manager/`, `worker/`, `openclaw-base/` here b
 
 - fix: set container timezone from TZ env var in both Manager and Worker (install tzdata in base image, configure /etc/localtime and /etc/timezone at startup)
 - feat(manager): add User-Agent header (HiClaw/<version>) to default AI route via headerControl, and send it in LLM connectivity tests ([3242d06](https://github.com/higress-group/hiclaw/commit/3242d0630d196c35b5df6fd6fbd7ac6e6b72c08a))
+- feat(openclaw-base): install cron package in base image, start crond in Manager (supervisord) and Worker (entrypoint)

--- a/manager/supervisord.conf
+++ b/manager/supervisord.conf
@@ -8,6 +8,15 @@ pidfile=/var/run/supervisord.pid
 # Infrastructure Layer (start first)
 # ============================================================
 
+[program:cron]
+command=cron -f
+priority=10
+autorestart=true
+stdout_logfile=/var/log/hiclaw/cron.log
+stderr_logfile=/var/log/hiclaw/cron-error.log
+stdout_logfile_maxbytes=10MB
+stderr_logfile_maxbytes=10MB
+
 [program:minio]
 command=/opt/hiclaw/scripts/init/start-minio.sh
 priority=50

--- a/openclaw-base/Dockerfile
+++ b/openclaw-base/Dockerfile
@@ -38,7 +38,7 @@ RUN if [ -n "${APT_MIRROR}" ]; then \
     fi && \
     apt-get update && apt-get install -y \
     git python3 make g++ curl \
-    jq nginx gettext-base openssh-client ca-certificates procps tzdata \
+    jq nginx gettext-base openssh-client ca-certificates procps tzdata cron \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js 22 (all-in-one doesn't include Node.js)

--- a/worker/scripts/worker-entrypoint.sh
+++ b/worker/scripts/worker-entrypoint.sh
@@ -31,6 +31,12 @@ HICLAW_ROOT="/root/hiclaw-fs"
 WORKSPACE="${HICLAW_ROOT}/agents/${WORKER_NAME}"
 
 # ============================================================
+# Step 0.5: Start cron daemon
+# ============================================================
+cron
+log "Cron daemon started"
+
+# ============================================================
 # Step 1: Configure mc alias for centralized file system
 # ============================================================
 log "Configuring mc alias..."


### PR DESCRIPTION
## 变更说明

在 manager 和 worker 容器中启动标准 cron 守护进程，使 `crontab` 可用。

## 改动

- `openclaw-base/Dockerfile`: apt 安装列表显式加入 `cron`
- `manager/supervisord.conf`: 新增 `[program:cron]`，priority=10 最先启动
- `worker/scripts/worker-entrypoint.sh`: entrypoint 启动时运行 `cron` 守护进程

## 测试

在现有容器中验证：
- `cron` 包已存在（来自 higress/all-in-one 基础层）
- 手动启动 `cron` 后，`crontab` 设置的任务在 1 分钟内正常执行
- 与 Higress 自带的 `supercronic` 互不干扰（各自独立运行，supercronic 读 `/var/lib/istio/cron.txt`，标准 cron 读系统 crontab）