### PR TITLE
docs: improve FAQ for Manager/Worker not responding

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -189,13 +189,24 @@ The `.jsonl` files in that directory are written by OpenClaw in real time and co
 
 If Manager or Worker doesn't respond to your messages, check these common causes:
 
-### 1. Check the chat environment
+### 1. Check if the agent is working
+
+**If there's no response and no "typing" indicator**, the agent is almost certainly **busy working**.
+
+OpenClaw limits the "typing" indicator to a maximum of **2 minutes**. If the agent's task takes longer than 2 minutes, the typing indicator stops showing even though the agent is still working.
+
+**How to confirm your message is queued**:
+- After sending a message, look for a small **"m" icon** on the right side of your message
+- This icon indicates the Manager has **read** your message
+- When you see this icon, your message is in the queue and will be processed after the current task finishes
+
+### 2. Check the chat environment
 
 **Direct message vs. group chat**:
 - In a **direct message** (DM, just you and one agent), every message triggers a response
 - In a **group chat** (2+ participants), you must **@mention the agent** for it to respond — messages without mentions are ignored
 
-### 2. Check session status
+### 3. Check session status
 
 The OpenClaw session might be stuck. Enter the Manager or Worker container and use the OpenClaw TUI to investigate:
 
@@ -214,7 +225,7 @@ In the TUI:
 
 If the session is stuck, try `/reset` to reset it and see if that restores normal behavior.
 
-### 3. Check model configuration
+### 4. Check model configuration
 
 The model's context window size might be misconfigured, causing the window to fill up before compression happens. See [How to switch the Manager's model](#how-to-switch-the-managers-model) and [How to switch a Worker's model](#how-to-switch-a-workers-model) for proper configuration.
 

--- a/docs/zh-cn/faq.md
+++ b/docs/zh-cn/faq.md
@@ -190,13 +190,24 @@ docker exec -it <worker-name> ls .openclaw/agents/main/sessions/
 
 如果给 Manager 或 Worker 发送消息后没有回复，可以按以下步骤排查：
 
-### 1. 检查聊天环境
+### 1. 检查是否正在工作
+
+**如果一直不回复，且没有显示"输入中"**，绝大多数原因是 **Agent 正在工作**。
+
+OpenClaw 限制"输入中"状态最多持续 **2 分钟**，工作超过 2 分钟就不会再显示"输入中"了。
+
+**如何确认消息已入队列**：
+- 发送消息后，查看消息右边是否有一个 **m 小图标**
+- 这个图标表示 Manager 已读
+- 出现这个图标就说明消息已入队列，会在当前任务执行完后继续处理该消息
+
+### 2. 检查聊天环境
 
 **私聊 vs 群聊**：
 - 如果是**私聊**（只有你和一个 Agent），每条消息都会触发 Agent 响应
 - 如果是**2 人以上的房间**（群聊），必须 **@ Agent** 才能让它响应，没有 @ 的消息会被忽略
 
-### 2. 检查 Session 状态
+### 3. 检查 Session 状态
 
 可能是 OpenClaw session 卡住了。进入 Manager 或 Worker 容器，使用 OpenClaw TUI 查看：
 
@@ -215,7 +226,7 @@ docker exec -it <worker-name> openclaw tui
 
 如果 session 确实卡住了，可以尝试用 `/reset` 重置 session，看是否恢复正常。
 
-### 3. 检查模型配置
+### 4. 检查模型配置
 
 可能是模型的上下文窗口大小配置不正确，导致窗口耗尽前没有及时压缩。请参考 [如何切换 Manager 的模型](#如何切换-manager-的模型) 和 [如何切换 Worker 的模型](#如何切换-worker-的模型) 进行正确配置。
 


### PR DESCRIPTION
## Summary

Improve the FAQ entry for troubleshooting when Manager or Worker doesn't respond.

## Changes

Added to both `docs/zh-cn/faq.md` and `docs/faq.md`:

1. **Explain "typing" indicator limitation** - OpenClaw limits this to 2 minutes max; tasks longer than 2 minutes won't show "typing" anymore
2. **Explain the "m" read icon** - This indicates Manager has read the message and it's queued for processing
3. **Reorder sections** - Put "Check if the agent is working" first since it's the most common cause
4. **Clarify message queue behavior** - Messages are queued and processed after current task finishes

## Why

Users were confused when agents don't respond but also don't show "typing" indicator. This is actually normal behavior when the agent is working on a long task. The FAQ now clearly explains this.