### PR TITLE
fix(security): add Docker API proxy to prevent container escape

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       # also pushes :latest in the same buildx call, so no separate step needed.
       - name: Build and push multi-arch images
         run: |
-          make push-manager push-manager-aliyun push-worker push-copaw-worker \
+          make push-manager push-manager-aliyun push-worker push-copaw-worker push-docker-proxy \
             VERSION=${{ steps.meta.outputs.version }} \
             REGISTRY=${{ env.REGISTRY }} \
             REPO=${{ env.REPO }} \
@@ -77,11 +77,13 @@ jobs:
           MANAGER_ALIYUN_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-manager-aliyun
           WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-worker
           COPAW_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-copaw-worker
+          DOCKER_PROXY_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-docker-proxy
         run: |
           echo "### Build Summary" >> $GITHUB_STEP_SUMMARY
           echo "- Manager: \`${MANAGER_IMAGE}:${{ steps.meta.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Manager Aliyun: \`${MANAGER_ALIYUN_IMAGE}:${{ steps.meta.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Worker: \`${WORKER_IMAGE}:${{ steps.meta.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- CoPaw Worker: \`${COPAW_WORKER_IMAGE}:${{ steps.meta.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Docker Proxy: \`${DOCKER_PROXY_IMAGE}:${{ steps.meta.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Base: \`${OPENCLAW_BASE_IMAGE}:latest\` (pre-built, not rebuilt here)" >> $GITHUB_STEP_SUMMARY
           echo "- Platforms: \`linux/amd64, linux/arm64\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'manager/**'
+      - 'docker-proxy/**'
       - 'tests/**'
       - '.github/workflows/test-integration.yml'
   push:
@@ -15,6 +16,7 @@ on:
       - 'v*'
     paths:
       - 'manager/**'
+      - 'docker-proxy/**'
       - 'tests/**'
   workflow_dispatch:
     inputs:
@@ -43,6 +45,7 @@ env:
   MANAGER_IMAGE: hiclaw/manager-agent:ci-test
   WORKER_IMAGE: hiclaw/worker-agent:ci-test
   COPAW_WORKER_IMAGE: hiclaw/copaw-worker:ci-test
+  DOCKER_PROXY_IMAGE: hiclaw/docker-proxy:ci-test
   # Tests that do not require a GitHub token
   NON_GITHUB_TESTS: "01 02 03 04 05 06 14"
 
@@ -82,10 +85,10 @@ jobs:
         run: |
           RUNTIME="${{ inputs.worker_runtime || 'openclaw' }}"
           if [ "$RUNTIME" = "copaw" ]; then
-            make build-manager build-copaw-worker VERSION=ci-test HIGRESS_REGISTRY=higress-registry.us-west-1.cr.aliyuncs.com \
+            make build-manager build-copaw-worker build-docker-proxy VERSION=ci-test HIGRESS_REGISTRY=higress-registry.us-west-1.cr.aliyuncs.com \
               DOCKER_BUILD_ARGS="--build-arg APT_MIRROR= --build-arg PIP_INDEX_URL=https://pypi.org/simple/"
           else
-            make build-manager build-worker VERSION=ci-test HIGRESS_REGISTRY=higress-registry.us-west-1.cr.aliyuncs.com
+            make build-manager build-worker build-docker-proxy VERSION=ci-test HIGRESS_REGISTRY=higress-registry.us-west-1.cr.aliyuncs.com
           fi
 
       - name: Install dependencies
@@ -111,6 +114,7 @@ jobs:
           HICLAW_DEFAULT_MODEL="$MODEL" \
           HICLAW_INSTALL_MANAGER_IMAGE=${{ env.MANAGER_IMAGE }} \
           HICLAW_INSTALL_WORKER_IMAGE="$WORKER_IMG" \
+          HICLAW_INSTALL_DOCKER_PROXY_IMAGE=${{ env.DOCKER_PROXY_IMAGE }} \
           bash ./install/hiclaw-install.sh manager
 
       - name: Wait for Manager to be ready

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,14 @@ MANAGER_IMAGE        ?= $(REGISTRY)/$(REPO)/hiclaw-manager
 MANAGER_ALIYUN_IMAGE ?= $(REGISTRY)/$(REPO)/hiclaw-manager-aliyun
 WORKER_IMAGE         ?= $(REGISTRY)/$(REPO)/hiclaw-worker
 COPAW_WORKER_IMAGE   ?= $(REGISTRY)/$(REPO)/hiclaw-copaw-worker
+DOCKER_PROXY_IMAGE   ?= $(REGISTRY)/$(REPO)/hiclaw-docker-proxy
 OPENCLAW_BASE_IMAGE  ?= $(REGISTRY)/$(REPO)/openclaw-base
 
 MANAGER_TAG        ?= $(MANAGER_IMAGE):$(VERSION)
 MANAGER_ALIYUN_TAG ?= $(MANAGER_ALIYUN_IMAGE):$(VERSION)
 WORKER_TAG         ?= $(WORKER_IMAGE):$(VERSION)
 COPAW_WORKER_TAG   ?= $(COPAW_WORKER_IMAGE):$(VERSION)
+DOCKER_PROXY_TAG   ?= $(DOCKER_PROXY_IMAGE):$(VERSION)
 OPENCLAW_BASE_TAG  ?= $(OPENCLAW_BASE_IMAGE):$(VERSION)
 
 # Local image names (no registry prefix, used by tests and install script)
@@ -41,6 +43,7 @@ LOCAL_MANAGER        = hiclaw/manager-agent:$(VERSION)
 LOCAL_MANAGER_ALIYUN = hiclaw/manager-aliyun:$(VERSION)
 LOCAL_WORKER         = hiclaw/worker-agent:$(VERSION)
 LOCAL_COPAW_WORKER   = hiclaw/copaw-worker:$(VERSION)
+LOCAL_DOCKER_PROXY   = hiclaw/docker-proxy:$(VERSION)
 LOCAL_OPENCLAW_BASE  = hiclaw/openclaw-base:$(VERSION)
 
 # Higress base image registry (regional mirrors auto-synced from cn-hangzhou primary)
@@ -89,8 +92,8 @@ LINES          ?= 50
 
 # ---------- Phony targets ----------
 
-.PHONY: all build build-openclaw-base build-manager build-manager-aliyun build-worker build-copaw-worker \
-        tag push push-openclaw-base push-manager push-manager-aliyun push-worker push-copaw-worker \
+.PHONY: all build build-openclaw-base build-manager build-manager-aliyun build-worker build-copaw-worker build-docker-proxy \
+        tag push push-openclaw-base push-manager push-manager-aliyun push-worker push-copaw-worker push-docker-proxy \
         push-native push-native-manager push-native-worker push-native-copaw-worker \
         buildx-setup \
         test test-quick test-installed \
@@ -105,7 +108,7 @@ all: build
 
 # ---------- Build ----------
 
-build: build-manager build-manager-aliyun build-worker build-copaw-worker ## Build all images (base image pulled from registry, not rebuilt locally)
+build: build-manager build-manager-aliyun build-worker build-copaw-worker build-docker-proxy ## Build all images (base image pulled from registry, not rebuilt locally)
 
 build-openclaw-base: ## Build OpenClaw base image
 	@echo "==> Building OpenClaw base image: $(LOCAL_OPENCLAW_BASE) (registry: $(HIGRESS_REGISTRY))"
@@ -145,6 +148,12 @@ build-copaw-worker: ## Build CoPaw Worker image
 		-t $(LOCAL_COPAW_WORKER) \
 		./copaw/
 
+build-docker-proxy: ## Build Docker API proxy image
+	@echo "==> Building Docker Proxy image: $(LOCAL_DOCKER_PROXY)"
+	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(DOCKER_BUILD_ARGS) \
+		-t $(LOCAL_DOCKER_PROXY) \
+		./docker-proxy/
+
 # ---------- Tag ----------
 
 tag: build ## Tag images for registry push
@@ -152,11 +161,13 @@ tag: build ## Tag images for registry push
 	docker tag $(LOCAL_MANAGER_ALIYUN) $(MANAGER_ALIYUN_TAG)
 	docker tag $(LOCAL_WORKER) $(WORKER_TAG)
 	docker tag $(LOCAL_COPAW_WORKER) $(COPAW_WORKER_TAG)
+	docker tag $(LOCAL_DOCKER_PROXY) $(DOCKER_PROXY_TAG)
 ifeq ($(PUSH_LATEST),yes)
 	docker tag $(LOCAL_MANAGER) $(MANAGER_IMAGE):latest
 	docker tag $(LOCAL_MANAGER_ALIYUN) $(MANAGER_ALIYUN_IMAGE):latest
 	docker tag $(LOCAL_WORKER) $(WORKER_IMAGE):latest
 	docker tag $(LOCAL_COPAW_WORKER) $(COPAW_WORKER_IMAGE):latest
