### PR TITLE
fix(install): allow changing worker runtime during upgrade

### DIFF
--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -311,7 +311,7 @@ $script:Messages = @{
 
     # --- Default worker runtime ---
     "worker_runtime.title" = @{ zh = "--- 默认 Worker 运行时 ---"; en = "--- Default Worker Runtime ---" }
-    "worker_runtime.openclaw" = @{ zh = "OpenClaw（Node.js 容器，~500MB 内存，功能完整）"; en = "OpenClaw (Node.js container, ~500MB RAM, full-featured)" }
+    "worker_runtime.openclaw" = @{ zh = "OpenClaw（Node.js 容器，~500MB 内存）"; en = "OpenClaw (Node.js container, ~500MB RAM)" }
     "worker_runtime.copaw" = @{ zh = "CoPaw（Python 容器，~100MB 内存，默认关闭控制台，可跟 Manager 对话按需开启）"; en = "CoPaw (Python container, ~100MB RAM, console off by default, enable on demand via Manager)" }
     "worker_runtime.choice" = @{ zh = "请选择 [1/2]"; en = "Enter choice [1/2]" }
     "worker_runtime.selected" = @{ zh = "默认 Worker 运行时: {0}"; en = "Default Worker runtime: {0}" }
@@ -1662,8 +1662,18 @@ function Install-Manager {
     Write-Host "  1) $(Get-Msg 'worker_runtime.openclaw')"
     Write-Host "  2) $(Get-Msg 'worker_runtime.copaw')"
     Write-Host ""
-    if ($script:HICLAW_NON_INTERACTIVE -or $env:HICLAW_DEFAULT_WORKER_RUNTIME) {
+    if ($script:HICLAW_NON_INTERACTIVE) {
         $config.DEFAULT_WORKER_RUNTIME = if ($env:HICLAW_DEFAULT_WORKER_RUNTIME) { $env:HICLAW_DEFAULT_WORKER_RUNTIME } else { "openclaw" }
+    } elseif ($script:HICLAW_UPGRADE -and $env:HICLAW_DEFAULT_WORKER_RUNTIME) {
+        Write-Log (Get-Msg "prompt.upgrade_keep" -f "HICLAW_DEFAULT_WORKER_RUNTIME", $env:HICLAW_DEFAULT_WORKER_RUNTIME)
+        $rtChoice = Read-Host (Get-Msg "worker_runtime.choice")
+        if ($rtChoice) {
+            $config.DEFAULT_WORKER_RUNTIME = if ($rtChoice -eq "2") { "copaw" } else { "openclaw" }
+        } else {
+            $config.DEFAULT_WORKER_RUNTIME = $env:HICLAW_DEFAULT_WORKER_RUNTIME
+        }
+    } elseif ($env:HICLAW_DEFAULT_WORKER_RUNTIME) {
+        $config.DEFAULT_WORKER_RUNTIME = $env:HICLAW_DEFAULT_WORKER_RUNTIME
     } else {
         $rtChoice = Read-Host (Get-Msg "worker_runtime.choice")
         $rtChoice = if ($rtChoice) { $rtChoice } else { "1" }

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -399,8 +399,8 @@ msg() {
         # --- Default worker runtime ---
         "worker_runtime.title.zh") text="--- 默认 Worker 运行时 ---" ;;
         "worker_runtime.title.en") text="--- Default Worker Runtime ---" ;;
-        "worker_runtime.openclaw.zh") text="OpenClaw（Node.js 容器，~500MB 内存，功能完整）" ;;
-        "worker_runtime.openclaw.en") text="OpenClaw (Node.js container, ~500MB RAM, full-featured)" ;;
+        "worker_runtime.openclaw.zh") text="OpenClaw（Node.js 容器，~500MB 内存）" ;;
+        "worker_runtime.openclaw.en") text="OpenClaw (Node.js container, ~500MB RAM)" ;;
         "worker_runtime.copaw.zh") text="CoPaw（Python 容器，~100MB 内存，默认关闭控制台，可跟 Manager 对话按需开启）" ;;
         "worker_runtime.copaw.en") text="CoPaw (Python container, ~100MB RAM, console off by default, enable on demand via Manager)" ;;
         "worker_runtime.choice.zh") text="请选择 [1/2]" ;;
@@ -1575,6 +1575,16 @@ install_manager() {
     echo ""
     if [ "${HICLAW_NON_INTERACTIVE}" = "1" ]; then
         HICLAW_DEFAULT_WORKER_RUNTIME="${HICLAW_DEFAULT_WORKER_RUNTIME:-openclaw}"
+    elif [ "${HICLAW_UPGRADE}" = "1" ] && [ -n "${HICLAW_DEFAULT_WORKER_RUNTIME}" ]; then
+        log "$(msg prompt.upgrade_keep "HICLAW_DEFAULT_WORKER_RUNTIME" "${HICLAW_DEFAULT_WORKER_RUNTIME}")"
+        read -p "$(msg worker_runtime.choice): " _runtime_choice
+        if [ -n "${_runtime_choice}" ]; then
+            case "${_runtime_choice}" in
+                2) HICLAW_DEFAULT_WORKER_RUNTIME="copaw" ;;
+                *) HICLAW_DEFAULT_WORKER_RUNTIME="openclaw" ;;
+            esac
+        fi
+        unset _runtime_choice
     elif [ -z "${HICLAW_DEFAULT_WORKER_RUNTIME+x}" ]; then
         read -p "$(msg worker_runtime.choice): " _runtime_choice
         _runtime_choice="${_runtime_choice:-1}"


### PR DESCRIPTION
## Summary

- During in-place upgrade, the worker runtime selection was silently skipped because `HICLAW_DEFAULT_WORKER_RUNTIME` was already loaded from the existing env file. Now the installer shows the current value and lets the user change it (consistent with how `prompt_required` / `prompt_optional` handle upgrades).
- Remove "功能完整" / "full-featured" from the OpenClaw runtime description.

## Test plan

- [ ] Run a fresh install — verify worker runtime selection prompt appears normally
- [ ] Run an upgrade (with existing env file) — verify current runtime is shown and user can press Enter to keep or type 1/2 to change
- [ ] Run upgrade in non-interactive mode — verify it keeps the existing value silently
- [ ] Verify both bash and PowerShell scripts behave consistently


Made with [Cursor](https://cursor.com)