### PR TITLE
fix(worker/copaw): apply port remap in Matrix re-login

### DIFF
--- a/copaw/pyproject.toml
+++ b/copaw/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "copaw-worker"
-version = "0.1.9"
+version = "0.1.10"
 description = "Lightweight HiClaw Worker runtime based on CoPaw"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/copaw/src/copaw_worker/worker.py
+++ b/copaw/src/copaw_worker/worker.py
@@ -282,7 +282,10 @@ class Worker:
 
         matrix_password = matrix_password.strip()
         matrix_cfg = openclaw_cfg.get("channels", {}).get("matrix", {})
-        homeserver = matrix_cfg.get("homeserver", "")
+        from .bridge import _port_remap, _is_in_container
+        homeserver = _port_remap(
+            matrix_cfg.get("homeserver", ""), _is_in_container()
+        )
 
         if not homeserver or not matrix_password:
             return openclaw_cfg


### PR DESCRIPTION
## Summary
- `_matrix_relogin` was reading homeserver URL directly from `openclaw.json` without applying `_port_remap`, causing `Connection refused` on port 8080 when running outside the container (host uses 18080)
- Now uses `_port_remap` / `_is_in_container` from `bridge.py`, consistent with how CoPaw's config.json is generated
- Bump copaw-worker version to 0.1.10

## Test plan
- [ ] Run copaw-worker outside container, verify no more "Matrix re-login failed: Connection refused" warning
- [ ] Run copaw-worker inside container, verify re-login still uses :8080
- [ ] Verify E2EE messaging works after worker restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)