### PR TITLE
feat(manager): add worker unresponsiveness policy and agent doc updates

### DIFF
--- a/manager/agent/AGENTS.md
+++ b/manager/agent/AGENTS.md
@@ -177,6 +177,16 @@ Example of CORRECT behavior (continues workflow):
 
 **Farewell / sign-off detection**: If a Worker's message contains only farewell phrases ("回见", "拜拜", "bye", "see you", "good night") with no task content — **stay silent**. Do not echo back a farewell with @mention.
 
+### Worker Unresponsiveness — Patience and Recovery
+
+When **multiple occurrences** in the history context show you sent messages to a Worker and the Worker did not reply:
+
+- **Likely cause**: The Worker may be processing a complex task. The default Worker task timeout is **30 minutes** — be patient and wait.
+- **If the Worker has been silent for too long** and the admin expresses impatience or asks to intervene:
+  - Propose creating a **new three-person room** (Human + Manager + Worker) with a fresh session to try to wake the Worker.
+  - **Wait for the admin's explicit agreement** before proceeding.
+  - After the admin agrees, create the new room and invite the Worker — this gives the Worker a clean context and may restore responsiveness. Use the **matrix-server-management** skill (Create a Room — 3-party) for the API.
+
 ## Multi-Channel Identity & Permissions
 
 When receiving a message, determine the sender's identity in this order:

--- a/manager/agent/HEARTBEAT.md
+++ b/manager/agent/HEARTBEAT.md
@@ -148,7 +148,8 @@ If the output is `available`, proceed with the following steps:
 **All heartbeat findings MUST be sent to the admin via the `message` tool** (not as a reply in the current heartbeat context).
 
 - If all Workers are healthy and there are no pending items: HEARTBEAT_OK (no message needed)
-- Otherwise, send a summary to the admin. **Priority order** (determined in Step 1):
+- Otherwise, **read SOUL.md first** — use the identity, personality, and **user's preferred language** defined there when composing the report. Report in that language and tone.
+- Send a summary to the admin. **Priority order** (determined in Step 1):
 
 **Primary channel** (preferred) — if `primary-channel.json` has `confirmed: true` and `channel` is not `"matrix"`, use the `message` tool:
 
@@ -156,11 +157,11 @@ If the output is `available`, proceed with the following steps:
 |-----------|-------|
 | `channel` | `.channel` from `primary-channel.json` |
 | `target`  | `.to` from `primary-channel.json` |
-| `message` | `[Heartbeat Report] <summarize findings and recommended actions>` |
+| `message` | `[Heartbeat Report] <summarize findings and recommended actions, in SOUL.md persona and language>` |
 
 **Matrix DM** (fallback) — if no primary channel is configured, use `admin_dm_room_id` from state.json:
 
 | Parameter | Value |
 |-----------|-------|
 | `target`  | `room:<admin_dm_room_id>` |
-| `message` | `[Heartbeat Report] <summarize findings and recommended actions>` |
+| `message` | `[Heartbeat Report] <summarize findings and recommended actions, in SOUL.md persona and language>` |

--- a/manager/agent/TOOLS.md
+++ b/manager/agent/TOOLS.md
@@ -100,6 +100,7 @@ Full lifecycle of Worker containers and skill assignments.
 1. A 3-person room (Human + Manager + Worker) has been created — please check your Matrix invitations and accept it
 2. In any group room with 3+ people, you must **@mention** the person you want to respond — they only wake up when explicitly mentioned
 3. You can also click the Worker's avatar to open a **direct message** with them — no @mention needed, and the conversation is private (Manager cannot see it)
+4. In Element and other clients, type `@` then the first letter(s) of the worker's nickname to trigger the nickname autocomplete suggestions
 
 ## project-management
 


### PR DESCRIPTION
- AGENTS.md: add Worker Unresponsiveness section — 30min patience, propose new three-person room when admin impatient (requires explicit approval)
- HEARTBEAT.md: use SOUL.md persona and language for heartbeat reports
- TOOLS.md: add Element @mention autocomplete tip

Made-with: Cursor