### PR TITLE
fix(ci): prevent test-06 from capturing stale manager replies

### DIFF
--- a/tests/lib/matrix-client.sh
+++ b/tests/lib/matrix-client.sh
@@ -108,24 +108,33 @@ matrix_read_messages() {
 }
 
 # Wait for a reply from a specific user in a room
-# Usage: matrix_wait_for_reply <access_token> <room_id> <from_user_prefix> [timeout_seconds]
+# Usage: matrix_wait_for_reply <access_token> <room_id> <from_user_prefix> [timeout_seconds] [after_event_id]
 # Returns: the reply message body, or empty string on timeout
 #
-# This function snapshots the latest known event_id before polling, then only
-# returns messages that appear AFTER that snapshot. This prevents returning
-# stale messages from previous conversations (important in --use-existing mode).
+# This function only returns messages that appear AFTER a baseline event.
+# If after_event_id is provided (e.g. the event_id of the message you just sent),
+# it is used as the baseline — this is more reliable than snapshotting, because it
+# avoids a race where a delayed response to a *previous* request lands between
+# your send and the snapshot and is then mistaken for the reply you're waiting for.
+# When after_event_id is omitted, the function falls back to snapshotting the
+# latest event_id from the target user (legacy behaviour).
 matrix_wait_for_reply() {
     local token="$1"
     local room_id="$2"
     local from_user="$3"
     local timeout="${4:-180}"
+    local after_event="${5:-}"
     local elapsed=0
 
-    # Snapshot the latest event_id from the target user before we start waiting
+    # Determine baseline: prefer the caller-supplied event_id, fall back to snapshot
     local baseline_event
-    baseline_event=$(matrix_read_messages "${token}" "${room_id}" 5 2>/dev/null | \
-        jq -r --arg user "${from_user}" \
-        '[.chunk[] | select(.sender | startswith($user)) | .event_id] | first // ""' 2>/dev/null)
+    if [ -n "${after_event}" ]; then
+        baseline_event="${after_event}"
+    else
+        baseline_event=$(matrix_read_messages "${token}" "${room_id}" 5 2>/dev/null | \
+            jq -r --arg user "${from_user}" \
+            '[.chunk[] | select(.sender | startswith($user)) | .event_id] | first // ""' 2>/dev/null)
+    fi
 
     while [ "${elapsed}" -lt "${timeout}" ]; do
         sleep 10
@@ -134,21 +143,52 @@ matrix_wait_for_reply() {
         local messages
         messages=$(matrix_read_messages "${token}" "${room_id}" 10 2>/dev/null) || continue
 
-        # Get the latest message from the target user
-        local latest_event latest_body
-        latest_event=$(echo "${messages}" | jq -r --arg user "${from_user}" \
-            '[.chunk[] | select(.sender | startswith($user)) | .event_id] | first // ""' 2>/dev/null)
-        latest_body=$(echo "${messages}" | jq -r --arg user "${from_user}" \
-            '[.chunk[] | select(.sender | startswith($user)) | .content.body] | first // empty' 2>/dev/null)
+        if [ -n "${after_event}" ]; then
+            # Strict mode: only consider messages whose origin_server_ts is strictly
+            # greater than the after_event's timestamp. This filters out delayed
+            # responses to earlier requests that happen to arrive during our poll window.
+            local after_ts latest_body
+            after_ts=$(echo "${messages}" | jq -r --arg eid "${after_event}" \
+                '[.chunk[] | select(.event_id == $eid) | .origin_server_ts] | first // 0' 2>/dev/null)
+            # If the after_event isn't in this batch, fetch its timestamp directly
+            if [ "${after_ts}" = "0" ] || [ -z "${after_ts}" ]; then
+                local room_enc
+                room_enc="$(_encode_room_id "${room_id}")"
+                after_ts=$(exec_in_manager curl -sf \
+                    "${TEST_MATRIX_DIRECT_URL}/_matrix/client/v3/rooms/${room_enc}/event/$(_encode_event_id "${after_event}")" \
+                    -H "Authorization: Bearer ${token}" 2>/dev/null | jq -r '.origin_server_ts // 0' 2>/dev/null)
+            fi
+            latest_body=$(echo "${messages}" | jq -r --arg user "${from_user}" --argjson ts "${after_ts:-0}" \
+                '[.chunk[] | select(.sender | startswith($user)) | select(.origin_server_ts > $ts) | .content.body] | first // empty' 2>/dev/null)
+            if [ -n "${latest_body}" ]; then
+                echo "${latest_body}"
+                return 0
+            fi
+        else
+            # Legacy mode: compare event_id against baseline snapshot
+            local latest_event latest_body
+            latest_event=$(echo "${messages}" | jq -r --arg user "${from_user}" \
+                '[.chunk[] | select(.sender | startswith($user)) | .event_id] | first // ""' 2>/dev/null)
+            latest_body=$(echo "${messages}" | jq -r --arg user "${from_user}" \
+                '[.chunk[] | select(.sender | startswith($user)) | .content.body] | first // empty' 2>/dev/null)
 
-        # Only return if the event_id differs from baseline (i.e., it's a NEW message)
-        if [ -n "${latest_body}" ] && [ "${latest_event}" != "${baseline_event}" ]; then
-            echo "${latest_body}"
-            return 0
+            if [ -n "${latest_body}" ] && [ "${latest_event}" != "${baseline_event}" ]; then
+                echo "${latest_body}"
+                return 0
+            fi
         fi
     done
 
     return 1
+}
+
+# URL-encode a Matrix event ID for use in URL paths ($ -> %24, etc.)
+_encode_event_id() {
+    local eid="$1"
+    eid="${eid//\$/%24}"
+    eid="${eid//\//%2F}"
+    eid="${eid//+/%2B}"
+    echo "${eid}"
 }
 
 # Wait for a message containing a specific keyword from a user

--- a/tests/test-06-multi-worker.sh
+++ b/tests/test-06-multi-worker.sh
@@ -38,19 +38,29 @@ wait_for_manager_agent_ready 300 "${DM_ROOM}" "${ADMIN_TOKEN}" || {
 # Alice is running from previous tests; bob will be created below (offset=0 is correct for new workers)
 wait_for_worker_container "alice" 60
 METRICS_BASELINE=$(snapshot_baseline "alice" "bob")
-matrix_send_message "${ADMIN_TOKEN}" "${DM_ROOM}" \
-    "Create a new Worker for backend development. The worker's name (username) must be exactly 'bob'. He should have access to GitHub MCP."
+SEND_RESULT=$(matrix_send_message "${ADMIN_TOKEN}" "${DM_ROOM}" \
+    "Create a new Worker for backend development. The worker's name (username) must be exactly 'bob'. He should have access to GitHub MCP.")
+SEND_EVENT=$(echo "${SEND_RESULT}" | jq -r '.event_id // empty')
 
-log_info "Waiting for Manager to create Worker Bob..."
-REPLY=$(matrix_wait_for_reply "${ADMIN_TOKEN}" "${DM_ROOM}" "@manager" 180)
+log_info "Waiting for Manager to create Worker Bob... (after event: ${SEND_EVENT})"
+REPLY=$(matrix_wait_for_reply "${ADMIN_TOKEN}" "${DM_ROOM}" "@manager" 180 "${SEND_EVENT}")
 
 assert_not_empty "${REPLY}" "Manager replied to create bob request"
 assert_contains_i "${REPLY}" "bob" "Reply mentions worker name 'bob'"
 
-# Verify Bob's infrastructure (may take a moment for LLM to complete setup)
-sleep 30
+# Verify Bob's infrastructure — poll with retries instead of fixed sleep
+log_info "Waiting for Higress consumer 'worker-bob' to appear..."
 higress_login "${TEST_ADMIN_USER}" "${TEST_ADMIN_PASSWORD}" > /dev/null
-CONSUMERS=$(higress_get_consumers)
+CONSUMERS=""
+HIGRESS_ELAPSED=0
+while [ "${HIGRESS_ELAPSED}" -lt 90 ]; do
+    CONSUMERS=$(higress_get_consumers 2>/dev/null || echo "")
+    if echo "${CONSUMERS}" | grep -qi "worker-bob"; then
+        break
+    fi
+    sleep 10
+    HIGRESS_ELAPSED=$((HIGRESS_ELAPSED + 10))
+done
 assert_contains_i "${CONSUMERS}" "worker-bob" "Higress consumer 'worker-bob' exists"
 
 minio_setup
@@ -60,11 +70,12 @@ assert_eq "0" "${BOB_EXISTS}" "Worker Bob SOUL.md exists in MinIO"
 
 log_section "Assign Collaborative Task"
 
-matrix_send_message "${ADMIN_TOKEN}" "${DM_ROOM}" \
-    "I need Alice and Bob to collaborate on a task: Build a simple REST API. Alice handles the frontend HTML page, Bob handles the backend API endpoint. They should coordinate via shared files."
+SEND_RESULT2=$(matrix_send_message "${ADMIN_TOKEN}" "${DM_ROOM}" \
+    "I need Alice and Bob to collaborate on a task: Build a simple REST API. Alice handles the frontend HTML page, Bob handles the backend API endpoint. They should coordinate via shared files.")
+SEND_EVENT2=$(echo "${SEND_RESULT2}" | jq -r '.event_id // empty')
 
-log_info "Waiting for Manager to split and assign task..."
-REPLY=$(matrix_wait_for_reply "${ADMIN_TOKEN}" "${DM_ROOM}" "@manager" 300)
+log_info "Waiting for Manager to split and assign task... (after event: ${SEND_EVENT2})"
+REPLY=$(matrix_wait_for_reply "${ADMIN_TOKEN}" "${DM_ROOM}" "@manager" 300 "${SEND_EVENT2}")
 
 if [ -z "${REPLY}" ]; then
     log_info "No DM reply yet, checking if Manager created a Project Room instead..."


### PR DESCRIPTION
## Summary
- `matrix_wait_for_reply` 新增 `after_event_id` 参数，使用 `origin_server_ts` 时间戳比较替代 event_id 快照，消除延迟响应被误捕获的竞态窗口
- test-06 的两处 send+wait 改为捕获 event_id 并传入作为时间锚点
- Higress consumer 检查从 `sleep 30` + 单次检查改为最多 90s 的轮询重试

## Root Cause
Manager 对前一个请求（WebAssembly 任务）的延迟响应在 test-06 发送 "create bob" 之后才到达，被 `matrix_wait_for_reply` 的快照机制误认为是新回复。该回复不含 "bob"，导致断言失败；随后 Higress consumer 检查也因固定等待时间不足而失败。

## Test plan
- [ ] CI integration tests pass, test-06-multi-worker 不再因竞态条件失败
- [ ] 未传 `after_event_id` 的其他测试用例行为不变（向后兼容）

🤖 Generated with [Claude Code](https://claude.com/claude-code)