### PR TITLE
feat(manager): reduce default context windows and support --context-w…

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -5,3 +5,4 @@ Record image-affecting changes to `manager/`, `worker/`, `openclaw-base/` here b
 ---
 
 - fix(manager): allow unstable room versions in Tuwunel to fix room version 11 error
+- feat(manager): reduce default context windows (qwen3.5-plus: 960k→200k, unknown models: 200k→150k) and support `--context-window` override for unknown models in model-switch skills

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -119,7 +119,7 @@ Alternatively, you can click the Worker's avatar and open a **direct message** (
 
 **Why use Manager instead of manual config?**
 
-OpenClaw requires setting the model's context window size (`contextWindow`) in its config. HiClaw defaults to qwen3.5-plus's 1M token window. If you switch to a model with a smaller window without updating this setting, the session may fail when approaching the window limit — OpenClaw won't know when to compress context.
+OpenClaw requires setting the model's context window size (`contextWindow`) in its config. HiClaw defaults to qwen3.5-plus's 200K token window. If you switch to a model with a different window without updating this setting, the session may fail when approaching the window limit — OpenClaw won't know when to compress context.
 
 Manager has a built-in **model-switch skill** that:
 1. Looks up the correct `contextWindow` and `maxTokens` for the target model

--- a/docs/zh-cn/faq.md
+++ b/docs/zh-cn/faq.md
@@ -116,7 +116,7 @@ http://<局域网IP>:18080
 
 **为什么让 Manager 切换而不是手动改配置？**
 
-OpenClaw 需要在配置中设置模型的上下文窗口大小（`contextWindow`）。HiClaw 默认使用 qwen3.5-plus 的 1M token 窗口。如果切换到窗口更小的模型但没有更新这个设置，当对话接近窗口上限时，OpenClaw 不知道何时压缩上下文，可能导致 session 无法使用。
+OpenClaw 需要在配置中设置模型的上下文窗口大小（`contextWindow`）。HiClaw 默认使用 qwen3.5-plus 的 200K token 窗口。如果切换到窗口不同的模型但没有更新这个设置，当对话接近窗口上限时，OpenClaw 不知道何时压缩上下文，可能导致 session 无法使用。
 
 为此，HiClaw 给 Manager 配备了**模型切换技能**，会根据模型名自动修改 OpenClaw 配置中的 `contextWindow` 和 `maxTokens`。
 

--- a/manager/agent/skills/model-switch/SKILL.md
+++ b/manager/agent/skills/model-switch/SKILL.md
@@ -10,18 +10,19 @@ Switch the Manager's own LLM model. The script tests connectivity first, then ho
 ## Usage
 
 ```bash
-bash /opt/hiclaw/agent/skills/model-switch/scripts/update-manager-model.sh <MODEL_ID>
+bash /opt/hiclaw/agent/skills/model-switch/scripts/update-manager-model.sh <MODEL_ID> [--context-window <SIZE>]
 ```
 
-Example:
+Examples:
 ```bash
 bash /opt/hiclaw/agent/skills/model-switch/scripts/update-manager-model.sh claude-sonnet-4-6
+bash /opt/hiclaw/agent/skills/model-switch/scripts/update-manager-model.sh my-custom-model --context-window 300000
 ```
 
 ## What the script does
 
 1. Strips any `hiclaw-gateway/` prefix from the model name
-2. Resolves `contextWindow` and `maxTokens` for the model
+2. Resolves `contextWindow` and `maxTokens` for the model (uses `--context-window` override if provided)
 3. Tests the model via `POST /v1/chat/completions` on the AI Gateway — exits with error if unreachable
 4. Patches `openclaw.json`: updates `models[0].id/name/contextWindow/maxTokens` and `agents.defaults.model.primary`
 
@@ -51,7 +52,18 @@ No changes are made to `openclaw.json` in this case.
 | claude-opus-4-6 | 1,000,000 | 128,000 |
 | claude-sonnet-4-6 | 1,000,000 | 64,000 |
 | claude-haiku-4-5 | 200,000 | 64,000 |
