### PR TITLE
fix(manager): enforce state.json registration for all task types and add idle-stop safety

### DIFF
--- a/manager/agent/AGENTS.md
+++ b/manager/agent/AGENTS.md
@@ -55,6 +55,7 @@ YOLO mode check: `HICLAW_YOLO=1` env var or `~/yolo-mode` file exists. In YOLO m
 - **Peer mentions default off** — only Manager/Admin can @mention Workers. To enable inter-worker mentions, see worker-management skill's peer-mentions reference
 - **Identity and permissions** — sender identification and trusted contact rules are in the channel-management skill
 - **Worker reports completion → load task-management skill and execute full flow** — do NOT just acknowledge in chat. You MUST: (1) pull task directory from MinIO, (2) read result, (3) update meta.json + state.json, (4) write memory, (5) notify admin. Skipping any step leaves stale state and missing results.
+- **Every task delegated to a Worker MUST be registered in state.json** — no exceptions for "simple", "coordination", or "non-coding" tasks. Unregistered tasks cause the Worker to be auto-stopped mid-work by idle timeout.
 - **Push to MinIO BEFORE notifying Worker** — Worker cannot file-sync until files exist in MinIO. Always verify `mc cp` succeeds before sending @mention. If you notify first, Worker gets an empty sync.
 - **After re-syncing files for a Worker, always @mention them** — if a Worker reports they can't find files and you push/re-push to MinIO, you MUST @mention the Worker telling them to file-sync again. Without the @mention, the Worker never knows the files are ready.
 - **Always notify admin in DM after task/project milestones** — don't only reply in Worker/Project rooms; admin expects status updates in DM too

--- a/manager/agent/skills/task-management/SKILL.md
+++ b/manager/agent/skills/task-management/SKILL.md
@@ -11,6 +11,7 @@ description: Use when admin gives a task to delegate to a Worker, when a Worker 
 - **Delegation-first** — always prefer assigning to a Worker over doing it yourself. Only self-execute when admin explicitly says "do it yourself" or the task is within your management skills
 - **Never @mention a Worker after recording infinite task execution** — this creates a rapid-fire loop (execute → report → trigger → execute → ...) that burns tokens continuously. Triggering happens only during heartbeat
 - **Always use `manage-state.sh` to modify state.json** — never edit manually with jq. The script handles atomicity, deduplication, and initialization
+- **Every task assigned to a Worker MUST be registered in state.json** — this includes coordination, research, review, and management tasks, not just coding tasks. If a task is missing from state.json, the Worker's container will be auto-stopped by idle timeout while still working
 - **Always push task files to MinIO before notifying Worker** — Worker needs to file-sync to get the spec
 - **Always pull task directory from MinIO before reading results** — Worker pushes results there
 - **Read SOUL.md before composing notifications** — use the persona and language defined there

--- a/manager/agent/skills/task-management/references/finite-tasks.md
+++ b/manager/agent/skills/task-management/references/finite-tasks.md
@@ -29,13 +29,14 @@
    ```
    If Worker has `find-skills` (`test -d /root/hiclaw-fs/agents/{worker}/skills/find-skills`), add: `Run \`skills find <keyword>\` if you need additional capabilities.`
 
-5. Add to state.json:
+5. **MANDATORY — Add to state.json** (this step is NOT optional, even for coordination, research, or management tasks):
    ```bash
    bash /opt/hiclaw/agent/skills/task-management/scripts/manage-state.sh \
      --action add-finite --task-id {task-id} --title "{title}" \
      --assigned-to {worker} --room-id {room-id}
    ```
    If task belongs to a project, append `--project-room-id {project-room-id}`.
+   **WARNING**: Skipping this step causes the Worker to be auto-stopped by idle timeout. Every task assigned to a Worker MUST be registered here.
 
 ## On completion
 

--- a/manager/agent/skills/worker-management/scripts/lifecycle-worker.sh
+++ b/manager/agent/skills/worker-management/scripts/lifecycle-worker.sh
@@ -71,18 +71,9 @@ EOF
 }
 EOF
     else
-        # Sync idle_timeout_minutes from env var — env file is the authority
-        local env_timeout="${HICLAW_WORKER_IDLE_TIMEOUT:-}"
-        if [ -n "$env_timeout" ]; then
-            local file_timeout
-            file_timeout=$(jq -r '.idle_timeout_minutes' "$LIFECYCLE_FILE" 2>/dev/null)
-            if [ "$file_timeout" != "$env_timeout" ]; then
-                _log "Updating idle_timeout_minutes: $file_timeout -> $env_timeout (from HICLAW_WORKER_IDLE_TIMEOUT)"
-                local tmp
-                tmp=$(mktemp)
-                jq --argjson t "$env_timeout" '.idle_timeout_minutes = $t' "$LIFECYCLE_FILE" > "$tmp" && mv "$tmp" "$LIFECYCLE_FILE"
-            fi
-        fi
+        # File already exists — respect any manual edits.
+        # HICLAW_WORKER_IDLE_TIMEOUT is only used for initial creation (above).
+        true
     fi
 
     if [ ! -f "$STATE_FILE" ]; then
@@ -237,6 +228,22 @@ action_check_idle() {
             # Worker has no active tasks (neither finite nor infinite)
             if [ "$container_status" != "running" ]; then
                 continue
+            fi
+
+            # Safety net: if worker was recently started, don't mark idle yet.
+            # This protects against races where the Manager hasn't registered
+            # the task in state.json yet.
+            local last_started
+            last_started=$(_get_worker_field "$worker" "last_started_at")
+            if [ -n "$last_started" ] && [ "$last_started" != "null" ]; then
+                local started_epoch
+                started_epoch=$(date -u -d "$last_started" +%s 2>/dev/null || date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$last_started" +%s 2>/dev/null)
+                local since_start=$(( now_epoch - started_epoch ))
+                local grace_seconds=$(( idle_timeout * 60 ))
+                if [ "$since_start" -lt "$grace_seconds" ]; then
+                    _log "Worker $worker has no tasks but was started ${since_start}s ago (grace: ${grace_seconds}s) — skipping idle check"
+                    continue
+                fi
             fi
 
             local idle_since


### PR DESCRIPTION

Manager agent was skipping state.json registration for coordination/management tasks, causing workers to be incorrectly auto-stopped by idle timeout while actively working. 

This commit:

1. Strengthens prompt instructions in finite-tasks.md, SKILL.md, and AGENTS.md to make state.json registration mandatory for ALL task types (coding, coordination, research, review, etc.)
2. Adds a last_started_at grace period check in check-idle to prevent stopping recently-started workers even if state.json registration was delayed
3. Removes env var override of idle_timeout_minutes so runtime edits to worker-lifecycle.json are respected

fixes https://github.com/alibaba/hiclaw/issues/435