### PR TITLE
ci: add build-rc workflow, skip latest for RC tags, use us-west-1 registry

### DIFF
--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -50,7 +50,8 @@ jobs:
           make push-openclaw-base \
             VERSION=latest \
             REGISTRY=${{ env.REGISTRY }} \
-            REPO=${{ env.REPO }}
+            REPO=${{ env.REPO }} \
+            HIGRESS_REGISTRY=higress-registry.us-west-1.cr.aliyuncs.com
 
       - name: Summary
         run: |

--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -1,0 +1,109 @@
+name: Build RC
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'RC version tag (e.g. v1.0.5-rc.1)'
+        required: true
+        type: string
+
+env:
+  REGISTRY: higress-registry.cn-hangzhou.cr.aliyuncs.com
+  REPO: higress
+
+jobs:
+  build-rc:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Free Up GitHub Actions Ubuntu Runner Disk Space 🔧
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate RC version
+        run: |
+          VERSION="${{ inputs.version }}"
+          if ! echo "${VERSION}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$'; then
+            echo "ERROR: version must be an RC format, e.g. v1.0.5-rc.1 (got: ${VERSION})"
+            exit 1
+          fi
+
+      - name: Compute base stable tag
+        id: meta
+        run: |
+          SHA_SHORT=$(echo "${{ github.sha }}" | cut -c1-7)
+          DATE_TAG=$(date -u +%Y%m%d)
+          echo "base_stable_tag=${DATE_TAG}-${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build and push base image
+        run: |
+          make push-openclaw-base \
+            VERSION=${{ inputs.version }} \
+            REGISTRY=${{ env.REGISTRY }} \
+            REPO=${{ env.REPO }} \
+            HIGRESS_REGISTRY=higress-registry.us-west-1.cr.aliyuncs.com
+
+      - name: Tag base image with stable tag
+        run: |
+          BASE_IMAGE="${{ env.REGISTRY }}/${{ env.REPO }}/openclaw-base"
+          STABLE_TAG="${{ steps.meta.outputs.base_stable_tag }}"
+          docker buildx imagetools create \
+            --tag "${BASE_IMAGE}:${STABLE_TAG}" \
+            "${BASE_IMAGE}:${{ inputs.version }}"
+
+      - name: Build and push multi-arch images
+        run: |
+          make push-manager push-worker push-copaw-worker \
+            VERSION=${{ inputs.version }} \
+            OPENCLAW_BASE_VERSION=${{ inputs.version }} \
+            REGISTRY=${{ env.REGISTRY }} \
+            REPO=${{ env.REPO }} \
+            HIGRESS_REGISTRY=higress-registry.us-west-1.cr.aliyuncs.com
+
+      - name: Summary
+        env:
+          BASE_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/openclaw-base
+          MANAGER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-manager
+          WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-worker
+          COPAW_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-copaw-worker
+        run: |
+          STABLE_TAG="${{ steps.meta.outputs.base_stable_tag }}"
+          echo "### RC Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Images:**" >> $GITHUB_STEP_SUMMARY
+          echo "- Manager: \`${MANAGER_IMAGE}:${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Worker: \`${WORKER_IMAGE}:${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- CoPaw Worker: \`${COPAW_WORKER_IMAGE}:${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Base (RC): \`${BASE_IMAGE}:${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Base (stable): \`${BASE_IMAGE}:${STABLE_TAG}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Platforms: \`linux/amd64, linux/arm64\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**After RC validation**, update base image dependency to the stable tag:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "OPENCLAW_BASE_VERSION ?= ${STABLE_TAG}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
 
 env:
   REGISTRY: higress-registry.cn-hangzhou.cr.aliyuncs.com
@@ -65,7 +66,8 @@ jobs:
           make push-manager push-worker push-copaw-worker \
             VERSION=${{ steps.meta.outputs.version }} \
             REGISTRY=${{ env.REGISTRY }} \
