### PR TITLE
fix(manager): Worker ExtraHosts 支持自定义域名，修复 ECS 公网部署 NAT 回环问题 || fix(manager): Worker ExtraHosts supports custom domain names and fixes NAT loopback issues in ECS public network deployment

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -31,3 +31,4 @@ Record image-affecting changes to `manager/`, `worker/`, `openclaw-base/` here b
 - feat(manager): pre-configure all known models in openclaw.json templates — switching between known models is now a hot-reload (no restart); unknown models are appended dynamically with RESTART_REQUIRED output
 - feat(manager): model-switch and worker-model-switch scripts detect known vs unknown models via openclaw.json models array instead of overwriting models[0]
 - feat(manager): model-switch and worker-model-switch SKILL.md updated — Agent checks script output for RESTART_REQUIRED to decide whether to prompt user for restart
+- fix(manager): ExtraHosts now injected for all configured domains when creating Worker containers, not just `*-local.hiclaw.io` — fixes NAT hairpin issue on ECS where Workers could not reach Manager via custom public domains

--- a/manager/scripts/lib/container-api.sh
+++ b/manager/scripts/lib/container-api.sh
@@ -147,9 +147,7 @@ container_create_worker() {
     local fs_host="${HICLAW_FS_DOMAIN:-fs-local.hiclaw.io}"
 
     for h in "${matrix_host}" "${matrix_client_host}" "${ai_gw_host}" "${fs_host}"; do
-        if [[ "${h}" == *-local.hiclaw.io ]]; then
-            extra_hosts="${extra_hosts}\"${h}:${manager_ip}\","
-        fi
+        extra_hosts="${extra_hosts}\"${h}:${manager_ip}\","
     done
     extra_hosts="${extra_hosts%,}"
 
@@ -383,9 +381,7 @@ container_create_copaw_worker() {
     local fs_host="${HICLAW_FS_DOMAIN:-fs-local.hiclaw.io}"
 
     for h in "${matrix_host}" "${matrix_client_host}" "${ai_gw_host}" "${fs_host}"; do
-        if [[ "${h}" == *-local.hiclaw.io ]]; then
-            extra_hosts="${extra_hosts}\"${h}:${manager_ip}\","
-        fi
+        extra_hosts="${extra_hosts}\"${h}:${manager_ip}\","
     done
     extra_hosts="${extra_hosts%,}"
 


### PR DESCRIPTION
## 问题描述

在 ECS 上使用自定义域名部署 HiClaw 时（如 `matrix.cnkirito.cn`），Worker 容器无法与 Manager 正常通信。

### 根因分析

云厂商的 ECS 存在 **NAT 回环（Hairpin NAT）限制**：ECS 上的容器无法通过自身的公网 IP 访问自己。

当前 `container_create_worker` 和 `container_create_copaw_worker` 在创建 Worker 容器时，使用 `ExtraHosts` 将域名解析到 Manager 内网 IP，但有一个过滤条件：

```bash
if [[ "${h}" == *-local.hiclaw.io ]]; then
    extra_hosts="${extra_hosts}\"${h}:${manager_ip}\","
fi
```

**只有 `*-local.hiclaw.io` 格式的域名才会被注入 ExtraHosts**，自定义域名（如 `matrix.cnkirito.cn`）会被跳过。

### 影响

在 ECS 公网部署场景下：

1. 用户配置自定义域名，DNS 解析到 ECS 公网 IP
2. Worker 容器访问 `matrix.cnkirito.cn:18080` 时，解析到公网 IP
3. ECS 无法通过自身公网 IP 回环访问自己，请求被 NAT 丢弃
4. **Worker 与 Manager 之间的 Matrix 通信完全断开**

HiClaw 所有 Manager-Worker 通信都经过 Matrix Server（via Higress Gateway），Matrix 域名不通意味着整个系统不可用。

### 修复方案

去掉 `*-local.hiclaw.io` 的过滤条件，对所有配置的域名都注入 ExtraHosts，使 Worker 容器内的域名直接解析到 Manager 容器的内网 IP。

修改涉及 `container-api.sh` 中的两处：
- `container_create_worker`（OpenClaw Worker）
- `container_create_copaw_worker`（CoPaw Worker）

### 对默认部署（*-local.hiclaw.io）的影响

无影响。默认域名同样会被注入 ExtraHosts，行为与之前一致。

## 测试计划

- [ ] 使用默认 `*-local.hiclaw.io` 域名部署，验证 Worker 创建和通信正常（回归测试）
- [ ] 使用自定义域名部署，验证 Worker ExtraHosts 包含所有域名
- [ ] 在 ECS 上使用自定义域名部署，验证 Worker 与 Manager Matrix 通信正常

🤖 Generated with [Qoder][https://qoder.com]
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Problem description

When deploying HiClaw on ECS using a custom domain name (such as `matrix.cnkirito.cn`), the Worker container cannot communicate with the Manager normally.

### Root cause analysis

Cloud vendors' ECS has **NAT loopback (Hairpin NAT) limitations**: containers on ECS cannot access themselves through their own public IPs.

Currently, `container_create_worker` and `container_create_copaw_worker` use `ExtraHosts` to resolve the domain name to the Manager intranet IP when creating the Worker container, but there is a filter condition:

```bash
if [[ "${h}" == *-local.hiclaw.io ]]; then
    extra_hosts="${extra_hosts}\"${h}:${manager_ip}\","
fi
```

**Only domain names in the format of `*-local.hiclaw.io` will be injected into ExtraHosts**, custom domain names (such as `matrix.cnkirito.cn`) will be skipped.

### Impact

In the ECS public network deployment scenario:

1. The user configures a custom domain name, and DNS resolves to the ECS public IP
2. When the Worker container accesses `matrix.cnkirito.cn:18080`, it resolves to the public IP
3. ECS cannot access itself through its own public IP loopback, and the request is dropped by NAT.
4. **Matrix communication between Worker and Manager is completely disconnected**

All HiClaw Manager-Worker communications pass through the Matrix Server (via Higress Gateway). An unreachable Matrix domain name means that the entire system is unavailable.

### Repair plan

Remove the filter condition of `*-local.hiclaw.io` and inject ExtraHosts into all configured domain names so that the domain names in the Worker container can be directly resolved to the intranet IP of the Manager container.

The modification involves two places in `container-api.sh`:
- `container_create_worker` (OpenClaw Worker)
- `container_create_copaw_worker` (CoPaw Worker)

### Impact on default deployment (*-local.hiclaw.io)

No impact. The default domain name will also be injected into ExtraHosts, and the behavior will be the same as before.

## Test plan

- [ ] Use the default `*-local.hiclaw.io` domain name to deploy and verify that Worker creation and communication are normal (regression testing)
- [ ] Deploy using custom domain names, verify that Worker ExtraHosts include all domain names
- [ ] Deploy using a custom domain name on ECS and verify that the communication between Worker and Manager Matrix is normal

🤖 Generated with [Qoder][https://qoder.com]
