### PR TITLE
fix(install): show friendly labels instead of env var names in upgrade prompts

### DIFF
--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -378,6 +378,7 @@ $script:Messages = @{
     "worker_runtime.copaw" = @{ zh = "CoPaw（Python 容器，~150MB 内存，默认关闭控制台，可跟 Manager 对话按需开启）"; en = "CoPaw (Python container, ~150MB RAM, console off by default, enable on demand via Manager)" }
     "worker_runtime.choice" = @{ zh = "请选择 [1/2]"; en = "Enter choice [1/2]" }
     "worker_runtime.selected" = @{ zh = "默认 Worker 运行时: {0}"; en = "Default Worker runtime: {0}" }
+    "worker_runtime.title_short" = @{ zh = "默认 Worker 运行时"; en = "Default Worker Runtime" }
 
     # --- Matrix E2EE ---
     "matrix_e2ee.title" = @{ zh = "--- Matrix 端到端加密（E2EE）---"; en = "--- Matrix End-to-End Encryption (E2EE) ---" }
@@ -390,6 +391,9 @@ $script:Messages = @{
     "matrix_e2ee.choice" = @{ zh = "请选择 [1/2]"; en = "Enter choice [1/2]" }
     "matrix_e2ee.selected_enabled" = @{ zh = "Matrix E2EE: 已启用"; en = "Matrix E2EE: enabled" }
     "matrix_e2ee.selected_disabled" = @{ zh = "Matrix E2EE: 已禁用（默认）"; en = "Matrix E2EE: disabled (default)" }
+    "matrix_e2ee.title_short" = @{ zh = "Matrix E2EE"; en = "Matrix E2EE" }
+    "matrix_e2ee.val_enabled" = @{ zh = "已启用"; en = "enabled" }
+    "matrix_e2ee.val_disabled" = @{ zh = "已禁用"; en = "disabled" }
 
     # --- Docker API proxy ---
     "docker_proxy.title" = @{ zh = "--- Docker API 安全代理 ---"; en = "--- Docker API Security Proxy ---" }
@@ -399,12 +403,17 @@ $script:Messages = @{
     "docker_proxy.choice" = @{ zh = "请选择 [1/2]"; en = "Enter choice [1/2]" }
     "docker_proxy.selected_enabled" = @{ zh = "Docker API 代理: 已启用"; en = "Docker API proxy: enabled" }
     "docker_proxy.selected_disabled" = @{ zh = "Docker API 代理: 已禁用"; en = "Docker API proxy: disabled" }
+    "docker_proxy.title_short" = @{ zh = "Docker API 代理"; en = "Docker API Proxy" }
+    "docker_proxy.val_enabled" = @{ zh = "已启用"; en = "enabled" }
+    "docker_proxy.val_disabled" = @{ zh = "已禁用"; en = "disabled" }
     "docker_proxy.registries_desc" = @{ zh = "默认放行的镜像来源：本地镜像、localhost、Higress 仓库（所有 region）。`n  如需放行其他镜像仓库，请输入逗号分隔的地址前缀。`n  示例: ghcr.io/myorg,registry.example.com/team"; en = "Default allowed image sources: local images, localhost, Higress registries (all regions).`n  To allow additional image sources, enter comma-separated address prefixes.`n  Example: ghcr.io/myorg,registry.example.com/team" }
     "docker_proxy.registries_prompt" = @{ zh = "额外放行的镜像来源（按回车跳过）"; en = "Additional allowed image sources (press Enter to skip)" }
+    "docker_proxy.registries_label" = @{ zh = "额外放行的镜像来源"; en = "Additional allowed image sources" }
 
     # --- Worker idle timeout ---
     "idle_timeout.prompt" = @{ zh = "Worker 空闲自动停止超时（分钟）[720]"; en = "Worker idle auto-stop timeout in minutes [720]" }
     "idle_timeout.selected" = @{ zh = "Worker 空闲超时: {0} 分钟"; en = "Worker idle timeout: {0} minutes" }
+    "idle_timeout.label" = @{ zh = "Worker 空闲超时（分钟）"; en = "Worker idle timeout (min)" }
 
     # --- Secrets and config ---
     "install.generating_secrets" = @{ zh = "正在生成密钥..."; en = "Generating secrets..." }
@@ -843,7 +852,7 @@ function Read-Prompt {
                     $displayValue = $envValue.Substring(0, 4) + "****" + $envValue.Substring($envValue.Length - 4)
                 }
             }
-            Write-Log (Get-Msg "prompt.upgrade_keep" -f $VarName, $displayValue)
+            Write-Log (Get-Msg "prompt.upgrade_keep" -f $PromptText, $displayValue)
             $prompt = $PromptText
             if ($Secret) {
                 $newValue = Read-Host -Prompt $prompt -AsSecureString
@@ -859,12 +868,12 @@ function Read-Prompt {
             }
             return $envValue
         }
-        Write-Log (Get-Msg "prompt.preset" -f $VarName)
+        Write-Log (Get-Msg "prompt.preset" -f $PromptText)
         return $envValue
     }
     # Upgrade mode: optional fields with empty value — let user set a new value
     elseif ($Optional -and $script:HICLAW_UPGRADE -and -not $script:HICLAW_NON_INTERACTIVE) {
-        Write-Log (Get-Msg "prompt.upgrade_empty" -f $VarName)
+        Write-Log (Get-Msg "prompt.upgrade_empty" -f $PromptText)
         $prompt = $PromptText
         if ($Secret) {
             $newValue = Read-Host -Prompt $prompt -AsSecureString
@@ -884,7 +893,7 @@ function Read-Prompt {
     # Non-interactive or quickstart mode
     if ($script:HICLAW_NON_INTERACTIVE -or $script:HICLAW_QUICKSTART) {
         if ($Default) {
-            Write-Log (Get-Msg "prompt.default" -f $VarName, $Default)
+            Write-Log (Get-Msg "prompt.default" -f $PromptText, $Default)
             return $Default
         }
         elseif ($Optional) {
@@ -892,7 +901,7 @@ function Read-Prompt {
         }
         elseif ($script:HICLAW_NON_INTERACTIVE) {
             # Only hard-error in fully non-interactive mode, not quickstart
-            Write-Error (Get-Msg "prompt.required" -f $VarName)
+            Write-Error (Get-Msg "prompt.required" -f $PromptText)
         }
         # quickstart + no default + not optional: fall through to interactive prompt
     }
@@ -916,7 +925,7 @@ function Read-Prompt {
     }
 
     if (-not $value -and -not $Optional) {
-        Write-Error (Get-Msg "prompt.required_empty" -f $VarName)
+        Write-Error (Get-Msg "prompt.required_empty" -f $PromptText)
     }
 
     return $value
@@ -1733,7 +1742,7 @@ function Step-Admin {
         }
     } else {
         $script:config.ADMIN_PASSWORD = $env:HICLAW_ADMIN_PASSWORD
-        Write-Log (Get-Msg "prompt.preset" -f "HICLAW_ADMIN_PASSWORD")
+        Write-Log (Get-Msg "prompt.preset" -f (Get-Msg "admin.password_prompt"))
     }
 
     if ($script:config.ADMIN_PASSWORD.Length -lt 8) {
@@ -1844,7 +1853,7 @@ function Step-Runtime {
     if ($script:HICLAW_NON_INTERACTIVE) {
         $script:config.DEFAULT_WORKER_RUNTIME = if ($env:HICLAW_DEFAULT_WORKER_RUNTIME) { $env:HICLAW_DEFAULT_WORKER_RUNTIME } else { "openclaw" }
     } elseif ($script:HICLAW_UPGRADE -and $env:HICLAW_DEFAULT_WORKER_RUNTIME) {
-        Write-Log (Get-Msg "prompt.upgrade_keep" -f "HICLAW_DEFAULT_WORKER_RUNTIME", $env:HICLAW_DEFAULT_WORKER_RUNTIME)
+        Write-Log (Get-Msg "prompt.upgrade_keep" -f (Get-Msg "worker_runtime.title_short"), $env:HICLAW_DEFAULT_WORKER_RUNTIME)
         $rtChoice = Read-Host (Get-Msg "worker_runtime.choice")
         if ($rtChoice -eq "b") { $script:StepResult = "back"; return }
         if ($rtChoice) {
@@ -1874,7 +1883,8 @@ function Step-E2ee {
     Write-Host ""
 
     if ($script:HICLAW_UPGRADE -and $env:HICLAW_MATRIX_E2EE) {
-        Write-Log (Get-Msg "prompt.upgrade_keep" -f "HICLAW_MATRIX_E2EE", $env:HICLAW_MATRIX_E2EE)
+        $e2eeDisplay = if ($env:HICLAW_MATRIX_E2EE -eq "1") { Get-Msg "matrix_e2ee.val_enabled" } else { Get-Msg "matrix_e2ee.val_disabled" }
+        Write-Log (Get-Msg "prompt.upgrade_keep" -f (Get-Msg "matrix_e2ee.title_short"), $e2eeDisplay)
         $e2eeChoice = Read-Host (Get-Msg "matrix_e2ee.choice")
         if ($e2eeChoice -eq "b") { $script:StepResult = "back"; return }
         if ($e2eeChoice) {
@@ -1914,7 +1924,8 @@ function Step-DockerProxy {
     Write-Host ""
 
     if ($script:HICLAW_UPGRADE -and $env:HICLAW_DOCKER_PROXY) {
-        Write-Log (Get-Msg "prompt.upgrade_keep" -f "HICLAW_DOCKER_PROXY", $env:HICLAW_DOCKER_PROXY)
+        $proxyDisplay = if ($env:HICLAW_DOCKER_PROXY -eq "1") { Get-Msg "docker_proxy.val_enabled" } else { Get-Msg "docker_proxy.val_disabled" }
+        Write-Log (Get-Msg "prompt.upgrade_keep" -f (Get-Msg "docker_proxy.title_short"), $proxyDisplay)
         $proxyChoice = Read-Host (Get-Msg "docker_proxy.choice")
         if ($proxyChoice -eq "b") { $script:StepResult = "back"; return }
         if ($proxyChoice) {
@@ -1939,7 +1950,7 @@ function Step-DockerProxy {
         Write-Host "  $(Get-Msg 'docker_proxy.registries_desc')"
         Write-Host ""
         if ($script:HICLAW_UPGRADE -and $env:HICLAW_PROXY_ALLOWED_REGISTRIES) {
-            Write-Log (Get-Msg "prompt.upgrade_keep" -f "HICLAW_PROXY_ALLOWED_REGISTRIES", $env:HICLAW_PROXY_ALLOWED_REGISTRIES)
+            Write-Log (Get-Msg "prompt.upgrade_keep" -f (Get-Msg "docker_proxy.registries_label"), $env:HICLAW_PROXY_ALLOWED_REGISTRIES)
             $regInput = Read-Host (Get-Msg "docker_proxy.registries_prompt")
             if ($regInput -eq "b") { $script:StepResult = "back"; return }
             $script:config.PROXY_ALLOWED_REGISTRIES = if ($regInput) { $regInput } else { $env:HICLAW_PROXY_ALLOWED_REGISTRIES }
@@ -1957,7 +1968,7 @@ function Step-DockerProxy {
 
 function Step-Idle {
     if ($script:HICLAW_UPGRADE -and $env:HICLAW_WORKER_IDLE_TIMEOUT) {
-        Write-Log (Get-Msg "prompt.upgrade_keep" -f "HICLAW_WORKER_IDLE_TIMEOUT", $env:HICLAW_WORKER_IDLE_TIMEOUT)
+        Write-Log (Get-Msg "prompt.upgrade_keep" -f (Get-Msg "idle_timeout.label"), $env:HICLAW_WORKER_IDLE_TIMEOUT)
         $idleInput = Read-Host (Get-Msg "idle_timeout.prompt")
         if ($idleInput -eq "b") { $script:StepResult = "back"; return }
         $script:config.WORKER_IDLE_TIMEOUT = if ($idleInput) { $idleInput } else { $env:HICLAW_WORKER_IDLE_TIMEOUT }

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -469,6 +469,8 @@ msg() {
         "worker_runtime.choice.en") text="Enter choice [1/2]" ;;
         "worker_runtime.selected.zh") text="默认 Worker 运行时: %s" ;;
         "worker_runtime.selected.en") text="Default Worker runtime: %s" ;;
+        "worker_runtime.title_short.zh") text="默认 Worker 运行时" ;;
+        "worker_runtime.title_short.en") text="Default Worker Runtime" ;;
         # --- Secrets and config ---
         "install.generating_secrets.zh") text="正在生成密钥..." ;;
         "install.generating_secrets.en") text="Generating secrets..." ;;
@@ -505,6 +507,12 @@ msg() {
         "matrix_e2ee.selected_enabled.en") text="Matrix E2EE: enabled" ;;
         "matrix_e2ee.selected_disabled.zh") text="Matrix E2EE: 已禁用（默认）" ;;
         "matrix_e2ee.selected_disabled.en") text="Matrix E2EE: disabled (default)" ;;
+        "matrix_e2ee.title_short.zh") text="Matrix E2EE" ;;
+        "matrix_e2ee.title_short.en") text="Matrix E2EE" ;;
+        "matrix_e2ee.val_enabled.zh") text="已启用" ;;
+        "matrix_e2ee.val_enabled.en") text="enabled" ;;
+        "matrix_e2ee.val_disabled.zh") text="已禁用" ;;
+        "matrix_e2ee.val_disabled.en") text="disabled" ;;
         # --- Docker API proxy ---
         "docker_proxy.title.zh") text="--- Docker API 安全代理 ---" ;;
         "docker_proxy.title.en") text="--- Docker API Security Proxy ---" ;;
@@ -520,15 +528,25 @@ msg() {
         "docker_proxy.selected_enabled.en") text="Docker API proxy: enabled" ;;
         "docker_proxy.selected_disabled.zh") text="Docker API 代理: 已禁用" ;;
         "docker_proxy.selected_disabled.en") text="Docker API proxy: disabled" ;;
+        "docker_proxy.title_short.zh") text="Docker API 代理" ;;
+        "docker_proxy.title_short.en") text="Docker API Proxy" ;;
+        "docker_proxy.val_enabled.zh") text="已启用" ;;
+        "docker_proxy.val_enabled.en") text="enabled" ;;
+        "docker_proxy.val_disabled.zh") text="已禁用" ;;
+        "docker_proxy.val_disabled.en") text="disabled" ;;
         "docker_proxy.registries_desc.zh") text="默认放行的镜像来源：本地镜像、localhost、Higress 仓库（所有 region）。\n  如需放行其他镜像仓库，请输入逗号分隔的地址前缀。\n  示例: ghcr.io/myorg,registry.example.com/team" ;;
         "docker_proxy.registries_desc.en") text="Default allowed image sources: local images, localhost, Higress registries (all regions).\n  To allow additional image sources, enter comma-separated address prefixes.\n  Example: ghcr.io/myorg,registry.example.com/team" ;;
         "docker_proxy.registries_prompt.zh") text="额外放行的镜像来源（按回车跳过）" ;;
         "docker_proxy.registries_prompt.en") text="Additional allowed image sources (press Enter to skip)" ;;
