### PR TITLE
fix: security and robustness improvements (#116)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,41 @@
+# Set default behavior to automatically handle line endings
+* text=auto
+
+# Explicitly declare source files that should always use LF line endings
+*.sh text eol=lf
+*.py text eol=lf
+*.js text eol=lf
+*.ts text eol=lf
+*.go text eol=lf
+*.rs text eol=lf
+
+# Documentation files should use LF
+*.md text eol=lf
+*.txt text eol=lf
+
+# Config files should use LF
+*.yaml text eol=lf
+*.yml text eol=lf
+*.json text eol=lf
+*.toml text eol=lf
+*.xml text eol=lf
+
+# Docker files
+Dockerfile text eol=lf
+*.dockerfile text eol=lf
+
+# Shell scripts must always use LF
+.gitattributes text eol=lf
+Makefile text eol=lf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary

--- a/BUGFIX_REPORT.md
+++ b/BUGFIX_REPORT.md
@@ -1,0 +1,94 @@
+# HiClaw 代码库 Bug 修复与优化报告
+
+## 发现的问题及修复建议
+
+### 1. [高危] create-worker.sh 临时文件权限问题
+
+**文件**: `manager/agent/skills/worker-management/scripts/create-worker.sh:175`
+
+**问题**: 
+```bash
+POLICY_FILE=$(mktemp /tmp/minio-policy-XXXXXX.json)
+```
+临时文件创建在 `/tmp` 目录，可能被其他用户读取。MinIO 策略文件包含敏感权限配置。
+
+**修复建议**:
+```bash
+POLICY_FILE=$(mktemp "${TMPDIR:-/tmp}/minio-policy-XXXXXX.json")
+chmod 600 "${POLICY_FILE}"
+```
+
+**影响**: 中等 - 信息泄露风险
+
+---
+
+### 2. [中危] run-all-tests.sh 硬编码测试密码
+
+**文件**: `tests/run-all-tests.sh:23-24`
+
+**问题**:
+```bash
+export TEST_ADMIN_PASSWORD="${TEST_ADMIN_PASSWORD:-testpassword123}"
+export TEST_MINIO_PASSWORD="${TEST_MINIO_PASSWORD:-${TEST_ADMIN_PASSWORD}}"
+```
+默认密码过于简单，且明文写在代码中。
+
+**修复建议**:
+```bash
+export TEST_ADMIN_PASSWORD="${TEST_ADMIN_PASSWORD:-$(openssl rand -hex 12)}"
+export TEST_MINIO_PASSWORD="${TEST_MINIO_PASSWORD:-$(openssl rand -hex 12)}"
+```
+
+**影响**: 低 - 仅影响测试环境
+
+---
+
+### 3. [优化] Makefile 缺少错误处理
+
+**文件**: `Makefile` 多处
+
+**问题**: 某些命令缺少错误检查，如 `docker tag` 失败时继续执行。
+
+**修复建议**: 在关键命令后添加 `|| exit 1`
+
+**影响**: 低 - 可能导致不完整的构建
+
+---
+
+### 4. [优化] hiclaw-install.sh 时区检测可改进
+
+**文件**: `install/hiclaw-install.sh:52-75`
+
+**问题**: 时区检测逻辑在 macOS 上可能失败，没有充分的回退机制。
+
+**修复建议**: 添加更多检测方法和更明确的错误提示。
+
+**影响**: 低 - 用户体验问题
+
+---
+
+### 5. [优化] 缺少 .gitattributes 配置
+
+**文件**: 仓库根目录
+
+**问题**: 没有 `.gitattributes` 文件，可能导致跨平台换行符问题。
+
+**修复建议**: 添加 `.gitattributes` 文件：
+```
+* text=auto
+*.sh text eol=lf
+*.md text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+```
+
+**影响**: 低 - 跨平台兼容性问题
+
+---
+
+## 已创建的修复
+
+1. ✅ 修复临时文件权限问题
+2. ✅ 修复测试密码硬编码问题
+3. ✅ 添加 .gitattributes 文件
+4. ✅ 改进错误处理

--- a/Makefile
+++ b/Makefile
@@ -118,11 +118,11 @@ build-worker: ## Build Worker image
 # ---------- Tag ----------
 
 tag: build ## Tag images for registry push
-	docker tag $(LOCAL_MANAGER) $(MANAGER_TAG)
-	docker tag $(LOCAL_WORKER) $(WORKER_TAG)
+	docker tag $(LOCAL_MANAGER) $(MANAGER_TAG) || exit 1
+	docker tag $(LOCAL_WORKER) $(WORKER_TAG) || exit 1
 ifeq ($(PUSH_LATEST),yes)
-	docker tag $(LOCAL_MANAGER) $(MANAGER_IMAGE):latest
-	docker tag $(LOCAL_WORKER) $(WORKER_IMAGE):latest
+	docker tag $(LOCAL_MANAGER) $(MANAGER_IMAGE):latest || exit 1
+	docker tag $(LOCAL_WORKER) $(WORKER_IMAGE):latest || exit 1
 	@echo "==> Images tagged as $(VERSION) and latest"
 else
 	@echo "==> Images tagged as $(VERSION) (latest not pushed for pre-release)"

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -62,12 +62,26 @@ detect_timezone() {
 
     # Try /etc/localtime symlink (macOS and some Linux)
     if [ -z "${tz}" ] && [ -L /etc/localtime ]; then
-        tz=$(ls -l /etc/localtime 2>/dev/null | sed 's|.*/zoneinfo/||')
+        tz=$(readlink /etc/localtime 2>/dev/null | sed 's|.*/zoneinfo/||')
     fi
 
     # Try timedatectl (systemd)
     if [ -z "${tz}" ]; then
-        tz=$(timedatectl show --value -p Timezone 2>/dev/null)
+        tz=$(timedatectl show --value -p Timezone 2>/dev/null || true)
+    fi
+
+    # Try date command (macOS fallback)
+    if [ -z "${tz}" ]; then
+        tz=$(date +%Z 2>/dev/null | tr -d '[:space:]')
+        # Map common timezone abbreviations to IANA names
+        case "${tz}" in
+            CST) tz="Asia/Shanghai" ;;
+            PST|PDT) tz="America/Los_Angeles" ;;
+            EST|EDT) tz="America/New_York" ;;
+            JST) tz="Asia/Tokyo" ;;
+            KST) tz="Asia/Seoul" ;;
+            *) tz="" ;;  # Unknown abbreviation, will prompt user
+        esac
     fi
 
     # If still not detected, warn and prompt user

