### PR TITLE
fix(install): use max_completion_tokens for GPT-5 models in LLM tests

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,6 +4,7 @@ Record image-affecting changes to `manager/`, `worker/`, `openclaw-base/` here b
 
 ---
 
+- fix(manager): use max_completion_tokens for GPT-5 models in LLM connectivity tests (fixes #334)
 - fix(manager): normalize worker name to lowercase in create-worker.sh to match Tuwunel's username storage behavior, fixing invite failures when worker names contain uppercase letters
 - feat(cloud): add Alibaba Cloud native deployment support with unified cloud/local abstraction layer
 - feat(cloud): add CoPaw worker support for cloud deployment

--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -909,6 +909,18 @@ function Read-Prompt {
 # OpenAI-Compatible Provider
 # ============================================================
 
+# Helper: Get the correct max_tokens parameter name for a model
+# GPT-5 series models require 'max_completion_tokens' instead of 'max_tokens'
+function Get-MaxTokensParam {
+    param([string]$Model)
+    # Match gpt-5, gpt-5.4, gpt-5-mini, gpt-5-nano, etc.
+    if ($Model -match '^gpt-5(\.|-|[0-9]|$)') {
+        return "max_completion_tokens"
+    } else {
+        return "max_tokens"
+    }
+}
+
 function Test-LlmConnectivity {
     param(
         [string]$BaseUrl,
@@ -918,11 +930,13 @@ function Test-LlmConnectivity {
     )
     Write-Log (Get-Msg "llm.openai.test.testing")
     $uri = ($BaseUrl.TrimEnd('/')) + "/chat/completions"
-    $body = @{
+    $maxTokensParam = Get-MaxTokensParam -Model $Model
+    $bodyHash = @{
         model    = $Model
         messages = @(@{ role = "user"; content = "hi" })
-        max_tokens = 1
-    } | ConvertTo-Json -Compress
+    }
+    $bodyHash[$maxTokensParam] = 1
+    $body = $bodyHash | ConvertTo-Json -Compress
     try {
         $response = Invoke-WebRequest -Uri $uri -Method POST `
             -Headers @{ "Authorization" = "Bearer $ApiKey"; "Content-Type" = "application/json"; "User-Agent" = "HiClaw/$($script:HICLAW_VERSION)" } `

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -2327,6 +2327,18 @@ install_worker() {
 # LLM API connectivity test
 # ============================================================
 
+# Helper: Get the correct max_tokens parameter name for a model
+# GPT-5 series models require 'max_completion_tokens' instead of 'max_tokens'
+_get_max_tokens_param() {
+    local model="$1"
+    # Match gpt-5, gpt-5.4, gpt-5-mini, gpt-5-nano, etc.
+    if [[ "${model}" =~ ^gpt-5(\.|-|[0-9]|$) ]]; then
+        echo "max_completion_tokens"
+    else
+        echo "max_tokens"
+    fi
+}
+
 test_llm_connectivity() {
     local base_url="$1"
     local api_key="$2"
@@ -2337,7 +2349,8 @@ test_llm_connectivity() {
         return
     fi
     log "$(msg llm.openai.test.testing)"
-    local _body _http_code _tmpfile
+    local _body _http_code _tmpfile _max_tokens_param
+    _max_tokens_param=$(_get_max_tokens_param "${model}")
     _tmpfile=$(mktemp)
     _http_code=$(curl -s -o "${_tmpfile}" -w "%{http_code}" \
         -X POST "${base_url%/}/chat/completions" \
@@ -2345,7 +2358,7 @@ test_llm_connectivity() {
         -H "Content-Type: application/json" \
         -H "User-Agent: HiClaw/${HICLAW_VERSION:-latest}" \
         --max-time 30 \
-        -d "{\"model\":\"${model}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":1}" \
+        -d "{\"model\":\"${model}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"${_max_tokens_param}\":1}" \
         2>/dev/null)
     _body=$(cat "${_tmpfile}")
     rm -f "${_tmpfile}"

--- a/manager/agent/skills/model-switch/scripts/update-manager-model.sh
+++ b/manager/agent/skills/model-switch/scripts/update-manager-model.sh
@@ -15,6 +15,15 @@
 set -e
 source /opt/hiclaw/scripts/lib/base.sh
 
+_get_max_tokens_param() {
+    local model="$1"
+    if [[ "${model}" =~ ^gpt-5(\.|-|[0-9]|$) ]]; then
+        echo "max_completion_tokens"
+    else
+        echo "max_tokens"
+    fi
+}
+
 MODEL_NAME="${1:-}"
 if [ -z "${MODEL_NAME}" ]; then
     echo "Usage: $0 <MODEL_ID> [--context-window <SIZE>] [--no-reasoning]"
@@ -102,11 +111,12 @@ if [ -z "${GATEWAY_KEY}" ] && [ -f "/data/hiclaw-secrets.env" ]; then
 fi
 
 log "Testing model reachability: ${GATEWAY_URL} (model=${MODEL_NAME})..."
+MAX_TOKENS_PARAM=$(_get_max_tokens_param "${MODEL_NAME}")
 HTTP_CODE=$(curl -s -o /tmp/model-test-resp.json -w '%{http_code}' \
     -X POST "${GATEWAY_URL}" \
     -H "Authorization: Bearer ${GATEWAY_KEY}" \
     -H "Content-Type: application/json" \
-    -d "{\"model\":\"${MODEL_NAME}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":1}" \
+    -d "{\"model\":\"${MODEL_NAME}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"${MAX_TOKENS_PARAM}\":1}" \
     --connect-timeout 10 --max-time 30 2>/dev/null) || HTTP_CODE="000"
 
 if [ "${HTTP_CODE}" != "200" ]; then

--- a/manager/agent/skills/worker-model-switch/scripts/update-worker-model.sh
+++ b/manager/agent/skills/worker-model-switch/scripts/update-worker-model.sh
@@ -15,6 +15,15 @@
 set -euo pipefail
 source /opt/hiclaw/scripts/lib/hiclaw-env.sh
 
+_get_max_tokens_param() {
+    local model="$1"
+    if [[ "${model}" =~ ^gpt-5(\.|-|[0-9]|$) ]]; then
+        echo "max_completion_tokens"
+    else
+        echo "max_tokens"
+    fi
+}
+
 REGISTRY_FILE="${HOME}/workers-registry.json"
 
 _ts() {
@@ -98,12 +107,13 @@ update_worker_model() {
         gateway_key="${HICLAW_MANAGER_GATEWAY_KEY:-}"
     fi
     _log "Testing model reachability: ${gateway_url} (model=${new_model})..."
-    local http_code
+    local http_code max_tokens_param
+    max_tokens_param=$(_get_max_tokens_param "${new_model}")
     http_code=$(curl -s -o /tmp/model-test-resp-${worker}.json -w '%{http_code}' \
         -X POST "${gateway_url}" \
         -H "Authorization: Bearer ${gateway_key}" \
         -H "Content-Type: application/json" \
-        -d "{\"model\":\"${new_model}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":1}" \
+        -d "{\"model\":\"${new_model}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"${max_tokens_param}\":1}" \
         --connect-timeout 10 --max-time 30 2>/dev/null) || http_code="000"
     if [ "${http_code}" != "200" ]; then
         local resp_body

--- a/tests/unit/test-max-tokens-param.sh
+++ b/tests/unit/test-max-tokens-param.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Unit test for max_tokens parameter handling for GPT-5 models
+#
+# This is a LOCAL unit test that tests the _get_max_tokens_param function
+# behavior and JSON body generation. It does NOT require a running system.
+#
+# Run: ./tests/unit/test-max-tokens-param.sh
+
+set -e
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+PASSED=0
+FAILED=0
+
+pass() {
+    echo -e "${GREEN}✓ PASS${NC}: $1"
+    PASSED=$((PASSED + 1))
+}
+
+fail() {
+    echo -e "${RED}✗ FAIL${NC}: $1"
+    FAILED=$((FAILED + 1))
+}
+
+# ============================================================
+# Test 1: Test _get_max_tokens_param function
+# ============================================================
+echo -e "\n${YELLOW}=== Test 1: _get_max_tokens_param function ===${NC}\n"
+
+# Define the function (copy from hiclaw-install.sh)
+_get_max_tokens_param() {
+    local model="$1"
+    # Match gpt-5, gpt-5.4, gpt-5-mini, gpt-5-nano, etc.
+    if [[ "${model}" =~ ^gpt-5(\.|-|[0-9]|$) ]]; then
+        echo "max_completion_tokens"
+    else
+        echo "max_tokens"
+    fi
+}
+
+# Test cases for _get_max_tokens_param (format: "model:expected")
+TEST_CASES=(
+    "gpt-5:max_completion_tokens"
+    "gpt-5.4:max_completion_tokens"
+    "gpt-5-mini:max_completion_tokens"
+    "gpt-5-nano:max_completion_tokens"
+    "gpt-5-turbo:max_completion_tokens"
+    "gpt-5.1:max_completion_tokens"
+    "gpt-5-2024-01-01:max_completion_tokens"
+    "gpt-4:max_tokens"
+    "gpt-4o:max_tokens"
+    "gpt-4-turbo:max_tokens"
+    "gpt-3.5-turbo:max_tokens"
+    "claude-3-opus:max_tokens"
+    "claude-3-sonnet:max_tokens"
+    "gemini-pro:max_tokens"
+    "deepseek-chat:max_tokens"
+)
+
+for test_case in "${TEST_CASES[@]}"; do
+    model="${test_case%%:*}"
+    expected="${test_case##*:}"
+    actual=$(_get_max_tokens_param "$model")
+    if [[ "$actual" == "$expected" ]]; then
+        pass "_get_max_tokens_param('$model') = '$actual'"
+    else
+        fail "_get_max_tokens_param('$model') expected '$expected', got '$actual'"
+    fi
+done
+
+# ============================================================
+# Test 2: Test JSON body generation
+# ============================================================
+echo -e "\n${YELLOW}=== Test 2: JSON body generation ===${NC}\n"
+
+test_json_body() {
+    local model="$1"
+    local expected_param="$2"
+
+    local max_tokens_param=$(_get_max_tokens_param "${model}")
+    local json_body="{\"model\":\"${model}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"${max_tokens_param}\":1}"
+
+    # Verify JSON is valid
+    if echo "$json_body" | jq . > /dev/null 2>&1; then
+        pass "Valid JSON for $model"
+    else
+        fail "Invalid JSON for $model: $json_body"
+        return
+    fi
+
+    # Verify correct parameter is used
+    local actual_param=$(echo "$json_body" | jq -r 'keys | .[]' | grep -E 'max_tokens|max_completion_tokens')
+    if [[ "$actual_param" == "$expected_param" ]]; then
+        pass "Correct param '$expected_param' in JSON for $model"
+    else
+        fail "Wrong param in JSON for $model: expected '$expected_param', got '$actual_param'"
+    fi
+}
+
+# Test JSON generation for key models
+test_json_body "gpt-5" "max_completion_tokens"
+test_json_body "gpt-5.4" "max_completion_tokens"
+test_json_body "gpt-5-mini" "max_completion_tokens"
+test_json_body "gpt-4o" "max_tokens"
+test_json_body "claude-3-opus" "max_tokens"
+
+
+# ============================================================
+# Summary
+# ============================================================
+echo -e "\n${YELLOW}=== Summary ===${NC}\n"
+echo -e "Passed: ${GREEN}$PASSED${NC}"
+echo -e "Failed: ${RED}$FAILED${NC}"
+
+if [[ $FAILED -eq 0 ]]; then
+    echo -e "\n${GREEN}All tests passed!${NC}"
+    exit 0
+else
+    echo -e "\n${RED}Some tests failed!${NC}"
+    exit 1
+fi


### PR DESCRIPTION
GPT-5 series models require 'max_completion_tokens' instead of 'max_tokens' parameter. This fix updates all LLM connectivity test functions to dynamically select the correct parameter name based on the model being tested.

Changes:
- Add _get_max_tokens_param helper function to detect GPT-5 models
- Update Test-LlmConnectivity in PowerShell installer
- Update test_llm_connectivity in Bash installer
- Update model-switch skill scripts for manager and worker
- Add unit tests for the new function

Fixes #334