### PR TITLE
fix(controller): deploy package to MinIO atomically during worker update

### DIFF
--- a/hiclaw-controller/internal/controller/worker_controller.go
+++ b/hiclaw-controller/internal/controller/worker_controller.go
@@ -131,7 +131,7 @@ func (r *WorkerReconciler) handleCreate(ctx context.Context, w *v1beta1.Worker) 
 			return reconcile.Result{RequeueAfter: time.Minute}, err
 		}
 		if extractedDir != "" {
-			if err := r.Packages.DeployToMinIO(ctx, extractedDir, w.Name); err != nil {
+			if err := r.Packages.DeployToMinIO(ctx, extractedDir, w.Name, false); err != nil {
 				_ = r.Get(ctx, client.ObjectKeyFromObject(w), w)
 				w.Status.Phase = "Failed"
 				w.Status.Message = fmt.Sprintf("package deploy failed: %v", err)
@@ -255,8 +255,16 @@ func (r *WorkerReconciler) handleUpdate(ctx context.Context, w *v1beta1.Worker) 
 			return reconcile.Result{RequeueAfter: time.Minute}, err
 		}
 		if extractedDir != "" {
+			// Deploy package files to local + MinIO atomically (excludes memory to preserve existing state)
+			if err := r.Packages.DeployToMinIO(ctx, extractedDir, w.Name, true); err != nil {
+				_ = r.Get(ctx, client.ObjectKeyFromObject(w), w)
+				w.Status.Phase = "Failed"
+				w.Status.Message = fmt.Sprintf("package deploy failed: %v", err)
+				r.Status().Update(ctx, w)
+				return reconcile.Result{RequeueAfter: time.Minute}, err
+			}
 			packageDir = extractedDir
-			logger.Info("package resolved for update", "name", w.Name, "dir", extractedDir)
+			logger.Info("package deployed for update", "name", w.Name, "dir", extractedDir)
 		}
 	}
 

--- a/hiclaw-controller/internal/executor/package.go
+++ b/hiclaw-controller/internal/executor/package.go
@@ -126,7 +126,7 @@ func (p *PackageResolver) ResolveAndExtract(ctx context.Context, uri, name strin
 
 // DeployToMinIO copies extracted package contents to the worker's MinIO agent space.
 // This ensures SOUL.md, custom skills, etc. are in place before create-worker.sh runs.
-func (p *PackageResolver) DeployToMinIO(ctx context.Context, extractedDir, workerName string) error {
+func (p *PackageResolver) DeployToMinIO(ctx context.Context, extractedDir, workerName string, excludeMemory bool) error {
 	agentDir := fmt.Sprintf("/root/hiclaw-fs/agents/%s", workerName)
 	if err := os.MkdirAll(agentDir, 0755); err != nil {
 		return fmt.Errorf("create agent dir: %w", err)
@@ -200,7 +200,11 @@ func (p *PackageResolver) DeployToMinIO(ctx context.Context, extractedDir, worke
 		storagePrefix = "hiclaw/hiclaw-storage"
 	}
 	minioDest := fmt.Sprintf("%s/agents/%s/", storagePrefix, workerName)
-	mcCmd := exec.CommandContext(ctx, "mc", "mirror", agentDir+"/", minioDest, "--overwrite")
+	args := []string{"mirror", agentDir + "/", minioDest, "--overwrite"}
+	if excludeMemory {
+		args = append(args, "--exclude", "memory/*", "--exclude", "MEMORY.md")
+	}
+	mcCmd := exec.CommandContext(ctx, "mc", args...)
 	if out, err := mcCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("mc mirror to %s failed: %s: %w", minioDest, string(out), err)
 	}


### PR DESCRIPTION
Add DeployToMinIO call in handleUpdate to make package file deployment (local write + MinIO sync) atomic, eliminating the race window where the 5-minute fallback mc mirror (MinIO → local) could overwrite locally-copied files before the update script's final mc mirror.

This fixes intermittent test-17 failures where SOUL.md was not updated after re-import.