--- a/manager/agent/skills/worker-management/scripts/create-worker.sh
+++ b/manager/agent/skills/worker-management/scripts/create-worker.sh
@@ -172,7 +172,8 @@ chmod 600 "${WORKER_CREDS_FILE}"
 # ============================================================
 log "Step 1b: Creating MinIO user for ${WORKER_NAME}..."
 POLICY_NAME="worker-${WORKER_NAME}"
-POLICY_FILE=$(mktemp /tmp/minio-policy-XXXXXX.json)
+POLICY_FILE=$(mktemp "${TMPDIR:-/tmp}/minio-policy-XXXXXX.json")
+chmod 600 "${POLICY_FILE}"
 cat > "${POLICY_FILE}" <<POLICY
 {
   "Version": "2012-10-17",

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -24,9 +24,9 @@ HICLAW_VERSION="${HICLAW_VERSION:-latest}"
 
 # Test environment variables
 export TEST_ADMIN_USER="${TEST_ADMIN_USER:-admin}"
-export TEST_ADMIN_PASSWORD="${TEST_ADMIN_PASSWORD:-testpassword123}"
+export TEST_ADMIN_PASSWORD="${TEST_ADMIN_PASSWORD:-$(openssl rand -hex 12)}"
 export TEST_MINIO_USER="${TEST_MINIO_USER:-${TEST_ADMIN_USER}}"
-export TEST_MINIO_PASSWORD="${TEST_MINIO_PASSWORD:-${TEST_ADMIN_PASSWORD}}"
+export TEST_MINIO_PASSWORD="${TEST_MINIO_PASSWORD:-$(openssl rand -hex 12)}"
 export TEST_REGISTRATION_TOKEN="${TEST_REGISTRATION_TOKEN:-test-reg-token-$(openssl rand -hex 8)}"
 export TEST_MATRIX_DOMAIN="${TEST_MATRIX_DOMAIN:-matrix-local.hiclaw.io:18080}"
 export TEST_MANAGER_HOST="${TEST_MANAGER_HOST:-127.0.0.1}"


### PR DESCRIPTION
## 🔒 Security & Robustness Improvements

This PR fixes several security issues and improves code robustness:

### Security Fixes

1. **Temporary file permissions** (`create-worker.sh`)
   - Added `chmod 600` to restrict MinIO policy file permissions
   - Prevents unauthorized access to sensitive configuration

2. **Hardcoded test passwords** (`run-all-tests.sh`)
   - Replaced `testpassword123` with auto-generated secure passwords
   - Uses `openssl rand -hex 12` for strong random generation

### Robustness Improvements

3. **Cross-platform compatibility** (`.gitattributes`)
   - Added `.gitattributes` file for consistent LF line endings
   - Prevents CRLF/LF issues across Windows/macOS/Linux

4. **Makefile error handling**
   - Added `|| exit 1` to tag target commands
   - Ensures build fails fast on errors

5. **Timezone detection** (`hiclaw-install.sh`)
   - Added `date` command fallback for macOS
   - Improved symlink resolution with `readlink`
   - Better timezone abbreviation mapping

### Files Changed
- `manager/agent/skills/worker-management/scripts/create-worker.sh`
- `tests/run-all-tests.sh`
- `Makefile`
- `install/hiclaw-install.sh`
- `.gitattributes` (new)
- `BUGFIX_REPORT.md` (new)

---

*Generated by HiClaw Manager Agent* 🤖