### PR TITLE
fix: update console section - conversational interaction with Manager

### DIFF
--- a/blog/hiclaw-1.0.4-release.md
+++ b/blog/hiclaw-1.0.4-release.md
@@ -125,17 +125,16 @@ This means you can run more Workers on the same hardware. Previously, 8GB of mem
 
 **On-demand Console**
 
-CoPaw Worker starts with a web console by default for easy debugging. But in production, you might not need a console for every Worker.
+CoPaw Workers start without the web console by default to save resources. When you need to debug, just tell the Manager in Element:
 
-We provide an `enable-worker-console.sh` script to toggle the console on demand:
-
-```bash
-# Disable Worker console
-/opt/hiclaw/scripts/enable-worker-console.sh alice disable
-
-# Enable when debugging needed
-/opt/hiclaw/scripts/enable-worker-console.sh alice enable
 ```
+You: Enable console for alice
+
+Manager: Sure, enabling alice's console...
+         Container restarted, console URL: http://localhost:18089
+```
+
+The Manager will automatically restart the CoPaw Worker container with the console enabled. No manual scripting needed. When you're done debugging, you can also ask the Manager to disable the console.
 
 ### Mode 2: Local Host Mode — Direct Access to Your Computer
 

--- a/blog/zh-cn/hiclaw-1.0.4-release.md
+++ b/blog/zh-cn/hiclaw-1.0.4-release.md
@@ -124,17 +124,16 @@ HiClaw 1.0.4 接入 CoPaw，核心代码只有两个文件：
 
 **按需启用控制台**
 
-CoPaw Worker 默认启动时会加载 Web 控制台，方便调试。但在生产环境中，你可能不需要每个 Worker 都开控制台。
+CoPaw Worker 默认启动时可能不加载 Web 控制台（取决于创建时的配置），以节省资源。需要调试时，只需要在 Element 里告诉 Manager：
 
-我们提供了 `enable-worker-console.sh` 脚本，可以按需开关控制台：
-
-```bash
-# 关闭 Worker 控制台
-/opt/hiclaw/scripts/enable-worker-console.sh alice disable
-
-# 需要调试时再开启
-/opt/hiclaw/scripts/enable-worker-console.sh alice enable
 ```
+你: 打开 alice 的控制台
+
+Manager: 好的，正在启用 alice 的控制台...
+         容器已重启，控制台地址：http://localhost:18089
+```
+
+Manager 会自动重启 CoPaw Worker 容器并启用控制台，无需手动操作。调试完成后，也可以让 Manager 关闭控制台以节省资源。
 
 ### 模式二：本地 Host 模式 —— 直接操作你的电脑
 


### PR DESCRIPTION
## Summary

Update the "on-demand console" section to reflect the actual user experience:

**Before**: Manual script execution (`enable-worker-console.sh`)
**After**: Conversational interaction — just tell the Manager in Element to enable/disable console

## Changes

- `blog/zh-cn/hiclaw-1.0.4-release.md`: Updated console section with conversational example
- `blog/hiclaw-1.0.4-release.md`: Same update in English

## Example

```
你: 打开 alice 的控制台

Manager: 好的，正在启用 alice 的控制台...
         容器已重启，控制台地址：http://localhost:18089
```

The Manager automatically restarts the CoPaw Worker container and provides the console URL — no manual scripting needed.