+	docker tag $(LOCAL_DOCKER_PROXY) $(DOCKER_PROXY_IMAGE):latest
 	@echo "==> Images tagged as $(VERSION) and latest"
 else
 	@echo "==> Images tagged as $(VERSION) (latest not pushed for pre-release)"
@@ -184,7 +195,7 @@ else
 	fi
 endif
 
-push: push-manager push-manager-aliyun push-worker push-copaw-worker ## Build + push multi-arch images (amd64 + arm64); base image built separately via build-base.yml
+push: push-manager push-manager-aliyun push-worker push-copaw-worker push-docker-proxy ## Build + push multi-arch images (amd64 + arm64); base image built separately via build-base.yml
 
 push-openclaw-base: buildx-setup ## Build + push multi-arch OpenClaw base image
 	@echo "==> Building + pushing multi-arch OpenClaw base: $(OPENCLAW_BASE_TAG) [$(MULTIARCH_PLATFORMS)]"
@@ -317,6 +328,31 @@ else
 		./copaw/
 endif
 
+push-docker-proxy: buildx-setup ## Build + push multi-arch Docker Proxy image
+	@echo "==> Building + pushing multi-arch Docker Proxy: $(DOCKER_PROXY_TAG) [$(MULTIARCH_PLATFORMS)]"
+ifeq ($(IS_PODMAN),1)
+	-podman manifest rm $(DOCKER_PROXY_TAG) 2>/dev/null
+	$(foreach plat,$(subst $(comma), ,$(MULTIARCH_PLATFORMS)), \
+		echo "  -> Building Docker Proxy for $(plat)..." && \
+		podman build --platform $(plat) \
+			$(DOCKER_BUILD_ARGS) \
+			--manifest $(DOCKER_PROXY_TAG) \
+			./docker-proxy/ && ) true
+	podman manifest push --all $(DOCKER_PROXY_TAG) docker://$(DOCKER_PROXY_TAG)
+	$(if $(PUSH_LATEST), \
+		podman manifest push --all $(DOCKER_PROXY_TAG) docker://$(DOCKER_PROXY_IMAGE):latest && \
+		echo "  -> Also pushed :latest tag")
+else
+	docker buildx build \
+		--builder $(BUILDX_BUILDER) \
+		--platform $(MULTIARCH_PLATFORMS) \
+		$(DOCKER_BUILD_ARGS) \
+		-t $(DOCKER_PROXY_TAG) \
+		$(if $(PUSH_LATEST),-t $(DOCKER_PROXY_IMAGE):latest) \
+		--push \
+		./docker-proxy/
+endif
+
 # ---------- Push native-arch only (dev use) ----------
 # WARNING: Pushing single-arch images will overwrite multi-arch manifests.
 # Only use for local development / testing, never for release.
@@ -406,6 +442,7 @@ endif
 		HICLAW_INSTALL_MANAGER_IMAGE=$(LOCAL_MANAGER) \
 		HICLAW_INSTALL_WORKER_IMAGE=$(LOCAL_WORKER) \
 		HICLAW_INSTALL_COPAW_WORKER_IMAGE=$(LOCAL_COPAW_WORKER) \
+		HICLAW_INSTALL_DOCKER_PROXY_IMAGE=$(LOCAL_DOCKER_PROXY) \
 		bash ./install/hiclaw-install.sh manager
 
 install-interactive: ## Install Manager interactively (prompts for config)

--- a/docker-proxy/Dockerfile
+++ b/docker-proxy/Dockerfile
@@ -1,0 +1,12 @@
+ARG HIGRESS_REGISTRY=higress-registry.cn-hangzhou.cr.aliyuncs.com
+
+FROM ${HIGRESS_REGISTRY}/higress/golang:1.23-alpine AS builder
+WORKDIR /app
+COPY go.mod ./
+COPY *.go ./
+RUN CGO_ENABLED=0 go build -o /hiclaw-docker-proxy .
+
+FROM ${HIGRESS_REGISTRY}/higress/alpine:3.20
+COPY --from=builder /hiclaw-docker-proxy /usr/local/bin/
+EXPOSE 2375
+CMD ["hiclaw-docker-proxy"]

--- a/docker-proxy/go.mod
+++ b/docker-proxy/go.mod
@@ -1,0 +1,3 @@
+module github.com/alibaba/hiclaw/docker-proxy
+
+go 1.23

