### PR TITLE
fix(install): only pull selected worker runtime image and defer container stop until after config+pull

### DIFF
--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -1288,21 +1288,8 @@ function Install-Manager {
                     }
                 }
 
-                # Stop and remove containers
-                if ($runningManager -or (docker ps -a --format "{{.Names}}" 2>$null | Select-String "^hiclaw-manager$")) {
-                    Write-Log (Get-Msg "install.existing.stopping_manager")
-                    docker stop hiclaw-manager *>$null
-                    docker rm hiclaw-manager *>$null
-                }
-
-                if ($existingWorkers) {
-                    Write-Log (Get-Msg "install.existing.stopping_workers")
-                    $existingWorkers | ForEach-Object {
-                        docker stop $_ *>$null
-                        docker rm $_ *>$null
-                        Write-Log (Get-Msg "install.existing.removed" -f $_)
-                    }
-                }
+                # Remember workers to stop later (after config + image pull)
+                $script:UPGRADE_EXISTING_WORKERS = $existingWorkers
                 break
             }
             "^(2|reinstall)$" {
@@ -1762,14 +1749,6 @@ function Install-Manager {
     # Image
     $dockerArgs += $script:MANAGER_IMAGE
 
-    # Remove existing container
-    $existingContainer = docker ps -a --format "{{.Names}}" 2>$null | Select-String "^hiclaw-manager$"
-    if ($existingContainer) {
-        Write-Log (Get-Msg "install.removing_existing")
-        docker stop hiclaw-manager *>$null
-        docker rm hiclaw-manager *>$null
-    }
-
     # Check if the Docker volume exists; create if not (reuse on reinstall)
     $volumeExists = docker volume ls -q 2>$null | Select-String "^$($config.DATA_DIR)$"
     if (-not $volumeExists) {
@@ -1793,31 +1772,39 @@ function Install-Manager {
         & docker pull $script:MANAGER_IMAGE
     }
 
-    if ($script:WORKER_IMAGE.StartsWith($LocalImagePrefix)) {
-        $workerImageExists = docker image inspect $script:WORKER_IMAGE 2>$null
+    # Pull only the worker image matching the selected runtime
+    $selectedWorkerImage = if ($config.DEFAULT_WORKER_RUNTIME -eq "copaw") { $script:COPAW_WORKER_IMAGE } else { $script:WORKER_IMAGE }
+    if ($selectedWorkerImage.StartsWith($LocalImagePrefix)) {
+        $workerImageExists = docker image inspect $selectedWorkerImage 2>$null
         if ($LASTEXITCODE -eq 0) {
-            Write-Log (Get-Msg "install.image.worker_exists" -f $script:WORKER_IMAGE)
+            Write-Log (Get-Msg "install.image.worker_exists" -f $selectedWorkerImage)
         } else {
-            Write-Log (Get-Msg "install.image.pulling_worker" -f $script:WORKER_IMAGE)
-            & docker pull $script:WORKER_IMAGE
+            Write-Log (Get-Msg "install.image.pulling_worker" -f $selectedWorkerImage)
+            & docker pull $selectedWorkerImage
         }
     } else {
-        Write-Log (Get-Msg "install.image.pulling_worker" -f $script:WORKER_IMAGE)
-        & docker pull $script:WORKER_IMAGE
+        Write-Log (Get-Msg "install.image.pulling_worker" -f $selectedWorkerImage)
+        & docker pull $selectedWorkerImage
     }
-    if ($script:COPAW_WORKER_IMAGE.StartsWith($LocalImagePrefix)) {
-        $copawImageExists = docker image inspect $script:COPAW_WORKER_IMAGE 2>$null
-        if ($LASTEXITCODE -eq 0) {
-            Write-Log "Copaw worker image exists: $($script:COPAW_WORKER_IMAGE)"
-        } else {
-            Write-Log "Pulling copaw worker image: $($script:COPAW_WORKER_IMAGE)"
-            & docker pull $script:COPAW_WORKER_IMAGE 2>$null
-            if ($LASTEXITCODE -ne 0) { Write-Log "Copaw worker image not available (optional)" }
+
+    # Stop and remove existing containers (deferred until after all
+    # configuration is collected and images are pulled successfully)
+    $existingContainer = docker ps -a --format "{{.Names}}" 2>$null | Select-String "^hiclaw-manager$"
+    if ($existingContainer) {
+        Write-Log (Get-Msg "install.removing_existing")
+        docker stop hiclaw-manager *>$null
+        docker rm hiclaw-manager *>$null
+    }
+
+    # Stop and remove worker containers saved during upgrade detection
+    # (Manager IP changes on restart, so workers must be recreated)
+    if ($script:UPGRADE_EXISTING_WORKERS) {
+        Write-Log (Get-Msg "install.existing.stopping_workers")
+        $script:UPGRADE_EXISTING_WORKERS | ForEach-Object {
+            docker stop $_ *>$null
+            docker rm $_ *>$null
+            Write-Log (Get-Msg "install.existing.removed" -f $_)
         }
-    } else {
-        Write-Log "Pulling copaw worker image: $($script:COPAW_WORKER_IMAGE)"
-        & docker pull $script:COPAW_WORKER_IMAGE 2>$null
-        if ($LASTEXITCODE -ne 0) { Write-Log "Copaw worker image not available (optional)" }
     }
 
     # Run container

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -1192,7 +1192,8 @@ install_manager() {
                 HICLAW_UPGRADE=1
                 log "$(msg install.existing.upgrading)"
 
-                # Warn about running containers
+                # Warn about running containers (actual stop is deferred until
+                # all configuration is collected and images are pulled)
                 if [ -n "${running_manager}" ] || [ -n "${running_workers}" ]; then
                     echo ""
                     echo -e "\033[33m$(msg install.existing.warn_manager_stop)\033[0m"
@@ -1209,23 +1210,8 @@ install_manager() {
                     fi
                 fi
 
-                # Stop and remove manager container
-                if [ -n "${running_manager}" ] || ${DOCKER_CMD} ps -a --format '{{.Names}}' | grep -q "^hiclaw-manager$"; then
-                    log "$(msg install.existing.stopping_manager)"
-                    ${DOCKER_CMD} stop hiclaw-manager 2>/dev/null || true
-                    ${DOCKER_CMD} rm hiclaw-manager 2>/dev/null || true
-                fi
-
-                # Stop and remove worker containers (Manager IP changes on restart,
-                # so workers must be recreated to get updated /etc/hosts entries)
-                if [ -n "${existing_workers}" ]; then
-                    log "$(msg install.existing.stopping_workers)"
-                    for w in ${existing_workers}; do
-                        ${DOCKER_CMD} stop "${w}" 2>/dev/null || true
-                        ${DOCKER_CMD} rm "${w}" 2>/dev/null || true
-                        log "$(msg install.existing.removed "${w}")"
-                    done
-                fi
+                # Remember workers to stop later (after config + image pull)
+                UPGRADE_EXISTING_WORKERS="${existing_workers}"
                 # Continue with installation using existing config
                 ;;
             2|reinstall)
@@ -1683,13 +1669,6 @@ EOF
         fi
     fi
 
-    # Remove existing container if present
-    if ${DOCKER_CMD} ps -a --format '{{.Names}}' | grep -q "^hiclaw-manager$"; then
-        log "$(msg install.removing_existing)"
-        ${DOCKER_CMD} stop hiclaw-manager 2>/dev/null || true
-        ${DOCKER_CMD} rm hiclaw-manager 2>/dev/null || true
-    fi
-
     # Create the data volume if it doesn't already exist (reuse on reinstall)
     if ! ${DOCKER_CMD} volume ls -q | grep -q "^${HICLAW_DATA_DIR}$"; then
         ${DOCKER_CMD} volume create "${HICLAW_DATA_DIR}" > /dev/null
@@ -1729,40 +1708,50 @@ EOF
         log "$(msg install.yolo)"
     fi
 
-    # Pull images (worker image must be ready before manager creates workers)
+    # Pull images (only pull the worker image matching the selected runtime)
     LOCAL_IMAGE_PREFIX="hiclaw/"
-    if echo "${MANAGER_IMAGE}" | grep -q "^${LOCAL_IMAGE_PREFIX}"; then
-        if ${DOCKER_CMD} image inspect "${MANAGER_IMAGE}" >/dev/null 2>&1; then
-            log "$(msg install.image.exists "${MANAGER_IMAGE}")"
-        else
-            log "$(msg install.image.pulling_manager "${MANAGER_IMAGE}")"
-            ${DOCKER_CMD} pull "${MANAGER_IMAGE}"
+
+    # Helper: pull or skip a single image
+    # Args: $1=image  $2=exists_msg_key  $3=pulling_msg_key
+    _pull_image() {
+        local _img="$1" _exists_key="$2" _pull_key="$3"
+        if echo "${_img}" | grep -q "^${LOCAL_IMAGE_PREFIX}"; then
+            if ${DOCKER_CMD} image inspect "${_img}" >/dev/null 2>&1; then
+                log "$(msg "${_exists_key}" "${_img}")"
+                return 0
+            fi
         fi
+        log "$(msg "${_pull_key}" "${_img}")"
+        ${DOCKER_CMD} pull "${_img}"
+    }
+
+    # Manager image is always required
+    _pull_image "${MANAGER_IMAGE}" "install.image.exists" "install.image.pulling_manager"
+
+    # Pull only the worker image for the selected runtime
+    if [ "${HICLAW_DEFAULT_WORKER_RUNTIME}" = "copaw" ]; then
+        _pull_image "${COPAW_WORKER_IMAGE}" "install.image.worker_exists" "install.image.pulling_worker"
     else
-        log "$(msg install.image.pulling_manager "${MANAGER_IMAGE}")"
-        ${DOCKER_CMD} pull "${MANAGER_IMAGE}"
+        _pull_image "${WORKER_IMAGE}" "install.image.worker_exists" "install.image.pulling_worker"
     fi
-    if echo "${WORKER_IMAGE}" | grep -q "^${LOCAL_IMAGE_PREFIX}"; then
-        if ${DOCKER_CMD} image inspect "${WORKER_IMAGE}" >/dev/null 2>&1; then
-            log "$(msg install.image.worker_exists "${WORKER_IMAGE}")"
-        else
-            log "$(msg install.image.pulling_worker "${WORKER_IMAGE}")"
-            ${DOCKER_CMD} pull "${WORKER_IMAGE}"
-        fi
-    else
-        log "$(msg install.image.pulling_worker "${WORKER_IMAGE}")"
-        ${DOCKER_CMD} pull "${WORKER_IMAGE}"
+
+    # Stop and remove existing containers (deferred from upgrade detection
+    # so that all configuration is collected and images are pulled first)
+    if ${DOCKER_CMD} ps -a --format '{{.Names}}' | grep -q "^hiclaw-manager$"; then
+        log "$(msg install.removing_existing)"
+        ${DOCKER_CMD} stop hiclaw-manager 2>/dev/null || true
+        ${DOCKER_CMD} rm hiclaw-manager 2>/dev/null || true
     fi
-    if echo "${COPAW_WORKER_IMAGE}" | grep -q "^${LOCAL_IMAGE_PREFIX}"; then
-        if ${DOCKER_CMD} image inspect "${COPAW_WORKER_IMAGE}" >/dev/null 2>&1; then
-            log "Copaw worker image exists: ${COPAW_WORKER_IMAGE}"
-        else
-            log "Pulling copaw worker image: ${COPAW_WORKER_IMAGE}"
-            ${DOCKER_CMD} pull "${COPAW_WORKER_IMAGE}" 2>/dev/null || log "Copaw worker image not available (optional)"
-        fi
-    else
-        log "Pulling copaw worker image: ${COPAW_WORKER_IMAGE}"
-        ${DOCKER_CMD} pull "${COPAW_WORKER_IMAGE}" 2>/dev/null || log "Copaw worker image not available (optional)"
+
+    # Stop and remove worker containers saved during upgrade detection
+    # (Manager IP changes on restart, so workers must be recreated)
+    if [ -n "${UPGRADE_EXISTING_WORKERS:-}" ]; then
+        log "$(msg install.existing.stopping_workers)"
+        for w in ${UPGRADE_EXISTING_WORKERS}; do
+            ${DOCKER_CMD} stop "${w}" 2>/dev/null || true
+            ${DOCKER_CMD} rm "${w}" 2>/dev/null || true
+            log "$(msg install.existing.removed "${w}")"
+        done
     fi
 
     # Run Manager container


### PR DESCRIPTION
## 改动说明

### 1. 按选择的 worker 运行时拉取镜像

之前安装时无论用户选择 openclaw 还是 copaw，都会拉取全部三个镜像（manager + worker + copaw-worker）。现在改为只拉取 manager 镜像 + 用户选择的那一个 worker 镜像，节省带宽和时间。

### 2. 升级场景延迟停容器

之前升级流程中，用户确认升级后立即停掉 manager 和 worker 容器，然后才进入配置收集和镜像拉取。如果用户在配置过程中取消或镜像拉取失败，服务已经停了。

现在改为：
1. 检测到已有安装 → 用户确认升级 → 只记录需要停的 worker 列表
2. 完成所有配置收集、写入 env 文件
3. 拉取镜像
4. 镜像拉取成功后，才停掉旧容器
5. 启动新容器

这样如果中途取消或拉取失败，旧容器不受影响，服务保持运行。

### 影响范围

- `install/hiclaw-install.sh` (bash)
- `install/hiclaw-install.ps1` (PowerShell)

两个脚本做了同步修改。
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Change description

### 1. Pull the image according to the selected worker runtime

During previous installation, no matter whether the user chooses openclaw or copaw, all three images (manager + worker + copaw-worker) will be pulled. Now it is changed to only pull the manager image + the worker image selected by the user, saving bandwidth and time.

### 2. Delayed container shutdown in upgrade scenarios

In the previous upgrade process, users immediately stopped the manager and worker containers after confirming the upgrade, and then entered configuration collection and image pulling. If the user cancels during the configuration process or the image pull fails, the service has been stopped.

Now change to:
1. It is detected that the installation has already been installed → the user confirms the upgrade → only records the list of workers that need to be stopped.
2. Complete all configuration collection and write env files
3. Pull the image
4. Stop the old container only after the image is pulled successfully.
5. Start a new container

In this way, if it is canceled midway or the pull fails, the old container will not be affected and the service will keep running.

### Scope of influence

- `install/hiclaw-install.sh` (bash)
- `install/hiclaw-install.ps1` (PowerShell)

The two scripts have been modified simultaneously.
