### PR TITLE
fix(manager): use HICLAW_PROXY_CONTAINER_PREFIX for cms tracing naming consistency

### DIFF
--- a/manager/agent/skills/worker-management/scripts/generate-worker-config.sh
+++ b/manager/agent/skills/worker-management/scripts/generate-worker-config.sh
@@ -166,7 +166,7 @@ if [ "${_cms_traces_lc}" = "true" ]; then
     elif [ -z "${HICLAW_CMS_ENDPOINT:-}" ] || [ -z "${HICLAW_CMS_LICENSE_KEY:-}" ] || [ -z "${HICLAW_CMS_WORKSPACE:-}" ]; then
         log "WARNING: HICLAW_CMS_TRACES_ENABLED=true but HICLAW_CMS_ENDPOINT / HICLAW_CMS_LICENSE_KEY / HICLAW_CMS_WORKSPACE are not all set; skipping CMS config for worker ${WORKER_NAME}"
     else
-        _cms_worker_service="hiclaw-worker-${WORKER_NAME}"
+        _cms_worker_service="${HICLAW_PROXY_CONTAINER_PREFIX:-hiclaw-worker-}${WORKER_NAME}"
         _cms_metrics_lc="$(echo "${HICLAW_CMS_METRICS_ENABLED:-false}" | tr '[:upper:]' '[:lower:]')"
         _diag_plugin_dir="/opt/openclaw/extensions/diagnostics-otel"
         _diag_available="0"

--- a/manager/scripts/lib/container-api.sh
+++ b/manager/scripts/lib/container-api.sh
@@ -22,7 +22,7 @@ if [ -z "${CONTAINER_API_BASE}" ]; then
 fi
 WORKER_IMAGE="${HICLAW_WORKER_IMAGE:-hiclaw/worker-agent:latest}"
 COPAW_WORKER_IMAGE="${HICLAW_COPAW_WORKER_IMAGE:-hiclaw/copaw-worker:latest}"
-WORKER_CONTAINER_PREFIX="hiclaw-worker-"
+WORKER_CONTAINER_PREFIX="${HICLAW_PROXY_CONTAINER_PREFIX:-hiclaw-worker-}"
 
 _log() {
     echo "[hiclaw-container $(date '+%Y-%m-%d %H:%M:%S')] $1"


### PR DESCRIPTION
## Summary
- `docker-proxy` already reads `HICLAW_PROXY_CONTAINER_PREFIX` to validate container names, but `container-api.sh` and `generate-worker-config.sh` had the prefix hardcoded to `hiclaw-worker-`. This caused mismatches when a custom prefix was configured — container operations and CMS service names wouldn't align with the proxy's security rules.
- Now all three components read the same env var with the same default.

## Test plan
- [x] Deploy with default config (no `HICLAW_PROXY_CONTAINER_PREFIX` set) — verify worker containers and CMS traces still use `hiclaw-worker-<name>`
- [x] Set `HICLAW_PROXY_CONTAINER_PREFIX=custom-` and verify container names and CMS service names both use `custom-<name>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)