### PR TITLE
fix(cli): preserve explicit openclaw runtime in generated YAML

### DIFF
--- a/hiclaw-controller/cmd/hiclaw/main.go
+++ b/hiclaw-controller/cmd/hiclaw/main.go
@@ -181,7 +181,7 @@ func applyWorkerFromParams(name, model, packageURI, skills, mcpServers, runtime 
 	// Build YAML
 	var specLines []string
 	specLines = append(specLines, fmt.Sprintf("  model: %s", model))
-	if runtime != "" && runtime != "openclaw" {
+	if runtime != "" {
 		specLines = append(specLines, fmt.Sprintf("  runtime: %s", runtime))
 	}
 	if packageURI != "" {


### PR DESCRIPTION
## Summary

- 用户通过声明式配置指定 `runtime: openclaw` 时，CLI 在生成 YAML 时将其视为默认值而省略，导致 controller 不传 `--runtime` 参数给 `create-worker.sh`
- `create-worker.sh` fallback 到环境变量 `HICLAW_DEFAULT_WORKER_RUNTIME`，在安装时选择了 copaw 的机器上会错误地启动 copaw worker
- 修复：不再省略显式声明的 openclaw runtime，确保用户意图被完整保留

## Test plan

- [ ] 在 `HICLAW_DEFAULT_WORKER_RUNTIME=copaw` 的环境中，声明 `runtime: openclaw` 后验证生成的 YAML 包含 runtime 字段
- [ ] 验证 controller 正确传递 `--runtime openclaw` 给 create-worker.sh
- [ ] 验证不指定 runtime 时仍然走默认 fallback 逻辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Summary

- When the user specifies `runtime: openclaw` through declarative configuration, the CLI treats it as a default value and omits it when generating YAML, causing the controller not to pass the `--runtime` parameter to `create-worker.sh`
- `create-worker.sh` fallsback to the environment variable `HICLAW_DEFAULT_WORKER_RUNTIME`, which will incorrectly start the copaw worker on a machine where copaw is selected during installation
- Fix: Explicitly declared openclaw runtime is no longer omitted to ensure user intent is fully preserved

## Test plan

- [ ] In the environment of `HICLAW_DEFAULT_WORKER_RUNTIME=copaw`, verify that the generated YAML contains the runtime field after declaring `runtime: openclaw`
- [ ] Verify that the controller correctly passes `--runtime openclaw` to create-worker.sh
- [ ] Verify that the default fallback logic is still used when runtime is not specified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