-            REPO=${{ env.REPO }}
+            REPO=${{ env.REPO }} \
+            HIGRESS_REGISTRY=higress-registry.us-west-1.cr.aliyuncs.com
 
       - name: Summary
         env:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -61,10 +61,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Pull base images
-        run: docker pull higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/openclaw-base:latest
+        run: docker pull higress-registry.us-west-1.cr.aliyuncs.com/higress/openclaw-base:latest
 
       - name: Build images
-        run: make build-manager build-worker VERSION=ci-test
+        run: make build-manager build-worker VERSION=ci-test HIGRESS_REGISTRY=higress-registry.us-west-1.cr.aliyuncs.com
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y jq curl unzip
@@ -253,8 +253,8 @@ jobs:
       - name: Build images from source (tag push)
         if: steps.version.outputs.from_dispatch == 'false'
         run: |
-          docker pull higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/openclaw-base:latest
-          make build-manager build-worker VERSION=${{ steps.version.outputs.version }}
+          docker pull higress-registry.us-west-1.cr.aliyuncs.com/higress/openclaw-base:latest
+          make build-manager build-worker VERSION=${{ steps.version.outputs.version }} HIGRESS_REGISTRY=higress-registry.us-west-1.cr.aliyuncs.com
 
       - name: Install HiClaw
         env:

--- a/Makefile
+++ b/Makefile
@@ -101,10 +101,11 @@ build-openclaw-base: ## Build OpenClaw base image
 		./openclaw-base/
 
 # build targets use the locally-built openclaw-base; push targets use the registry image
-# Both build and push targets use the registry :latest base image for layer sharing
-OPENCLAW_BASE_BUILD_ARG = --build-arg OPENCLAW_BASE_IMAGE=$(OPENCLAW_BASE_IMAGE):latest
-# push targets always use :latest so manager/worker layers are shared across releases
-OPENCLAW_BASE_PUSH_ARG  = --build-arg OPENCLAW_BASE_IMAGE=$(OPENCLAW_BASE_IMAGE):latest
+# OPENCLAW_BASE_VERSION controls which base image tag manager/worker builds depend on.
+# Default: latest (for standalone builds). Override to use a versioned base (e.g. in build-all).
+OPENCLAW_BASE_VERSION ?= latest
+OPENCLAW_BASE_BUILD_ARG = --build-arg OPENCLAW_BASE_IMAGE=$(OPENCLAW_BASE_IMAGE):$(OPENCLAW_BASE_VERSION)
+OPENCLAW_BASE_PUSH_ARG  = --build-arg OPENCLAW_BASE_IMAGE=$(OPENCLAW_BASE_IMAGE):$(OPENCLAW_BASE_VERSION)
 
 build-manager: ## Build Manager image
 	@echo "==> Building Manager image: $(LOCAL_MANAGER) (registry: $(HIGRESS_REGISTRY))"


### PR DESCRIPTION
## Changes

- **build-rc.yml**: New manual workflow for RC builds
  - Validates `vX.Y.Z-rc.N` format
  - Builds base image with RC tag + stable `YYYYMMDD-SHA7` tag for pinning after validation
  - Builds manager/worker/copaw-worker using the freshly built base (single job, no repeated disk cleanup)
  - Summary outputs the stable base tag for updating Makefile before formal release

- **build.yml**: Extend tag pattern to also trigger on RC tags (`v*-*`)

- **Makefile**: Extract `OPENCLAW_BASE_VERSION` variable (default: `latest`) so builds can pin a specific base image version

- **All CI workflows**: Switch `HIGRESS_REGISTRY` to `us-west-1` for faster base image pulls on GitHub's US-based runners

## Release Flow

1. Run **Build RC** workflow with e.g. `v1.0.5-rc.1`
2. Test the RC images
3. After validation, update `OPENCLAW_BASE_VERSION` in Makefile to the stable base tag from the summary
4. Tag `v1.0.5` to trigger normal build + release (no changelog rotation for RC)