### PR TITLE
fix(import): add install command hints when HiClaw is not found

### DIFF
--- a/install/hiclaw-import.ps1
+++ b/install/hiclaw-import.ps1
@@ -38,14 +38,27 @@ if (-not $ContainerCmd) {
     try { $null = & podman info 2>$null; $ContainerCmd = "podman" } catch {}
 }
 if (-not $ContainerCmd) {
-    Write-Host "[HiClaw Import ERROR] Neither docker nor podman found" -ForegroundColor Red
+    Write-Host "[HiClaw Import ERROR] Neither docker nor podman found." -ForegroundColor Red
+    Write-Host ""
+    Write-Host "Docker is required to run HiClaw. Install Docker Desktop first, then install HiClaw:" -ForegroundColor Yellow
+    Write-Host "  Set-ExecutionPolicy Bypass -Scope Process -Force; `$wc=New-Object Net.WebClient; `$wc.Encoding=[Text.Encoding]::UTF8; iex `$wc.DownloadString('https://higress.ai/hiclaw/install.ps1')"
     exit 1
 }
 
 # Verify Manager container
 $mgrRunning = & $ContainerCmd ps --filter "name=hiclaw-manager" --format "{{.Names}}" 2>$null
 if ($mgrRunning -notmatch "hiclaw-manager") {
-    Write-Host "[HiClaw Import ERROR] hiclaw-manager container is not running" -ForegroundColor Red
+    Write-Host "[HiClaw Import ERROR] hiclaw-manager container is not running." -ForegroundColor Red
+    Write-Host ""
+    # Check if the container exists but is stopped
+    $mgrExists = & $ContainerCmd ps -a --filter "name=hiclaw-manager" --format "{{.Names}}" 2>$null
+    if ($mgrExists -match "hiclaw-manager") {
+        Write-Host "The hiclaw-manager container exists but is stopped. Start it with:" -ForegroundColor Yellow
+        Write-Host "  $ContainerCmd start hiclaw-manager"
+    } else {
+        Write-Host "HiClaw does not appear to be installed. Install it first:" -ForegroundColor Yellow
+        Write-Host "  Set-ExecutionPolicy Bypass -Scope Process -Force; `$wc=New-Object Net.WebClient; `$wc.Encoding=[Text.Encoding]::UTF8; iex `$wc.DownloadString('https://higress.ai/hiclaw/install.ps1')"
+    }
     exit 1
 }
 

--- a/install/hiclaw-import.sh
+++ b/install/hiclaw-import.sh
@@ -25,13 +25,25 @@ elif command -v podman &>/dev/null && podman info &>/dev/null 2>&1; then
     CONTAINER_CMD="podman"
 fi
 if [ -z "${CONTAINER_CMD}" ]; then
-    echo "ERROR: Neither docker nor podman found" >&2
+    echo "ERROR: Neither docker nor podman found." >&2
+    echo "" >&2
+    echo "Docker is required to run HiClaw. Install Docker first, then install HiClaw:" >&2
+    echo "  bash <(curl -sSL https://higress.ai/hiclaw/install.sh)" >&2
     exit 1
 fi
 
 # Verify Manager container
 if ! ${CONTAINER_CMD} ps --filter name=hiclaw-manager --format '{{.Names}}' 2>/dev/null | grep -q 'hiclaw-manager'; then
-    echo "ERROR: hiclaw-manager container is not running" >&2
+    echo "ERROR: hiclaw-manager container is not running." >&2
+    echo "" >&2
+    # Check if the container exists but is stopped
+    if ${CONTAINER_CMD} ps -a --filter name=hiclaw-manager --format '{{.Names}}' 2>/dev/null | grep -q 'hiclaw-manager'; then
+        echo "The hiclaw-manager container exists but is stopped. Start it with:" >&2
+        echo "  ${CONTAINER_CMD} start hiclaw-manager" >&2
+    else
+        echo "HiClaw does not appear to be installed. Install it first:" >&2
+        echo "  bash <(curl -sSL https://higress.ai/hiclaw/install.sh)" >&2
+    fi
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- When docker/podman is missing or hiclaw-manager container doesn't exist, show platform-specific install commands instead of a bare error message
- `hiclaw-import.sh` shows bash install command, `hiclaw-import.ps1` shows PowerShell install command
- Distinguishes stopped containers (suggest `docker start`) from missing installations (suggest one-click installer)

## Test plan
- [ ] Run `hiclaw-import.sh` without Docker installed, verify bash install hint is shown
- [ ] Run `hiclaw-import.sh` with Docker but no hiclaw-manager container, verify install hint
- [ ] Run `hiclaw-import.sh` with stopped hiclaw-manager, verify `docker start` hint
- [ ] Run `hiclaw-import.ps1` on Windows without Docker, verify PowerShell install hint
- [ ] Run `hiclaw-import.ps1` with stopped hiclaw-manager, verify `docker start` hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)