### PR TITLE
fix(scripts): add Python 3.7+ compatibility for export-debug-log

### DIFF
--- a/scripts/export-debug-log.py
+++ b/scripts/export-debug-log.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 """
 Export HiClaw debug logs: Matrix messages + agent session logs.
 


### PR DESCRIPTION
## Summary
- Add `from __future__ import annotations` to `scripts/export-debug-log.py` so it runs on Python 3.7+ instead of requiring 3.10+
- Fixes `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` when running with older Python versions

## Test plan
- [x] Run `python scripts/export-debug-log.py --range 1h` with Python 3.7/3.8/3.9 and verify no import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)