### PR TITLE
fix: use URL hash redirect for Control UI token injection

### DIFF
--- a/manager/scripts/init/start-element-web.sh
+++ b/manager/scripts/init/start-element-web.sh
@@ -51,9 +51,11 @@ server {
 NGINX
 
 # Generate Nginx config for OpenClaw Console reverse proxy.
-# Injects the gateway token into the HTML via sub_filter so the Control UI
-# auto-authenticates without requiring the user to enter a token manually.
-# Supports both old (localStorage) and new (sessionStorage) token storage for compatibility.
+# Injects the gateway token via inline script that sets location.hash with #token=...
+# This is the only reliable method across all openclaw versions — the Control UI
+# reads the token from the URL hash on load (both old and new versions support this).
+# CSP must be stripped to allow the inline script, and proxy headers (Host, X-Real-IP)
+# are omitted to avoid triggering untrusted-proxy detection in the gateway.
 OPENCLAW_TOKEN="${HICLAW_MANAGER_GATEWAY_KEY:-}"
 cat > /etc/nginx/conf.d/openclaw-console.conf << NGINX
 # OpenClaw Console — reverse proxy to gateway loopback with auto-token injection
@@ -65,8 +67,6 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;
         proxy_set_header Connection "upgrade";
-        proxy_set_header Host \$host;
-        proxy_set_header X-Real-IP \$remote_addr;
         # Disable upstream compression so sub_filter can modify HTML responses
         proxy_set_header Accept-Encoding "";
         proxy_read_timeout 3600s;
@@ -75,10 +75,10 @@ server {
         # Strip upstream CSP so inline token-injection script can run
         proxy_hide_header Content-Security-Policy;
 
-        # Auto-inject gateway token into both localStorage and sessionStorage for compatibility
+        # Auto-inject gateway token via URL hash redirect (works across all openclaw versions)
         sub_filter_types text/html;
         sub_filter_once on;
-        sub_filter '</head>' '<script>(function(){var T="${OPENCLAW_TOKEN}";if(!T)return;try{var K="openclaw.control.settings.v1",r=localStorage.getItem(K),s=r?JSON.parse(r):{};s.token=T;localStorage.setItem(K,JSON.stringify(s))}catch(e){}try{var p=location.protocol==="https:"?"wss":"ws";var gw=p+"://"+location.host;sessionStorage.setItem("openclaw.control.token.v1:"+gw,T)}catch(e){}})();</script></head>';
+        sub_filter '</head>' '<script>(function(){var T="${OPENCLAW_TOKEN}";if(!T||location.hash.indexOf("token=")!==-1)return;location.replace(location.pathname+"#token="+T)})();</script></head>';
     }
 }
 NGINX


### PR DESCRIPTION
## Summary

Replace localStorage/sessionStorage token injection with `location.hash` redirect (`#token=...`) for the OpenClaw Control UI nginx proxy.

## Problem

The Control UI intentionally scrubs persisted tokens from localStorage on load (`token: defaults.token` which is always `""`). Previous injection methods (localStorage, sessionStorage) were silently ignored by the UI, causing "device identity required" errors.

Additionally, `X-Real-IP` and `Host` proxy headers triggered untrusted-proxy detection in the gateway, preventing local client recognition even with `dangerouslyDisableDeviceAuth: true`.

## Solution

- Inject an inline script that redirects to `/#token=...` on first load — this is the native token ingestion path supported by all openclaw versions
- Strip `Content-Security-Policy` header to allow the inline script
- Remove `Host` and `X-Real-IP` proxy headers to avoid untrusted-proxy detection

## Testing

Verified on local hiclaw deployment with openclaw v2026.3.8 — Control UI auto-authenticates without manual token input.