### PR TITLE
fix(manager): allow unstable room versions in Tuwunel

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,3 +4,4 @@ Record image-affecting changes to `manager/`, `worker/`, `openclaw-base/` here b
 
 ---
 
+- fix(manager): allow unstable room versions in Tuwunel to fix room version 11 error

--- a/manager/scripts/init/start-tuwunel.sh
+++ b/manager/scripts/init/start-tuwunel.sh
@@ -11,6 +11,7 @@ export CONDUWUIT_PORT=6167
 export CONDUWUIT_ALLOW_REGISTRATION=true
 export CONDUWUIT_REGISTRATION_TOKEN="${HICLAW_REGISTRATION_TOKEN}"
 export CONDUWUIT_ALLOW_LEGACY_MEDIA=true
+export CONDUWUIT_ALLOW_UNSTABLE_ROOM_VERSIONS=true
 
 # User creation is handled by start-manager-agent.sh via Registration API
 # (single-step registration, no UIAA flow needed)


### PR DESCRIPTION
## Problem

Tuwunel rejects room version 11 with error:
> This room is running room version 11, which this homeserver has marked as unstable.

## Solution

Add `CONDUWUIT_ALLOW_UNSTABLE_ROOM_VERSIONS=true` environment variable to `start-tuwunel.sh` so Tuwunel accepts unstable room versions (including v11).

## Changes

- `manager/scripts/init/start-tuwunel.sh`: add env var
- `changelog/current.md`: record the change