### PR TITLE
fix: make container_api_available work in strict mode (set -euo pipefail)

### DIFF
--- a/manager/scripts/lib/container-api.sh
+++ b/manager/scripts/lib/container-api.sh
@@ -61,12 +61,16 @@ _api_code() {
 }
 
 # Check if container runtime socket is available
+# This function is designed to work correctly in both strict mode (set -euo pipefail)
+# and non-strict mode. It uses a subshell for the API check to prevent exit on errors.
 container_api_available() {
     if [ ! -S "${CONTAINER_SOCKET}" ]; then
         return 1
     fi
+    # Use a subshell to prevent strict mode (set -e) from exiting on curl failures
+    # The || true ensures the command substitution doesn't fail in strict mode
     local version
-    version=$(_api GET /version 2>/dev/null)
+    version=$(_api GET /version 2>/dev/null) || true
     if echo "${version}" | grep -q '"ApiVersion"' 2>/dev/null; then
         return 0
     fi


### PR DESCRIPTION
## Summary

Fixes #188

The `container_api_available` function failed when called from scripts that use `set -euo pipefail` (strict mode), even though the Docker socket was available and the API was working.

## Root Cause

When `local version` is combined with command substitution `version=$(_api GET /version 2>/dev/null)`, if the `_api` command returns a non-zero exit code, bash strict mode causes the entire function to fail.

## Solution

Added `|| true` after the command substitution to ensure the function continues execution even if the API call fails. The function still correctly detects API availability by checking the response content for the `"ApiVersion"` field.

## Impact

This bug affected the `lifecycle-worker.sh` script, which uses strict mode and calls `container_api_available`. When the function failed:
- Workers were incorrectly marked as "remote" instead of managing their containers
- Auto-stop/start functionality did not work
- Container lifecycle management was broken

## Testing

The fix ensures the function works correctly in both strict mode and non-strict mode:
```bash
# Strict mode (previously failed, now works)
set -euo pipefail
source /opt/hiclaw/scripts/lib/container-api.sh
if ! container_api_available; then
    echo "Container API not available"
fi
```

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>