### PR TITLE
fix(install): use unconditional assignment for LLM base URL on provider switch

### DIFF
--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -252,7 +252,7 @@ $script:Messages = @{
     "llm.provider.selected_codingplan" = @{ zh = "  提供商: 阿里云百炼 CodingPlan"; en = "  Provider: Alibaba Cloud Bailian CodingPlan" }
     "llm.provider.selected_qwen" = @{ zh = "  提供商: 阿里云百炼"; en = "  Provider: Alibaba Cloud Bailian" }
     "llm.provider.selected_openai" = @{ zh = "  提供商: {0}（OpenAI 兼容）"; en = "  Provider: {0} (OpenAI-compatible)" }
-    "llm.provider.invalid" = @{ zh = "无效选择，默认使用阿里云百炼 CodingPlan"; en = "Invalid choice, defaulting to Alibaba Cloud Bailian CodingPlan" }
+    "llm.provider.invalid" = @{ zh = "无效选择: {0}（请输入 1 或 2）"; en = "Invalid choice: {0} (please enter 1 or 2)" }
     "llm.qwen.model_prompt" = @{ zh = "默认模型 ID [qwen3.5-plus]"; en = "Default Model ID [qwen3.5-plus]" }
     "llm.openai.base_url_prompt" = @{ zh = "Base URL（例如 https://api.openai.com/v1）"; en = "Base URL (e.g., https://api.openai.com/v1)" }
     "llm.openai.model_prompt" = @{ zh = "默认模型 ID [gpt-5.4]"; en = "Default Model ID [gpt-5.4]" }
@@ -1423,7 +1423,7 @@ function Install-Manager {
                     Write-Log (Get-Msg "llm.provider.selected_qwen")
                 } else {
                     $config.LLM_PROVIDER = "openai-compat"
-                    $config.OPENAI_BASE_URL = if ($env:HICLAW_OPENAI_BASE_URL) { $env:HICLAW_OPENAI_BASE_URL } else { "https://coding.dashscope.aliyuncs.com/v1" }
+                    $config.OPENAI_BASE_URL = "https://coding.dashscope.aliyuncs.com/v1"
 
                     # Sub-menu: Select CodingPlan model
                     Write-Host ""
@@ -1491,52 +1491,7 @@ function Install-Manager {
                 Test-LlmConnectivity -BaseUrl $config.OPENAI_BASE_URL -ApiKey $config.LLM_API_KEY -Model $config.DEFAULT_MODEL
             }
             default {
-                Write-Log (Get-Msg "llm.provider.invalid")
-                $config.LLM_PROVIDER = "openai-compat"
-                $config.OPENAI_BASE_URL = if ($env:HICLAW_OPENAI_BASE_URL) { $env:HICLAW_OPENAI_BASE_URL } else { "https://coding.dashscope.aliyuncs.com/v1" }
-
-                # Sub-menu: Select CodingPlan model
-                Write-Host ""
-                Write-Host (Get-Msg "llm.codingplan.models_title")
-                Write-Host (Get-Msg "llm.codingplan.model.qwen35plus")
-                Write-Host (Get-Msg "llm.codingplan.model.glm5")
-                Write-Host (Get-Msg "llm.codingplan.model.kimi")
-                Write-Host (Get-Msg "llm.codingplan.model.minimax")
-                Write-Host ""
-
-                if ($script:HICLAW_QUICKSTART) {
-                    $codingPlanModelChoice = Read-Host "$(Get-Msg 'llm.codingplan.model.select') [1]"
-                } else {
-                    $codingPlanModelChoice = Read-Host (Get-Msg "llm.codingplan.model.select")
-                }
-                $codingPlanModelChoice = if ($codingPlanModelChoice) { $codingPlanModelChoice } else { "1" }
-
-                switch -Regex ($codingPlanModelChoice) {
-                    "^(1|qwen3\.5-plus)$" {
-                        $config.DEFAULT_MODEL = "qwen3.5-plus"
-                    }
-                    "^(2|glm-5)$" {
-                        $config.DEFAULT_MODEL = "glm-5"
-                    }
-                    "^(3|kimi-k2\.5)$" {
-                        $config.DEFAULT_MODEL = "kimi-k2.5"
-                    }
-                    "^(4|MiniMax-M2\.5)$" {
-                        $config.DEFAULT_MODEL = "MiniMax-M2.5"
-                    }
-                    default {
-                        $config.DEFAULT_MODEL = "qwen3.5-plus"
-                    }
-                }
-
-                Write-Log (Get-Msg "llm.provider.selected_codingplan")
-                Write-Log (Get-Msg "llm.model.label" -f $config.DEFAULT_MODEL)
-                Write-Log ""
-                Write-Log (Get-Msg "llm.apikey_hint")
-                Write-Log (Get-Msg "llm.apikey_url")
-                Write-Log ""
-                $config.LLM_API_KEY = Read-Prompt -VarName "HICLAW_LLM_API_KEY" -PromptText (Get-Msg "llm.apikey_prompt") -Secret
-                Test-LlmConnectivity -BaseUrl $config.OPENAI_BASE_URL -ApiKey $config.LLM_API_KEY -Model $config.DEFAULT_MODEL -Hint (Get-Msg "llm.openai.test.fail.codingplan")
+                Write-Error (Get-Msg "llm.provider.invalid" -f $providerChoice)
             }
         }
     }

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -305,8 +305,8 @@ msg() {
         "llm.provider.selected_qwen.en") text="  Provider: Alibaba Cloud Bailian" ;;
         "llm.provider.selected_openai.zh") text="  提供商: %s（OpenAI 兼容）" ;;
         "llm.provider.selected_openai.en") text="  Provider: %s (OpenAI-compatible)" ;;