-| qwen3.5-plus | 960,000 | 64,000 |
+| qwen3.5-plus | 200,000 | 64,000 |
 | deepseek-chat / deepseek-reasoner / kimi-k2.5 | 256,000 | 128,000 |
 | glm-5 / MiniMax-M2.5 | 200,000 | 128,000 |
-| *(other)* | 200,000 | 128,000 |
+| *(other)* | 150,000 | 128,000 |
+
+## Switching to an unknown model
+
+When the human admin requests switching to a model **not listed in the table above**, you MUST:
+
+1. **Ask the admin for the model's context window size** before running the script. Example: "This model is not in the known list. What is its context window size (in tokens)?"
+2. Once the admin provides the context window, run the script with `--context-window`:
+   ```bash
+   bash /opt/hiclaw/agent/skills/model-switch/scripts/update-manager-model.sh <MODEL_ID> --context-window <SIZE>
+   ```
+3. If the admin does not know the context window, use the default (150,000) by omitting `--context-window`.

--- a/manager/agent/skills/model-switch/scripts/update-manager-model.sh
+++ b/manager/agent/skills/model-switch/scripts/update-manager-model.sh
@@ -5,22 +5,39 @@
 # OpenClaw detects the file change (~300ms) and reloads config automatically.
 #
 # Usage:
-#   update-manager-model.sh <MODEL_ID>
+#   update-manager-model.sh <MODEL_ID> [--context-window <SIZE>]
 #
 # Example:
 #   update-manager-model.sh claude-sonnet-4-6
+#   update-manager-model.sh my-custom-model --context-window 300000
 
 set -e
 source /opt/hiclaw/scripts/lib/base.sh
 
 MODEL_NAME="${1:-}"
 if [ -z "${MODEL_NAME}" ]; then
-    echo "Usage: $0 <MODEL_ID>"
+    echo "Usage: $0 <MODEL_ID> [--context-window <SIZE>]"
     echo "Example: $0 claude-sonnet-4-6"
+    echo "         $0 my-custom-model --context-window 300000"
     exit 1
 fi
+shift
 # Strip provider prefix if caller passed "hiclaw-gateway/<model>" by mistake
 MODEL_NAME="${MODEL_NAME#hiclaw-gateway/}"
+
+CTX_OVERRIDE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --context-window)
+            CTX_OVERRIDE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
 
 CONFIG_FILE="${HOME}/manager-workspace/openclaw.json"
 if [ ! -f "${CONFIG_FILE}" ]; then
@@ -45,14 +62,19 @@ case "${MODEL_NAME}" in
     claude-haiku-4-5)
         CTX=200000; MAX=64000 ;;
     qwen3.5-plus)
-        CTX=960000; MAX=64000 ;;
+        CTX=200000; MAX=64000 ;;
     deepseek-chat|deepseek-reasoner|kimi-k2.5)
         CTX=256000; MAX=128000 ;;
     glm-5|MiniMax-M2.5)
         CTX=200000; MAX=128000 ;;
     *)
-        CTX=200000; MAX=128000 ;;
+        CTX=150000; MAX=128000 ;;
 esac
+
+# Allow explicit context-window override (for unknown models)
+if [ -n "${CTX_OVERRIDE:-}" ]; then
+    CTX="${CTX_OVERRIDE}"
+fi
 
 # Resolve input modalities: only vision-capable models get "image"
 case "${MODEL_NAME}" in

--- a/manager/agent/skills/worker-management/scripts/generate-worker-config.sh
+++ b/manager/agent/skills/worker-management/scripts/generate-worker-config.sh
@@ -41,13 +41,13 @@ case "${MODEL_NAME}" in
     claude-haiku-4-5)
         CTX=200000; MAX=64000 ;;
     qwen3.5-plus)
