### PR TITLE
fix: worker creation defaults to local mode unless remote explicitly requested

### DIFF
--- a/manager/agent/skills/worker-management/SKILL.md
+++ b/manager/agent/skills/worker-management/SKILL.md
@@ -107,9 +107,10 @@ When `--runtime copaw` is specified:
 - The worker entry in `workers-registry.json` will have `"runtime": "copaw"`
 - Lifecycle management (auto-stop/start) is skipped for copaw workers — they are treated like remote workers
 
-**Deployment behavior** (without `--remote`):
-- If container socket is available: auto-starts Worker container locally
-- If no socket: falls back to outputting install command
+**Default behavior** (without `--remote`):
+- Starts the Worker container locally. In a standard HiClaw installation the Docker socket is always mounted — this is the expected path for all local deployments.
+
+Only use `--remote` when the admin **explicitly** requests deploying the Worker on a separate machine (e.g., "create a remote worker", "I'll run it on my laptop"). Do **NOT** use `--remote` when the admin just says "create a worker" or does not mention deployment location.
 
 The script outputs a JSON result after `---RESULT---`:
 


### PR DESCRIPTION
## Summary

Fixes #89: Manager was creating Workers in remote mode even when the user didn't request it.

Root cause: the SKILL.md exposed Docker socket detection logic, causing the LLM to second-guess whether to use `--remote` and sometimes choosing it defensively.

Now the instruction clearly states: **local is the default**; `--remote` is only for when the admin explicitly requests remote deployment (e.g., "create a remote worker", "I'll run it on my laptop").

## Changes

`manager/agent/skills/worker-management/SKILL.md`: replaced the conditional "if socket available → local, else fallback" description with a clear rule — default is local, only use `--remote` on explicit admin request.

## Test plan

- [ ] Ask Manager "创建一个 Worker" (no mode specified) → should create in local mode
- [ ] Ask Manager "创建一个 remote Worker" → should use `--remote` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)