### PR TITLE
fix: correct blog content for 1.0.4 release

### DIFF
--- a/blog/hiclaw-1.0.4-release.md
+++ b/blog/hiclaw-1.0.4-release.md
@@ -262,7 +262,9 @@ Select default worker runtime:
 Enter your choice [1-2]:
 ```
 
-When upgrading, the script will automatically detect your existing installation — just select "in-place upgrade". After upgrading, the Manager will automatically support CoPaw Workers, and existing OpenClaw Workers will continue to run normally.
+When upgrading, the script will automatically detect your existing installation — just select "in-place upgrade". You'll also be prompted to choose a default Worker runtime:
+- **Existing Workers**: Unaffected, continue using their original runtime
+- **New Workers**: Will use the default runtime you selected (CoPaw or OpenClaw)
 
 ---
 

--- a/blog/zh-cn/hiclaw-1.0.4-release.md
+++ b/blog/zh-cn/hiclaw-1.0.4-release.md
@@ -261,7 +261,9 @@ Select default worker runtime:
 Enter your choice [1-2]:
 ```
 
-升级时，脚本会自动检测现有安装，选择"就地升级"即可。升级后，Manager 会自动支持 CoPaw Worker，现有的 OpenClaw Worker 不受影响。
+升级时，脚本会自动检测现有安装，选择"就地升级"即可。升级过程中也会询问默认 Worker 运行时，选择后：
+- **已有的 Worker**：不受影响，继续使用原有运行时
+- **新创建的 Worker**：会使用你选择的默认运行时（CoPaw 或 OpenClaw）
 
 ---
 


### PR DESCRIPTION
## Summary

Fix two issues found after #158 was merged:

1. **Console memory description**: Removed incorrect claim that disabling CoPaw console saves 500MB. The actual benefit is that CoPaw uses ~100MB vs OpenClaw's ~500MB (80% less).

2. **Upgrade instructions**: Simplified to clarify that installation and upgrade use the same command with interactive guidance — just select "in-place upgrade" when prompted.

## Changes

- `blog/zh-cn/hiclaw-1.0.4-release.md`: Fixed console description and merged installation/upgrade sections
- `blog/hiclaw-1.0.4-release.md`: Same fixes in English version

## Test Plan

- [x] Verified changes in local diff
- [x] Content accurately reflects actual behavior