--- a/docker-proxy/main.go
+++ b/docker-proxy/main.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"regexp"
+)
+
+var (
+	// URL patterns for POST/DELETE allowlist
+	containerAction = regexp.MustCompile(`^(/v[\d.]+)?/containers/[a-zA-Z0-9_.-]+/(start|stop|kill|restart|wait|resize|attach|logs)$`)
+	containerExec   = regexp.MustCompile(`^(/v[\d.]+)?/containers/[a-zA-Z0-9_.-]+/exec$`)
+	containerCreate = regexp.MustCompile(`^(/v[\d.]+)?/containers/create$`)
+	containerDelete = regexp.MustCompile(`^(/v[\d.]+)?/containers/[a-zA-Z0-9_.-]+$`)
+	execStart       = regexp.MustCompile(`^(/v[\d.]+)?/exec/[a-zA-Z0-9]+/(start|resize|json)$`)
+	imageCreate     = regexp.MustCompile(`^(/v[\d.]+)?/images/create$`)
+)
+
+func main() {
+	socketPath := os.Getenv("HICLAW_PROXY_SOCKET")
+	if socketPath == "" {
+		socketPath = "/var/run/docker.sock"
+	}
+
+	listenAddr := os.Getenv("HICLAW_PROXY_LISTEN")
+	if listenAddr == "" {
+		listenAddr = ":2375"
+	}
+
+	validator := NewSecurityValidator()
+
+	transport := &http.Transport{
+		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+			return net.Dial("unix", socketPath)
+		},
+	}
+
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = "http"
+			req.URL.Host = "localhost"
+		},
+		Transport: transport,
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+
+		// GET requests are read-only, always allow
+		if r.Method == http.MethodGet || r.Method == http.MethodHead {
+			proxy.ServeHTTP(w, r)
+			return
+		}
+
+		// POST/DELETE allowlist
+		switch {
+		case r.Method == http.MethodPost && containerCreate.MatchString(path):
+			handleContainerCreate(w, r, proxy, validator)
+			return
+
+		case r.Method == http.MethodPost && containerAction.MatchString(path):
+			// start/stop/kill/restart/wait/resize/attach/logs — allow
+		case r.Method == http.MethodPost && containerExec.MatchString(path):
+			// exec create — allow
+		case r.Method == http.MethodPost && execStart.MatchString(path):
+			// exec start — allow
+		case r.Method == http.MethodPost && imageCreate.MatchString(path):
+			// image pull — allow
+		case r.Method == http.MethodDelete && containerDelete.MatchString(path):
+			// container remove — allow
+
+		default:
+			log.Printf("[DENIED] %s %s", r.Method, r.URL.String())
+			http.Error(w, fmt.Sprintf(`{"message":"hiclaw-docker-proxy: %s %s is not allowed"}`, r.Method, path), http.StatusForbidden)
+			return
+		}
+
+		proxy.ServeHTTP(w, r)
+	})
+
+	log.Printf("hiclaw-docker-proxy listening on %s, backend: %s", listenAddr, socketPath)
+	if len(validator.AllowedRegistries) > 0 {
+		log.Printf("Allowed registries: %v", validator.AllowedRegistries)
+	}
+	if err := http.ListenAndServe(listenAddr, handler); err != nil {
+		log.Fatalf("Failed to start server: %v", err)
+	}
+}
+
+func handleContainerCreate(w http.ResponseWriter, r *http.Request, proxy *httputil.ReverseProxy, v *SecurityValidator) {
+	// Read body
+	body, err := io.ReadAll(r.Body)
+	r.Body.Close()
+	if err != nil {
+		http.Error(w, `{"message":"hiclaw-docker-proxy: failed to read request body"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Parse container name from query param
+	containerName := r.URL.Query().Get("name")
+
+	// Parse request
+	var req ContainerCreateRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, `{"message":"hiclaw-docker-proxy: invalid JSON in request body"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Validate
+	if err := v.ValidateContainerCreate(req, containerName); err != nil {
+		log.Printf("[BLOCKED] POST /containers/create name=%s: %s", containerName, err)
+		msg, _ := json.Marshal(map[string]string{"message": fmt.Sprintf("hiclaw-docker-proxy: %s", err)})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		w.Write(msg)
+		return
+	}
+
+	log.Printf("[ALLOWED] POST /containers/create name=%s image=%s", containerName, req.Image)
+
+	// Restore body and forward
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
+	proxy.ServeHTTP(w, r)
+}

--- a/docker-proxy/security.go
+++ b/docker-proxy/security.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Higress registry pattern: higress-registry.{region}.cr.aliyuncs.com
+const higressRegistrySuffix = ".cr.aliyuncs.com/"
+
+func isHigressRegistry(image string) bool {
+	// Match higress-registry-*.cr.aliyuncs.com/* or higress-registry.*.cr.aliyuncs.com/*
+	idx := strings.Index(image, higressRegistrySuffix)
+	if idx < 0 {
+		return false
+	}
+	prefix := image[:idx]
+	return strings.HasPrefix(prefix, "higress-registry")
+}
+
+func isLocalImage(image string) bool {
+	// Local images have no dots before the first slash: e.g. "hiclaw/worker-agent:latest"
+	// Registry images have dots: e.g. "registry.example.com/repo/image:tag"
+	slashIdx := strings.Index(image, "/")
+	if slashIdx < 0 {
+		// No slash at all (e.g. "ubuntu:latest") — treat as local
+		return true
+	}
+	firstPart := image[:slashIdx]
+	return !strings.Contains(firstPart, ".")
+}
+
+func isLocalhostImage(image string) bool {
+	return strings.HasPrefix(image, "localhost/") || strings.HasPrefix(image, "localhost:") ||
+		strings.HasPrefix(image, "127.0.0.1/") || strings.HasPrefix(image, "127.0.0.1:")
+}
+
+// ContainerCreateRequest is a minimal representation of Docker's container create payload.
+// Only fields relevant to security validation are included.
+type ContainerCreateRequest struct {
+	Image      string      `json:"Image"`
+	HostConfig *HostConfig `json:"HostConfig,omitempty"`
+}
+
+type HostConfig struct {
+	Binds       []string `json:"Binds,omitempty"`
+	Mounts      []Mount  `json:"Mounts,omitempty"`
+	Privileged  bool     `json:"Privileged,omitempty"`
+	NetworkMode string   `json:"NetworkMode,omitempty"`
+	PidMode     string   `json:"PidMode,omitempty"`
+	CapAdd      []string `json:"CapAdd,omitempty"`
+}
+
+type Mount struct {
+	Type string `json:"Type,omitempty"`
+}
+
+// SecurityValidator enforces container creation policies.
+type SecurityValidator struct {
+	AllowedRegistries []string
+	ContainerPrefix   string
+	DangerousCaps     map[string]bool
+}
+
+// NewSecurityValidator creates a validator from environment variables.
+func NewSecurityValidator() *SecurityValidator {
+	// Additional allowed image sources — can be a registry (e.g. "ghcr.io")
+	// or registry+path (e.g. "ghcr.io/myorg", "registry.example.com/team/workers")
+	var allowedRegistries []string
+	if env := os.Getenv("HICLAW_PROXY_ALLOWED_REGISTRIES"); env != "" {
+		for _, r := range strings.Split(env, ",") {
+			r = strings.TrimSpace(r)
+			if r != "" {
+				allowedRegistries = append(allowedRegistries, r)
+			}
+		}
+	}
+
+	prefix := "hiclaw-worker-"
+	if env := os.Getenv("HICLAW_PROXY_CONTAINER_PREFIX"); env != "" {
+		prefix = env
+	}
+
+	return &SecurityValidator{
+		AllowedRegistries: allowedRegistries,
+		ContainerPrefix:   prefix,
+		DangerousCaps: map[string]bool{
+			"SYS_ADMIN":    true,
+			"SYS_PTRACE":   true,
+			"DAC_OVERRIDE":  true,
+			"NET_ADMIN":    true,
+			"SYS_RAWIO":    true,
+			"SYS_MODULE":   true,
+		},
+	}
+}
+
+// ValidateContainerCreate checks a container creation request against security policies.
+func (v *SecurityValidator) ValidateContainerCreate(req ContainerCreateRequest, containerName string) error {
+	// 1. Container name prefix
+	if containerName != "" && !strings.HasPrefix(containerName, v.ContainerPrefix) {
+		return fmt.Errorf("container name %q must start with %q", containerName, v.ContainerPrefix)
+	}
+	if strings.Contains(containerName, "/") || strings.Contains(containerName, "..") {
+		return fmt.Errorf("container name %q contains invalid characters", containerName)
+	}
+
+	// 2. Image allowlist
+	if !v.isImageAllowed(req.Image) {
+		return fmt.Errorf("image %q is not allowed (not a local image, localhost, Higress registry, or configured registry)", req.Image)
+	}
+
+	if req.HostConfig == nil {
+		return nil
+	}
+
+	// 3. No bind mounts (workers use MinIO, not host volumes)
+	if len(req.HostConfig.Binds) > 0 {
+		return fmt.Errorf("bind mounts are not allowed (got %d bind(s))", len(req.HostConfig.Binds))
+	}
+	for _, m := range req.HostConfig.Mounts {
+		if strings.EqualFold(m.Type, "bind") {
+			return fmt.Errorf("bind-type mounts are not allowed")
+		}
+	}
+
+	// 4. No privileged mode
+	if req.HostConfig.Privileged {
+		return fmt.Errorf("privileged mode is not allowed")
+	}
+
+	// 5. No host network
+	if req.HostConfig.NetworkMode == "host" {
+		return fmt.Errorf("host network mode is not allowed")
+	}
+
+	// 6. No host PID
+	if req.HostConfig.PidMode == "host" {
+		return fmt.Errorf("host PID mode is not allowed")
+	}
+
+	// 7. No dangerous capabilities
+	for _, cap := range req.HostConfig.CapAdd {
+		if v.DangerousCaps[strings.ToUpper(cap)] {
+			return fmt.Errorf("capability %q is not allowed", cap)
+		}
+	}
+
+	return nil
+}
+
+func (v *SecurityValidator) isImageAllowed(image string) bool {
+	// Allow all images from Higress registries (any region)
+	if isHigressRegistry(image) {
+		return true
+	}
+	// Allow local images (no registry prefix, e.g. "hiclaw/worker-agent:latest")
+	if isLocalImage(image) {
+		return true
+	}
+	// Allow localhost images
+	if isLocalhostImage(image) {
+		return true
+	}
+	// Check configured allowed image sources (registry or registry/path prefix)
+	for _, reg := range v.AllowedRegistries {
+		if strings.HasPrefix(image, reg+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/docker-proxy/security_test.go
+++ b/docker-proxy/security_test.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"testing"
+)
+
+func newTestValidator() *SecurityValidator {
+	return &SecurityValidator{
+		AllowedRegistries: []string{},
+		ContainerPrefix:   "hiclaw-worker-",
+		DangerousCaps: map[string]bool{
+			"SYS_ADMIN":   true,
+			"SYS_PTRACE":  true,
+			"DAC_OVERRIDE": true,
+			"NET_ADMIN":   true,
+			"SYS_RAWIO":   true,
+			"SYS_MODULE":  true,
+		},
+	}
+}
+
+func TestValidWorkerCreate(t *testing.T) {
+	v := newTestValidator()
+	req := ContainerCreateRequest{
+		Image:      "hiclaw/worker-agent:latest",
+		HostConfig: &HostConfig{},
+	}
+	if err := v.ValidateContainerCreate(req, "hiclaw-worker-alice"); err != nil {
+		t.Errorf("expected valid request to pass, got: %v", err)
+	}
+}
+
+func TestValidCopawWorkerCreate(t *testing.T) {
+	v := newTestValidator()
+	req := ContainerCreateRequest{
+		Image:      "hiclaw/copaw-worker:latest",
+		HostConfig: &HostConfig{},
+	}
+	if err := v.ValidateContainerCreate(req, "hiclaw-worker-bob"); err != nil {
+		t.Errorf("expected valid copaw request to pass, got: %v", err)
+	}
+}
+
+func TestNoHostConfig(t *testing.T) {
+	v := newTestValidator()
+	req := ContainerCreateRequest{
+		Image: "hiclaw/worker-agent:latest",
+	}
+	if err := v.ValidateContainerCreate(req, "hiclaw-worker-alice"); err != nil {
+		t.Errorf("expected nil HostConfig to pass, got: %v", err)
+	}
+}
+
+func TestEmptyContainerName(t *testing.T) {
+	v := newTestValidator()
+	req := ContainerCreateRequest{
+		Image:      "hiclaw/worker-agent:latest",
+		HostConfig: &HostConfig{},
+	}
+	// Empty name should pass (Docker generates one)
+	if err := v.ValidateContainerCreate(req, ""); err != nil {
+		t.Errorf("expected empty name to pass, got: %v", err)
+	}
+}
+
+// --- Rejection tests ---
+
+func TestRejectBadContainerName(t *testing.T) {
+	v := newTestValidator()
+	req := ContainerCreateRequest{
+		Image:      "hiclaw/worker-agent:latest",
+		HostConfig: &HostConfig{},
+	}
+	cases := []string{
+		"evil-container",
+		"my-worker-alice",
+		"hiclaw-manager-backdoor",
+	}
+	for _, name := range cases {
+		if err := v.ValidateContainerCreate(req, name); err == nil {
+			t.Errorf("expected name %q to be rejected", name)
+		}
+	}
+}
+
+func TestRejectContainerNameTraversal(t *testing.T) {
+	v := newTestValidator()
+	req := ContainerCreateRequest{
+		Image:      "hiclaw/worker-agent:latest",
+		HostConfig: &HostConfig{},
+	}
+	cases := []string{
+		"hiclaw-worker-../escape",
+		"hiclaw-worker-foo/bar",
+	}
+	for _, name := range cases {
+		if err := v.ValidateContainerCreate(req, name); err == nil {
+			t.Errorf("expected name %q to be rejected", name)
+		}
+	}
+}
+
+func TestRejectUnallowedImage(t *testing.T) {
+	v := newTestValidator()
+	// Only external registry images not in higress should be rejected
+	cases := []string{
+		"docker.io/library/ubuntu:latest",
+		"gcr.io/my-project/evil:latest",
+		"registry.example.com/repo/image:tag",
+	}
+	for _, img := range cases {
+		req := ContainerCreateRequest{
+			Image:      img,
+			HostConfig: &HostConfig{},
+		}
+		if err := v.ValidateContainerCreate(req, "hiclaw-worker-test"); err == nil {
+			t.Errorf("expected image %q to be rejected", img)
+		}
+	}
+}
+
+func TestAllowLocalImages(t *testing.T) {
+	v := newTestValidator()
+	cases := []string{
+		"hiclaw/worker-agent:latest",
+		"hiclaw/copaw-worker:latest",
+		"hiclaw/manager-agent:latest",
+		"myteam/custom-worker:v1",
+		"ubuntu:latest",
+	}
+	for _, img := range cases {
+		req := ContainerCreateRequest{
+			Image:      img,
+			HostConfig: &HostConfig{},
+		}
+		if err := v.ValidateContainerCreate(req, "hiclaw-worker-test"); err != nil {
+			t.Errorf("expected local image %q to be allowed, got: %v", img, err)
+		}
+	}
+}
+
+func TestAllowLocalhostImages(t *testing.T) {
+	v := newTestValidator()
+	cases := []string{
+		"localhost/myimage:latest",
+		"localhost:5000/myimage:latest",
+		"127.0.0.1/myimage:latest",
+		"127.0.0.1:5000/myimage:latest",
+	}
+	for _, img := range cases {
+		req := ContainerCreateRequest{
+			Image:      img,
+			HostConfig: &HostConfig{},
+		}
+		if err := v.ValidateContainerCreate(req, "hiclaw-worker-test"); err != nil {
+			t.Errorf("expected localhost image %q to be allowed, got: %v", img, err)
+		}
+	}
+}
+
+func TestAllowHigressRegistryImages(t *testing.T) {
+	v := newTestValidator()
+	cases := []string{
+		"higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/hiclaw-worker:latest",
+		"higress-registry.us-west-1.cr.aliyuncs.com/higress/hiclaw-worker:v1.0",
+		"higress-registry.ap-southeast-7.cr.aliyuncs.com/higress/custom-image:latest",
+	}
+	for _, img := range cases {
+		req := ContainerCreateRequest{
+			Image:      img,
+			HostConfig: &HostConfig{},
+		}
+		if err := v.ValidateContainerCreate(req, "hiclaw-worker-test"); err != nil {
+			t.Errorf("expected higress image %q to be allowed, got: %v", img, err)
+		}
+	}
+}
+
+func TestAllowConfiguredRegistries(t *testing.T) {
+	v := newTestValidator()
+	v.AllowedRegistries = []string{"ghcr.io/myorg", "registry.example.com"}
+
+	cases := []string{
+		"ghcr.io/myorg/custom-worker:latest",
+		"ghcr.io/myorg/tools/builder:v2",
+		"registry.example.com/team/worker:latest",
+	}
+	for _, img := range cases {
+		req := ContainerCreateRequest{
+			Image:      img,
+			HostConfig: &HostConfig{},
+		}
+		if err := v.ValidateContainerCreate(req, "hiclaw-worker-test"); err != nil {
+			t.Errorf("expected configured registry image %q to be allowed, got: %v", img, err)
+		}
+	}
+
+	// Should still block other registries
+	blocked := []string{
+		"ghcr.io/otherorg/evil:latest",
+		"gcr.io/myorg/image:latest",
+	}
+	for _, img := range blocked {
+		req := ContainerCreateRequest{
+			Image:      img,
+			HostConfig: &HostConfig{},
+		}
+		if err := v.ValidateContainerCreate(req, "hiclaw-worker-test"); err == nil {
+			t.Errorf("expected image %q to be rejected", img)
+		}
+	}
+}
+
+func TestRejectBindMounts(t *testing.T) {
+	v := newTestValidator()
+	req := ContainerCreateRequest{
+		Image: "hiclaw/worker-agent:latest",
+		HostConfig: &HostConfig{
+			Binds: []string{"/root:/hostroot"},
+		},
+	}
+	if err := v.ValidateContainerCreate(req, "hiclaw-worker-test"); err == nil {
+		t.Error("expected bind mount to be rejected")
+	}
+}
+
+func TestRejectBindTypeMounts(t *testing.T) {
+	v := newTestValidator()
+	req := ContainerCreateRequest{
+		Image: "hiclaw/worker-agent:latest",
+		HostConfig: &HostConfig{
+			Mounts: []Mount{{Type: "bind"}},
+		},
+	}
+	if err := v.ValidateContainerCreate(req, "hiclaw-worker-test"); err == nil {
+		t.Error("expected bind-type mount to be rejected")
+	}
+}
+
+func TestRejectPrivileged(t *testing.T) {
+	v := newTestValidator()
+	req := ContainerCreateRequest{
+		Image: "hiclaw/worker-agent:latest",
+		HostConfig: &HostConfig{
+			Privileged: true,
+		},
+	}
+	if err := v.ValidateContainerCreate(req, "hiclaw-worker-test"); err == nil {
+		t.Error("expected privileged to be rejected")
+	}
+}
+
+func TestRejectHostNetwork(t *testing.T) {
+	v := newTestValidator()
+	req := ContainerCreateRequest{
+		Image: "hiclaw/worker-agent:latest",
+		HostConfig: &HostConfig{
+			NetworkMode: "host",
+		},
+	}
+	if err := v.ValidateContainerCreate(req, "hiclaw-worker-test"); err == nil {
+		t.Error("expected host network to be rejected")
+	}
+}
+
+func TestRejectHostPID(t *testing.T) {
+	v := newTestValidator()
+	req := ContainerCreateRequest{
+		Image: "hiclaw/worker-agent:latest",
+		HostConfig: &HostConfig{
+			PidMode: "host",
+		},
+	}
+	if err := v.ValidateContainerCreate(req, "hiclaw-worker-test"); err == nil {
+		t.Error("expected host PID to be rejected")
+	}
+}
+
+func TestRejectDangerousCaps(t *testing.T) {
+	v := newTestValidator()
+	caps := []string{"SYS_ADMIN", "SYS_PTRACE", "DAC_OVERRIDE", "NET_ADMIN", "sys_admin"}
+	for _, cap := range caps {
+		req := ContainerCreateRequest{
+			Image: "hiclaw/worker-agent:latest",
+			HostConfig: &HostConfig{
+				CapAdd: []string{cap},
+			},
+		}
+		if err := v.ValidateContainerCreate(req, "hiclaw-worker-test"); err == nil {
+			t.Errorf("expected capability %q to be rejected", cap)
+		}
+	}
+}
+
+func TestAllowBridgeNetwork(t *testing.T) {
+	v := newTestValidator()
+	req := ContainerCreateRequest{
+		Image: "hiclaw/worker-agent:latest",
+		HostConfig: &HostConfig{
+			NetworkMode: "bridge",
+		},
+	}
+	if err := v.ValidateContainerCreate(req, "hiclaw-worker-test"); err != nil {
+		t.Errorf("expected bridge network to pass, got: %v", err)
+	}
+}
+
+func TestAllowSafeCaps(t *testing.T) {
+	v := newTestValidator()
+	req := ContainerCreateRequest{
+		Image: "hiclaw/worker-agent:latest",
+		HostConfig: &HostConfig{
+			CapAdd: []string{"NET_BIND_SERVICE"},
+		},
+	}
+	if err := v.ValidateContainerCreate(req, "hiclaw-worker-test"); err != nil {
+		t.Errorf("expected safe cap to pass, got: %v", err)
+	}
+}

--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -391,6 +391,17 @@ $script:Messages = @{
     "matrix_e2ee.selected_enabled" = @{ zh = "Matrix E2EE: 已启用"; en = "Matrix E2EE: enabled" }
     "matrix_e2ee.selected_disabled" = @{ zh = "Matrix E2EE: 已禁用（默认）"; en = "Matrix E2EE: disabled (default)" }
 
+    # --- Docker API proxy ---
+    "docker_proxy.title" = @{ zh = "--- Docker API 安全代理 ---"; en = "--- Docker API Security Proxy ---" }
+    "docker_proxy.desc" = @{ zh = "Docker API 代理可防止 AI Agent 通过 Docker API 越狱访问宿主机。`n  启用后，Manager 不再直接持有 Docker socket，所有容器操作经过安全校验。"; en = "Docker API proxy prevents AI Agents from escaping via Docker API to access the host.`n  When enabled, Manager no longer has direct Docker socket access; all container operations go through security validation." }
+    "docker_proxy.enable" = @{ zh = "启用（推荐）"; en = "Enable (recommended)" }
+    "docker_proxy.disable" = @{ zh = "禁用（直接挂载 Docker socket）"; en = "Disable (mount Docker socket directly)" }
+    "docker_proxy.choice" = @{ zh = "请选择 [1/2]"; en = "Enter choice [1/2]" }
+    "docker_proxy.selected_enabled" = @{ zh = "Docker API 代理: 已启用"; en = "Docker API proxy: enabled" }
+    "docker_proxy.selected_disabled" = @{ zh = "Docker API 代理: 已禁用"; en = "Docker API proxy: disabled" }
+    "docker_proxy.registries_desc" = @{ zh = "默认放行的镜像来源：本地镜像、localhost、Higress 仓库（所有 region）。`n  如需放行其他镜像仓库，请输入逗号分隔的地址前缀。`n  示例: ghcr.io/myorg,registry.example.com/team"; en = "Default allowed image sources: local images, localhost, Higress registries (all regions).`n  To allow additional image sources, enter comma-separated address prefixes.`n  Example: ghcr.io/myorg,registry.example.com/team" }
+    "docker_proxy.registries_prompt" = @{ zh = "额外放行的镜像来源（按回车跳过）"; en = "Additional allowed image sources (press Enter to skip)" }
+
     # --- Worker idle timeout ---
     "idle_timeout.prompt" = @{ zh = "Worker 空闲自动停止超时（分钟）[720]"; en = "Worker idle auto-stop timeout in minutes [720]" }
     "idle_timeout.selected" = @{ zh = "Worker 空闲超时: {0} 分钟"; en = "Worker idle timeout: {0} minutes" }
@@ -781,6 +792,12 @@ HICLAW_DEFAULT_WORKER_RUNTIME=$($Config.DEFAULT_WORKER_RUNTIME)
 
 # Matrix E2EE (0=disabled, 1=enabled; default: 0)
 HICLAW_MATRIX_E2EE=$($Config.MATRIX_E2EE)
+
+# Docker API proxy (0=disabled, 1=enabled; default: 1)
+HICLAW_DOCKER_PROXY=$($Config.DOCKER_PROXY)
+
+# Docker API proxy: additional allowed image sources (comma-separated)
+HICLAW_PROXY_ALLOWED_REGISTRIES=$($Config.PROXY_ALLOWED_REGISTRIES)
 
 # Worker idle timeout in minutes (default: 720 = 12 hours)
 HICLAW_WORKER_IDLE_TIMEOUT=$($Config.WORKER_IDLE_TIMEOUT)
@@ -1308,7 +1325,7 @@ function Test-ShouldSkipStep {
             if ($script:HICLAW_QUICKSTART) { return $true }
             return $false
         }
-        { $_ -in @("Step-E2ee", "Step-Idle") } {
+        { $_ -in @("Step-E2ee", "Step-Idle", "Step-DockerProxy") } {
             if ($script:HICLAW_NON_INTERACTIVE) { return $true }
             if ($script:HICLAW_QUICKSTART -and -not $script:HICLAW_UPGRADE) { return $true }
             return $false
@@ -1371,6 +1388,10 @@ function Clear-StepVars {
         }
         "Step-E2ee" {
             [Environment]::SetEnvironmentVariable("HICLAW_MATRIX_E2EE", $null, "Process")
+        }
+        "Step-DockerProxy" {
+            [Environment]::SetEnvironmentVariable("HICLAW_DOCKER_PROXY", $null, "Process")
+            [Environment]::SetEnvironmentVariable("HICLAW_PROXY_ALLOWED_REGISTRIES", $null, "Process")
         }
         "Step-Idle" {
             [Environment]::SetEnvironmentVariable("HICLAW_WORKER_IDLE_TIMEOUT", $null, "Process")
@@ -1877,6 +1898,63 @@ function Step-E2ee {
     }
 }
 
+function Step-DockerProxy {
+    if (-not $script:HICLAW_MOUNT_SOCKET) {
+        $script:config.DOCKER_PROXY = "0"
+        return
+    }
+
+    Write-Host ""
+    Write-Log (Get-Msg "docker_proxy.title")
+    Write-Host ""
+    Write-Host "  $(Get-Msg 'docker_proxy.desc')"
+    Write-Host ""
+    Write-Host "  1) $(Get-Msg 'docker_proxy.enable')"
+    Write-Host "  2) $(Get-Msg 'docker_proxy.disable')"
+    Write-Host ""
+
+    if ($script:HICLAW_UPGRADE -and $env:HICLAW_DOCKER_PROXY) {
+        Write-Log (Get-Msg "prompt.upgrade_keep" -f "HICLAW_DOCKER_PROXY", $env:HICLAW_DOCKER_PROXY)
+        $proxyChoice = Read-Host (Get-Msg "docker_proxy.choice")
+        if ($proxyChoice -eq "b") { $script:StepResult = "back"; return }
+        if ($proxyChoice) {
+            $script:config.DOCKER_PROXY = if ($proxyChoice -eq "2") { "0" } else { "1" }
+        } else {
+            $script:config.DOCKER_PROXY = $env:HICLAW_DOCKER_PROXY
+        }
+    } elseif (-not $env:HICLAW_DOCKER_PROXY) {
+        $proxyChoice = Read-Host (Get-Msg "docker_proxy.choice")
+        if ($proxyChoice -eq "b") { $script:StepResult = "back"; return }
+        $proxyChoice = if ($proxyChoice) { $proxyChoice } else { "1" }
+        $script:config.DOCKER_PROXY = if ($proxyChoice -eq "2") { "0" } else { "1" }
+    } else {
+        $script:config.DOCKER_PROXY = $env:HICLAW_DOCKER_PROXY
+    }
+
+    if ($script:config.DOCKER_PROXY -eq "1") {
+        Write-Log (Get-Msg "docker_proxy.selected_enabled")
+
+        # Prompt for additional allowed image sources
+        Write-Host ""
+        Write-Host "  $(Get-Msg 'docker_proxy.registries_desc')"
+        Write-Host ""
+        if ($script:HICLAW_UPGRADE -and $env:HICLAW_PROXY_ALLOWED_REGISTRIES) {
+            Write-Log (Get-Msg "prompt.upgrade_keep" -f "HICLAW_PROXY_ALLOWED_REGISTRIES", $env:HICLAW_PROXY_ALLOWED_REGISTRIES)
+            $regInput = Read-Host (Get-Msg "docker_proxy.registries_prompt")
+            if ($regInput -eq "b") { $script:StepResult = "back"; return }
+            $script:config.PROXY_ALLOWED_REGISTRIES = if ($regInput) { $regInput } else { $env:HICLAW_PROXY_ALLOWED_REGISTRIES }
+        } elseif (-not $env:HICLAW_PROXY_ALLOWED_REGISTRIES) {
+            $regInput = Read-Host (Get-Msg "docker_proxy.registries_prompt")
+            if ($regInput -eq "b") { $script:StepResult = "back"; return }
+            $script:config.PROXY_ALLOWED_REGISTRIES = if ($regInput) { $regInput } else { "" }
+        } else {
+            $script:config.PROXY_ALLOWED_REGISTRIES = $env:HICLAW_PROXY_ALLOWED_REGISTRIES
+        }
+    } else {
+        Write-Log (Get-Msg "docker_proxy.selected_disabled")
+    }
+}
+
 function Step-Idle {
     if ($script:HICLAW_UPGRADE -and $env:HICLAW_WORKER_IDLE_TIMEOUT) {
         Write-Log (Get-Msg "prompt.upgrade_keep" -f "HICLAW_WORKER_IDLE_TIMEOUT", $env:HICLAW_WORKER_IDLE_TIMEOUT)
@@ -1958,6 +2036,12 @@ function Install-Manager {
         "$($script:HICLAW_REGISTRY)/higress/hiclaw-copaw-worker:$($script:HICLAW_VERSION)"
     }
 
+    $script:DOCKER_PROXY_IMAGE = if ($env:HICLAW_INSTALL_DOCKER_PROXY_IMAGE) {
+        $env:HICLAW_INSTALL_DOCKER_PROXY_IMAGE
+    } else {
+        "$($script:HICLAW_REGISTRY)/higress/hiclaw-docker-proxy:$($script:HICLAW_VERSION)"
+    }
+
     Write-Log (Get-Msg "install.registry" -f $script:HICLAW_REGISTRY)
     Write-Log ""
     Write-Log (Get-Msg "install.dir" -f (Get-Location))
@@ -2031,7 +2115,7 @@ function Install-Manager {
     # ── State machine ─────────────────────────────────────────────────────────
     $_steps = @("Step-Lang", "Step-Mode", "Step-Existing", "Step-Llm", "Step-Admin",
                 "Step-Network", "Step-Ports", "Step-Domains", "Step-Github", "Step-Skills",
-                "Step-Volume", "Step-Workspace", "Step-Runtime", "Step-E2ee", "Step-Idle",
+                "Step-Volume", "Step-Workspace", "Step-Runtime", "Step-E2ee", "Step-DockerProxy", "Step-Idle",
                 "Step-Hostshare")
     $_stepHistory = [System.Collections.Generic.List[int]]::new()
     $_stepIdx = 0
@@ -2137,11 +2221,32 @@ function Install-Manager {
 
     # Docker socket mount (Windows uses named pipe)
     # On Windows, we test socket availability by running docker commands
+    $socketMounted = $false
     if ($script:HICLAW_MOUNT_SOCKET) {
         $socketAvailable = Test-DockerRunning
         if ($socketAvailable) {
-            $dockerArgs += @("-v", "//var/run/docker.sock:/var/run/docker.sock")
-            Write-Log (Get-Msg "install.socket_detected" -f "//var/run/docker.sock")
+            # Start Docker API proxy if enabled
+            if ($config.DOCKER_PROXY -eq "1") {
+                $proxyImage = $script:DOCKER_PROXY_IMAGE
+                # Ensure Docker network exists (reuse if already present)
+                docker network inspect hiclaw-net *>$null
+                if ($LASTEXITCODE -ne 0) { docker network create hiclaw-net *>$null }
+                Write-Log "Starting Docker API proxy..."
+                docker rm -f hiclaw-docker-proxy *>$null
+                docker run -d --name hiclaw-docker-proxy `
+                    --network hiclaw-net `
+                    -v "//var/run/docker.sock:/var/run/docker.sock" `
+                    --security-opt label=disable `
+                    $(if ($config.PROXY_ALLOWED_REGISTRIES) { @("-e", "HICLAW_PROXY_ALLOWED_REGISTRIES=$($config.PROXY_ALLOWED_REGISTRIES)") }) `
+                    --restart unless-stopped `
+                    $proxyImage
+                $dockerArgs += @("-e", "HICLAW_CONTAINER_API=http://hiclaw-docker-proxy:2375")
+                $dockerArgs += @("--network", "hiclaw-net")
+                Write-Log (Get-Msg "docker_proxy.selected_enabled")
+            } else {
+                $dockerArgs += @("-v", "//var/run/docker.sock:/var/run/docker.sock")
+                Write-Log (Get-Msg "install.socket_detected" -f "//var/run/docker.sock")
+            }
         } else {
             Write-Log (Get-Msg "install.socket_not_found")
             # Interactive confirmation when socket not found
@@ -2245,6 +2350,11 @@ function Install-Manager {
 
     # Stop and remove existing containers (deferred until after all
     # configuration is collected and images are pulled successfully)
+    $existingProxy = docker ps -a --format "{{.Names}}" 2>$null | Select-String "^hiclaw-docker-proxy$"
+    if ($existingProxy) {
+        docker stop hiclaw-docker-proxy *>$null
+        docker rm hiclaw-docker-proxy *>$null
+    }
     $existingContainer = docker ps -a --format "{{.Names}}" 2>$null | Select-String "^hiclaw-manager$"
     if ($existingContainer) {
         Write-Log (Get-Msg "install.removing_existing")

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -36,6 +36,7 @@ set -e
 HICLAW_VERSION="${HICLAW_VERSION:-latest}"
 HICLAW_NON_INTERACTIVE="${HICLAW_NON_INTERACTIVE:-0}"
 HICLAW_MOUNT_SOCKET="${HICLAW_MOUNT_SOCKET:-1}"
+HICLAW_DOCKER_PROXY="${HICLAW_DOCKER_PROXY:-1}"
 STEP_RESULT=""  # Used by state machine to signal "back" navigation
 
 # ============================================================
@@ -504,6 +505,25 @@ msg() {
         "matrix_e2ee.selected_enabled.en") text="Matrix E2EE: enabled" ;;
         "matrix_e2ee.selected_disabled.zh") text="Matrix E2EE: 已禁用（默认）" ;;
         "matrix_e2ee.selected_disabled.en") text="Matrix E2EE: disabled (default)" ;;
+        # --- Docker API proxy ---
+        "docker_proxy.title.zh") text="--- Docker API 安全代理 ---" ;;
+        "docker_proxy.title.en") text="--- Docker API Security Proxy ---" ;;
+        "docker_proxy.desc.zh") text="Docker API 代理可防止 AI Agent 通过 Docker API 越狱访问宿主机。\n  启用后，Manager 不再直接持有 Docker socket，所有容器操作经过安全校验。" ;;
+        "docker_proxy.desc.en") text="Docker API proxy prevents AI Agents from escaping via Docker API to access the host.\n  When enabled, Manager no longer has direct Docker socket access; all container operations go through security validation." ;;
+        "docker_proxy.enable.zh") text="启用（推荐）" ;;
+        "docker_proxy.enable.en") text="Enable (recommended)" ;;
+        "docker_proxy.disable.zh") text="禁用（直接挂载 Docker socket）" ;;
+        "docker_proxy.disable.en") text="Disable (mount Docker socket directly)" ;;
+        "docker_proxy.choice.zh") text="请选择 [1/2]" ;;
+        "docker_proxy.choice.en") text="Enter choice [1/2]" ;;
+        "docker_proxy.selected_enabled.zh") text="Docker API 代理: 已启用" ;;
+        "docker_proxy.selected_enabled.en") text="Docker API proxy: enabled" ;;
+        "docker_proxy.selected_disabled.zh") text="Docker API 代理: 已禁用" ;;
+        "docker_proxy.selected_disabled.en") text="Docker API proxy: disabled" ;;
+        "docker_proxy.registries_desc.zh") text="默认放行的镜像来源：本地镜像、localhost、Higress 仓库（所有 region）。\n  如需放行其他镜像仓库，请输入逗号分隔的地址前缀。\n  示例: ghcr.io/myorg,registry.example.com/team" ;;
+        "docker_proxy.registries_desc.en") text="Default allowed image sources: local images, localhost, Higress registries (all regions).\n  To allow additional image sources, enter comma-separated address prefixes.\n  Example: ghcr.io/myorg,registry.example.com/team" ;;
+        "docker_proxy.registries_prompt.zh") text="额外放行的镜像来源（按回车跳过）" ;;
+        "docker_proxy.registries_prompt.en") text="Additional allowed image sources (press Enter to skip)" ;;
         # --- Worker idle timeout ---
         "idle_timeout.prompt.zh") text="Worker 空闲自动停止超时（分钟）[720]" ;;
         "idle_timeout.prompt.en") text="Worker idle auto-stop timeout in minutes [720]" ;;
