### PR TITLE
fix(copaw_worker): render newlines as in Matrix HTML messages

### DIFF
--- a/copaw/src/copaw_worker/matrix_channel.py
+++ b/copaw/src/copaw_worker/matrix_channel.py
@@ -7,6 +7,7 @@ so CoPaw's channel registry picks it up automatically.
 from __future__ import annotations
 
 import asyncio
+import html
 import io
 import logging
 import mimetypes
@@ -55,6 +56,11 @@ except ImportError:  # pragma: no cover
 
 
 CHANNEL_KEY = "matrix"
+
+
+def _text_to_html(text: str) -> str:
+    """Escape HTML special chars and convert newlines to <br> for Matrix."""
+    return html.escape(text).replace("\n", "<br>\n")
 
 # Markers that separate accumulated history from the triggering message,
 # matching the convention used by OpenClaw so agents can parse uniformly.
@@ -883,8 +889,10 @@ class MatrixChannel(BaseChannel):
         )
 
         body = content.get("body", "")
+        # Reuse already-converted formatted_body (set by send()) or convert now
+        html_body = content.get("formatted_body") or _text_to_html(body)
         content["format"] = "org.matrix.custom.html"
-        content["formatted_body"] = f"{pill} {body}" if body else pill
+        content["formatted_body"] = f"{pill} {html_body}" if html_body else pill
         # Prepend plain-text fallback so non-HTML clients also see the mention
         content["body"] = f"{display_name} {body}" if body else display_name
 
@@ -916,7 +924,12 @@ class MatrixChannel(BaseChannel):
             return
 
         room_id = to_handle
-        content: dict[str, Any] = {"msgtype": "m.text", "body": text}
+        content: dict[str, Any] = {
+            "msgtype": "m.text",
+            "body": text,
+            "format": "org.matrix.custom.html",
+            "formatted_body": _text_to_html(text),
+        }
 
         sender_id = (meta or {}).get("sender_id") or (meta or {}).get("user_id")
         if sender_id:


### PR DESCRIPTION
## Summary                                                                                                                                       
                                                                                                                                                   
  Fix newlines not rendering in Matrix channel messages. Matrix clients (e.g. Element) ignore `\n` in the plain-text `body` field and only render
  line breaks via HTML `<br>` tags, causing multi-line AI replies to appear as a single collapsed line.                                            
                                                                      
  ## Changes                                                                                                                                       
                                                                      
  In `copaw/src/copaw_worker/matrix_channel.py`:
                                                
  1. Added `_text_to_html()` helper — escapes HTML special chars and converts `\n` to `<br>`
  2. `send()` — all outgoing messages now include `format: org.matrix.custom.html` and a `formatted_body`
  3. `_apply_mention()` — reuses the already-converted `formatted_body` from `send()` to avoid double-escaping

  ## Root Cause

  The Matrix spec requires newlines to be expressed via `formatted_body` (HTML). The plain-text `body` field is only a fallback for non-HTML
  clients and its `\n` characters are not rendered as line breaks.