### PR TITLE
fix(install): detect orphan Docker volume when env file is missing

### DIFF
--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -260,6 +260,18 @@ $script:Messages = @{
     "install.reinstall.cleanup_done" = @{ zh = "清理完成。开始全新安装..."; en = "Cleanup complete. Starting fresh installation..." }
     "install.reinstall.failed_rm_workspace" = @{ zh = "无法移除工作空间目录"; en = "Failed to remove workspace directory" }
 
+    # --- Orphan volume detection ---
+    "install.orphan_volume.detected" = @{ zh = "⚠️  检测到残留数据卷 '{0}'，但未找到对应的 env 配置文件。"; en = "⚠️  Found leftover data volume '{0}' but no matching env config file." }
+    "install.orphan_volume.warn" = @{ zh = "这可能是之前安装的残留数据，会导致新安装出现异常（如密码冲突、服务启动失败）。"; en = "This is likely leftover data from a previous installation and may cause issues (e.g., credential conflicts, service startup failures)." }
+    "install.orphan_volume.choose" = @{ zh = "选择操作:"; en = "Choose an action:" }
+    "install.orphan_volume.clean" = @{ zh = "  1) 清理残留数据卷后继续安装（推荐）"; en = "  1) Remove leftover volume and continue installation (recommended)" }
+    "install.orphan_volume.keep" = @{ zh = "  2) 保留数据卷继续安装（可能出现异常）"; en = "  2) Keep the volume and continue installation (may cause issues)" }
+    "install.orphan_volume.prompt" = @{ zh = "请选择 [1/2]"; en = "Enter choice [1/2]" }
+    "install.orphan_volume.cleaning" = @{ zh = "正在清理残留数据卷..."; en = "Removing leftover data volume..." }
+    "install.orphan_volume.cleaned" = @{ zh = "残留数据卷已清理。继续全新安装..."; en = "Leftover volume removed. Continuing with fresh installation..." }
+    "install.orphan_volume.keeping" = @{ zh = "保留数据卷，继续安装。如遇异常请选择全新重装。"; en = "Keeping existing volume. If you encounter issues, consider a clean reinstall." }
+    "install.orphan_volume.clean_noninteractive" = @{ zh = "非交互模式: 自动清理残留数据卷..."; en = "Non-interactive mode: automatically removing leftover volume..." }
+
     # --- Loading existing config ---
     "install.loading_config" = @{ zh = "从 {0} 加载已有配置（shell 环境变量优先）..."; en = "Loading existing config from {0} (shell env vars take priority)..." }
 
@@ -1388,6 +1400,57 @@ function Install-Manager {
                     # Only set if not already in environment
                     if (-not [Environment]::GetEnvironmentVariable($key)) {
                         [Environment]::SetEnvironmentVariable($key, $value, "Process")
+                    }
+                }
+            }
+        }
+    }
+    else {
+        # --- Orphan volume detection (env file gone but volume remains) ---
+        $dataVol = if ($env:HICLAW_DATA_DIR) { $env:HICLAW_DATA_DIR } else { "hiclaw-data" }
+        $volumeExists = docker volume ls -q 2>$null | Select-String "^${dataVol}$"
+        if ($volumeExists) {
+            Write-Host ""
+            Write-Log (Get-Msg "install.orphan_volume.detected" -f $dataVol)
+            Write-Log (Get-Msg "install.orphan_volume.warn")
+
+            if ($script:HICLAW_NON_INTERACTIVE) {
+                Write-Log (Get-Msg "install.orphan_volume.clean_noninteractive")
+                # Stop containers that may reference the volume
+                docker stop hiclaw-manager *>$null
+                docker rm hiclaw-manager *>$null
+                docker ps -a --format "{{.Names}}" 2>$null | Select-String "^hiclaw-worker-" | ForEach-Object {
+                    docker stop $_.ToString().Trim() *>$null
+                    docker rm $_.ToString().Trim() *>$null
+                }
+                Write-Log (Get-Msg "install.orphan_volume.cleaning")
+                docker volume rm $dataVol *>$null
+                Write-Log (Get-Msg "install.orphan_volume.cleaned")
+            }
+            else {
+                Write-Host ""
+                Write-Host (Get-Msg "install.orphan_volume.choose")
+                Write-Host (Get-Msg "install.orphan_volume.clean")
+                Write-Host (Get-Msg "install.orphan_volume.keep")
+                Write-Host ""
+                $orphanChoice = Read-Host (Get-Msg "install.orphan_volume.prompt")
+                if (-not $orphanChoice) { $orphanChoice = "1" }
+
+                switch -Regex ($orphanChoice) {
+                    "^(1|clean)$" {
+                        # Stop containers that may reference the volume
+                        docker stop hiclaw-manager *>$null
+                        docker rm hiclaw-manager *>$null
+                        docker ps -a --format "{{.Names}}" 2>$null | Select-String "^hiclaw-worker-" | ForEach-Object {
+                            docker stop $_.ToString().Trim() *>$null
+                            docker rm $_.ToString().Trim() *>$null
+                        }
+                        Write-Log (Get-Msg "install.orphan_volume.cleaning")
+                        docker volume rm $dataVol *>$null
+                        Write-Log (Get-Msg "install.orphan_volume.cleaned")
+                    }
+                    "^(2|keep)$" {
+                        Write-Log (Get-Msg "install.orphan_volume.keeping")
                     }
                 }
             }

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -269,6 +269,27 @@ msg() {
         "install.reinstall.cleanup_done.en") text="Cleanup complete. Starting fresh installation..." ;;
         "install.reinstall.failed_rm_workspace.zh") text="无法移除工作空间目录" ;;
         "install.reinstall.failed_rm_workspace.en") text="Failed to remove workspace directory" ;;
