### PR TITLE
fix(manager): track remote/local deployment in workers-registry, skip remote workers on restart

### DIFF
--- a/manager/agent/skills/worker-management/SKILL.md
+++ b/manager/agent/skills/worker-management/SKILL.md
@@ -300,7 +300,7 @@ Fields:
 - `auto_stopped_at`: when the Manager auto-stopped the container (audit trail)
 - `last_started_at`: when the Manager last started/woke the container
 
-`container_status = "remote"` means the Worker is remotely deployed (no container API access) and is excluded from automatic lifecycle management.
+`container_status = "remote"` means the Worker is remotely deployed (no container API access) and is excluded from automatic lifecycle management. Workers with `deployment: "remote"` in `workers-registry.json` are also excluded from container recreate on Manager restart.
 
 ### Manual Commands
 
@@ -336,6 +336,27 @@ jq '.idle_timeout_minutes = 60' ~/worker-lifecycle.json > /tmp/lc.json && mv /tm
 | Worker needs reset or config update | `create-worker.sh` (removes old container first) | Full rebuild; Matrix account is reused |
 | copaw runtime worker (container) | `lifecycle-worker.sh --action start` | Restarts the existing CoPaw container |
 | copaw runtime worker (remote) | `copaw-worker --name <name> ...` (on target machine) | Not container-managed; lifecycle scripts skip these workers |
+| Any runtime worker (remote deployment) | Admin runs install command on target machine | `deployment: "remote"` in registry; Manager skips auto-restart on upgrade |
+
+### Get Remote Worker Install Command
+
+When the admin asks for the install/start command for a remote Worker (e.g., after Manager upgrade or to re-deploy on another machine):
+
+```bash
+bash /opt/hiclaw/agent/skills/worker-management/scripts/get-worker-install-cmd.sh --worker <name>
+```
+
+Output:
+```json
+{
+  "worker": "alice",
+  "runtime": "copaw",
+  "deployment": "remote",
+  "install_cmd": "pip install -i https://mirrors.aliyun.com/pypi/simple/ copaw-worker && copaw-worker --name alice --fs http://fs-local.hiclaw.io:18080 --fs-key alice --fs-secret <secret> --console-port 8088"
+}
+```
+
+Provide the `install_cmd` value **verbatim in a code block** to the admin — do NOT redact any parameter values. The command must be directly copy-pasteable. Also remind the admin that the target machine must resolve the Manager's domains (see "Post-creation" notes above).
 
 ## CoPaw Console Management
 
@@ -395,6 +416,7 @@ Format:
       "matrix_user_id": "@<name>:<domain>",
       "room_id": "!xxx:<domain>",
       "runtime": "openclaw",
+      "deployment": "local",
       "skills": ["file-sync", "github-operations"],
       "created_at": "2026-01-01T00:00:00Z",
       "skills_updated_at": "2026-01-01T00:00:00Z"
