### PR TITLE
feat(manager): support openclaw gateway restart and expose console at…

### DIFF
--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -354,6 +354,8 @@ msg() {
         "port.console_prompt.en") text="Host port for Higress console (8001 inside container)" ;;
         "port.element_prompt.zh") text="Element Web 直接访问主机端口（容器内 8088）" ;;
         "port.element_prompt.en") text="Host port for Element Web direct access (8088 inside container)" ;;
+        "port.openclaw_console_prompt.zh") text="OpenClaw 控制台主机端口（容器内 18888）" ;;
+        "port.openclaw_console_prompt.en") text="Host port for OpenClaw console (18888 inside container)" ;;
         # --- Local-only binding ---
         "port.local_only.title.zh") text="--- 网络访问模式 ---" ;;
         "port.local_only.title.en") text="--- Network Access Mode ---" ;;
@@ -1489,6 +1491,7 @@ install_manager() {
     prompt HICLAW_PORT_GATEWAY "$(msg port.gateway_prompt)" "18080"
     prompt HICLAW_PORT_CONSOLE "$(msg port.console_prompt)" "18001"
     prompt HICLAW_PORT_ELEMENT_WEB "$(msg port.element_prompt)" "18088"
+    prompt HICLAW_PORT_OPENCLAW_CONSOLE "$(msg port.openclaw_console_prompt)" "18888"
 
     log ""
 
@@ -1599,6 +1602,7 @@ HICLAW_ADMIN_PASSWORD=${HICLAW_ADMIN_PASSWORD}
 HICLAW_PORT_GATEWAY=${HICLAW_PORT_GATEWAY}
 HICLAW_PORT_CONSOLE=${HICLAW_PORT_CONSOLE}
 HICLAW_PORT_ELEMENT_WEB=${HICLAW_PORT_ELEMENT_WEB}
+HICLAW_PORT_OPENCLAW_CONSOLE=${HICLAW_PORT_OPENCLAW_CONSOLE:-18888}
 
 # Matrix
 HICLAW_MATRIX_DOMAIN=${HICLAW_MATRIX_DOMAIN}
@@ -1775,6 +1779,7 @@ EOF
         -p "${_port_prefix}${HICLAW_PORT_GATEWAY}:8080" \
         -p "${_port_prefix}${HICLAW_PORT_CONSOLE}:8001" \
         -p "${_port_prefix}${HICLAW_PORT_ELEMENT_WEB:-18088}:8088" \
+        -p "${_port_prefix}${HICLAW_PORT_OPENCLAW_CONSOLE:-18888}:18888" \
         ${DATA_MOUNT_ARGS} \
         ${WORKSPACE_MOUNT_ARGS} \
         ${HOST_SHARE_MOUNT_ARGS} \

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -62,6 +62,10 @@ ENV OPENCLAW_CONFIG_PATH="/root/manager-workspace/openclaw.json"
 # Our supervisord.conf replaces the Higress one; our scripts handle all components
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY scripts/ /opt/hiclaw/scripts/
+
+# Install systemctl shim so 'openclaw gateway restart' works without systemd
+RUN cp /opt/hiclaw/scripts/systemctl-shim.sh /usr/local/bin/systemctl && \
+    chmod +x /usr/local/bin/systemctl
 COPY agent/ /opt/hiclaw/agent/
 COPY configs/ /opt/hiclaw/configs/
 
@@ -79,7 +83,8 @@ RUN chmod +x /opt/hiclaw/scripts/init/*.sh /opt/hiclaw/scripts/lib/*.sh && \
 # 8080: Higress Gateway (unified entry point)
 # 8001: Higress Console
 # 9001: MinIO Console
-EXPOSE 8080 8001 9001
+# 18888: OpenClaw Console (via nginx reverse proxy to gateway loopback 18799)
+EXPOSE 8080 8001 9001 18888
 
 # ---- Persistent data ----
 # /data: MinIO object storage, secrets, worker credentials

--- a/manager/configs/manager-openclaw.json.tmpl
+++ b/manager/configs/manager-openclaw.json.tmpl
@@ -90,5 +90,9 @@
     "entries": {
       "matrix": { "enabled": true }
     }
+  },
+
+  "commands": {
+    "restart": true
   }
 }

--- a/manager/scripts/init/start-element-web.sh
+++ b/manager/scripts/init/start-element-web.sh
@@ -48,6 +48,24 @@ server {
         add_header Cache-Control "no-cache";
     }
 }
+
+# OpenClaw Console reverse proxy
+# Listens on 0.0.0.0:18799 and proxies to gateway loopback 127.0.0.1:18799
+# Exposed to host at 127.0.0.1:18888 via Docker port mapping
+server {
+    listen 18888;
+
+    location / {
+        proxy_pass http://127.0.0.1:18799;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+}
 NGINX
 
 # Remove default nginx site if exists

--- a/manager/scripts/init/start-manager-agent.sh
+++ b/manager/scripts/init/start-manager-agent.sh
@@ -302,7 +302,8 @@ if [ -f /root/manager-workspace/openclaw.json ]; then
         | .models.providers["hiclaw-gateway"].models[0].contextWindow = $ctx
         | .models.providers["hiclaw-gateway"].models[0].maxTokens = $max
         | .models.providers["hiclaw-gateway"].models[0].input = $input
-        | .agents.defaults.model.primary = ("hiclaw-gateway/" + $model)' \
+        | .agents.defaults.model.primary = ("hiclaw-gateway/" + $model)
+        | .commands.restart = true' \
        /root/manager-workspace/openclaw.json > /tmp/openclaw.json.tmp && \
         mv /tmp/openclaw.json.tmp /root/manager-workspace/openclaw.json
     # Verify the token was written correctly

--- a/manager/scripts/systemctl-shim.sh
+++ b/manager/scripts/systemctl-shim.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# systemctl shim for openclaw gateway restart support in Docker (no systemd available).
+# Intercepts openclaw-gateway service operations and uses SIGUSR1 for in-process restart.
+# All other calls are delegated to the real systemctl binary if present.
+
+# Parse subcommand and first unit (non-flag) argument from "$@"
+SUBCOMMAND=""
+UNIT=""
+for arg in "$@"; do
+    case "$arg" in
+        --*|-*) ;;
+        *)
+            if [[ -z "$SUBCOMMAND" ]]; then
+                SUBCOMMAND="$arg"
+            elif [[ -z "$UNIT" ]]; then
+                UNIT="$arg"
+            fi
+            ;;
+    esac
+done
+
+# Find a running gateway PID via the lock file directory
+find_gateway_pid() {
+    local lock_dir="/tmp/openclaw-$(id -u)"
+    local f pid
+    for f in "$lock_dir"/gateway.*.lock; do
+        [[ -f "$f" ]] || continue
+        pid=$(jq -r '.pid // empty' "$f" 2>/dev/null)
+        [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null && echo "$pid" && return 0
+    done
+    return 1
+}
+
+# Handle openclaw-gateway service operations, or bare 'status' (for assertSystemdAvailable)
+if [[ "$UNIT" == openclaw-gateway* || ( "$SUBCOMMAND" == "status" && -z "$UNIT" ) ]]; then
+    case "$SUBCOMMAND" in
+        status|daemon-reload|enable|disable)
+            exit 0
+            ;;
+        is-enabled)
+            if find_gateway_pid > /dev/null 2>&1; then
+                echo "enabled"
+                exit 0
+            fi
+            echo "disabled"
+            exit 1
+            ;;
+        restart)
+            pid=$(find_gateway_pid)
+            if [[ -z "$pid" ]]; then
+                echo "systemctl: openclaw gateway is not running" >&2
+                exit 1
+            fi
+            kill -USR1 "$pid"
+            echo "Restarted openclaw gateway (pid $pid via SIGUSR1)"
+            exit 0
+            ;;
+        stop)
+            pid=$(find_gateway_pid)
+            if [[ -n "$pid" ]]; then
+                kill -TERM "$pid"
+                echo "Stopped openclaw gateway (pid $pid)"
+            fi
+            exit 0
+            ;;
+    esac
+fi
+
+# Delegate everything else to the real systemctl
+for real in /bin/systemctl /usr/bin/systemctl /usr/sbin/systemctl; do
+    [[ -x "$real" ]] && exec "$real" "$@"
+done
+echo "systemctl: not available in this container" >&2
+exit 1


### PR DESCRIPTION
… 18888

Two independent features:

1. openclaw gateway restart support (without systemd):
   - Add systemctl-shim.sh installed as /usr/local/bin/systemctl Intercepts openclaw-gateway service calls: status/is-enabled/restart. restart uses kill -USR1 on the PID from the gateway lock file.
   - Enable commands.restart=true in openclaw.json template so the gateway accepts external SIGUSR1 for in-process restart.
   - Update jq update path in start-manager-agent.sh to also set commands.restart=true when updating an existing openclaw.json.

2. OpenClaw Console exposed at host port 18888:
   - Add nginx reverse-proxy server block (listen 18888 → proxy 127.0.0.1:18799) with WebSocket support in start-element-web.sh.
   - EXPOSE 18888 in Dockerfile.
   - Add HICLAW_PORT_OPENCLAW_CONSOLE (default 18888) to install script, written to env file and passed as -p to docker run.

Change-Id: I3abcf881088940feb66602a88d6d261f8bc68014
Co-developed-by: Claude <noreply@anthropic.com>