+        # --- Orphan volume detection ---
+        "install.orphan_volume.detected.zh") text="⚠️  检测到残留数据卷 '%s'，但未找到对应的 env 配置文件。" ;;
+        "install.orphan_volume.detected.en") text="⚠️  Found leftover data volume '%s' but no matching env config file." ;;
+        "install.orphan_volume.warn.zh") text="这可能是之前安装的残留数据，会导致新安装出现异常（如密码冲突、服务启动失败）。" ;;
+        "install.orphan_volume.warn.en") text="This is likely leftover data from a previous installation and may cause issues (e.g., credential conflicts, service startup failures)." ;;
+        "install.orphan_volume.choose.zh") text="选择操作:" ;;
+        "install.orphan_volume.choose.en") text="Choose an action:" ;;
+        "install.orphan_volume.clean.zh") text="  1) 清理残留数据卷后继续安装（推荐）" ;;
+        "install.orphan_volume.clean.en") text="  1) Remove leftover volume and continue installation (recommended)" ;;
+        "install.orphan_volume.keep.zh") text="  2) 保留数据卷继续安装（可能出现异常）" ;;
+        "install.orphan_volume.keep.en") text="  2) Keep the volume and continue installation (may cause issues)" ;;
+        "install.orphan_volume.prompt.zh") text="请选择 [1/2]" ;;
+        "install.orphan_volume.prompt.en") text="Enter choice [1/2]" ;;
+        "install.orphan_volume.cleaning.zh") text="正在清理残留数据卷..." ;;
+        "install.orphan_volume.cleaning.en") text="Removing leftover data volume..." ;;
+        "install.orphan_volume.cleaned.zh") text="残留数据卷已清理。继续全新安装..." ;;
+        "install.orphan_volume.cleaned.en") text="Leftover volume removed. Continuing with fresh installation..." ;;
+        "install.orphan_volume.keeping.zh") text="保留数据卷，继续安装。如遇异常请选择全新重装。" ;;
+        "install.orphan_volume.keeping.en") text="Keeping existing volume. If you encounter issues, consider a clean reinstall." ;;
+        "install.orphan_volume.clean_noninteractive.zh") text="非交互模式: 自动清理残留数据卷..." ;;
+        "install.orphan_volume.clean_noninteractive.en") text="Non-interactive mode: automatically removing leftover volume..." ;;
         # --- Loading existing config ---
         "install.loading_config.zh") text="从 %s 加载已有配置（shell 环境变量优先）..." ;;
         "install.loading_config.en") text="Loading existing config from %s (shell env vars take priority)..." ;;
