### PR TITLE
feat(makefile): add make status and make logs dev flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@
 #   make push                     # Build + push multi-arch images (amd64 + arm64)
 #   make push-native              # Push native-arch images only (dev use, NOT recommended for registry)
 #   make clean                    # Remove local images and test containers
+#   make status                   # Show status of Manager and all Worker containers
+#   make logs                     # Show recent logs for Manager and all Workers (LINES=N)
 # ============================================================
 
 # ---------- Configuration ----------
@@ -82,6 +84,9 @@ PUSH_LATEST := $(if $(filter latest,$(VERSION)),,$(if $(filter 1,$(IS_PRERELEASE
 SKIP_BUILD     ?=
 TEST_FILTER    ?=
 
+# Logs flags
+LINES          ?= 50
+
 # ---------- Phony targets ----------
 
 .PHONY: all build build-openclaw-base build-manager build-manager-aliyun build-worker build-copaw-worker \
@@ -90,6 +95,7 @@ TEST_FILTER    ?=
         buildx-setup \
         test test-quick test-installed \
         install uninstall replay replay-log \
+        status logs \
         mirror-images clean help
 
 # ---------- Default ----------
@@ -458,6 +464,23 @@ replay-log: ## View the latest replay conversation log
 		cat "$$LATEST"; \
 	fi
 
+# ---------- Dev utils ----------
+
+status: ## Show status of Manager and all Worker containers
+	@echo "==> HiClaw container status:"
+	@docker ps -a --filter "name=hiclaw-" --format "table {{.Names}}\t{{.Status}}\t{{.Image}}" 2>/dev/null \
+		|| echo "  (no containers found or Docker not available)"
+
+logs: ## Show recent logs for Manager and all Workers (override with LINES=N, default 50)
+	@echo "==> Manager logs (last $(LINES) lines):"
+	@docker logs hiclaw-manager --tail $(LINES) 2>/dev/null || echo "  (Manager container not found)"
+	@echo ""
+	@for c in $$(docker ps -a --filter "name=hiclaw-worker-" --format '{{.Names}}' 2>/dev/null); do \
+		echo "==> Worker: $$c (last $(LINES) lines):"; \
+		docker logs "$$c" --tail $(LINES) 2>/dev/null || echo "  (container not running)"; \
+		echo ""; \
+	done
+
 # ---------- Mirror upstream images ----------
 
 mirror-images: ## Mirror upstream images to Higress registry (multi-arch, via skopeo)
@@ -508,6 +531,11 @@ help: ## Show this help
 	@echo "  make push VERSION=0.1.0             # Build amd64+arm64 and push"
 	@echo "  make push MULTIARCH_PLATFORMS=linux/amd64,linux/arm64,linux/arm/v7"
 	@echo "  make push-native VERSION=dev        # Push native-arch only (dev, overwrites multi-arch!)"
+	@echo ""
+	@echo "Dev utils:"
+	@echo "  make status                                     # Show all hiclaw container statuses"
+	@echo "  make logs                                       # Show last 50 lines of Manager + Worker logs"
+	@echo "  make logs LINES=100                             # Show last 100 lines"
 	@echo ""
 	@echo "Install / Uninstall / Replay:"
 	@echo "  HICLAW_LLM_API_KEY=sk-xxx make install          # Build + install Manager (non-interactive)"


### PR DESCRIPTION
```bash log
➜  hiclaw git:(feat/install-step-back-navigation) ✗ make status
==> HiClaw container status:
NAMES                     STATUS          IMAGE
hiclaw-worker-assistant   Up 18 minutes   higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/hiclaw-worker:latest
hiclaw-manager            Up 5 hours      higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/hiclaw-manager:latest
➜  hiclaw git:(feat/makefile-dev-utils) make logs  
==> Manager logs (last 50 lines):
2026-03-18 14:55:16,920 INFO Set uid to user 0 succeeded
2026-03-18 14:55:16,923 INFO supervisord started with pid 1
2026-03-18 14:55:17,931 INFO spawned: 'minio' with pid 34
2026-03-18 14:55:17,934 INFO spawned: 'tuwunel' with pid 35
2026-03-18 14:55:17,936 INFO spawned: 'higress-apiserver' with pid 36
2026-03-18 14:55:17,939 INFO spawned: 'higress-controller' with pid 38
2026-03-18 14:55:17,942 INFO spawned: 'higress-pilot' with pid 40
2026-03-18 14:55:17,944 INFO spawned: 'higress-gateway' with pid 43
2026-03-18 14:55:17,949 INFO spawned: 'higress-console' with pid 45
2026-03-18 14:55:17,952 INFO spawned: 'element-web' with pid 46
2026-03-18 14:55:17,956 INFO spawned: 'mc-mirror' with pid 49
2026-03-18 14:55:17,975 INFO spawned: 'setup-host-symlinks' with pid 55
2026-03-18 14:55:17,980 INFO spawned: 'manager-agent' with pid 60
2026-03-18 14:55:17,981 INFO success: setup-host-symlinks entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
2026-03-18 14:55:18,015 INFO exited: setup-host-symlinks (exit status 0; expected)
2026-03-18 14:55:18,999 INFO success: minio entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2026-03-18 14:55:18,999 INFO success: tuwunel entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2026-03-18 14:55:18,999 INFO success: higress-apiserver entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2026-03-18 14:55:18,999 INFO success: higress-controller entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2026-03-18 14:55:18,999 INFO success: higress-pilot entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2026-03-18 14:55:18,999 INFO success: higress-gateway entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2026-03-18 14:55:18,999 INFO success: higress-console entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2026-03-18 14:55:18,999 INFO success: element-web entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2026-03-18 14:55:18,999 INFO success: mc-mirror entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2026-03-18 14:55:18,999 INFO success: manager-agent entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2026-03-18 14:57:08,745 INFO reaped unknown pid 1565 (exit status 0)

==> Worker: hiclaw-worker-assistant (last 50 lines):
│ Total │ Transferred │ Duration │ Speed │
│ 0 B   │ 0 B         │ 00m00s   │ 0 B/s │
└───────┴─────────────┴──────────┴───────┘
`/root/hiclaw-fs/agents/assistant/.openclaw/credentials/matrix/credentials.json` -> `hiclaw/hiclaw-storage/agents/assistant/.openclaw/credentials/matrix/credentials.json`
┌───────┬─────────────┬──────────┬────────────┐
│ Total │ Transferred │ Duration │ Speed      │
│ 251 B │ 251 B       │ 00m00s   │ 2.69 KiB/s │
└───────┴─────────────┴──────────┴────────────┘
┌───────┬─────────────┬──────────┬───────┐
│ Total │ Transferred │ Duration │ Speed │
│ 0 B   │ 0 B         │ 00m00s   │ 0 B/s │
└───────┴─────────────┴──────────┴───────┘
┌───────┬─────────────┬──────────┬───────┐
│ Total │ Transferred │ Duration │ Speed │
│ 0 B   │ 0 B         │ 00m00s   │ 0 B/s │
└───────┴─────────────┴──────────┴───────┘
┌───────┬─────────────┬──────────┬───────┐
│ Total │ Transferred │ Duration │ Speed │
│ 0 B   │ 0 B         │ 00m00s   │ 0 B/s │
└───────┴─────────────┴──────────┴───────┘
┌───────┬─────────────┬──────────┬───────┐
│ Total │ Transferred │ Duration │ Speed │
│ 0 B   │ 0 B         │ 00m00s   │ 0 B/s │
└───────┴─────────────┴──────────┴───────┘
`/root/hiclaw-fs/agents/assistant/.openclaw/credentials/matrix/credentials.json` -> `hiclaw/hiclaw-storage/agents/assistant/.openclaw/credentials/matrix/credentials.json`
┌───────┬─────────────┬──────────┬────────────┐
│ Total │ Transferred │ Duration │ Speed      │
│ 251 B │ 251 B       │ 00m00s   │ 2.13 KiB/s │
└───────┴─────────────┴──────────┴────────────┘
┌───────┬─────────────┬──────────┬───────┐
│ Total │ Transferred │ Duration │ Speed │
│ 0 B   │ 0 B         │ 00m00s   │ 0 B/s │
└───────┴─────────────┴──────────┴───────┘
┌───────┬─────────────┬──────────┬───────┐
│ Total │ Transferred │ Duration │ Speed │
│ 0 B   │ 0 B         │ 00m00s   │ 0 B/s │
└───────┴─────────────┴──────────┴───────┘
┌───────┬─────────────┬──────────┬───────┐
│ Total │ Transferred │ Duration │ Speed │
│ 0 B   │ 0 B         │ 00m00s   │ 0 B/s │
└───────┴─────────────┴──────────┴───────┘
`/root/hiclaw-fs/agents/assistant/.openclaw/credentials/matrix/credentials.json` -> `hiclaw/hiclaw-storage/agents/assistant/.openclaw/credentials/matrix/credentials.json`
┌───────┬─────────────┬──────────┬────────────┐
│ Total │ Transferred │ Duration │ Speed      │
│ 251 B │ 251 B       │ 00m00s   │ 2.77 KiB/s │
└───────┴─────────────┴──────────┴────────────┘
┌───────┬─────────────┬──────────┬───────┐
│ Total │ Transferred │ Duration │ Speed │
│ 0 B   │ 0 B         │ 00m00s   │ 0 B/s │
└───────┴─────────────┴──────────┴───────┘

```