### PR TITLE
fix(worker): fix ELOOP symlink loop in skills directory on container restart

### DIFF
--- a/worker/scripts/worker-entrypoint.sh
+++ b/worker/scripts/worker-entrypoint.sh
@@ -69,7 +69,12 @@ ln -sf "${WORKSPACE}/openclaw.json" "${HOME}/.openclaw/openclaw.json"
 # Skills in ~/skills/ will be synced to MinIO and persist across container restarts
 mkdir -p "${HOME}/skills"
 mkdir -p "${HOME}/.agents"
-ln -sf "${HOME}/skills" "${HOME}/.agents/skills"
+# Clean up circular symlink from previous buggy ln -sf (which followed
+# the existing symlink-to-directory and created skills/skills -> skills inside it).
+[ -L "${HOME}/skills/skills" ] && rm -f "${HOME}/skills/skills"
+# Use -n (--no-dereference) so ln replaces an existing symlink-to-directory
+# instead of creating a nested symlink inside the target directory.
+ln -sfn "${HOME}/skills" "${HOME}/.agents/skills"
 
 log "Worker config pulled successfully"
 


### PR DESCRIPTION
## Summary

- Fix `ln -sf` → `ln -sfn` in `worker-entrypoint.sh` to prevent circular symlink creation on container restart
- Add cleanup for `~/skills/skills` circular symlink to fix already-affected users

## Root Cause

On container restart, `ln -sf ~/skills ~/.agents/skills` encounters an existing symlink-to-directory (`.agents/skills -> ~/skills`). The `ln -sf` command follows this symlink and treats it as a directory, creating a **nested** symlink `~/skills/skills -> ~/skills` inside the target — instead of replacing the original symlink.

This produces an infinite circular symlink:
```
~/skills/skills -> ~/skills -> (contains skills/) -> ~/skills/skills -> ...
```

The OpenClaw `[skills]` watcher then fails with:
```
ELOOP: too many symbolic links encountered, stat '.../skills/skills/skills/skills/...'
```

The fix uses `-n` (`--no-dereference`) so `ln` replaces the existing symlink atomically without following it.

## Test plan

- [x] Verified the bug is reproducible: `ln -sf` on a symlink-to-directory creates the circular symlink
- [x] Verified `ln -sfn` correctly replaces the existing symlink without creating the loop
- [x] Verified the cleanup line removes the stale `skills/skills` symlink for already-affected users
- [ ] Test Worker container restart: first boot → stop → start → skills watcher should work without ELOOP

	🤖 Generated with [Qoder][https://qoder.com]