@@ -1320,6 +1341,54 @@ install_manager() {
                 exit 0
                 ;;
         esac
+    else
+        # --- Orphan volume detection (env file gone but volume remains) ---
+        local data_vol="${HICLAW_DATA_DIR:-hiclaw-data}"
+        if ${DOCKER_CMD} volume ls -q | grep -q "^${data_vol}$"; then
+            echo ""
+            log "$(msg install.orphan_volume.detected "${data_vol}")"
+            log "$(msg install.orphan_volume.warn)"
+
+            if [ "${HICLAW_NON_INTERACTIVE}" = "1" ]; then
+                log "$(msg install.orphan_volume.clean_noninteractive)"
+                # Stop containers that may reference the volume
+                ${DOCKER_CMD} stop hiclaw-manager 2>/dev/null || true
+                ${DOCKER_CMD} rm hiclaw-manager 2>/dev/null || true
+                for w in $(${DOCKER_CMD} ps -a --format '{{.Names}}' | grep "^hiclaw-worker-" || true); do
+                    ${DOCKER_CMD} stop "${w}" 2>/dev/null || true
+                    ${DOCKER_CMD} rm "${w}" 2>/dev/null || true
+                done
+                log "$(msg install.orphan_volume.cleaning)"
+                ${DOCKER_CMD} volume rm "${data_vol}" 2>/dev/null || true
+                log "$(msg install.orphan_volume.cleaned)"
+            else
+                echo ""
+                echo "$(msg install.orphan_volume.choose)"
+                echo "$(msg install.orphan_volume.clean)"
+                echo "$(msg install.orphan_volume.keep)"
+                echo ""
+                read -e -p "$(msg install.orphan_volume.prompt): " ORPHAN_CHOICE
+                ORPHAN_CHOICE="${ORPHAN_CHOICE:-1}"
+
+                case "${ORPHAN_CHOICE}" in
+                    1|clean)
+                        # Stop containers that may reference the volume
+                        ${DOCKER_CMD} stop hiclaw-manager 2>/dev/null || true
+                        ${DOCKER_CMD} rm hiclaw-manager 2>/dev/null || true
+                        for w in $(${DOCKER_CMD} ps -a --format '{{.Names}}' | grep "^hiclaw-worker-" || true); do
+                            ${DOCKER_CMD} stop "${w}" 2>/dev/null || true
+                            ${DOCKER_CMD} rm "${w}" 2>/dev/null || true
+                        done
+                        log "$(msg install.orphan_volume.cleaning)"
+                        ${DOCKER_CMD} volume rm "${data_vol}" 2>/dev/null || true
+                        log "$(msg install.orphan_volume.cleaned)"
+                        ;;
+                    2|keep)
+                        log "$(msg install.orphan_volume.keeping)"
+                        ;;
+                esac
+            fi
+        fi
     fi
 
     # Load existing env file as fallback (shell env vars take priority)


### PR DESCRIPTION
## Summary

- Fixes #293
- 当用户手动删除 env 文件但未删除 Docker volume 时，安装脚本现在会检测到残留的 `hiclaw-data` 数据卷并提示用户处理
- 用户可选择清理残留数据卷（推荐）或保留继续安装
- 非交互模式下自动清理残留数据卷
- sh 和 ps1 脚本同步修改，中英文 i18n 消息已添加

## Test plan

- [ ] 删除 env 文件但保留 volume，运行安装脚本，确认出现残留数据卷提示
- [ ] 选择清理 → 确认 volume 被删除，安装正常完成
- [ ] 选择保留 → 确认安装继续，不删除 volume
- [ ] 设置 `HICLAW_NON_INTERACTIVE=1` → 确认自动清理
- [ ] 正常全新安装（无残留 volume）→ 确认不出现额外提示
- [ ] Windows 下使用 ps1 脚本重复以上测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Summary

- Fixes #293
- When the user manually deletes the env file but does not delete the Docker volume, the installation script will now detect the residual `hiclaw-data` data volume and prompt the user to handle it
- Users can choose to clean the residual data volume (recommended) or keep it and continue the installation
- Automatically clean up residual data volumes in non-interactive mode
- sh and ps1 scripts are modified simultaneously, Chinese and English i18n messages have been added

## Test plan

- [ ] Delete the env file but keep the volume, run the installation script, and confirm that the residual data volume prompt appears
- [ ] Select Clean → Confirm that the volume is deleted and the installation completes normally
- [ ] Select Keep → Confirm installation to continue without deleting the volume
- [ ] Set `HICLAW_NON_INTERACTIVE=1` → Confirm automatic cleanup
- [ ] Normal new installation (no residual volume) → Confirm that no additional prompts will appear
- [ ] Repeat the above test using ps1 script under Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
