### PR TITLE
feat(install): add custom model parameter prompts to PowerShell installer

### DIFF
--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -308,6 +308,14 @@ $script:Messages = @{
     "llm.openai.model_prompt" = @{ zh = "默认模型 ID [gpt-5.4]"; en = "Default Model ID [gpt-5.4]" }
     "llm.openai.base_url_label" = @{ zh = "  Base URL: {0}"; en = "  Base URL: {0}" }
 
+    # --- Custom model parameters ---
+    "llm.custom_model.detected" = @{ zh = "  ⚠️  模型 '{0}' 不在内置模型列表中，请配置模型参数:"; en = "  ⚠️  Model '{0}' is not in the built-in model list. Please configure model parameters:" }
+    "llm.custom_model.context_prompt" = @{ zh = "最大上下文长度（token 数）[150000]"; en = "Max context window (tokens) [150000]" }
+    "llm.custom_model.max_tokens_prompt" = @{ zh = "最大输出长度（token 数）[128000]"; en = "Max output tokens [128000]" }
+    "llm.custom_model.reasoning_prompt" = @{ zh = "是否支持推理/思考模式？[Y/n]"; en = "Does it support reasoning/thinking mode? [Y/n]" }
+    "llm.custom_model.vision_prompt" = @{ zh = "是否支持图片输入？[y/N]"; en = "Does it support image input? [y/N]" }
+    "llm.custom_model.summary" = @{ zh = "  自定义模型参数: 上下文={0}, 最大输出={1}, 推理={2}, 图片={3}"; en = "  Custom model params: context={0}, maxTokens={1}, reasoning={2}, vision={3}" }
+
     # --- Admin Credentials ---
     "admin.title" = @{ zh = "--- 管理员凭据 ---"; en = "--- Admin Credentials ---" }
     "admin.username_prompt" = @{ zh = "管理员用户名"; en = "Admin Username" }
@@ -582,6 +590,42 @@ function Get-LanIP {
     return ""
 }
 
+# Known models list — used to detect custom models during install
+$script:KnownModels = @(
+    "gpt-5.4", "gpt-5.3-codex", "gpt-5-mini", "gpt-5-nano",
+    "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5",
+    "qwen3.5-plus", "deepseek-chat", "deepseek-reasoner",
+    "kimi-k2.5", "glm-5", "MiniMax-M2.5"
+)
+
+function Test-KnownModel {
+    param([string]$Model)
+    return $script:KnownModels -contains $Model
+}
+
+function Request-CustomModelParams {
+    param([string]$Model)
+    if (Test-KnownModel $Model) {
+        $config.MODEL_CONTEXT_WINDOW = ""
+        $config.MODEL_MAX_TOKENS = ""
+        $config.MODEL_REASONING = ""
+        $config.MODEL_VISION = ""
+        return
+    }
+    Write-Host ""
+    Write-Log (Get-Msg "llm.custom_model.detected" -f $Model)
+    Write-Host ""
+    $ctxInput = Read-Host "  $(Get-Msg 'llm.custom_model.context_prompt')"
+    $config.MODEL_CONTEXT_WINDOW = if ($ctxInput) { $ctxInput } else { "150000" }
+    $maxInput = Read-Host "  $(Get-Msg 'llm.custom_model.max_tokens_prompt')"
+    $config.MODEL_MAX_TOKENS = if ($maxInput) { $maxInput } else { "128000" }
+    $reasoningInput = Read-Host "  $(Get-Msg 'llm.custom_model.reasoning_prompt')"
+    $config.MODEL_REASONING = if ($reasoningInput -match "^[nN]") { "false" } else { "true" }
+    $visionInput = Read-Host "  $(Get-Msg 'llm.custom_model.vision_prompt')"
+    $config.MODEL_VISION = if ($visionInput -match "^[yY]") { "true" } else { "false" }
+    Write-Log (Get-Msg "llm.custom_model.summary" -f $config.MODEL_CONTEXT_WINDOW, $config.MODEL_MAX_TOKENS, $config.MODEL_REASONING, $config.MODEL_VISION)
+}
+
 function New-RandomKey {
     # Generate 64 character hex string (32 bytes)
     $bytes = New-Object byte[] 32
@@ -681,6 +725,10 @@ HICLAW_LLM_PROVIDER=$($Config.LLM_PROVIDER)
 HICLAW_DEFAULT_MODEL=$($Config.DEFAULT_MODEL)
 HICLAW_LLM_API_KEY=$($Config.LLM_API_KEY)
 HICLAW_OPENAI_BASE_URL=$($Config.OPENAI_BASE_URL)
+HICLAW_MODEL_CONTEXT_WINDOW=$($Config.MODEL_CONTEXT_WINDOW)
+HICLAW_MODEL_MAX_TOKENS=$($Config.MODEL_MAX_TOKENS)
+HICLAW_MODEL_REASONING=$($Config.MODEL_REASONING)
+HICLAW_MODEL_VISION=$($Config.MODEL_VISION)
 
 # Admin
 HICLAW_ADMIN_USER=$($Config.ADMIN_USER)
@@ -1551,6 +1599,7 @@ function Install-Manager {
                         $config.DEFAULT_MODEL = if ($qwenModelInput) { $qwenModelInput } elseif ($env:HICLAW_DEFAULT_MODEL) { $env:HICLAW_DEFAULT_MODEL } else { "qwen3.5-plus" }
                         $config.OPENAI_BASE_URL = ""
                         Write-Log (Get-Msg "llm.provider.selected_qwen")
+                        Request-CustomModelParams $config.DEFAULT_MODEL
                     } else {
                         $config.LLM_PROVIDER = "openai-compat"
                         $config.OPENAI_BASE_URL = "https://coding.dashscope.aliyuncs.com/v1"
@@ -1617,6 +1666,7 @@ function Install-Manager {
 
                 Write-Log (Get-Msg "llm.openai.base_url_label" -f $config.OPENAI_BASE_URL)
                 Write-Log (Get-Msg "llm.model.label" -f $config.DEFAULT_MODEL)
+                Request-CustomModelParams $config.DEFAULT_MODEL
                 Write-Log ""
                 $config.LLM_API_KEY = Read-Prompt -VarName "HICLAW_LLM_API_KEY" -PromptText (Get-Msg "llm.apikey_prompt") -Secret
                 Test-LlmConnectivity -BaseUrl $config.OPENAI_BASE_URL -ApiKey $config.LLM_API_KEY -Model $config.DEFAULT_MODEL


### PR DESCRIPTION
## Summary
- Sync custom model detection logic from bash installer to `hiclaw-install.ps1`
- When users enter a model name not in the built-in list, prompt for: context window, max output tokens, reasoning support, and vision support
- Save custom model parameters (`HICLAW_MODEL_CONTEXT_WINDOW`, `HICLAW_MODEL_MAX_TOKENS`, `HICLAW_MODEL_REASONING`, `HICLAW_MODEL_VISION`) to the env file
- Parameters are passed to the container via `--env-file` and consumed by manager/worker startup scripts (added in #328)

## Test plan
- [ ] Run `hiclaw-install.ps1` on Windows with a known model (e.g., `qwen3.5-plus`) — should skip custom param prompts
- [ ] Run with a custom model name (e.g., `my-custom-llm`) — should prompt for all 4 parameters
- [ ] Verify env file contains the custom model parameters after installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)