### PR TITLE
fix(ci): improve git-collab test reliability

### DIFF
--- a/manager/agent/AGENTS.md
+++ b/manager/agent/AGENTS.md
@@ -33,8 +33,16 @@ Don't ask permission. Just do it.
 
 YOLO mode check: `HICLAW_YOLO=1` env var or `~/yolo-mode` file exists. In YOLO mode, the admin has delegated full authority to you and is unavailable — you cannot reach them for confirmation. Any attempt to ask for confirmation will stall the workflow indefinitely. Make every decision yourself: create Workers, assign tasks, confirm projects, skip missing credentials, and proceed without pause.
 
+## MinIO Storage
+
+- **Local mirror:** `/root/hiclaw-fs/` — your local filesystem, NOT automatically synced
+- **MinIO prefix:** always use `${HICLAW_STORAGE_PREFIX}` in mc commands (this env var is pre-set in your shell, format: `<mc-alias>/<bucket>`)
+- **Example:** `mc mirror ${HICLAW_STORAGE_PREFIX}/shared/tasks/{task-id}/ /root/hiclaw-fs/shared/tasks/{task-id}/ --overwrite`
+- **NEVER guess or hardcode the prefix** — do NOT use `hiclaw-fs/...`, `hiclaw-storage/...`, or any literal path. Always use `${HICLAW_STORAGE_PREFIX}`. If unsure, run `echo $HICLAW_STORAGE_PREFIX` to check.
+
 ## Gotchas
 
+- **Create multiple Workers in parallel** — when you need 2+ Workers, run all `create-worker.sh` calls concurrently (e.g. via the `exec` tool's background mode or sequential-but-non-blocking invocations). Each creation takes ~45s; sequential creation of 3 Workers wastes ~90s. The scripts are independent and safe to run in parallel.
 - **@mention must use full Matrix ID** (with domain, e.g. `@alice:matrix-local.hiclaw.io:18080`) — writing "alice" or "@alice" without domain will NOT wake the Worker
 - **History context: only act on the Current message section** — do not @mention anyone based on the history section's senders
 - **Phase handoff requires immediate @mention** — just describing "bob will handle phase 2" without actually sending `@bob:...` stalls the workflow permanently

--- a/tests/test-14-git-collab.sh
+++ b/tests/test-14-git-collab.sh
@@ -99,7 +99,7 @@ DO NOT assign any phase to a different worker. DO NOT give alice phase 2 or phas
 IMPORTANT: You MUST use the EXACT branch names and file paths specified below. Do not rename, substitute, or simplify them. The verification system checks these exact names.
 
 Before starting any phase:
-1. Ensure workers with usernames exactly 'alice', 'bob', and 'charlie' exist with the git-delegation skill. The username (container name) must match exactly — do not use variations like 'alice-dev' or 'bob-backend'.
+1. Ensure workers with usernames exactly 'alice', 'bob', and 'charlie' exist with the git-delegation skill. The username (container name) must match exactly — do not use variations like 'alice-dev' or 'bob-backend'. IMPORTANT: Create any missing workers IN PARALLEL (run all create-worker.sh calls concurrently) to save time — do NOT create them one by one sequentially.
 2. Create a shared project room that includes alice, bob, charlie, and the human admin (use the create-project.sh script). All phase assignments and reports MUST happen in this project room — never in individual worker rooms.
 
 Run the phases strictly in order, waiting for each phase's report before starting the next.
@@ -172,9 +172,9 @@ while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
 done
 assert_not_empty "${MANAGER_TOKEN}" "Manager Matrix token available"
 
-log_info "Waiting for project room to be created (timeout: 600s)..."
+log_info "Waiting for project room to be created (timeout: 900s)..."
 PROJECT_ROOM=""
-DEADLINE=$(( $(date +%s) + 600 ))
+DEADLINE=$(( $(date +%s) + 900 ))
 while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
     PROJECT_ROOM=$(matrix_find_room_by_name "${MANAGER_TOKEN}" "Project:" 2>/dev/null || true)
     [ -n "${PROJECT_ROOM}" ] && break


### PR DESCRIPTION
## Summary

- Increase project room creation timeout from 600s to 900s in test-14-git-collab
- Instruct Manager to create multiple workers in parallel via AGENTS.md gotcha + test prompt
- Add MinIO Storage section to AGENTS.md so Manager uses `$HICLAW_STORAGE_PREFIX` instead of guessing wrong paths

## Context

CI run [#275](https://github.com/alibaba/hiclaw/actions/runs/23370223281) failed because the 4-phase Git Collaboration Test only completed Phase 1 before timeout. Root cause: ~18 minutes were consumed on sequential worker creation and earlier tasks, leaving only ~4 minutes for the 4-phase workflow. Additionally, the Manager wasted time trial-and-erroring MinIO paths.

## Test plan

- [ ] Re-run integration tests with test-14 to verify the git-collab workflow completes within the new timeout
- [ ] Verify Manager reads the MinIO Storage section and uses `$HICLAW_STORAGE_PREFIX` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)