### PR TITLE
fix(install): surface Matrix API error details instead of silent failures

### DIFF
--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -1008,12 +1008,14 @@ function Send-WelcomeMessage {
 MATRIX_URL="http://127.0.0.1:6167"
 MANAGER_FULL_ID="@manager:${MATRIX_DOMAIN}"
 
-login_resp=$(curl -s -X POST "${MATRIX_URL}/_matrix/client/v3/login" \
+_raw=$(curl -s -w '\nHTTP_CODE:%{http_code}' -X POST "${MATRIX_URL}/_matrix/client/v3/login" \
     -H 'Content-Type: application/json' \
     -d "{\"type\":\"m.login.password\",\"identifier\":{\"type\":\"m.id.user\",\"user\":\"${ADMIN_USER}\"},\"password\":\"${ADMIN_PASSWORD}\"}" 2>&1) || true
+_http_code=$(echo "${_raw}" | tail -1 | sed 's/HTTP_CODE://')
+login_resp=$(echo "${_raw}" | sed '$d')
 access_token=$(echo "${login_resp}" | jq -r '.access_token // empty' 2>/dev/null)
 if [ -z "${access_token}" ]; then
-    echo "LOGIN_FAILED: ${login_resp}"; exit 0
+    echo "LOGIN_FAILED (HTTP ${_http_code}): ${login_resp}"; exit 0
 fi
 
 room_id=""
@@ -1029,13 +1031,15 @@ for rid in ${rooms}; do
 done
 
 if [ -z "${room_id}" ]; then
-    create_resp=$(curl -s -X POST "${MATRIX_URL}/_matrix/client/v3/createRoom" \
+    _raw=$(curl -s -w '\nHTTP_CODE:%{http_code}' -X POST "${MATRIX_URL}/_matrix/client/v3/createRoom" \
         -H "Authorization: Bearer ${access_token}" \
         -H 'Content-Type: application/json' \
         -d "{\"is_direct\":true,\"invite\":[\"${MANAGER_FULL_ID}\"],\"preset\":\"trusted_private_chat\"}" 2>&1) || true
+    _http_code=$(echo "${_raw}" | tail -1 | sed 's/HTTP_CODE://')
+    create_resp=$(echo "${_raw}" | sed '$d')
     room_id=$(echo "${create_resp}" | jq -r '.room_id // empty' 2>/dev/null)
     if [ -z "${room_id}" ]; then
-        echo "NO_ROOM: ${create_resp}"; exit 0
+        echo "NO_ROOM (HTTP ${_http_code}): ${create_resp}"; exit 0
     fi
 fi
 
@@ -1082,14 +1086,16 @@ The human admin will start chatting shortly."
 
 txn_id="welcome-$(date +%s)"
 payload=$(jq -nc --arg body "${welcome_msg}" '{"msgtype":"m.text","body":$body}')
-send_resp=$(curl -s -X PUT "${MATRIX_URL}/_matrix/client/v3/rooms/${room_id}/send/m.room.message/${txn_id}" \
+_raw=$(curl -s -w '\nHTTP_CODE:%{http_code}' -X PUT "${MATRIX_URL}/_matrix/client/v3/rooms/${room_id}/send/m.room.message/${txn_id}" \
     -H "Authorization: Bearer ${access_token}" \
     -H 'Content-Type: application/json' \
     -d "${payload}" 2>&1) || true
+_http_code=$(echo "${_raw}" | tail -1 | sed 's/HTTP_CODE://')
+send_resp=$(echo "${_raw}" | sed '$d')
 if echo "${send_resp}" | jq -e '.event_id' > /dev/null 2>&1; then
     echo "OK"
 else
-    echo "SEND_FAILED: ${send_resp}"; exit 0
+    echo "SEND_FAILED (HTTP ${_http_code}): ${send_resp}"; exit 0
 fi
 '@
 

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -879,12 +879,14 @@ send_welcome_message() {
 MATRIX_URL="http://127.0.0.1:6167"
 MANAGER_FULL_ID="@manager:${MATRIX_DOMAIN}"
 
-login_resp=$(curl -s -X POST "${MATRIX_URL}/_matrix/client/v3/login" \
+_raw=$(curl -s -w '\nHTTP_CODE:%{http_code}' -X POST "${MATRIX_URL}/_matrix/client/v3/login" \
     -H 'Content-Type: application/json' \
     -d "{\"type\":\"m.login.password\",\"identifier\":{\"type\":\"m.id.user\",\"user\":\"${ADMIN_USER}\"},\"password\":\"${ADMIN_PASSWORD}\"}" 2>&1) || true
+_http_code=$(echo "${_raw}" | tail -1 | sed 's/HTTP_CODE://')
+login_resp=$(echo "${_raw}" | sed '$d')
 access_token=$(echo "${login_resp}" | jq -r '.access_token // empty' 2>/dev/null)
 if [ -z "${access_token}" ]; then
-    echo "LOGIN_FAILED: ${login_resp}"; exit 0
+    echo "LOGIN_FAILED (HTTP ${_http_code}): ${login_resp}"; exit 0
 fi
 
 room_id=""
@@ -900,13 +902,15 @@ for rid in ${rooms}; do
 done
 
 if [ -z "${room_id}" ]; then
-    create_resp=$(curl -s -X POST "${MATRIX_URL}/_matrix/client/v3/createRoom" \
+    _raw=$(curl -s -w '\nHTTP_CODE:%{http_code}' -X POST "${MATRIX_URL}/_matrix/client/v3/createRoom" \
         -H "Authorization: Bearer ${access_token}" \
         -H 'Content-Type: application/json' \
         -d "{\"is_direct\":true,\"invite\":[\"${MANAGER_FULL_ID}\"],\"preset\":\"trusted_private_chat\"}" 2>&1) || true
+    _http_code=$(echo "${_raw}" | tail -1 | sed 's/HTTP_CODE://')
+    create_resp=$(echo "${_raw}" | sed '$d')
     room_id=$(echo "${create_resp}" | jq -r '.room_id // empty' 2>/dev/null)
     if [ -z "${room_id}" ]; then
-        echo "NO_ROOM: ${create_resp}"; exit 0
+        echo "NO_ROOM (HTTP ${_http_code}): ${create_resp}"; exit 0
     fi
 fi
 
@@ -953,14 +957,16 @@ The human admin will start chatting shortly."
 
 txn_id="welcome-$(date +%s)"
 payload=$(jq -nc --arg body "${welcome_msg}" '{"msgtype":"m.text","body":$body}')
-send_resp=$(curl -s -X PUT "${MATRIX_URL}/_matrix/client/v3/rooms/${room_id}/send/m.room.message/${txn_id}" \
+_raw=$(curl -s -w '\nHTTP_CODE:%{http_code}' -X PUT "${MATRIX_URL}/_matrix/client/v3/rooms/${room_id}/send/m.room.message/${txn_id}" \
     -H "Authorization: Bearer ${access_token}" \
     -H 'Content-Type: application/json' \
     -d "${payload}" 2>&1) || true
+_http_code=$(echo "${_raw}" | tail -1 | sed 's/HTTP_CODE://')
+send_resp=$(echo "${_raw}" | sed '$d')
 if echo "${send_resp}" | jq -e '.event_id' > /dev/null 2>&1; then
     echo "OK"
 else
-    echo "SEND_FAILED: ${send_resp}"; exit 0
+    echo "SEND_FAILED (HTTP ${_http_code}): ${send_resp}"; exit 0
 fi
 INNER_SCRIPT
 )

--- a/manager/scripts/init/start-manager-agent.sh
+++ b/manager/scripts/init/start-manager-agent.sh
@@ -316,15 +316,17 @@ else
             log "Existing DM room found: ${DM_ROOM_ID}"
         else
             log "Creating DM room with Manager..."
-            _CREATE_RESP=$(curl -s -X POST "${HICLAW_MATRIX_SERVER}/_matrix/client/v3/createRoom" \
+            _RAW=$(curl -s -w '\nHTTP_CODE:%{http_code}' -X POST "${HICLAW_MATRIX_SERVER}/_matrix/client/v3/createRoom" \
                 -H "Authorization: Bearer ${ADMIN_MATRIX_TOKEN}" \
                 -H 'Content-Type: application/json' \
                 -d "{\"is_direct\":true,\"invite\":[\"${MANAGER_FULL_ID}\"],\"preset\":\"trusted_private_chat\"}" 2>&1) || true
+            _HTTP_CODE=$(echo "${_RAW}" | tail -1 | sed 's/HTTP_CODE://')
+            _CREATE_RESP=$(echo "${_RAW}" | sed '$d')
             DM_ROOM_ID=$(echo "${_CREATE_RESP}" | jq -r '.room_id // empty' 2>/dev/null)
             if [ -n "${DM_ROOM_ID}" ]; then
                 log "DM room created: ${DM_ROOM_ID}"
             else
-                log "WARNING: Failed to create DM room: ${_CREATE_RESP}"
+                log "WARNING: Failed to create DM room (HTTP ${_HTTP_CODE}): ${_CREATE_RESP}"
             fi
         fi
 
@@ -373,14 +375,16 @@ Please begin the onboarding conversation:
 The human admin will start chatting shortly."
                 _txn_id="welcome-cloud-$(date +%s)"
                 _payload=$(jq -nc --arg body "${_welcome_msg}" '{"msgtype":"m.text","body":$body}')
-                _send_resp=$(curl -s -X PUT "${HICLAW_MATRIX_SERVER}/_matrix/client/v3/rooms/${DM_ROOM_ID}/send/m.room.message/${_txn_id}" \
+                _raw=$(curl -s -w '\nHTTP_CODE:%{http_code}' -X PUT "${HICLAW_MATRIX_SERVER}/_matrix/client/v3/rooms/${DM_ROOM_ID}/send/m.room.message/${_txn_id}" \
                     -H "Authorization: Bearer ${ADMIN_MATRIX_TOKEN}" \
                     -H 'Content-Type: application/json' \
                     -d "${_payload}" 2>&1) || true
+                _http_code=$(echo "${_raw}" | tail -1 | sed 's/HTTP_CODE://')
+                _send_resp=$(echo "${_raw}" | sed '$d')
                 if echo "${_send_resp}" | jq -e '.event_id' > /dev/null 2>&1; then
                     echo "[cloud-manager] Welcome message sent to DM room"
                 else
-                    echo "[cloud-manager] WARNING: Failed to send welcome message: ${_send_resp}"
+                    echo "[cloud-manager] WARNING: Failed to send welcome message (HTTP ${_http_code}): ${_send_resp}"
                 fi
             ) &
             log "Welcome message background process started (PID: $!)"
@@ -704,16 +708,18 @@ if [ -f /root/manager-workspace/.upgrade-pending-worker-notify ]; then
                     _worker_id="@${_worker_name}:${MATRIX_DOMAIN}"
                     _txn_id="upgrade-$(date +%s%N)"
                     _msg="@${_worker_name}:${MATRIX_DOMAIN} Manager upgraded builtin files (AGENTS.md, skills). Please use your file-sync skill to sync the latest config."
-                    _notify_resp=$(curl -s -X PUT \
+                    _raw=$(curl -s -w '\nHTTP_CODE:%{http_code}' -X PUT \
                         "${HICLAW_MATRIX_SERVER}/_matrix/client/v3/rooms/${_room_id}/send/m.room.message/${_txn_id}" \
                         -H "Authorization: Bearer ${MANAGER_TOKEN}" \
                         -H 'Content-Type: application/json' \
                         -d "{\"msgtype\":\"m.text\",\"body\":\"${_msg}\",\"m.mentions\":{\"user_ids\":[\"${_worker_id}\"]}}" \
                         2>&1) || true
+                    _http_code=$(echo "${_raw}" | tail -1 | sed 's/HTTP_CODE://')
+                    _notify_resp=$(echo "${_raw}" | sed '$d')
                     if echo "${_notify_resp}" | jq -e '.event_id' > /dev/null 2>&1; then
                         log "  Notified ${_worker_name}"; _notify_ok=true
                     else
-                        log "  WARNING: Failed to notify ${_worker_name}: ${_notify_resp}"
+                        log "  WARNING: Failed to notify ${_worker_name} (HTTP ${_http_code}): ${_notify_resp}"
                     fi
                 fi
             done


### PR DESCRIPTION
## Summary
- Room creation, login, and welcome message sending failures were silently swallowed by `2>/dev/null` and `curl -sf`, making installation issues hard to diagnose
- Now all Matrix API error responses are captured and displayed to the user with detailed error info
- Covers all three scripts: bash installer, PowerShell installer, and manager startup (cloud deployment + worker notification)

## Changes
- `curl -sf` → `curl -s` to capture error response body instead of discarding it
- `2>/dev/null` → `2>&1` on critical API calls to capture connection errors
- Inner script outputs `STATUS: <detail>` format (e.g., `NO_ROOM: {"errcode":"M_UNKNOWN",...}`)
- Outer handler parses and displays the detail with `Detail:` prefix
- Cloud deployment welcome message and worker upgrade notification also surface errors

## Test plan
- [ ] Install with Matrix server down — should show connection error detail
- [ ] Install with wrong admin password — should show login error from Matrix API
- [ ] Install with room creation failure — should show API error response
- [ ] Install with message send failure — should show API error response
- [ ] Normal successful install — should still show "OK" / welcome sent message

🤖 Generated with [Claude Code](https://claude.com/claude-code)