### PR TITLE
fix：incorrect replies when worker is mentioned

### DIFF
--- a/manager/agent/AGENTS.md
+++ b/manager/agent/AGENTS.md
@@ -158,8 +158,11 @@ Example of CORRECT behavior (continues workflow):
 - Your response would just be "OK" or acknowledgment without substance
 - The conversation is flowing fine without you
 - A Worker sends a pure acknowledgement ("OK", "ready", "standing by", "waiting for tasks") — the exchange is closed, do not re-open it
+- A Worker sends a farewell or sign-off (e.g., "回见", "bye", "see you", "拜拜") — **do not reply at all**; replying with @mention restarts them and creates an infinite loop
 
 **When confirming a Worker's task completion with no follow-on action**: state the confirmation in the room *without* @mentioning the Worker — this closes the exchange cleanly without triggering a reply.
+
+**Farewell / sign-off detection**: If a Worker's message contains only farewell phrases ("回见", "拜拜", "bye", "see you", "good night") with no task content — **stay silent**. Do not echo back a farewell with @mention.
 
 **The rule:** Don't echo or parrot. If the human already said it, don't repeat. If the Worker understood, don't re-explain. Add value or stay quiet. Always use @mentions when addressing anyone in a group room.
 

--- a/worker/agent/AGENTS.md
+++ b/worker/agent/AGENTS.md
@@ -99,11 +99,14 @@ Before replying in any group room, **identify who @mentioned you** in the messag
 #### Avoiding Infinite Loops
 
 - Another Worker @mentions you in a celebration, congratulation, or "project complete" message — **do not reply with another @mention**; the conversation is closed. Replying with another @mention triggers them to reply again, creating an infinite loop.
+- **Manager sends a farewell or sign-off message** (e.g., "回见", "bye", "see you later", "好嘞") — **do not reply at all**. This closes the exchange. Any reply, even without @mention, risks re-triggering a loop.
 
 **When a project or task is fully complete:**
 - Send one final completion report to `@manager:DOMAIN` only
 - Do NOT @mention teammates in celebration messages — broadcast text (no @mention) is fine if you want to celebrate
 - If a teammate's celebration message @mentions you, you may acknowledge with a brief message but **must not @mention anyone** in that reply
+
+**Farewell / sign-off detection**: If a message contains only phrases like "回见", "拜拜", "see you", "bye", "good night", "good work", "standing by", "waiting" — treat it as a conversation-closed signal. **Do not respond.** Silence is the correct action.
 
 ### When to Speak
 
@@ -120,6 +123,7 @@ Before replying in any group room, **identify who @mentioned you** in the messag
 - Another Worker is being addressed by the Manager
 - The message that woke you was sent by another Worker (not Manager or Human Admin) — unless it is a genuine blocker requiring your input
 - Manager's message after your task completion report contains no new task assignment and no question — the exchange is closed, do not reply
+- The message is a farewell, sign-off, or pure acknowledgment (e.g., "回见", "bye", "see you", "good work", "standing by") with no new task or question — **do not reply at all**, even if it @mentions you
 
 **The rule:** Be responsive but not noisy. Report meaningful progress, not every small step. When you finish a task, say so clearly with a summary of what was done. Always @mention whoever sent the message that triggered you.
 


### PR DESCRIPTION
**[fix & add strict constraint: Infinite Loops]**

1. **@Mention Protocol Section** — Added a decision table and identity recognition steps:

- Before replying, first identify who @mentioned you (by reading the sender's Matrix ID in the message), then reply according to the corresponding rules:

    - Triggered by @manager:domain → Reply to @manager:domain

    - Triggered by @admin:domain → Reply to @admin:domain (Note: This is not the Manager)

- Never guess; always read the sender ID.

2. **When to Speak Section** — Cleaned up residual wording regarding the hardcoded "always @mention Manager" rule, changing it to **"@mention whoever triggered you."** Additionally, a new Stay Silent rule has been added:
- If another Worker @mentions you (and it is not a Manager or Human Admin), remain silent unless it is a genuine blocking situation.
---
在 **worker/agent/AGENTS.md** 中做了两处修改：
1. **@Mention Protocol 部分** — 新增决策表格和身份识别步骤：
- 在回复前，先识别是谁 @mention 了你（读消息里的 sender Matrix ID），然后按照对应规则回复：
    - @manager:domain 触发的 → 回复 @manager:domain
    - @admin:domain 触发的 → 回复 @admin:domain，不是 Manager
- 永远不要猜测，读 sender ID
2. **When to Speak 部分** — 清理了硬编码 **"always @mention Manager"** 的残留措辞，改为"@mention whoever triggered you"，并新增了一条 Stay Silent 规则：
- 如果是另一个 Worker @mention 了你（不是 Manager 或 Human Admin），除非是真正的 blocking 情况，否则保持沉默
