### PR TITLE
fix(manager): normalize worker name to lowercase

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,3 +4,5 @@ Record image-affecting changes to `manager/`, `worker/`, `openclaw-base/` here b
 
 ---
 
+- fix(manager): normalize worker name to lowercase in create-worker.sh to match Tuwunel's username storage behavior, fixing invite failures when worker names contain uppercase letters
+

--- a/manager/agent/skills/worker-management/scripts/create-worker.sh
+++ b/manager/agent/skills/worker-management/scripts/create-worker.sh
@@ -50,6 +50,11 @@ if [ -z "${WORKER_NAME}" ]; then
     exit 1
 fi
 
+# Normalize worker name to lowercase
+# Tuwunel (Matrix server) stores usernames in lowercase, so we must ensure
+# consistency to avoid issues when inviting workers to rooms.
+WORKER_NAME=$(echo "${WORKER_NAME}" | tr 'A-Z' 'a-z')
+
 # copaw runtime supports both container and pip-installed modes
 # (previously forced REMOTE_MODE=true; now containers are supported)
 


### PR DESCRIPTION
## Problem

When creating a worker with uppercase letters in the name (e.g., `--name WorkerA`), inviting the worker to Matrix rooms fails because:

1. Tuwunel (Matrix homeserver) stores usernames in lowercase: `@workera:domain`
2. HiClaw tracks the mxid with original case: `@WorkerA:domain`
3. Invite API uses `@WorkerA:domain` → user not found

## Root Cause

Tuwunel normalizes usernames to lowercase during registration:

```rust
// src/api/client/register.rs:192-198
let body_username = if is_matrix_appservice_irc {
    username.clone()
} else {
    username.to_lowercase()  // Always lowercase!
};
```

## Solution

Normalize `WORKER_NAME` to lowercase immediately after argument parsing in `create-worker.sh`. This ensures consistency throughout the worker lifecycle:
- Matrix registration
- MinIO user creation
- Higress consumer setup
- mxid generation for invites and groupAllowFrom

## Testing

- Created worker with uppercase name before fix: invite failed
- After fix: all worker names are lowercase, invites work correctly