### PR TITLE
fix(manager): prevent zombie process from welcome message background task

### DIFF
--- a/manager/scripts/init/start-manager-agent.sh
+++ b/manager/scripts/init/start-manager-agent.sh
@@ -355,6 +355,9 @@ else
     # Schedule welcome message in background (only on first boot)
     if [ -n "${DM_ROOM_ID}" ] && [ ! -f "/root/manager-workspace/soul-configured" ]; then
         log "Scheduling welcome message (background, waiting for OpenClaw to start)..."
+        # Double-fork so the welcome-message process is reparented to PID 1
+        # and does not become a zombie after `exec openclaw` replaces this shell.
+        (
         (
             _HICLAW_LANGUAGE="${HICLAW_LANGUAGE:-zh}"
             _HICLAW_TIMEZONE="${TZ:-Asia/Shanghai}"
@@ -424,8 +427,8 @@ The human admin will start chatting shortly."
             else
                 echo "[manager] WARNING: Failed to send welcome message (HTTP ${_http_code}): ${_send_resp}"
             fi
-        ) &
-        log "Welcome message background process started (PID: $!)"
+        ) & )
+        log "Welcome message background process started"
     fi
 fi
 


### PR DESCRIPTION
## Summary
- The welcome message subshell was started with single fork `( cmd ) &` before `exec openclaw`, causing a `[start-manager-a] <defunct>` zombie in `ps -ef`
- After `exec` replaced the shell with `openclaw`, the new process never called `wait()` on the background child
- Use double-fork `( ( cmd ) & )` so the grandchild is reparented to PID 1 and reaped properly

## Test plan
- [ ] Start manager container, verify no `<defunct>` process in `ps -ef`
- [ ] Verify welcome message is still sent on first boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)