### PR TITLE
fix(manager): fix worker container recreation on Manager upgrade

### DIFF
--- a/manager/agent/HEARTBEAT.md
+++ b/manager/agent/HEARTBEAT.md
@@ -135,10 +135,11 @@ If the output is `available`, proceed with the following steps:
      message: Worker <name> container has been automatically paused due to idle timeout. It will be automatically resumed when a task is assigned.
      ```
 
-3. If a Worker has a running finite task but its container status is stopped (anomaly), start it and send an alert to the admin (see Step 7):
+3. If a Worker has a running finite task but its container status is `stopped` or `not_found` (anomaly), start/recreate it and send an alert to the admin (see Step 7):
    ```bash
    bash /opt/hiclaw/agent/skills/worker-management/scripts/lifecycle-worker.sh --action start --worker <name>
    ```
+   The `start` action automatically handles both cases: if the container exists but is stopped it will be started; if the container is missing it will be recreated from credentials and registry config.
 
 ---
 

--- a/manager/agent/skills/worker-management/scripts/lifecycle-worker.sh
+++ b/manager/agent/skills/worker-management/scripts/lifecycle-worker.sh
@@ -262,7 +262,8 @@ action_stop() {
     fi
 }
 
-# Start (wake up) a stopped worker container
+# Start (wake up) a stopped worker container, or recreate if the container
+# no longer exists (e.g. after Manager upgrade where old containers were removed).
 action_start() {
     local worker="$1"
     _init_lifecycle_file
@@ -273,8 +274,31 @@ action_start() {
         return 1
     fi
 
-    _log "Starting worker $worker"
-    if container_start_worker "$worker"; then
+    local status
+    status=$(container_status_worker "$worker")
+
+    local ok=false
+    if [ "$status" = "not_found" ]; then
+        _log "Worker $worker container not found — recreating"
+        local creds_file="/data/worker-creds/${worker}.env"
+        if [ ! -f "$creds_file" ]; then
+            _log "ERROR: No credentials found for $worker ($creds_file missing)"
+            return 1
+        fi
+        source "$creds_file"
+        local runtime
+        runtime=$(jq -r --arg w "$worker" '.workers[$w].runtime // "openclaw"' "$REGISTRY_FILE" 2>/dev/null)
+        if [ "$runtime" = "copaw" ]; then
+            container_create_copaw_worker "$worker" "$worker" "$WORKER_MINIO_PASSWORD" 2>&1 && ok=true
+        else
+            container_create_worker "$worker" "$worker" "$WORKER_MINIO_PASSWORD" 2>&1 && ok=true
+        fi
+    else
+        _log "Starting worker $worker (status: $status)"
+        container_start_worker "$worker" && ok=true
+    fi
+
+    if [ "$ok" = true ]; then
         local tmp
         tmp=$(mktemp)
         jq --arg w "$worker" --arg ts "$(_ts)" \
@@ -283,9 +307,9 @@ action_start() {
             | .workers[$w].last_started_at = $ts
             | .updated_at = $ts' \
             "$LIFECYCLE_FILE" > "$tmp" && mv "$tmp" "$LIFECYCLE_FILE"
-        _log "Worker $worker started and lifecycle file updated"
+        _log "Worker $worker running and lifecycle file updated"
     else
-        _log "ERROR: Failed to start worker $worker"
+        _log "ERROR: Failed to start/recreate worker $worker"
         return 1
     fi
 }

--- a/manager/scripts/init/start-manager-agent.sh
+++ b/manager/scripts/init/start-manager-agent.sh
@@ -367,9 +367,22 @@ if container_api_available; then
             _creds_file="/data/worker-creds/${_worker_name}.env"
             if [ -f "${_creds_file}" ]; then
                 source "${_creds_file}"
-                container_create_worker "${_worker_name}" "${_worker_name}" "${WORKER_MINIO_PASSWORD}" 2>&1 \
-                    && log "  Recreated worker: ${_worker_name}" \
-                    || log "  WARNING: Failed to recreate worker: ${_worker_name}"
+                _runtime=$(jq -r --arg w "${_worker_name}" '.workers[$w].runtime // "openclaw"' "${REGISTRY_FILE}" 2>/dev/null)
+                _recreated=false
+                for _attempt in 1 2 3; do
+                    if [ "${_runtime}" = "copaw" ]; then
+                        container_create_copaw_worker "${_worker_name}" "${_worker_name}" "${WORKER_MINIO_PASSWORD}" 2>&1 && _recreated=true && break
+                    else
+                        container_create_worker "${_worker_name}" "${_worker_name}" "${WORKER_MINIO_PASSWORD}" 2>&1 && _recreated=true && break
+                    fi
+                    log "  Attempt ${_attempt}/3 failed for ${_worker_name}, retrying in $((5 * _attempt))s..."
+                    sleep $((5 * _attempt))
+                done
+                if [ "${_recreated}" = true ]; then
+                    log "  Recreated ${_runtime} worker: ${_worker_name}"
+                else
+                    log "  ERROR: Failed to recreate ${_worker_name} after 3 attempts"
+                fi
             else
                 log "  WARNING: No credentials found for ${_worker_name} (${_creds_file} missing), skipping"
             fi

--- a/manager/scripts/lib/container-api.sh
+++ b/manager/scripts/lib/container-api.sh
@@ -29,7 +29,7 @@ _log() {
 _api() {
     local method="$1"
     local path="$2"
-    local data="$3"
+    local data="${3:-}"
     if [ -n "${data}" ]; then
         curl -s --unix-socket "${CONTAINER_SOCKET}" \
             -X "${method}" \
@@ -46,7 +46,7 @@ _api() {
 _api_code() {
     local method="$1"
     local path="$2"
-    local data="$3"
+    local data="${3:-}"
     if [ -n "${data}" ]; then
         curl -s -o /dev/null -w '%{http_code}' --unix-socket "${CONTAINER_SOCKET}" \
             -X "${method}" \
@@ -80,6 +80,38 @@ container_api_available() {
 # Get the Manager container's own IP (for Worker to connect back)
 container_get_manager_ip() {
     hostname -I 2>/dev/null | awk '{print $1}'
+}
+
+# Ensure a container image exists locally, pulling it if necessary.
+# Usage: _ensure_image <image>
+# The Docker/Podman "create image" API streams JSON progress; we wait for
+# completion and check the final status.
+_ensure_image() {
+    local image="$1"
+    # Quick check: does the image already exist locally?
+    local inspect
+    inspect=$(_api GET "/images/${image}/json" 2>/dev/null)
+    if echo "${inspect}" | grep -q '"Id"' 2>/dev/null; then
+        return 0
+    fi
+
+    _log "Image not found locally, pulling: ${image}"
+    # POST /images/create?fromImage=<ref> streams progress JSON.
+    # curl will block until the pull finishes (or fails).
+    local pull_output
+    pull_output=$(curl -s --unix-socket "${CONTAINER_SOCKET}" \
+        -X POST "${CONTAINER_API_BASE}/images/create?fromImage=${image}" 2>&1)
+
+    # Verify the image is now available
+    inspect=$(_api GET "/images/${image}/json" 2>/dev/null)
+    if echo "${inspect}" | grep -q '"Id"' 2>/dev/null; then
+        _log "Image pulled successfully: ${image}"
+        return 0
+    fi
+
+    _log "ERROR: Failed to pull image: ${image}"
+    _log "  Pull output (last 500 chars): ${pull_output: -500}"
+    return 1
 }
 
 # Create and start a Worker container
@@ -125,6 +157,11 @@ container_create_worker() {
     _log "  Image: ${WORKER_IMAGE}"
     _log "  FS endpoint: ${fs_endpoint}"
     _log "  Manager IP: ${manager_ip}"
+
+    # Pull image if not available locally
+    if ! _ensure_image "${WORKER_IMAGE}"; then
+        return 1
+    fi
 
     # Remove existing container with same name (if any)
     local existing
@@ -356,6 +393,11 @@ container_create_copaw_worker() {
     _log "  Image: ${COPAW_WORKER_IMAGE}"
     _log "  FS endpoint: ${fs_endpoint}"
     _log "  Manager IP: ${manager_ip}"
+
+    # Pull image if not available locally
+    if ! _ensure_image "${COPAW_WORKER_IMAGE}"; then
+        return 1
+    fi
 
     # Remove existing container with same name (if any)
     local existing


### PR DESCRIPTION
## Summary

- After Manager image upgrade, worker containers failed to recreate because the new version worker image was not present on the host (Docker API returned 404). Added `_ensure_image` helper that auto-pulls missing images via Docker/Podman API before container creation.
- The startup recreation logic always used `container_create_worker` (OpenClaw) regardless of the worker's actual runtime type recorded in `workers-registry.json`. CoPaw workers were incorrectly recreated with the OpenClaw image. Now dispatches to the correct creation function based on the `runtime` field.
- Extended `lifecycle-worker.sh` `action_start` to handle `not_found` containers by recreating them, so the heartbeat can recover workers whose containers were deleted (not just stopped).
- Added retry with backoff (3 attempts) to startup worker recreation for transient failures.
- Fixed `_api`/`_api_code` unbound `$3` variable under `set -u` strict mode, which caused `container_api_available` to always fail when called from scripts using `set -euo pipefail` (e.g. `lifecycle-worker.sh`).

## Test plan

- [x] Stop a worker container -> `lifecycle-worker.sh --action start` correctly starts it back
- [x] Remove a worker container -> `lifecycle-worker.sh --action start` detects `not_found`, reads runtime from registry, recreates with correct image (CoPaw)
- [x] Remove all worker containers -> restart Manager -> all workers recreated with correct runtime type and new version image
- [x] Verified `_api`/`_api_code` work under `set -euo pipefail` after the `${3:-}` fix
