### PR TITLE
fix(tests): resolve jq scope bug in compare_metrics_with_baseline

### DIFF
--- a/tests/lib/agent-metrics.sh
+++ b/tests/lib/agent-metrics.sh
@@ -819,9 +819,10 @@ compare_metrics_with_baseline() {
         {
             baseline_available: true,
             tests: (
+                (.[1]) as $b_doc |
                 .[0].tests | map(
                     . as $curr |
-                    (.[1].tests | map(select(.test_name == $curr.test_name)) | .[0]) as $base |
+                    ($b_doc.tests | map(select(.test_name == $curr.test_name)) | .[0]) as $base |
                     if $base then
                         {
                             test_name: $curr.test_name,


### PR DESCRIPTION
## Summary

- Fixes the CI metrics report showing blank values when a baseline exists (PR #331 and any other PRs with a baseline)

## Root Cause

In `compare_metrics_with_baseline`, the jq expression uses `-s` to read two JSON documents as an array. `.[0]` is the current summary and `.[1]` is the baseline.

Inside `.[0].tests | map(...)`, jq shifts `.` to the current array element (a test object). The expression `.[1].tests` was therefore trying to numerically index the test object with key `1` — not the outer `-s` array — causing:

```
jq: error (at <stdin>:983): Cannot index object with number
```

This silently emptied `$COMPARISON`, which caused `generate_comparison_markdown` to receive an empty string and produce a report with blank metric values.

## Fix

Capture `.[1]` as `$b_doc` before entering `map`, so the baseline document is referenced via a named variable instead of a positional index:

```diff
 tests: (
+    (.[1]) as $b_doc |
     .[0].tests | map(
         . as $curr |
-        (.[1].tests | map(select(.test_name == $curr.test_name)) | .[0]) as $base |
+        ($b_doc.tests | map(select(.test_name == $curr.test_name)) | .[0]) as $base |
```

## Test Plan

- [x] Reproduced the bug locally using CI artifact metrics + v1.0.7 baseline
- [x] Confirmed fix produces correct comparison report with all values and per-test breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)