### PR TITLE
chore(copaw): bump version to 0.1.1

### DIFF
--- a/copaw/pyproject.toml
+++ b/copaw/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "copaw-worker"
-version = "0.1.0"
+version = "0.1.1"
 description = "Lightweight HiClaw Worker runtime based on CoPaw"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary

Bump copaw-worker version from 0.1.0 to 0.1.1 to fix PyPI publish failure.

## Problem

The v1.0.4 release CI failed when trying to upload `copaw-worker 0.1.0` to PyPI:
```
ERROR HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
```

**Root cause**: Version 0.1.0 was already published to PyPI on 2026-03-09 via workflow_dispatch. PyPI does not allow re-uploading the same version number.

## Changes

- Bump version in `copaw/pyproject.toml`: `0.1.0` → `0.1.1`

## Impact

- Next release will successfully publish copaw-worker to PyPI
- Current 0.1.0 on PyPI already includes all latest code, no functionality gap

## Related

- Failed CI run: https://github.com/alibaba/hiclaw/actions/runs/22866160288/job/66333458437
- Existing PyPI package: https://pypi.org/project/copaw-worker/