### PR TITLE
fix(test): wait for bob-specific reply in test-06-multi-worker

### DIFF
--- a/tests/test-06-multi-worker.sh
+++ b/tests/test-06-multi-worker.sh
@@ -42,8 +42,9 @@ matrix_send_message "${ADMIN_TOKEN}" "${DM_ROOM}" \
     "Create a new Worker for backend development. The worker's name (username) must be exactly 'bob'. He should have access to GitHub MCP."
 
 log_info "Waiting for Manager to create Worker Bob..."
-REPLY=$(matrix_wait_for_reply "${ADMIN_TOKEN}" "${DM_ROOM}" "@manager" 180 \
-    "${ADMIN_TOKEN}" "${DM_ROOM}" "Please check if the request has been processed.")
+REPLY=$(matrix_wait_for_message_containing "${ADMIN_TOKEN}" "${DM_ROOM}" "@manager" \
+    "bob" 300 \
+    "${ADMIN_TOKEN}" "${DM_ROOM}" "Please check if the request to create worker bob has been processed.")
 
 assert_not_empty "${REPLY}" "Manager replied to create bob request"
 assert_contains_i "${REPLY}" "bob" "Reply mentions worker name 'bob'"


### PR DESCRIPTION
## Summary
- `matrix_wait_for_reply` picks up the first new Manager message, which may be an unrelated async reply from a previous test (e.g. alice task assignment). Switch to `matrix_wait_for_message_containing` with keyword `"bob"` so the test waits for the actual bob creation confirmation.
- This also fixes the subsequent Higress consumer check — it was running too early because the wrong message was returned quickly.

## Root cause
In [run #23711522292](https://github.com/alibaba/hiclaw/actions/runs/23711522292), the Manager replied about alice's task at 15:03:11 before replying about bob's creation at 15:05:01. The test grabbed the alice message as the "reply", causing both the `bob` name assertion and the Higress consumer check to fail.

## Test plan
- [ ] Re-run integration tests and verify test-06-multi-worker passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)