-        CTX=960000; MAX=64000 ;;
+        CTX=200000; MAX=64000 ;;
     deepseek-chat|deepseek-reasoner|kimi-k2.5)
         CTX=256000; MAX=128000 ;;
     glm-5|MiniMax-M2.5)
         CTX=200000; MAX=128000 ;;
     *)
-        CTX=200000; MAX=128000 ;;
+        CTX=150000; MAX=128000 ;;
 esac
 
 # Resolve input modalities: only vision-capable models get "image"

--- a/manager/agent/skills/worker-model-switch/SKILL.md
+++ b/manager/agent/skills/worker-model-switch/SKILL.md
@@ -11,19 +11,22 @@ Switch a Worker's LLM model. The script tests connectivity first, then patches t
 
 ```bash
 bash /opt/hiclaw/agent/skills/worker-model-switch/scripts/update-worker-model.sh \
-  --worker <WORKER_NAME> --model <MODEL_ID>
+  --worker <WORKER_NAME> --model <MODEL_ID> [--context-window <SIZE>]
 ```
 
-Example:
+Examples:
 ```bash
 bash /opt/hiclaw/agent/skills/worker-model-switch/scripts/update-worker-model.sh \
   --worker alice --model claude-sonnet-4-6
+
+bash /opt/hiclaw/agent/skills/worker-model-switch/scripts/update-worker-model.sh \
+  --worker alice --model my-custom-model --context-window 300000
 ```
 
 ## What the script does
 
 1. Strips any `hiclaw-gateway/` prefix from the model name
-2. Resolves `contextWindow` and `maxTokens` for the model
+2. Resolves `contextWindow` and `maxTokens` for the model (uses `--context-window` override if provided)
 3. Tests the model via `POST /v1/chat/completions` on the AI Gateway — exits with error if unreachable
 4. Pulls the Worker's `openclaw.json` from MinIO
 5. Patches model id, name, contextWindow, maxTokens (preserves all other config)
@@ -55,7 +58,19 @@ No changes are made to `openclaw.json` in this case.
 | claude-opus-4-6 | 1,000,000 | 128,000 |
 | claude-sonnet-4-6 | 1,000,000 | 64,000 |
 | claude-haiku-4-5 | 200,000 | 64,000 |
-| qwen3.5-plus | 960,000 | 64,000 |
+| qwen3.5-plus | 200,000 | 64,000 |
 | deepseek-chat / deepseek-reasoner / kimi-k2.5 | 256,000 | 128,000 |
 | glm-5 / MiniMax-M2.5 | 200,000 | 128,000 |
-| *(other)* | 200,000 | 128,000 |
+| *(other)* | 150,000 | 128,000 |
+
+## Switching to an unknown model
+
+When the human admin requests switching a Worker to a model **not listed in the table above**, you MUST:
+
+1. **Ask the admin for the model's context window size** before running the script. Example: "This model is not in the known list. What is its context window size (in tokens)?"
+2. Once the admin provides the context window, run the script with `--context-window`:
+   ```bash
+   bash /opt/hiclaw/agent/skills/worker-model-switch/scripts/update-worker-model.sh \
+     --worker <WORKER_NAME> --model <MODEL_ID> --context-window <SIZE>
+   ```
+3. If the admin does not know the context window, use the default (150,000) by omitting `--context-window`.

--- a/manager/agent/skills/worker-model-switch/scripts/update-worker-model.sh
+++ b/manager/agent/skills/worker-model-switch/scripts/update-worker-model.sh
@@ -5,10 +5,11 @@
 # and notifies the Worker via Matrix to reload config.
 #
 # Usage:
-#   update-worker-model.sh --worker <name> --model <model-id>
+#   update-worker-model.sh --worker <name> --model <model-id> [--context-window <size>]
 #
 # Example:
 #   update-worker-model.sh --worker alice --model claude-sonnet-4-6
+#   update-worker-model.sh --worker alice --model my-custom-model --context-window 300000
 
 set -euo pipefail
 
