### PR TITLE
fix(manager): use distinct hooks.token on first boot

### DIFF
--- a/manager/configs/manager-openclaw.json.tmpl
+++ b/manager/configs/manager-openclaw.json.tmpl
@@ -104,7 +104,7 @@
 
   "hooks": {
     "enabled": true,
-    "token": "${MANAGER_GATEWAY_KEY}"
+    "token": "${MANAGER_HOOKS_TOKEN}"
   },
 
   "plugins": {

--- a/manager/scripts/init/start-manager-agent.sh
+++ b/manager/scripts/init/start-manager-agent.sh
@@ -395,6 +395,7 @@ fi
 log "Generating Manager openclaw.json..."
 export MANAGER_MATRIX_TOKEN="${MANAGER_TOKEN}"
 export MANAGER_GATEWAY_KEY="${HICLAW_MANAGER_GATEWAY_KEY}"
+export MANAGER_HOOKS_TOKEN=$(echo -n "${HICLAW_MANAGER_GATEWAY_KEY}-hooks" | base64)
 
 # Resolve model parameters based on model name
 MODEL_NAME="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"


### PR DESCRIPTION
## Summary
- OpenClaw v2026.3.8 added validation that `hooks.token` must not match `gateway.auth.token`
- The manager template (`manager-openclaw.json.tmpl`) used the same `${MANAGER_GATEWAY_KEY}` for both, causing the gateway to fail on **first boot** with: `Invalid config: hooks.token must not match gateway auth token`
- The agent only recovered after supervisor restarted it and the update path (existing `openclaw.json`) generated a distinct base64-encoded hooks token
- Fix: pre-compute `MANAGER_HOOKS_TOKEN` as `base64(key + "-hooks")` in the template path, consistent with the update path, so the gateway starts successfully on the very first boot

## Test plan
- [x] `make install` with a clean volume (no existing `openclaw.json`) — gateway starts on first boot without exit status 1
- [ ] Verify `hooks.token` in generated `openclaw.json` differs from `gateway.auth.token`
- [ ] Verify upgrade path (existing `openclaw.json`) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)