-        "llm.provider.invalid.zh") text="无效选择，默认使用阿里云百炼 CodingPlan" ;;
-        "llm.provider.invalid.en") text="Invalid choice, defaulting to Alibaba Cloud Bailian CodingPlan" ;;
+        "llm.provider.invalid.zh") text="无效选择: %s（请输入 1 或 2）" ;;
+        "llm.provider.invalid.en") text="Invalid choice: %s (please enter 1 or 2)" ;;
         "llm.qwen.model_prompt.zh") text="默认模型 ID [qwen3.5-plus]" ;;
         "llm.qwen.model_prompt.en") text="Default Model ID [qwen3.5-plus]" ;;
         "llm.openai.base_url_prompt.zh") text="Base URL（例如 https://api.openai.com/v1）" ;;
@@ -1343,6 +1343,7 @@ install_manager() {
                 case "${ALIBABA_MODEL_CHOICE}" in
                     2|qwen)
                         HICLAW_LLM_PROVIDER="qwen"
+                        HICLAW_OPENAI_BASE_URL=""
                         echo ""
                         read -p "$(msg llm.qwen.model_prompt): " HICLAW_DEFAULT_MODEL
                         HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
@@ -1351,7 +1352,7 @@ install_manager() {
                         ;;
                     *)
                         HICLAW_LLM_PROVIDER="openai-compat"
-                        HICLAW_OPENAI_BASE_URL="${HICLAW_OPENAI_BASE_URL:-https://coding.dashscope.aliyuncs.com/v1}"
+                        HICLAW_OPENAI_BASE_URL="https://coding.dashscope.aliyuncs.com/v1"
 
                         # Sub-menu: Select CodingPlan model
                         echo ""
@@ -1417,52 +1418,7 @@ install_manager() {
                 test_llm_connectivity "${HICLAW_OPENAI_BASE_URL}" "${HICLAW_LLM_API_KEY}" "${HICLAW_DEFAULT_MODEL}"
                 ;;
             *)
