### PR TITLE
fix(test): wait for pending messages before create-worker test

### DIFF
--- a/tests/test-02-create-worker.sh
+++ b/tests/test-02-create-worker.sh
@@ -46,6 +46,12 @@ wait_for_manager_agent_ready 300 "${DM_ROOM}" "${ADMIN_TOKEN}" || {
     exit 1
 }
 
+# Wait for Manager to finish processing any pending messages from previous tests
+# (e.g., SOUL.md configuration from test-01) before sending a new request.
+# Without this, the SOUL.md reply may arrive after our baseline snapshot and
+# get mistaken for the create-worker reply.
+wait_for_session_stable 5 60
+
 # Snapshot metrics baseline before sending message (to calculate delta later)
 METRICS_BASELINE=$(snapshot_baseline)
 


### PR DESCRIPTION
## Summary

- Fix flaky `test-02-create-worker` failure caused by a race with the installation setup's SOUL.md configuration message.
- When test-02 starts, the Manager may still be processing the identity config message sent during installation. The SOUL.md reply arrives after `matrix_wait_for_reply`'s baseline snapshot, so it gets returned as the "new" reply — which doesn't contain "alice", failing the assertion.
- Add `wait_for_session_stable` before sending the create-worker request, ensuring all prior messages are processed and the baseline snapshot captures them.

Root cause identified by analyzing debug logs from CI run [#23701344511](https://github.com/alibaba/hiclaw/actions/runs/23701344511).

## Test plan

- [x] Verified timeline from Matrix message logs confirms the race condition
- [x] CI should no longer see SOUL.md reply mistaken for create-worker reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)