### PR TITLE
Fix: LLM API key configuration and Windows path compatibility (Issues #322, #320)

### DIFF
--- a/manager/scripts/init/start-manager-agent.sh
+++ b/manager/scripts/init/start-manager-agent.sh
@@ -42,6 +42,18 @@ if [ "${HICLAW_RUNTIME}" != "aliyun" ]; then
     # Create symlink for host directory access
     if [ -d "/host-share" ]; then
         ORIGINAL_HOST_HOME="${HOST_ORIGINAL_HOME:-$HOME}"
+
+        # Detect Windows path format (e.g., "C:\Users\xxx" or "D:\Users\xxx")
+        # Windows paths cannot be used directly in Linux containers for symlinks
+        if echo "${ORIGINAL_HOST_HOME}" | grep -qE '^[A-Za-z]:\\'; then
+            # Windows path detected - convert to Linux-compatible path or skip
+            # Extract drive letter and path, convert to /d/Users/xxx format
+            DRIVE=$(echo "${ORIGINAL_HOST_HOME}" | cut -c1 | tr 'A-Z' 'a-z')
+            WIN_PATH=$(echo "${ORIGINAL_HOST_HOME}" | cut -c3- | tr '\\' '/')
+            ORIGINAL_HOST_HOME="/${DRIVE}${WIN_PATH}"
+            log "Windows path detected, converted to: ${ORIGINAL_HOST_HOME}"
+        fi
+
         if [ ! -e "${ORIGINAL_HOST_HOME}" ] && [ "${ORIGINAL_HOST_HOME}" != "/" ] && [ "${ORIGINAL_HOST_HOME}" != "/root" ] && [ "${ORIGINAL_HOST_HOME}" != "/data" ] && [ "${ORIGINAL_HOST_HOME}" != "/host-share" ]; then
             mkdir -p "$(dirname "${ORIGINAL_HOST_HOME}")"
             ln -sfn /host-share "${ORIGINAL_HOST_HOME}"
@@ -459,8 +471,12 @@ if [ -f /root/manager-workspace/openclaw.json ]; then
     # Merge known models into existing config (add missing, preserve user-added)
     # Use known-models.json (valid JSON) instead of template (contains ${VAR} placeholders)
     KNOWN_MODELS=$(cat /opt/hiclaw/configs/known-models.json 2>/dev/null || echo '[]')
+    # Use HICLAW_LLM_API_KEY for LLM provider API key, fallback to HICLAW_MANAGER_GATEWAY_KEY
+    # HICLAW_LLM_API_KEY is the actual LLM provider key (e.g., Zhipu, OpenAI), while HICLAW_MANAGER_GATEWAY_KEY
+    # is for authenticating with the HiClaw Gateway service itself
+    LLM_API_KEY="${HICLAW_LLM_API_KEY:-${HICLAW_MANAGER_GATEWAY_KEY}}"
     jq --arg token "${MANAGER_TOKEN}" \
-       --arg key "${HICLAW_MANAGER_GATEWAY_KEY}" \
+       --arg key "${LLM_API_KEY}" \
        --arg model "${MODEL_NAME}" \
        --argjson e2ee "${MATRIX_E2EE_ENABLED}" \
        --argjson known_models "${KNOWN_MODELS}" \
@@ -521,9 +537,11 @@ fi
 # Cloud mode: overlay cloud-specific settings onto generated config
 if [ "${HICLAW_RUNTIME}" = "aliyun" ]; then
     log "Applying cloud overlay to openclaw.json..."
+    # Use HICLAW_LLM_API_KEY for LLM provider API key, fallback to HICLAW_MANAGER_GATEWAY_KEY
+    LLM_API_KEY="${HICLAW_LLM_API_KEY:-${HICLAW_MANAGER_GATEWAY_KEY}}"
     jq --arg homeserver "${HICLAW_MATRIX_SERVER}" \
        --arg gateway "${HICLAW_AI_GATEWAY_URL}/v1" \
-       --arg key "${HICLAW_MANAGER_GATEWAY_KEY}" \
+       --arg key "${LLM_API_KEY}" \
        '.channels.matrix.homeserver = $homeserver
         | .models.providers["hiclaw-gateway"].baseUrl = $gateway
         | .models.providers["hiclaw-gateway"].apiKey = $key


### PR DESCRIPTION
## Summary

This PR fixes two distinct issues that affect the Manager Agent initialization:

### Issue #322: Fix LLM API key configuration for OpenAI-compatible providers

**Problem:** The `start-manager-agent.sh` script was using `HICLAW_MANAGER_GATEWAY_KEY` as the LLM provider's API key in `openclaw.json`. This is incorrect - `HICLAW_MANAGER_GATEWAY_KEY` is meant for authenticating with the HiClaw Gateway service itself, while `HICLAW_LLM_API_KEY` is the API key for the actual LLM provider (Zhipu, OpenAI, etc.).

**Impact:** Users configuring OpenAI-compatible services (like Zhipu GLM-5-Turbo) would get HTTP 401 errors because the wrong API key was being used.

**Fix:** Changed both places where the LLM provider's `apiKey` is set to use `HICLAW_LLM_API_KEY` first, with `HICLAW_MANAGER_GATEWAY_KEY` as a fallback:
- In the existing openclaw.json update flow (line ~464)
- In the cloud mode overlay (line ~526)

```bash
# Before
--arg key "${HICLAW_MANAGER_GATEWAY_KEY}"

# After  
LLM_API_KEY="${HICLAW_LLM_API_KEY:-${HICLAW_MANAGER_GATEWAY_KEY}}"
--arg key "${LLM_API_KEY}"
```

### Issue #320: Fix Windows path format in HOST_ORIGINAL_HOME

**Problem:** On Windows hosts, the `HOST_ORIGINAL_HOME` environment variable contains Windows path format like `D:\Users\xxx`. Linux containers cannot use Windows paths directly when creating symlinks, causing failures like:
```
ln: failed to create symbolic link 'D:\Users\xxx': No such file or directory
```

**Fix:** Added Windows path detection and conversion before symlink creation:
- Detects Windows paths (drive letter + backslash pattern: `C:\`, `D:\`, etc.)
- Converts to Linux-compatible format: `D:\Users\xxx` → `/d/Users/xxx`
- Logs the conversion for debugging

## Testing

Both fixes have been validated:
- LLM API key: Tested with Zhipu GLM-5-Turbo (should work for all OpenAI-compatible providers)
- Windows path: Verified conversion logic handles edge cases (empty paths, root paths, etc.)

## Files Changed

- `manager/scripts/init/start-manager-agent.sh`: +20 lines, -2 lines

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>