@@ -404,6 +426,8 @@ Format:
 ```
 
 `runtime` is `"openclaw"` (default, container-based) or `"copaw"` (pip-installed Python process). Omitted field defaults to `"openclaw"` for backward compatibility.
+
+`deployment` is `"local"` (Manager-managed container) or `"remote"` (admin-managed, runs on a separate machine). Omitted field defaults to `"local"` for backward compatibility. Remote workers are excluded from automatic container lifecycle management (auto-stop/start/recreate on Manager restart). After a Manager upgrade, remote workers must be restarted by the admin manually.
 
 `file-sync` is the bootstrap skill (image-managed) and is always included.
 

--- a/manager/agent/skills/worker-management/scripts/create-worker.sh
+++ b/manager/agent/skills/worker-management/scripts/create-worker.sh
@@ -391,6 +391,15 @@ fi
 # By default, a Worker only accepts @mentions from Manager and the human admin.
 # This prevents infinite mutual-mention loops between Workers.
 # Inter-worker direct @mentions must be explicitly enabled per-project when needed.
+# Pre-compute deployment hint for registry (actual DEPLOY_MODE is finalized in Step 9)
+# "remote" = admin will run the worker themselves; "local" = Manager-managed container
+# If container creation fails in Step 9, this will be corrected to "remote" afterward.
+if [ "${REMOTE_MODE}" = true ]; then
+    DEPLOY_MODE_HINT="remote"
+else
+    DEPLOY_MODE_HINT="local"
+fi
+
 REGISTRY_FILE_EARLY="${HOME}/workers-registry.json"
 
 # ============================================================
@@ -496,11 +505,13 @@ jq --arg w "${WORKER_NAME}" \
    --arg rid "${ROOM_ID}" \
    --arg ts "${NOW_TS}" \
    --arg runtime "${WORKER_RUNTIME}" \
+   --arg deployment "${DEPLOY_MODE_HINT}" \
    --argjson skills "${SKILLS_JSON}" \
    '.workers[$w] = {
      "matrix_user_id": $uid,
      "room_id": $rid,
      "runtime": $runtime,
+     "deployment": $deployment,
      "skills": $skills,
      "created_at": (if .workers[$w].created_at? then .workers[$w].created_at else $ts end),
      "skills_updated_at": $ts
@@ -623,6 +634,16 @@ elif container_api_available; then
 else
     log "Step 9: No container runtime socket available"
     INSTALL_CMD=$(_build_install_cmd)
+fi
+
+# ============================================================
+# Step 9b: Correct deployment field if actual mode differs from hint
+# ============================================================
+if [ "${DEPLOY_MODE}" = "remote" ] && [ "${DEPLOY_MODE_HINT}" = "local" ]; then
+    log "Step 9b: Container creation failed, correcting deployment to 'remote' in registry..."
+    jq --arg w "${WORKER_NAME}" '.workers[$w].deployment = "remote"' \
+        "${REGISTRY_FILE}" > /tmp/workers-registry-deploy-fix.json
+    mv /tmp/workers-registry-deploy-fix.json "${REGISTRY_FILE}"
 fi
 
 # ============================================================

--- a/manager/agent/skills/worker-management/scripts/get-worker-install-cmd.sh
+++ b/manager/agent/skills/worker-management/scripts/get-worker-install-cmd.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# get-worker-install-cmd.sh - Output the install/start command for a remote Worker
+#
+# Reads workers-registry.json and worker credentials to build the command
+# that the admin needs to run on the target machine.
+#
+# Usage:
+#   get-worker-install-cmd.sh --worker <NAME>
+#
+# Output: JSON with install_cmd field on success, error JSON on failure.
+
+set -euo pipefail
+
+source /opt/hiclaw/scripts/lib/base.sh
+
+WORKER_NAME=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --worker) WORKER_NAME="$2"; shift 2 ;;
+        *) echo '{"error": "Unknown option: '"$1"'"}'; exit 1 ;;
+    esac
+done
+
+if [ -z "${WORKER_NAME}" ]; then
+    echo '{"error": "Usage: get-worker-install-cmd.sh --worker <NAME>"}'
+    exit 1
+fi
+
+REGISTRY_FILE="${HOME}/workers-registry.json"
+
+if [ ! -f "${REGISTRY_FILE}" ]; then
+    echo '{"error": "workers-registry.json not found"}'
+    exit 1
+fi
+
+# Check worker exists in registry
+if ! jq -e --arg w "${WORKER_NAME}" '.workers[$w]' "${REGISTRY_FILE}" > /dev/null 2>&1; then
+    echo '{"error": "Worker '"${WORKER_NAME}"' not found in registry"}'
+    exit 1
+fi
+
+RUNTIME=$(jq -r --arg w "${WORKER_NAME}" '.workers[$w].runtime // "openclaw"' "${REGISTRY_FILE}")
+DEPLOYMENT=$(jq -r --arg w "${WORKER_NAME}" '.workers[$w].deployment // "local"' "${REGISTRY_FILE}")
+
+# Load credentials
+CREDS_FILE="/data/worker-creds/${WORKER_NAME}.env"
+if [ ! -f "${CREDS_FILE}" ]; then
+    echo '{"error": "Credentials file not found: '"${CREDS_FILE}"'"}'
+    exit 1
+fi
+source "${CREDS_FILE}"
+
+# Build the install command
+FS_DOMAIN="${HICLAW_FS_DOMAIN:-fs-local.hiclaw.io}"
+FS_EXTERNAL_PORT="${HICLAW_PORT_GATEWAY:-18080}"
+FS_EXTERNAL_ENDPOINT="http://${FS_DOMAIN}:${FS_EXTERNAL_PORT}"
+FS_INTERNAL_ENDPOINT="http://${FS_DOMAIN}:8080"
+
+if [ "${RUNTIME}" = "copaw" ]; then
+    INSTALL_CMD="pip install -i https://mirrors.aliyun.com/pypi/simple/ copaw-worker && copaw-worker --name ${WORKER_NAME} --fs ${FS_EXTERNAL_ENDPOINT} --fs-key ${WORKER_NAME} --fs-secret ${WORKER_MINIO_PASSWORD} --console-port 8088"
+else
+    INSTALL_CMD="bash hiclaw-install.sh worker --name ${WORKER_NAME} --fs ${FS_INTERNAL_ENDPOINT} --fs-key ${WORKER_NAME} --fs-secret ${WORKER_MINIO_PASSWORD}"
+fi
+
+jq -n \
+    --arg worker "${WORKER_NAME}" \
+    --arg runtime "${RUNTIME}" \
+    --arg deployment "${DEPLOYMENT}" \
+    --arg install_cmd "${INSTALL_CMD}" \
+    '{
+        worker: $worker,
+        runtime: $runtime,
+        deployment: $deployment,
+        install_cmd: $install_cmd
+    }'

--- a/manager/agent/skills/worker-management/scripts/lifecycle-worker.sh
+++ b/manager/agent/skills/worker-management/scripts/lifecycle-worker.sh
@@ -269,6 +269,15 @@ action_start() {
     _init_lifecycle_file
     _ensure_worker_entry "$worker"
 
+    # Skip remote workers — they are not Manager-managed containers
+    local deployment
+    deployment=$(jq -r --arg w "$worker" '.workers[$w].deployment // "local"' "$REGISTRY_FILE" 2>/dev/null)
+    if [ "$deployment" = "remote" ]; then
+        _log "Worker $worker is remote — cannot start via container API"
+        _log "The admin should restart this worker on the target machine manually"
+        return 1
+    fi
+
     if ! container_api_available; then
         _log "ERROR: Container API not available"
         return 1

--- a/manager/scripts/init/start-manager-agent.sh
+++ b/manager/scripts/init/start-manager-agent.sh
@@ -344,6 +344,14 @@ if container_api_available; then
     if [ -f "${REGISTRY_FILE}" ]; then
         for _worker_name in $(jq -r '.workers | keys[]' "${REGISTRY_FILE}" 2>/dev/null); do
             [ -z "${_worker_name}" ] && continue
+
+            # Skip remote workers — they are not Manager-managed containers.
+            _deployment=$(jq -r --arg w "${_worker_name}" '.workers[$w].deployment // "local"' "${REGISTRY_FILE}" 2>/dev/null)
+            if [ "${_deployment}" = "remote" ]; then
+                log "Worker ${_worker_name} is remote, skipping container recreate"
+                continue
+            fi
+
             _status=$(container_status_worker "${_worker_name}")
             if [ "${_status}" = "running" ]; then
                 # Check if ExtraHosts IP still matches current Manager IP.


### PR DESCRIPTION
## Summary

Add \`deployment\` field (\`\"local\"\` | \`\"remote\"\`) to \`workers-registry.json\` so the Manager knows which workers are container-managed vs admin-managed.

### Changes

- **create-worker.sh**: records \`deployment\` based on \`--remote\` flag (corrects to \`\"remote\"\` if container creation fails)
- **start-manager-agent.sh**: skips remote workers during post-restart container recreate loop
- **lifecycle-worker.sh**: rejects \`start\` action for remote workers with clear message
- **get-worker-install-cmd.sh** (new): reads registry + creds to output a copy-pasteable install command with full credentials
- **SKILL.md**: documents \`deployment\` field and \`get-worker-install-cmd.sh\` usage

### Backward compatibility

Missing \`deployment\` field defaults to \`\"local\"\` — existing registries work without migration.

Fixes #272