### PR TITLE
fix(worker,copaw): Remote->Local sync allowlist for Manager-managed files only

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,3 +4,6 @@ Record image-affecting changes to `manager/`, `worker/`, `openclaw-base/` here b
 
 ---
 
+- fix(worker): Remote->Local sync pulls Manager-managed files only (allowlist) to avoid overwriting Worker-generated content (e.g. .openclaw sessions, memory)
+- fix(copaw): align sync ownership with OpenClaw worker (AGENTS.md/SOUL.md Worker-managed, push but never pull; allowlist for Remote->Local)
+

--- a/copaw/src/copaw_worker/sync.py
+++ b/copaw/src/copaw_worker/sync.py
@@ -1,8 +1,18 @@
 """MinIO file sync for copaw-worker.
 
 All MinIO operations use the `mc` CLI (MinIO Client).
-Pulls openclaw.json, SOUL.md, AGENTS.md, and skills from MinIO bucket.
-Runs a background loop that re-pulls on interval and calls on_pull callback.
+
+Ownership split (aligned with OpenClaw worker-entrypoint.sh):
+
+  Manager-managed (Worker read-only, pull only, never overwrite):
+    openclaw.json, mcporter-servers.json, skills/, shared/
+
+  Worker-managed (Worker read-write, push to MinIO, never pull-overwrite):
+    AGENTS.md, SOUL.md, .copaw/sessions/, memory/, etc.
+
+  Local -> Remote (push_loop): change-triggered push of Worker-managed content.
+  Remote -> Local (sync_loop pull_all): allowlist only, Manager-managed paths.
+  Prevents .copaw/sessions conflict: sessions backed up but never pulled back.
 """
 from __future__ import annotations
 
@@ -155,12 +165,15 @@ class FileSync:
         return self._cat(f"{self._prefix}/skills/{skill_name}/SKILL.md")
 
     def pull_all(self) -> list[str]:
-        """Pull all known files; return list of filenames that changed."""
+        """Pull Manager-managed files only (allowlist). Returns list of filenames that changed.
+
+        Does NOT pull AGENTS.md, SOUL.md (Worker-managed, sync up but never overwrite).
+        """
         changed: list[str] = []
+        # Manager-managed files (allowlist)
         files = {
             "openclaw.json": f"{self._prefix}/openclaw.json",
-            "SOUL.md": f"{self._prefix}/SOUL.md",
-            "AGENTS.md": f"{self._prefix}/AGENTS.md",
+            "mcporter-servers.json": f"{self._prefix}/mcporter-servers.json",
         }
         for name, key in files.items():
             content = self._cat(key)
@@ -169,10 +182,11 @@ class FileSync:
             local = self.local_dir / name
             existing = local.read_text() if local.exists() else None
             if content != existing:
+                local.parent.mkdir(parents=True, exist_ok=True)
                 local.write_text(content)
                 changed.append(name)
 
-        # Also check for skill changes
+        # Manager-managed: skills/
         for skill_name in self.list_skills():
             skill_md = self.get_skill_md(skill_name)
             if skill_md is None:
@@ -215,20 +229,17 @@ def push_local(sync: FileSync, since: float = 0) -> list[str]:
     mtime > `since` (epoch seconds), then content-compares before uploading.
     When since=0 (first run), scans all eligible files.
 
