### PR TITLE
fix(manager): use base64 -w 0 for hooks.token to prevent JSON parse error

### DIFF
--- a/manager/scripts/init/start-manager-agent.sh
+++ b/manager/scripts/init/start-manager-agent.sh
@@ -395,7 +395,7 @@ fi
 log "Generating Manager openclaw.json..."
 export MANAGER_MATRIX_TOKEN="${MANAGER_TOKEN}"
 export MANAGER_GATEWAY_KEY="${HICLAW_MANAGER_GATEWAY_KEY}"
-export MANAGER_HOOKS_TOKEN=$(echo -n "${HICLAW_MANAGER_GATEWAY_KEY}-hooks" | base64)
+export MANAGER_HOOKS_TOKEN=$(echo -n "${HICLAW_MANAGER_GATEWAY_KEY}-hooks" | base64 -w 0)
 
 # Resolve model parameters based on model name
 MODEL_NAME="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"


### PR DESCRIPTION
## Summary
- Linux `base64` wraps output at 76 chars by default. When `HICLAW_MANAGER_GATEWAY_KEY` is long, the encoded hooks token contains a newline (`\n`), producing invalid JSON after `envsubst` — causing OpenClaw to crash-loop with exit status 4.
- Fix: add `-w 0` to disable line wrapping, and use a distinct base64-encoded token for `hooks.token` to satisfy OpenClaw v2026.3.8 validation.

## Test plan
- [x] `make install` with a 32-byte random key, verify `openclaw.json` is valid JSON
- [x] Confirm `manager-agent` starts without crash-looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)