### PR TITLE
feat(release): preserve PR info and contributor attribution in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           fi
 
           cat > /tmp/release-body.md << EOF
-          ## What's Changed
+          ## Highlights
 
           ${changelog}
 
@@ -107,6 +107,7 @@ jobs:
         with:
           tag_name: ${{ steps.version.outputs.version }}
           body_path: /tmp/release-body.md
+          generate_release_notes: true
 
       - name: Archive changelog and reset
         run: |


### PR DESCRIPTION
## Summary

- Add `generate_release_notes: true` to the `softprops/action-gh-release` step so GitHub automatically appends a full list of merged PRs (with links and `@mentions`) to every release
- Rename the manual changelog section from "What's Changed" to "Highlights" to avoid collision with GitHub's auto-generated "What's Changed" section

## Result

Each GitHub Release will now contain:
1. **Highlights** — hand-written summary from `changelog/current.md`
2. **What's Changed** (auto-generated) — full list of merged PRs with contributor `@mentions` and PR links
3. **Full Changelog** diff link (auto-generated)
4. Docker Images / Quick Start / Documentation (existing)

## Test plan

- [ ] Trigger the Release workflow on a test tag and verify the release body contains both the Highlights section and the auto-generated PR list with contributor info

🤖 Generated with [Claude Code](https://claude.com/claude-code)