-                log "$(msg llm.provider.invalid)"
-                HICLAW_LLM_PROVIDER="openai-compat"
-                HICLAW_OPENAI_BASE_URL="${HICLAW_OPENAI_BASE_URL:-https://coding.dashscope.aliyuncs.com/v1}"
-
-                # Sub-menu: Select CodingPlan model
-                echo ""
-                echo "$(msg llm.codingplan.models_title)"
-                echo "$(msg llm.codingplan.model.qwen35plus)"
-                echo "$(msg llm.codingplan.model.glm5)"
-                echo "$(msg llm.codingplan.model.kimi)"
-                echo "$(msg llm.codingplan.model.minimax)"
-                echo ""
-                if [ "${HICLAW_QUICKSTART}" = "1" ]; then
-                    read -p "$(msg llm.codingplan.model.select) [1]: " CODINGPLAN_MODEL_CHOICE
-                    CODINGPLAN_MODEL_CHOICE="${CODINGPLAN_MODEL_CHOICE:-1}"
-                else
-                    read -p "$(msg llm.codingplan.model.select): " CODINGPLAN_MODEL_CHOICE
-                    CODINGPLAN_MODEL_CHOICE="${CODINGPLAN_MODEL_CHOICE:-1}"
-                fi
-
-                case "${CODINGPLAN_MODEL_CHOICE}" in
-                    1|qwen3.5-plus)
-                        HICLAW_DEFAULT_MODEL="qwen3.5-plus"
-                        ;;
-                    2|glm-5)
-                        HICLAW_DEFAULT_MODEL="glm-5"
-                        ;;
-                    3|kimi-k2.5)
-                        HICLAW_DEFAULT_MODEL="kimi-k2.5"
-                        ;;
-                    4|MiniMax-M2.5)
-                        HICLAW_DEFAULT_MODEL="MiniMax-M2.5"
-                        ;;
-                    *)
-                        HICLAW_DEFAULT_MODEL="qwen3.5-plus"
-                        ;;
-                esac
-
-                log "$(msg llm.provider.selected_codingplan)"
-                log "$(msg llm.model.label "${HICLAW_DEFAULT_MODEL}")"
-                log ""
-                log "$(msg llm.apikey_hint)"
-                log "$(msg llm.apikey_url)"
-                log ""
-                prompt HICLAW_LLM_API_KEY "$(msg llm.apikey_prompt)" "" "true"
-                test_llm_connectivity "${HICLAW_OPENAI_BASE_URL}" "${HICLAW_LLM_API_KEY}" "${HICLAW_DEFAULT_MODEL}" "$(msg llm.openai.test.fail.codingplan)"
+                error "$(msg llm.provider.invalid "${PROVIDER_CHOICE}")"
                 ;;
         esac
     fi


### PR DESCRIPTION
## Summary

- When upgrading and switching LLM provider (e.g. from qwen to CodingPlan), `HICLAW_OPENAI_BASE_URL` retained its stale value from the env file because `${VAR:-default}` only substitutes when the variable is unset or empty — a non-empty stale URL was preserved, causing the connectivity test to hit the wrong endpoint.
- Set `HICLAW_OPENAI_BASE_URL` unconditionally when CodingPlan is selected, and clear it when qwen is selected, ensuring the connectivity test always uses the correct base URL.
- Replace silent fallback on invalid provider choice with an explicit error exit (invalid input should not silently default to CodingPlan).
- Applied the same fixes to both `hiclaw-install.sh` (bash) and `hiclaw-install.ps1` (PowerShell).

## Test plan

- [ ] Fresh install with CodingPlan — verify connectivity test uses `https://coding.dashscope.aliyuncs.com/v1`
- [ ] Fresh install with qwen (百炼通用) — verify connectivity test uses `https://dashscope.aliyuncs.com/compatible-mode/v1`
- [ ] Upgrade from qwen to CodingPlan — verify connectivity test switches to `https://coding.dashscope.aliyuncs.com/v1`
- [ ] Upgrade from CodingPlan to qwen — verify connectivity test switches to `https://dashscope.aliyuncs.com/compatible-mode/v1`
- [ ] Enter invalid provider choice (e.g. "3") — verify script exits with error


Made with [Cursor](https://cursor.com)