### PR TITLE
fix(element-web): use external JS file for browser bypass to comply with CSP

### DIFF
--- a/manager/scripts/init/start-element-web.sh
+++ b/manager/scripts/init/start-element-web.sh
@@ -25,18 +25,22 @@ sed -i 's/^worker_processes [0-9]*;/worker_processes 2;/' /etc/nginx/nginx.conf 
 grep -q '^worker_processes' /etc/nginx/nginx.conf || \
 sed -i '1i worker_processes 2;' /etc/nginx/nginx.conf
 
+# Create browser bypass script as external JS file (allowed by CSP script-src 'self')
+# This avoids adding 'unsafe-inline' to CSP, preserving XSS protection
+echo 'window.localStorage.setItem("mx_accepts_unsupported_browser","true");' > /opt/element-web/browser-bypass.js
+
 # Generate Nginx config for Element Web
-# Note: We inject a script to automatically accept unsupported browsers
-# This bypasses the browser compatibility check in Element Web's SupportedBrowser.ts
+# Note: We inject an external script tag to automatically accept unsupported browsers
+# This bypasses the browser version check in Element Web's SupportedBrowser.ts
 cat > /etc/nginx/conf.d/element-web.conf << 'NGINX'
 server {
     listen 8088;
     root /opt/element-web;
     index index.html;
 
-    # Inject script to bypass browser compatibility check
-    # Sets localStorage.mx_accepts_unsupported_browser = true before app loads
-    sub_filter '</head>' '<script>window.localStorage.setItem("mx_accepts_unsupported_browser","true");</script></head>';
+    # Inject external script to bypass browser compatibility check
+    # Uses external JS file instead of inline script to comply with CSP (script-src 'self')
+    sub_filter '</head>' '<script src="browser-bypass.js"></script></head>';
     sub_filter_once on;
     sub_filter_types text/html;
 


### PR DESCRIPTION
## Summary

- The previous inline script injection via nginx `sub_filter` was silently blocked by Element Web's Content Security Policy (`script-src 'self'` without `'unsafe-inline'`), causing the browser compatibility warning to still appear on every page load.
- Replaced the inline `<script>` with an external JS file (`browser-bypass.js`) loaded via `<script src>`, which is allowed under the CSP `'self'` directive.
- This preserves Element Web's XSS protection — no CSP modifications needed.

## Test plan

- [x] Rebuild/restart the element-web container
- [x] Open Element Web in browser, confirm no "unsupported browser" warning page
- [x] Open DevTools Console, verify no CSP violation errors
- [x] Verify `localStorage.getItem("mx_accepts_unsupported_browser")` returns `"true"`
- [x] Check Network tab to confirm `browser-bypass.js` loads with HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)