### PR TITLE
fix(controller): propagate package resolve errors in handleUpdate

### DIFF
--- a/hiclaw-controller/internal/controller/worker_controller.go
+++ b/hiclaw-controller/internal/controller/worker_controller.go
@@ -248,8 +248,13 @@ func (r *WorkerReconciler) handleUpdate(ctx context.Context, w *v1beta1.Worker) 
 	if w.Spec.Package != "" {
 		extractedDir, err := r.Packages.ResolveAndExtract(ctx, w.Spec.Package, w.Name)
 		if err != nil {
-			logger.Error(err, "package resolve/extract failed during update", "name", w.Name)
-		} else if extractedDir != "" {
+			_ = r.Get(ctx, client.ObjectKeyFromObject(w), w)
+			w.Status.Phase = "Failed"
+			w.Status.Message = fmt.Sprintf("package resolve/extract failed: %v", err)
+			r.Status().Update(ctx, w)
+			return reconcile.Result{RequeueAfter: time.Minute}, err
+		}
+		if extractedDir != "" {
 			packageDir = extractedDir
 			logger.Info("package resolved for update", "name", w.Name, "dir", extractedDir)
 		}
@@ -259,10 +264,13 @@ func (r *WorkerReconciler) handleUpdate(ctx context.Context, w *v1beta1.Worker) 
 	if w.Spec.Identity != "" || w.Spec.Soul != "" || w.Spec.Agents != "" {
 		agentDir := fmt.Sprintf("/root/hiclaw-fs/agents/%s", w.Name)
 		if err := executor.WriteInlineConfigs(agentDir, w.Spec.Runtime, w.Spec.Identity, w.Spec.Soul, w.Spec.Agents); err != nil {
-			logger.Error(err, "write inline configs failed during update", "name", w.Name)
-		} else {
-			logger.Info("inline configs written for update", "name", w.Name)
+			_ = r.Get(ctx, client.ObjectKeyFromObject(w), w)
+			w.Status.Phase = "Failed"
+			w.Status.Message = fmt.Sprintf("write inline configs failed: %v", err)
+			r.Status().Update(ctx, w)
+			return reconcile.Result{RequeueAfter: time.Minute}, err
 		}
+		logger.Info("inline configs written for update", "name", w.Name)
 	}
 
 	// 2. Call update-worker-config.sh (handles credentials, openclaw.json, skills, MinIO sync)


### PR DESCRIPTION
## Summary

- `handleUpdate` silently logged package resolve/extract errors and continued execution, causing `update-worker-config.sh` to run without `--package-dir`. This meant SOUL.md was never updated on re-import.
- Root cause of `test-17-worker-config-verify` failures in recent CI runs ([#1](https://github.com/agentscope-ai/HiClaw/actions/runs/23751261417/job/69193700899), [#2](https://github.com/agentscope-ai/HiClaw/actions/runs/23751289021/job/69193799352)).
- Fix mirrors `handleCreate`'s behavior: set status to `Failed` and return with `RequeueAfter` so the reconciler retries after 1 minute.

## Test plan

- [x] CI test-17-worker-config-verify passes
- [x] Verify other tests remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)