### PR TITLE
docs: add Podman Engine version requirement for Mac M-series compatibility

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -64,13 +64,14 @@ bash <(curl -sSL https://higress.ai/hiclaw/install.sh)
 
 When the installer detects an existing installation, it will ask how to proceed. Choosing delete will wipe the stale data and start fresh.
 
-**Case 3: Mac with Apple Silicon and outdated Docker**
+**Case 3: Mac with Apple Silicon and outdated Docker/Podman**
 
 If you're using a Mac with Apple Silicon (M1/M2/M3/M4) and Docker Desktop is older than 4.39.0, Manager Agent may fail to start properly.
 
-**Solution:** Upgrade Docker Desktop to 4.39.0 or later.
+**Solutions:**
 
-Note: Podman does not have this issue.
+- **Docker Desktop**: Upgrade to 4.39.0 or later
+- **Podman**: Ensure Podman Engine **Server version ≥ 5.7.1** (check with `podman version`)
 
 ---
 

--- a/docs/zh-cn/faq.md
+++ b/docs/zh-cn/faq.md
@@ -61,13 +61,14 @@ bash <(curl -sSL https://higress.ai/hiclaw/install.sh)
 
 安装脚本检测到已有安装时会询问处理方式，选择删除后重装即可清除脏数据。
 
-**情况三：Mac M 系列芯片 + 低版本 Docker**
+**情况三：Mac M 系列芯片 + 低版本 Docker/Podman**
 
 如果你使用的是搭载 Apple M 系列芯片（M1/M2/M3/M4）的 Mac，且 Docker Desktop 版本低于 4.39.0，Manager Agent 可能无法正常启动。
 
-**解决方案：** 升级 Docker Desktop 到 4.39.0 或更高版本。
+**解决方案：**
 
-如果你使用的是 Podman，则不受此问题影响。
+- **Docker Desktop**：升级到 4.39.0 或更高版本
+- **Podman**：确保 Podman Engine **Server 版本 ≥ 5.7.1**（可通过 `podman version` 查看）
 
 ---
 


### PR DESCRIPTION
## Summary

- Add Podman Engine Server version requirement (≥5.7.1) for Mac M-series compatibility
- Update both Chinese and English FAQ

## Details

Previously the FAQ stated that Podman is unaffected by the Mac M-series compatibility issue. However, Podman Engine also has compatibility requirements:

- Podman Engine Server version must be 5.7.1 or higher

Users can check their version with `podman version` command.

## Test

- [x] Documentation review