-    Excludes Manager-owned config files and internal dirs, matching the
-    exclude list in worker-entrypoint.sh's Local->Remote sync.
+    Excludes Manager-managed files only. AGENTS.md, SOUL.md, .copaw/sessions/
+    are Worker-managed and are pushed (including session backup).
     """
-    # Manager-owned files that should never be pushed back (workspace root)
+    # Manager-managed files that should never be pushed back (workspace root)
     _EXCLUDE_FILES = {
         "openclaw.json",
-        "AGENTS.md",
-        "SOUL.md",
         "mcporter-servers.json",
     }
     # Directory name components to skip anywhere in the tree
     _EXCLUDE_DIRS = {
         ".agents",
-        ".openclaw",
         ".cache",
         ".npm",
         ".local",

--- a/copaw/src/copaw_worker/worker.py
+++ b/copaw/src/copaw_worker/worker.py
@@ -107,11 +107,13 @@ class Worker:
         self._copaw_working_dir = self.config.install_dir / self.worker_name / ".copaw"
         self._copaw_working_dir.mkdir(parents=True, exist_ok=True)
 
-        # Write SOUL.md / AGENTS.md into CoPaw working dir
+        # Write SOUL.md / AGENTS.md into CoPaw working dir and workspace root (Worker-managed)
         if soul_content:
             (self._copaw_working_dir / "SOUL.md").write_text(soul_content)
+            (self.sync.local_dir / "SOUL.md").write_text(soul_content)
         if agents_content:
             (self._copaw_working_dir / "AGENTS.md").write_text(agents_content)
+            (self.sync.local_dir / "AGENTS.md").write_text(agents_content)
 
         # 4. Bridge openclaw.json -> CoPaw config.json + providers.json
         console.print("[yellow]Bridging configuration to CoPaw...[/yellow]")
@@ -341,24 +343,22 @@ class Worker:
     # ------------------------------------------------------------------
 
     async def _on_files_pulled(self, pulled_files: list[str]) -> None:
-        """Re-bridge config when openclaw.json / SOUL.md / AGENTS.md change."""
+        """Re-bridge config when Manager-managed files change (openclaw.json).
+        SOUL.md, AGENTS.md are Worker-managed and not pulled; use local copies."""
         # Re-sync skills if any skill file changed
         if any(f.startswith("skills/") for f in pulled_files):
             self._sync_skills()
 
-        needs_rebridge = any(
-            name in f
-            for f in pulled_files
-            for name in ("openclaw.json", "SOUL.md", "AGENTS.md")
-        )
+        needs_rebridge = "openclaw.json" in pulled_files
         if not needs_rebridge:
             return
 
         console.print("[yellow]Config changed, re-bridging...[/yellow]")
         try:
             openclaw_cfg = self.sync.get_config()
-            soul = self.sync.get_soul()
-            agents = self.sync.get_agents_md()
+            # Use local Worker-managed files; fallback to MinIO for initial bootstrap
+            soul = (self.sync.local_dir / "SOUL.md").read_text() if (self.sync.local_dir / "SOUL.md").exists() else self.sync.get_soul()
+            agents = (self.sync.local_dir / "AGENTS.md").read_text() if (self.sync.local_dir / "AGENTS.md").exists() else self.sync.get_agents_md()
 
             if soul:
                 (self._copaw_working_dir / "SOUL.md").write_text(soul)

--- a/worker/scripts/worker-entrypoint.sh
+++ b/worker/scripts/worker-entrypoint.sh
@@ -92,21 +92,36 @@ log "HOME set to ${HOME} (workspace files will be synced to MinIO)"
 # ============================================================
 # Step 3: Start file sync
 # ============================================================
-
-# Local -> Remote: change-triggered sync (avoids mc mirror --watch TOCTOU crash bug)
-# Note: mc mirror --watch has a bug where it crashes when source files are deleted
-# during atomic operations (e.g., npm install, skills add). This approach:
-# - Uses find to detect recent file changes (lightweight, local filesystem only)
-# - Only runs mc mirror when changes are detected (avoids unnecessary network IO)
-# - mc mirror itself only transfers changed files (incremental)
+#
+# Bidirectional sync between Worker workspace and MinIO, with clear ownership split:
+#
+# Manager-managed (Worker read-only, Remote->Local pulls):
+#   openclaw.json, mcporter-servers.json, skills/, shared/
+#
+# Worker-managed (Worker read-write, Local->Remote pushes, never pulled):
+#   AGENTS.md, SOUL.md, .openclaw/ (sessions), memory/, skills add output, etc.
+#
+# Local -> Remote: change-triggered sync
+#   - Avoids mc mirror --watch TOCTOU bug (crashes when source files deleted during
+#     atomic ops e.g. npm install, skills add)
+#   - Uses find to detect files modified in last 10s; only runs mc mirror when needed
+#   - Excludes Manager-managed files (openclaw.json, mcporter-servers.json) and
+#     caches (.agents, .cache, .npm, .local, .mc)
+#   - Pushes Worker-managed content including .openclaw sessions (backup to MinIO)
+#
+# Remote -> Local: periodic pull (every 5m), allowlist only
+#   - Pulls only Manager-managed paths; never overwrites Worker-generated content
+#   - Prevents .openclaw session conflict: sessions are backed up up but never
+#     pulled back (would overwrite real-time session state)
+#   - On-demand pull also available via file-sync skill when Manager notifies
+#
 (
     while true; do
         # Check for files modified in the last 10 seconds
         CHANGED=$(find "${WORKSPACE}/" -type f -newermt "10 seconds ago" 2>/dev/null | head -1)
         if [ -n "${CHANGED}" ]; then
             if ! mc mirror "${WORKSPACE}/" "hiclaw/hiclaw-storage/agents/${WORKER_NAME}/" --overwrite \
-                --exclude "openclaw.json" --exclude "AGENTS.md" --exclude "SOUL.md" \
-                --exclude "mcporter-servers.json" --exclude ".agents/**" \
+                --exclude "openclaw.json" --exclude "mcporter-servers.json" --exclude ".agents/**" \
                 --exclude ".cache/**" --exclude ".npm/**" \
                 --exclude ".local/**" --exclude ".mc/**" 2>&1; then
                 log "WARNING: Local->Remote sync failed"
@@ -117,16 +132,17 @@ log "HOME set to ${HOME} (workspace files will be synced to MinIO)"
 ) &
 log "Local->Remote change-triggered sync started (PID: $!)"
 
-# Remote -> Local: periodic pull (configs from Manager + shared data)
-# On-demand pull via file-sync skill when Manager notifies
+# Remote -> Local: periodic pull (allowlist, see block above)
 (
     while true; do
         sleep 300
-        mc mirror "hiclaw/hiclaw-storage/agents/${WORKER_NAME}/" "${WORKSPACE}/" --overwrite --newer-than "5m" 2>/dev/null || true
+        mc cp "hiclaw/hiclaw-storage/agents/${WORKER_NAME}/openclaw.json" "${WORKSPACE}/openclaw.json" 2>/dev/null || true
+        mc cp "hiclaw/hiclaw-storage/agents/${WORKER_NAME}/mcporter-servers.json" "${WORKSPACE}/mcporter-servers.json" 2>/dev/null || true
+        mc mirror "hiclaw/hiclaw-storage/agents/${WORKER_NAME}/skills/" "${WORKSPACE}/skills/" --overwrite 2>/dev/null || true
         mc mirror "hiclaw/hiclaw-storage/shared/" "${HICLAW_ROOT}/shared/" --overwrite --newer-than "5m" 2>/dev/null || true
     done
 ) &
-log "Remote->Local periodic sync started (every 5m, PID: $!)"
+log "Remote->Local periodic sync started (Manager-managed files only, every 5m, PID: $!)"
 
 # ============================================================
 # Step 4: Configure mcporter (MCP tool CLI)


### PR DESCRIPTION
## Summary

Align Remote->Local sync with clear ownership split:
- **Manager-managed** (pull only): openclaw.json, mcporter-servers.json, skills/, shared/
- **Worker-managed** (push to MinIO, never pull): AGENTS.md, SOUL.md, .openclaw/ sessions, memory/, etc.

## Changes

### Worker (worker-entrypoint.sh)
- Remote->Local: allowlist only (mc cp + mc mirror for specific paths)
- AGENTS.md, SOUL.md: Worker-managed, sync up but never pull-overwrite
- .openclaw/ sessions: backed up to MinIO but never pulled back (avoids overwriting real-time session state)
- Add sync mechanism doc to Step 3 comment block

### CoPaw (sync.py, worker.py)
- pull_all: allowlist (openclaw.json, mcporter-servers.json, skills/, shared/)
- push_local: remove AGENTS.md, SOUL.md, .openclaw from exclude (Worker-managed)
- .copaw/sessions: push for backup, never pull
- _on_files_pulled: re-bridge uses local SOUL/AGENTS
- Bootstrap: write SOUL.md, AGENTS.md to both .copaw/ and local_dir root


Made with [Cursor](https://cursor.com)