@@ -756,6 +776,7 @@ HICLAW_REGISTRY="${HICLAW_REGISTRY:-$(detect_registry)}"
 MANAGER_IMAGE="${HICLAW_INSTALL_MANAGER_IMAGE:-${HICLAW_REGISTRY}/higress/hiclaw-manager:${HICLAW_VERSION}}"
 WORKER_IMAGE="${HICLAW_INSTALL_WORKER_IMAGE:-${HICLAW_REGISTRY}/higress/hiclaw-worker:${HICLAW_VERSION}}"
 COPAW_WORKER_IMAGE="${HICLAW_INSTALL_COPAW_WORKER_IMAGE:-${HICLAW_REGISTRY}/higress/hiclaw-copaw-worker:${HICLAW_VERSION}}"
+DOCKER_PROXY_IMAGE="${HICLAW_INSTALL_DOCKER_PROXY_IMAGE:-${HICLAW_REGISTRY}/higress/hiclaw-docker-proxy:${HICLAW_VERSION}}"
 
 # ============================================================
 # Known models list — used to detect custom models during install
@@ -1334,7 +1355,7 @@ should_skip_step() {
             [ "${HICLAW_NON_INTERACTIVE}" = "1" ] && return 0
             [ "${HICLAW_QUICKSTART}" = "1" ] && return 0
             ;;
-        step_e2ee|step_idle)
+        step_e2ee|step_idle|step_docker_proxy)
             [ "${HICLAW_NON_INTERACTIVE}" = "1" ] && return 0
             [ "${HICLAW_QUICKSTART}" = "1" ] && [ "${HICLAW_UPGRADE}" != "1" ] && return 0
             ;;
