### PR TITLE
fix(manager): improve shell script safety in init scripts

### DIFF
--- a/manager/scripts/init/setup-higress.sh
+++ b/manager/scripts/init/setup-higress.sh
@@ -292,9 +292,9 @@ else
 fi
 
 # ============================================================
-# Wait for AI plugin activation (~40 seconds for first config)
+# Wait for AI plugin activation (~45 seconds for first config)
 # ============================================================
-log "Waiting for AI Gateway plugin activation (40s)..."
+log "Waiting for AI Gateway plugin activation (45s)..."
 sleep 45
 
 log "Higress setup complete"

--- a/manager/scripts/init/start-manager-agent.sh
+++ b/manager/scripts/init/start-manager-agent.sh
@@ -150,7 +150,15 @@ fi
 # Local mode: wait for mc mirror initialization (shared + worker data in /root/hiclaw-fs/)
 if [ "${HICLAW_RUNTIME}" != "aliyun" ]; then
     log "Waiting for MinIO storage initialization..."
-    while [ ! -f /root/hiclaw-fs/.initialized ]; do sleep 2; done
+    _minio_wait=0
+    while [ ! -f /root/hiclaw-fs/.initialized ]; do
+        sleep 2
+        _minio_wait=$(( _minio_wait + 1 ))
+        if [ "${_minio_wait}" -ge 60 ]; then
+            log "ERROR: MinIO storage initialization timed out after 120s"
+            exit 1
+        fi
+    done
     log "MinIO storage initialized"
 fi
 

--- a/manager/scripts/init/start-mc-mirror.sh
+++ b/manager/scripts/init/start-mc-mirror.sh
@@ -31,7 +31,7 @@ waitForService "MinIO" "127.0.0.1" 9000
 mc alias set hiclaw http://127.0.0.1:9000 "${HICLAW_MINIO_USER:-${HICLAW_ADMIN_USER:-admin}}" "${HICLAW_MINIO_PASSWORD:-${HICLAW_ADMIN_PASSWORD:-admin}}"
 
 # Create default bucket
-mc mb ${HICLAW_STORAGE_PREFIX} --ignore-existing
+mc mb "${HICLAW_STORAGE_PREFIX}" --ignore-existing
 
 # Initialize placeholder directories for shared data and worker artifacts
 for dir in shared/knowledge shared/tasks workers; do
@@ -44,7 +44,7 @@ HICLAW_FS_ROOT="/root/hiclaw-fs"
 mkdir -p "${HICLAW_FS_ROOT}"
 
 # Initial full sync to local (workers + shared)
-mc mirror ${HICLAW_STORAGE_PREFIX}/ "${HICLAW_FS_ROOT}/" --overwrite
+mc mirror "${HICLAW_STORAGE_PREFIX}/" "${HICLAW_FS_ROOT}/" --overwrite
 
 # Signal that initialization is complete
 touch "${HICLAW_FS_ROOT}/.initialized"
@@ -56,5 +56,5 @@ log "MinIO storage initialized and synced to ${HICLAW_FS_ROOT}/"
 # This loop is a safety net only — see design principle above.
 while true; do
     sleep 300
-    mc mirror ${HICLAW_STORAGE_PREFIX}/ "${HICLAW_FS_ROOT}/" --overwrite --newer-than "5m" 2>/dev/null || true
+    mc mirror "${HICLAW_STORAGE_PREFIX}/" "${HICLAW_FS_ROOT}/" --overwrite --newer-than "5m" 2>/dev/null || true
 done


### PR DESCRIPTION
- Quote ${HICLAW_STORAGE_PREFIX} in start-mc-mirror.sh to prevent word splitting when the value contains spaces or special characters
- Add 120s timeout to MinIO initialization wait loop in start-manager-agent.sh to prevent indefinite blocking
- Fix misleading comment in setup-higress.sh: update "~40 seconds" and log message to match the actual sleep 45 value