+        "docker_proxy.registries_label.zh") text="额外放行的镜像来源" ;;
+        "docker_proxy.registries_label.en") text="Additional allowed image sources" ;;
         # --- Worker idle timeout ---
         "idle_timeout.prompt.zh") text="Worker 空闲自动停止超时（分钟）[720]" ;;
         "idle_timeout.prompt.en") text="Worker idle auto-stop timeout in minutes [720]" ;;
         "idle_timeout.selected.zh") text="Worker 空闲超时: %s 分钟" ;;
         "idle_timeout.selected.en") text="Worker idle timeout: %s minutes" ;;
+        "idle_timeout.label.zh") text="Worker 空闲超时（分钟）" ;;
+        "idle_timeout.label.en") text="Worker idle timeout (min)" ;;
         # --- YOLO mode ---
         "install.yolo.zh") text="YOLO 模式已启用（自主决策，无交互提示）" ;;
         "install.yolo.en") text="YOLO mode enabled (autonomous decisions, no interactive prompts)" ;;
@@ -1143,7 +1161,7 @@ prompt() {
                     display_value="${current_value:0:4}****${current_value: -4}"
                 fi
             fi
-            log "$(msg prompt.upgrade_keep "${var_name}" "${display_value}")"
+            log "$(msg prompt.upgrade_keep "${prompt_text}" "${display_value}")"
             local new_value=""
             if [ "${is_secret}" = "true" ]; then
                 read -s -e -p "${prompt_text}: " new_value
@@ -1157,7 +1175,7 @@ prompt() {
             fi
             return
         fi
-        log "$(msg prompt.preset "${var_name}")"
+        log "$(msg prompt.preset "${prompt_text}")"
         return
     fi
 
@@ -1165,11 +1183,11 @@ prompt() {
     if [ "${HICLAW_NON_INTERACTIVE}" = "1" ] || [ "${HICLAW_QUICKSTART}" = "1" ]; then
         if [ -n "${default_value}" ]; then
             eval "export ${var_name}='${default_value}'"
-            log "$(msg prompt.default "${var_name}" "${default_value}")"
+            log "$(msg prompt.default "${prompt_text}" "${default_value}")"
             return
         elif [ "${HICLAW_NON_INTERACTIVE}" = "1" ]; then
             # Only hard-error in fully non-interactive mode, not quickstart
-            error "$(msg prompt.required "${var_name}")"
+            error "$(msg prompt.required "${prompt_text}")"
         fi
         # quickstart + no default: fall through to interactive prompt below
     fi
@@ -1189,7 +1207,7 @@ prompt() {
 
     value="${value:-${default_value}}"
     if [ -z "${value}" ]; then
-        error "$(msg prompt.required_empty "${var_name}")"
+        error "$(msg prompt.required_empty "${prompt_text}")"
     fi
 
     eval "export ${var_name}='${value}'"
@@ -1221,12 +1239,12 @@ prompt_optional() {
             fi
             if [ -n "${current_value}" ]; then
                 if [ "${is_secret}" = "true" ]; then
-                    log "$(msg prompt.upgrade_keep_secret "${var_name}" "${display_value}")"
+                    log "$(msg prompt.upgrade_keep_secret "${prompt_text}" "${display_value}")"
                 else
-                    log "$(msg prompt.upgrade_keep "${var_name}" "${display_value}")"
+                    log "$(msg prompt.upgrade_keep "${prompt_text}" "${display_value}")"
                 fi
             else
-                log "$(msg prompt.upgrade_empty "${var_name}")"
+                log "$(msg prompt.upgrade_empty "${prompt_text}")"
             fi
             local new_value=""
             if [ "${is_secret}" = "true" ]; then
@@ -1241,7 +1259,7 @@ prompt_optional() {
             fi
             return
         fi
-        log "$(msg prompt.preset "${var_name}")"
+        log "$(msg prompt.preset "${prompt_text}")"
         return
     fi
 
@@ -1728,7 +1746,7 @@ step_admin() {
             log "$(msg admin.password_generated)"
         fi
     else
-        log "  $(msg prompt.preset "HICLAW_ADMIN_PASSWORD")"
+        log "  $(msg prompt.preset "$(msg admin.password_prompt)")"
     fi
     if [ ${#HICLAW_ADMIN_PASSWORD} -lt 8 ]; then
         error "$(msg admin.password_too_short "${#HICLAW_ADMIN_PASSWORD}")"
@@ -1832,7 +1850,7 @@ step_runtime() {
     if [ "${HICLAW_NON_INTERACTIVE}" = "1" ]; then
         HICLAW_DEFAULT_WORKER_RUNTIME="${HICLAW_DEFAULT_WORKER_RUNTIME:-openclaw}"
     elif [ "${HICLAW_UPGRADE}" = "1" ] && [ -n "${HICLAW_DEFAULT_WORKER_RUNTIME}" ]; then
-        log "$(msg prompt.upgrade_keep "HICLAW_DEFAULT_WORKER_RUNTIME" "${HICLAW_DEFAULT_WORKER_RUNTIME}")"
+        log "$(msg prompt.upgrade_keep "$(msg worker_runtime.title_short)" "${HICLAW_DEFAULT_WORKER_RUNTIME}")"
         local _runtime_choice
         read -e -p "$(msg worker_runtime.choice): " _runtime_choice
         if [ "${_runtime_choice}" = "b" ]; then STEP_RESULT="back"; return 0; fi
@@ -1866,7 +1884,8 @@ step_e2ee() {
     echo "  2) $(msg matrix_e2ee.enable)"
     echo ""
     if [ "${HICLAW_UPGRADE}" = "1" ] && [ -n "${HICLAW_MATRIX_E2EE}" ]; then
-        log "$(msg prompt.upgrade_keep "HICLAW_MATRIX_E2EE" "${HICLAW_MATRIX_E2EE}")"
+        local _e2ee_display; if [ "${HICLAW_MATRIX_E2EE}" = "1" ]; then _e2ee_display="$(msg matrix_e2ee.val_enabled)"; else _e2ee_display="$(msg matrix_e2ee.val_disabled)"; fi
+        log "$(msg prompt.upgrade_keep "$(msg matrix_e2ee.title_short)" "${_e2ee_display}")"
         local _e2ee_choice
         read -e -p "$(msg matrix_e2ee.choice): " _e2ee_choice
         if [ "${_e2ee_choice}" = "b" ]; then STEP_RESULT="back"; return 0; fi
@@ -1912,7 +1931,8 @@ step_docker_proxy() {
     echo ""
 
     if [ "${HICLAW_UPGRADE}" = "1" ] && [ -n "${HICLAW_DOCKER_PROXY}" ]; then
-        log "$(msg prompt.upgrade_keep "HICLAW_DOCKER_PROXY" "${HICLAW_DOCKER_PROXY}")"
+        local _proxy_display; if [ "${HICLAW_DOCKER_PROXY}" = "1" ]; then _proxy_display="$(msg docker_proxy.val_enabled)"; else _proxy_display="$(msg docker_proxy.val_disabled)"; fi
+        log "$(msg prompt.upgrade_keep "$(msg docker_proxy.title_short)" "${_proxy_display}")"
         local _choice
         read -e -p "$(msg docker_proxy.choice): " _choice
         if [ "${_choice}" = "b" ]; then STEP_RESULT="back"; return 0; fi
@@ -1942,7 +1962,7 @@ step_docker_proxy() {
         echo -e "  $(msg docker_proxy.registries_desc)"
         echo ""
         if [ "${HICLAW_UPGRADE}" = "1" ] && [ -n "${HICLAW_PROXY_ALLOWED_REGISTRIES}" ]; then
-            log "$(msg prompt.upgrade_keep "HICLAW_PROXY_ALLOWED_REGISTRIES" "${HICLAW_PROXY_ALLOWED_REGISTRIES}")"
+            log "$(msg prompt.upgrade_keep "$(msg docker_proxy.registries_label)" "${HICLAW_PROXY_ALLOWED_REGISTRIES}")"
             local _reg_input
             read -e -p "$(msg docker_proxy.registries_prompt): " _reg_input
             if [ "${_reg_input}" = "b" ]; then STEP_RESULT="back"; return 0; fi
@@ -1961,7 +1981,7 @@ step_docker_proxy() {
 
 step_idle() {
     if [ "${HICLAW_UPGRADE}" = "1" ] && [ -n "${HICLAW_WORKER_IDLE_TIMEOUT}" ]; then
-        log "$(msg prompt.upgrade_keep "HICLAW_WORKER_IDLE_TIMEOUT" "${HICLAW_WORKER_IDLE_TIMEOUT}")"
+        log "$(msg prompt.upgrade_keep "$(msg idle_timeout.label)" "${HICLAW_WORKER_IDLE_TIMEOUT}")"
         local _idle_timeout
         read -e -p "$(msg idle_timeout.prompt): " _idle_timeout
         if [ "${_idle_timeout}" = "b" ]; then STEP_RESULT="back"; return 0; fi


### PR DESCRIPTION
## Summary

- 升级模式下，提示信息从显示原始环境变量名（如 `HICLAW_DOCKER_PROXY`）改为显示友好标签（如 `Docker API 代理`）
- 布尔开关（E2EE、Docker Proxy）的值从 `0`/`1` 改为显示"已启用"/"已禁用"
- 同步修改了 bash（`.sh`）和 PowerShell（`.ps1`）两个安装脚本

## Test plan

- [ ] 以升级模式运行 bash 安装脚本（`HICLAW_UPGRADE=1`），确认所有提示行显示友好标签
- [ ] 确认 E2EE 和 Docker Proxy 的值显示为"已启用"/"已禁用"而非 0/1
- [ ] 切换语言确认英文标签也正确显示
- [ ] 以 `pwsh` 验证 PS1 脚本语法无误（已通过）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Summary

- In upgrade mode, the prompt information changes from displaying the original environment variable name (such as `HICLAW_DOCKER_PROXY`) to displaying a friendly label (such as `Docker API Proxy`)
- Boolean switch (E2EE, Docker Proxy) values changed from `0`/`1` to display "Enabled"/"Disabled"
- Simultaneously modified the two installation scripts of bash (`.sh`) and PowerShell (`.ps1`)

## Test plan

- [ ] Run the bash installation script in upgrade mode (`HICLAW_UPGRADE=1`) and make sure all prompt lines display friendly labels
- [ ] Confirm that E2EE and Docker Proxy values show "enabled"/"disabled" instead of 0/1
- [ ] Switch the language to confirm that the English labels are also displayed correctly
- [ ] Use `pwsh` to verify that the PS1 script syntax is correct (passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
