### PR TITLE
fix(ci): add tag trigger so release-baseline job runs on release

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -11,6 +11,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
     paths:
       - 'manager/**'
       - 'tests/**'


### PR DESCRIPTION
## Summary

- `release-baseline` job 的 `if` 条件检查 `refs/tags/v*`，但 workflow 的 `push` 触发器只配了 `branches: [main]`，没有 `tags`，导致打 tag 时 workflow 根本不触发，baseline 永远不会生成
- 加上 `tags: [v*]` 触发条件，使发版时自动跑测试并上传 `metrics-baseline.json` 到 release assets
- 这样后续 PR 的 CI 就能下载到 baseline 进行对比，不再显示 "No baseline available"

## Test plan

- [ ] 手动 dispatch 一次 `baseline_version=v1.0.7` 生成首个 baseline
- [ ] 下次发版打 tag 时确认 `release-baseline` job 自动触发
- [ ] 确认后续 PR 的 CI 评论中出现 baseline 对比数据

🤖 Generated with [Claude Code](https://claude.com/claude-code)