### PR TITLE
fix(copaw): add debug logging for MinIO config pull failure diagnosis

### DIFF
--- a/copaw/pyproject.toml
+++ b/copaw/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "copaw-worker"
-version = "0.1.2"
+version = "0.1.3"
 description = "Lightweight HiClaw Worker runtime based on CoPaw"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/copaw/src/copaw_worker/sync.py
+++ b/copaw/src/copaw_worker/sync.py
@@ -27,8 +27,12 @@ def _mc(*args: str, check: bool = True) -> subprocess.CompletedProcess:
     if not mc_bin:
         raise RuntimeError("mc binary not found on PATH. Please install mc first.")
     cmd = [mc_bin, *args]
-    logger.debug("mc cmd: %s", " ".join(cmd))
-    return subprocess.run(cmd, capture_output=True, text=True, check=check)
+    logger.info("mc cmd: %s", " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True, check=check)
+    logger.info("mc stdout (%d chars): %r", len(result.stdout), result.stdout[:200])
+    if result.stderr:
+        logger.info("mc stderr: %r", result.stderr[:200])
+    return result
 
 
 class FileSync:
@@ -121,6 +125,7 @@ class FileSync:
         text = self._cat(f"{self._prefix}/openclaw.json")
         if not text:
             raise RuntimeError(f"openclaw.json not found in MinIO for worker {self.worker_name}")
+        logger.info("openclaw.json raw content (%d chars): %r", len(text), text[:500])
         return json.loads(text)
 
     def get_soul(self) -> Optional[str]:


### PR DESCRIPTION
## Summary
- Add info-level logging for `mc` command execution (full command, stdout, stderr) to diagnose startup failures when pulling config from MinIO
- Log raw `openclaw.json` content before JSON parsing to identify the root cause of `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` errors
- Bump copaw-worker version to 0.1.3

## Test plan
- [ ] Install updated copaw-worker and start a CoPaw Worker against a valid MinIO endpoint — verify mc commands and config content appear in logs
- [ ] Start a CoPaw Worker with an unreachable/misconfigured MinIO endpoint — verify the logs clearly show what mc returned


Made with [Cursor](https://cursor.com)