### PR TITLE
fix(ci): add --repo flag to gh release download command

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -157,7 +157,7 @@ jobs:
             2>/dev/null || true)
           if [ -n "$LATEST" ] && [ "$LATEST" != "null" ]; then
             echo "Downloading baseline from release $LATEST"
-            gh release download "$LATEST" --pattern "metrics-baseline.json" --dir baseline-metrics
+            gh release download "$LATEST" --pattern "metrics-baseline.json" --dir baseline-metrics --repo "${{ github.repository }}"
           else
             echo "No release baseline found"
           fi


### PR DESCRIPTION
## Summary
- Add `--repo "${{ github.repository }}"` flag to `gh release download` command

## Problem
When running integration tests from fork PRs (`pull_request_target` event), the baseline download step failed with "release not found" error.

The `gh api` call correctly specified the repository via `github.repository`, but the subsequent `gh release download` command did not include `--repo`, causing it to use an incorrect default context.

## Fix
Add `--repo "${{ github.repository }}"` to the `gh release download` command to ensure it targets the correct repository.

## Test plan
- [ ] Verify CI runs successfully on this PR
- [ ] Confirm baseline download step finds and downloads the baseline from v1.0.7