### PR TITLE
fix: add Worker containers to hiclaw-net network for service connectivity

### DIFF
--- a/manager/scripts/lib/container-api.sh
+++ b/manager/scripts/lib/container-api.sh
@@ -221,10 +221,13 @@ container_create_worker() {
     fi
 
     # Create the container
-    local host_config="{}"
+    # Always use hiclaw-net network so Worker can access Manager services
+    local host_config
     if [ -n "${extra_hosts}" ]; then
-        host_config="{\"ExtraHosts\":[${extra_hosts}]}"
+        host_config="{\"NetworkMode\":\"hiclaw-net\",\"ExtraHosts\":[${extra_hosts}]}"
         _log "  ExtraHosts: ${extra_hosts}"
+    else
+        host_config="{\"NetworkMode\":\"hiclaw-net\"}"
     fi
 
     local worker_home="/root/hiclaw-fs/agents/${worker_name}"
@@ -495,16 +498,16 @@ container_create_copaw_worker() {
     local port_attempt=0
 
     while true; do
-        # Build HostConfig with ExtraHosts and optional PortBindings
+        # Build HostConfig with NetworkMode (hiclaw-net), ExtraHosts and optional PortBindings
         local host_config
         if [ -n "${console_port}" ] && [ -n "${extra_hosts}" ]; then
-            host_config="{\"ExtraHosts\":[${extra_hosts}],\"PortBindings\":{\"${console_port}/tcp\":[{\"HostPort\":\"${host_port}\"}]}}"
+            host_config="{\"NetworkMode\":\"hiclaw-net\",\"ExtraHosts\":[${extra_hosts}],\"PortBindings\":{\"${console_port}/tcp\":[{\"HostPort\":\"${host_port}\"}]}}"
         elif [ -n "${console_port}" ]; then
-            host_config="{\"PortBindings\":{\"${console_port}/tcp\":[{\"HostPort\":\"${host_port}\"}]}}"
+            host_config="{\"NetworkMode\":\"hiclaw-net\",\"PortBindings\":{\"${console_port}/tcp\":[{\"HostPort\":\"${host_port}\"}]}}"
         elif [ -n "${extra_hosts}" ]; then
-            host_config="{\"ExtraHosts\":[${extra_hosts}]}"
+            host_config="{\"NetworkMode\":\"hiclaw-net\",\"ExtraHosts\":[${extra_hosts}]}"
         else
-            host_config="{}"
+            host_config="{\"NetworkMode\":\"hiclaw-net\"}"
         fi
 
         local create_payload


### PR DESCRIPTION
## Problem

Worker containers created by Manager's Docker API were defaulting to the `bridge` network, preventing them from accessing Manager services (Higress, MinIO, Matrix) which run in `hiclaw-net` network.

Docker's default network isolation blocks cross-network communication even when `/etc/hosts` mappings are correctly configured via `ExtraHosts`.

## Root Cause

`container_create_worker()` and `container_create_copaw_worker()` in `container-api.sh` did not specify `NetworkMode` in `HostConfig`, causing containers to use the default `bridge` network.

## Fix

Add `"NetworkMode":"hiclaw-net"` to `HostConfig` in both functions:

- `container_create_worker()` (~line 221-230)
- `container_create_copaw_worker()` (~line 498-510)

## Verification

- **Before fix**: Worker container detection timed out after 60s, containers couldn't connect to MinIO
- **After fix**: Worker containers detected immediately (`took 0s`), full connectivity restored
- **Test results**: test-01 through test-05 all passed

## Network Topology After Fix

```
hiclaw-net (172.21.0.0/16):
├── hiclaw-manager
├── higress-gateway
├── minio
├── docker-proxy
└── hiclaw-worker-* (NEW - previously in bridge)
```