@@ -37,14 +38,18 @@ _resolve_model_params() {
         claude-haiku-4-5)
             CTX=200000; MAX=64000 ;;
         qwen3.5-plus)
-            CTX=960000; MAX=64000 ;;
+            CTX=200000; MAX=64000 ;;
         deepseek-chat|deepseek-reasoner|kimi-k2.5)
             CTX=256000; MAX=128000 ;;
         glm-5|MiniMax-M2.5)
             CTX=200000; MAX=128000 ;;
         *)
-            CTX=200000; MAX=128000 ;;
+            CTX=150000; MAX=128000 ;;
     esac
+    # Allow explicit context-window override (for unknown models)
+    if [ -n "${CTX_OVERRIDE:-}" ]; then
+        CTX="${CTX_OVERRIDE}"
+    fi
     # Resolve input modalities: only vision-capable models get "image"
     case "${model}" in
         gpt-5.4|gpt-5.3-codex|gpt-5-mini|gpt-5-nano|claude-opus-4-6|claude-sonnet-4-6|claude-haiku-4-5|qwen3.5-plus|kimi-k2.5)
@@ -187,6 +192,7 @@ update_worker_model() {
 
 WORKER=""
 MODEL=""
+CTX_OVERRIDE=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -198,6 +204,10 @@ while [[ $# -gt 0 ]]; do
             MODEL="$2"
             shift 2
             ;;
+        --context-window)
+            CTX_OVERRIDE="$2"
+            shift 2
+            ;;
         *)
             echo "Unknown argument: $1" >&2
             exit 1
@@ -206,8 +216,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ -z "$WORKER" ] || [ -z "$MODEL" ]; then
-    echo "Usage: $0 --worker <name> --model <model-id>" >&2
+    echo "Usage: $0 --worker <name> --model <model-id> [--context-window <size>]" >&2
     echo "Example: $0 --worker alice --model claude-sonnet-4-6" >&2
+    echo "         $0 --worker alice --model my-custom-model --context-window 300000" >&2
     exit 1
 fi
 

--- a/manager/scripts/init/start-manager-agent.sh
+++ b/manager/scripts/init/start-manager-agent.sh
@@ -268,13 +268,13 @@ case "${MODEL_NAME}" in
     claude-haiku-4-5)
         export MODEL_CONTEXT_WINDOW=200000 MODEL_MAX_TOKENS=64000 ;;
     qwen3.5-plus)
-        export MODEL_CONTEXT_WINDOW=960000 MODEL_MAX_TOKENS=64000 ;;
+        export MODEL_CONTEXT_WINDOW=200000 MODEL_MAX_TOKENS=64000 ;;
     deepseek-chat|deepseek-reasoner|kimi-k2.5)
         export MODEL_CONTEXT_WINDOW=256000 MODEL_MAX_TOKENS=128000 ;;
     glm-5|MiniMax-M2.5)
         export MODEL_CONTEXT_WINDOW=200000 MODEL_MAX_TOKENS=128000 ;;
     *)
-        export MODEL_CONTEXT_WINDOW=200000 MODEL_MAX_TOKENS=128000 ;;
+        export MODEL_CONTEXT_WINDOW=150000 MODEL_MAX_TOKENS=128000 ;;
 esac
 export MODEL_REASONING=true
 


### PR DESCRIPTION
…indow override

- Lower qwen3.5-plus context window from 960k to 200k across all 4 model-param resolution sites (start-manager-agent, update-manager-model, update-worker-model, generate-worker-config).
- Lower unknown/fallback model context window from 200k to 150k.
- Add --context-window flag to update-manager-model.sh and update-worker-model.sh so callers can override the default for unlisted models.
- Update both model-switch SKILL.md files with new values and a "Switching to an unknown model" section instructing the Manager to ask the human admin for context window size before switching.
- Update docs/faq.md and docs/zh-cn/faq.md to reflect the new defaults.

Made-with: Cursor