### PR TITLE
fix(install): create /tmp/import before apply copy

### DIFF
--- a/install/hiclaw-apply.sh
+++ b/install/hiclaw-apply.sh
@@ -45,6 +45,9 @@ if ! ${CONTAINER_CMD} ps --filter name=hiclaw-manager --format '{{.Names}}' 2>/d
     error "hiclaw-manager container is not running"
 fi
 
+# Ensure /tmp/import exists before copying files into container
+${CONTAINER_CMD} exec hiclaw-manager mkdir -p /tmp/import 2>/dev/null || true
+
 # ============================================================
 # Copy YAML files and referenced packages into container
 # ============================================================
@@ -73,9 +76,6 @@ for arg in "$@"; do
 
     ARGS+=("${arg}")
 done
-
-# Ensure /tmp/import exists
-${CONTAINER_CMD} exec hiclaw-manager mkdir -p /tmp/import 2>/dev/null || true
 
 # ============================================================
 # Forward to hiclaw CLI inside container


### PR DESCRIPTION
## Summary

Fixes the host-side declarative apply wrapper so it creates `/tmp/import` before copying YAML files into the Manager container.

Fixes #522

## Changes

- move `/tmp/import` creation ahead of the file-copy loop in `install/hiclaw-apply.sh`
- keep the wrapper behavior otherwise unchanged

## Why

`hiclaw-apply.sh` could fail on fresh environments because it tried to copy files into `hiclaw-manager:/tmp/import/...` before ensuring that `/tmp/import` existed.

## Validation

- `bash -n install/hiclaw-apply.sh`
- verified `bash install/hiclaw-apply.sh -f /tmp/repro-delete-team.yaml` succeeds without the previous missing `/tmp/import` error
