### PR TITLE
fix(manager): reply to admin before greeting worker in post-creation

### DIFF
--- a/manager/agent/skills/worker-management/references/create-worker.md
+++ b/manager/agent/skills/worker-management/references/create-worker.md
@@ -102,16 +102,16 @@ Only use `--remote` when admin **explicitly** requests deploying on a separate m
    bash -c 'source /opt/hiclaw/scripts/lib/container-api.sh && worker_backend_status "<NAME>"'
    ```
 
-2. Send greeting in Worker's Room:
+2. Immediately reply to admin in the DM (do NOT wait for Worker to greet first):
    ```
-   @<NAME>:${HICLAW_MATRIX_DOMAIN} You're all set! Please introduce yourself to everyone in this room.
-   ```
-
-3. After Worker greets, notify admin:
-   ```
-   @${HICLAW_ADMIN_USER}:${HICLAW_MATRIX_DOMAIN} <NAME> is ready. Remember to @mention them when giving tasks.
+   <NAME> is ready. Remember to @mention them when giving tasks.
 
    Note: By default, Workers only accept @mentions from Manager and admin — not from each other. Peer mentions can be enabled explicitly per-project.
+   ```
+
+3. Send greeting in Worker's Room:
+   ```
+   @<NAME>:${HICLAW_MATRIX_DOMAIN} You're all set! Please introduce yourself to everyone in this room.
    ```
 
 ## Imported Worker Pull-Up


### PR DESCRIPTION
## Summary

- Reorder post-creation steps in `create-worker.md` so Manager immediately replies to admin in the DM, then sends greeting to Worker room
- Previously step 3 said "After Worker greets, notify admin", causing Manager (qwen3.5-plus) to output `NO_REPLY` in admin DM while waiting for Worker's greeting — this made test-02 timeout

## Root cause

In CI run [#23742741478](https://github.com/agentscope-ai/HiClaw/actions/runs/23742741478), Manager correctly created Worker Alice but then:
1. Sent greeting to Alice's room
2. Output `NO_REPLY` in admin DM (interpreted "After Worker greets" as a blocking prerequisite)
3. Test waited 300s for a reply in DM, got nothing → FAIL

This is a different issue from the previous fix `9ecc2c5` which addressed a race condition with SOUL.md replies.

## Test plan

- [ ] Re-run integration tests, verify test-02-create-worker passes
- [ ] Verify Manager replies to admin in DM before greeting Worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)