@@ -1373,6 +1394,7 @@ clear_step_vars() {
         step_workspace) unset HICLAW_WORKSPACE_DIR ;;
         step_runtime)   unset HICLAW_DEFAULT_WORKER_RUNTIME ;;
         step_e2ee)      unset HICLAW_MATRIX_E2EE ;;
+        step_docker_proxy) unset HICLAW_DOCKER_PROXY; unset HICLAW_PROXY_ALLOWED_REGISTRIES ;;
         step_idle)      unset HICLAW_WORKER_IDLE_TIMEOUT ;;
         step_hostshare) unset HICLAW_HOST_SHARE_DIR ;;
     esac
@@ -1873,6 +1895,70 @@ step_e2ee() {
     fi
 }
 
+step_docker_proxy() {
+    # Only relevant when socket mounting is enabled
+    if [ "${HICLAW_MOUNT_SOCKET}" != "1" ]; then
+        HICLAW_DOCKER_PROXY="0"
+        return 0
+    fi
+
+    echo ""
+    echo -e "  \033[1m$(msg docker_proxy.title)\033[0m"
+    echo ""
+    echo -e "  $(msg docker_proxy.desc)"
+    echo ""
+    echo "  1) $(msg docker_proxy.enable)"
+    echo "  2) $(msg docker_proxy.disable)"
+    echo ""
+
+    if [ "${HICLAW_UPGRADE}" = "1" ] && [ -n "${HICLAW_DOCKER_PROXY}" ]; then
+        log "$(msg prompt.upgrade_keep "HICLAW_DOCKER_PROXY" "${HICLAW_DOCKER_PROXY}")"
+        local _choice
+        read -e -p "$(msg docker_proxy.choice): " _choice
+        if [ "${_choice}" = "b" ]; then STEP_RESULT="back"; return 0; fi
+        if [ -n "${_choice}" ]; then
+            case "${_choice}" in
+                2) HICLAW_DOCKER_PROXY="0" ;;
+                *) HICLAW_DOCKER_PROXY="1" ;;
+            esac
+        fi
+    elif [ -z "${HICLAW_DOCKER_PROXY+x}" ]; then
+        local _choice
+        read -e -p "$(msg docker_proxy.choice): " _choice
+        if [ "${_choice}" = "b" ]; then STEP_RESULT="back"; return 0; fi
+        _choice="${_choice:-1}"
+        case "${_choice}" in
+            2) HICLAW_DOCKER_PROXY="0" ;;
+            *) HICLAW_DOCKER_PROXY="1" ;;
+        esac
+    fi
+    HICLAW_DOCKER_PROXY="${HICLAW_DOCKER_PROXY:-1}"
+    export HICLAW_DOCKER_PROXY
+    if [ "${HICLAW_DOCKER_PROXY}" = "1" ]; then
+        log "$(msg docker_proxy.selected_enabled)"
+
+        # Prompt for additional allowed image sources
+        echo ""
+        echo -e "  $(msg docker_proxy.registries_desc)"
+        echo ""
+        if [ "${HICLAW_UPGRADE}" = "1" ] && [ -n "${HICLAW_PROXY_ALLOWED_REGISTRIES}" ]; then
+            log "$(msg prompt.upgrade_keep "HICLAW_PROXY_ALLOWED_REGISTRIES" "${HICLAW_PROXY_ALLOWED_REGISTRIES}")"
+            local _reg_input
+            read -e -p "$(msg docker_proxy.registries_prompt): " _reg_input
+            if [ "${_reg_input}" = "b" ]; then STEP_RESULT="back"; return 0; fi
+            [ -n "${_reg_input}" ] && HICLAW_PROXY_ALLOWED_REGISTRIES="${_reg_input}"
+        elif [ -z "${HICLAW_PROXY_ALLOWED_REGISTRIES+x}" ]; then
+            local _reg_input
+            read -e -p "$(msg docker_proxy.registries_prompt): " _reg_input
+            if [ "${_reg_input}" = "b" ]; then STEP_RESULT="back"; return 0; fi
+            HICLAW_PROXY_ALLOWED_REGISTRIES="${_reg_input:-}"
+        fi
+        export HICLAW_PROXY_ALLOWED_REGISTRIES
+    else
+        log "$(msg docker_proxy.selected_disabled)"
+    fi
+}
+
 step_idle() {
     if [ "${HICLAW_UPGRADE}" = "1" ] && [ -n "${HICLAW_WORKER_IDLE_TIMEOUT}" ]; then
         log "$(msg prompt.upgrade_keep "HICLAW_WORKER_IDLE_TIMEOUT" "${HICLAW_WORKER_IDLE_TIMEOUT}")"
@@ -1969,7 +2055,7 @@ install_manager() {
     # ── State machine ─────────────────────────────────────────────────────────
     local _STEPS=( step_lang step_mode step_existing step_llm step_admin step_network \
                    step_ports step_domains step_github step_skills step_volume \
-                   step_workspace step_runtime step_e2ee step_idle step_hostshare )
+                   step_workspace step_runtime step_e2ee step_docker_proxy step_idle step_hostshare )
     local _STEP_HISTORY=()
     local _step_idx=0
     while [ "${_step_idx}" -lt "${#_STEPS[@]}" ]; do
@@ -2087,6 +2173,12 @@ HICLAW_DEFAULT_WORKER_RUNTIME=${HICLAW_DEFAULT_WORKER_RUNTIME:-openclaw}
 
 # Matrix E2EE (0=disabled, 1=enabled; default: 0)
 HICLAW_MATRIX_E2EE=${HICLAW_MATRIX_E2EE:-0}
+
+# Docker API proxy (0=disabled, 1=enabled; default: 1)
+HICLAW_DOCKER_PROXY=${HICLAW_DOCKER_PROXY:-1}
+
+# Docker API proxy: additional allowed image sources (comma-separated)
+HICLAW_PROXY_ALLOWED_REGISTRIES=${HICLAW_PROXY_ALLOWED_REGISTRIES:-}
 
 # Worker idle timeout in minutes (default: 720 = 12 hours)
 HICLAW_WORKER_IDLE_TIMEOUT=${HICLAW_WORKER_IDLE_TIMEOUT:-720}
@@ -2208,6 +2300,10 @@ EOF
 
     # Stop and remove existing containers (deferred from upgrade detection
     # so that all configuration is collected and images are pulled first)
+    if ${DOCKER_CMD} ps -a --format '{{.Names}}' | grep -q "^hiclaw-docker-proxy$"; then
+        ${DOCKER_CMD} stop hiclaw-docker-proxy 2>/dev/null || true
+        ${DOCKER_CMD} rm hiclaw-docker-proxy 2>/dev/null || true
+    fi
     if ${DOCKER_CMD} ps -a --format '{{.Names}}' | grep -q "^hiclaw-manager$"; then
         log "$(msg install.removing_existing)"
         ${DOCKER_CMD} stop hiclaw-manager 2>/dev/null || true
@@ -2227,6 +2323,26 @@ EOF
 
     # Run Manager container
     log "$(msg install.starting_manager)"
+
+    # Start Docker API proxy if enabled (security layer between Manager and Docker daemon)
+    PROXY_ARGS=""
+    if [ "${HICLAW_DOCKER_PROXY:-0}" = "1" ] && [ -n "${CONTAINER_SOCK:-}" ]; then
+        local _proxy_image="${DOCKER_PROXY_IMAGE}"
+        # Ensure Docker network exists (reuse if already present)
+        ${DOCKER_CMD} network inspect hiclaw-net >/dev/null 2>&1 || ${DOCKER_CMD} network create hiclaw-net
+        log "Starting Docker API proxy..."
+        ${DOCKER_CMD} run -d \
+            --name hiclaw-docker-proxy \
+            --network hiclaw-net \
+            -v "${CONTAINER_SOCK}:/var/run/docker.sock" \
+            --security-opt label=disable \
+            ${HICLAW_PROXY_ALLOWED_REGISTRIES:+-e HICLAW_PROXY_ALLOWED_REGISTRIES="${HICLAW_PROXY_ALLOWED_REGISTRIES}"} \
+            --restart unless-stopped \
+            "${_proxy_image}"
+        PROXY_ARGS="-e HICLAW_CONTAINER_API=http://hiclaw-docker-proxy:2375 --network hiclaw-net"
+        SOCKET_MOUNT_ARGS=""  # Manager no longer needs direct socket access
+    fi
+
     # Build port binding args (127.0.0.1 prefix for local-only mode)
     if [ "${HICLAW_LOCAL_ONLY:-1}" = "1" ]; then
         _port_prefix="127.0.0.1:"
@@ -2243,6 +2359,7 @@ EOF
         ${YOLO_ARGS} \
         ${TZ_ARGS} \
         ${SOCKET_MOUNT_ARGS} \
+        ${PROXY_ARGS} \
         -p "${_port_prefix}${HICLAW_PORT_GATEWAY}:8080" \
         -p "${_port_prefix}${HICLAW_PORT_CONSOLE}:8001" \
         -p "${_port_prefix}${HICLAW_PORT_ELEMENT_WEB:-18088}:8088" \

--- a/manager/scripts/lib/container-api.sh
+++ b/manager/scripts/lib/container-api.sh
@@ -3,10 +3,9 @@
 # Provides functions to create/manage sibling containers via the host's
 # container runtime socket (Docker or Podman compatible).
 #
-# The Manager container must be started with:
-#   -v /var/run/docker.sock:/var/run/docker.sock --security-opt label=disable
-# or (Podman rootful):
-#   -v /run/podman/podman.sock:/var/run/docker.sock --security-opt label=disable
+# Supports two modes:
+#   1. HTTP proxy mode: set HICLAW_CONTAINER_API=http://hiclaw-docker-proxy:2375
+#   2. Unix socket mode (legacy): mount docker.sock into the container
 #
 # Usage:
 #   source /opt/hiclaw/scripts/lib/container-api.sh
@@ -17,7 +16,10 @@
 #   container_logs_worker "alice"     # get worker container logs
 
 CONTAINER_SOCKET="${HICLAW_CONTAINER_SOCKET:-/var/run/docker.sock}"
-CONTAINER_API_BASE="http://localhost"
+CONTAINER_API_BASE="${HICLAW_CONTAINER_API:-}"
+if [ -z "${CONTAINER_API_BASE}" ]; then
+    CONTAINER_API_BASE="http://localhost"
+fi
 WORKER_IMAGE="${HICLAW_WORKER_IMAGE:-hiclaw/worker-agent:latest}"
 COPAW_WORKER_IMAGE="${HICLAW_COPAW_WORKER_IMAGE:-hiclaw/copaw-worker:latest}"
 WORKER_CONTAINER_PREFIX="hiclaw-worker-"
@@ -30,16 +32,30 @@ _api() {
     local method="$1"
     local path="$2"
     local data="${3:-}"
-    if [ -n "${data}" ]; then
-        curl -s --unix-socket "${CONTAINER_SOCKET}" \
-            -X "${method}" \
-            -H 'Content-Type: application/json' \
-            -d "${data}" \
-            "${CONTAINER_API_BASE}${path}"
+    if [ -n "${HICLAW_CONTAINER_API}" ]; then
+        # HTTP proxy mode
+        if [ -n "${data}" ]; then
+            curl -s -X "${method}" \
+                -H 'Content-Type: application/json' \
+                -d "${data}" \
+                "${CONTAINER_API_BASE}${path}"
+        else
+            curl -s -X "${method}" \
+                "${CONTAINER_API_BASE}${path}"
+        fi
     else
-        curl -s --unix-socket "${CONTAINER_SOCKET}" \
-            -X "${method}" \
-            "${CONTAINER_API_BASE}${path}"
+        # Unix socket mode (legacy)
+        if [ -n "${data}" ]; then
+            curl -s --unix-socket "${CONTAINER_SOCKET}" \
+                -X "${method}" \
+                -H 'Content-Type: application/json' \
+                -d "${data}" \
+                "${CONTAINER_API_BASE}${path}"
+        else
+            curl -s --unix-socket "${CONTAINER_SOCKET}" \
+                -X "${method}" \
+                "${CONTAINER_API_BASE}${path}"
+        fi
     fi
 }
 
@@ -47,23 +63,48 @@ _api_code() {
     local method="$1"
     local path="$2"
     local data="${3:-}"
-    if [ -n "${data}" ]; then
-        curl -s -o /dev/null -w '%{http_code}' --unix-socket "${CONTAINER_SOCKET}" \
-            -X "${method}" \
-            -H 'Content-Type: application/json' \
-            -d "${data}" \
-            "${CONTAINER_API_BASE}${path}"
+    if [ -n "${HICLAW_CONTAINER_API}" ]; then
+        # HTTP proxy mode
+        if [ -n "${data}" ]; then
+            curl -s -o /dev/null -w '%{http_code}' -X "${method}" \
+                -H 'Content-Type: application/json' \
+                -d "${data}" \
+                "${CONTAINER_API_BASE}${path}"
+        else
+            curl -s -o /dev/null -w '%{http_code}' -X "${method}" \
+                "${CONTAINER_API_BASE}${path}"
+        fi
     else
-        curl -s -o /dev/null -w '%{http_code}' --unix-socket "${CONTAINER_SOCKET}" \
-            -X "${method}" \
-            "${CONTAINER_API_BASE}${path}"
+        # Unix socket mode (legacy)
+        if [ -n "${data}" ]; then
+            curl -s -o /dev/null -w '%{http_code}' --unix-socket "${CONTAINER_SOCKET}" \
+                -X "${method}" \
+                -H 'Content-Type: application/json' \
+                -d "${data}" \
+                "${CONTAINER_API_BASE}${path}"
+        else
+            curl -s -o /dev/null -w '%{http_code}' --unix-socket "${CONTAINER_SOCKET}" \
+                -X "${method}" \
+                "${CONTAINER_API_BASE}${path}"
+        fi
     fi
 }
 
-# Check if container runtime socket is available
+# Check if container runtime API is available
+# Supports both HTTP proxy mode (HICLAW_CONTAINER_API) and unix socket mode.
 # This function is designed to work correctly in both strict mode (set -euo pipefail)
 # and non-strict mode. It uses a subshell for the API check to prevent exit on errors.
 container_api_available() {
+    if [ -n "${HICLAW_CONTAINER_API}" ]; then
+        # HTTP proxy mode: check if proxy is reachable
+        local version
+        version=$(curl -s "${CONTAINER_API_BASE}/version" 2>/dev/null) || true
+        if echo "${version}" | grep -q '"ApiVersion"' 2>/dev/null; then
+            return 0
+        fi
+        return 1
+    fi
+    # Unix socket mode (legacy)
     if [ ! -S "${CONTAINER_SOCKET}" ]; then
         return 1
     fi
@@ -99,8 +140,12 @@ _ensure_image() {
     # POST /images/create?fromImage=<ref> streams progress JSON.
     # curl will block until the pull finishes (or fails).
     local pull_output
-    pull_output=$(curl -s --unix-socket "${CONTAINER_SOCKET}" \
-        -X POST "${CONTAINER_API_BASE}/images/create?fromImage=${image}" 2>&1)
+    if [ -n "${HICLAW_CONTAINER_API}" ]; then
+        pull_output=$(curl -s -X POST "${CONTAINER_API_BASE}/images/create?fromImage=${image}" 2>&1)
+    else
+        pull_output=$(curl -s --unix-socket "${CONTAINER_SOCKET}" \
+            -X POST "${CONTAINER_API_BASE}/images/create?fromImage=${image}" 2>&1)
+    fi
 
     # Verify the image is now available
     inspect=$(_api GET "/images/${image}/json" 2>/dev/null)
@@ -488,8 +533,13 @@ PAYLOAD
 
         # Start the container — capture both HTTP status code and response body
         local start_output
-        start_output=$(curl -s -w '\n%{http_code}' --unix-socket "${CONTAINER_SOCKET}" \
-            -X POST "${CONTAINER_API_BASE}/containers/${container_id}/start")
+        if [ -n "${HICLAW_CONTAINER_API}" ]; then
+            start_output=$(curl -s -w '\n%{http_code}' \
+                -X POST "${CONTAINER_API_BASE}/containers/${container_id}/start")
+        else
+            start_output=$(curl -s -w '\n%{http_code}' --unix-socket "${CONTAINER_SOCKET}" \
+                -X POST "${CONTAINER_API_BASE}/containers/${container_id}/start")
+        fi
         local start_code
         start_code=$(echo "${start_output}" | tail -1)
         local start_body


### PR DESCRIPTION
## Summary

- Add a lightweight Go HTTP proxy (`hiclaw-docker-proxy`) between Manager and Docker daemon to prevent AI agent container escape via Docker API (fixes #378)
- Manager no longer has Docker socket mounted; all container operations go through the security proxy
- Proxy enforces: no bind mounts, no privileged mode, no host network/PID, no dangerous capabilities, image allowlist, container name prefix validation
- Default allowed image sources: local images, localhost, Higress registries (all regions), plus configurable additional sources via `HICLAW_PROXY_ALLOWED_REGISTRIES`
- New install step `step_docker_proxy` (enabled by default, opt-out available)
- Backward compatible: setting `HICLAW_DOCKER_PROXY=0` falls back to direct socket mount

## Test plan

- [x] `go test` — 19 unit tests covering all security rules
- [x] `make install` — Manager starts with proxy, no docker.sock mounted
- [x] `make test` — all integration tests pass (worker creation, task assignment, heartbeat, multi-worker)
- [x] Manual verification: bind mount, privileged, host network, bad image, bad container name — all blocked by proxy
- [x] Custom image from Higress registry — allowed
- [x] Configured additional registry — allowed and enforced

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)