### PR TITLE
fix(copaw): download file attachments in group room history

### DIFF
--- a/copaw/src/copaw_manager/app/channels/matrix/channel.py
+++ b/copaw/src/copaw_manager/app/channels/matrix/channel.py
@@ -990,6 +990,18 @@ class MatrixChannel(BaseChannel):
                         )
         elif isinstance(event, RoomMessageFile):
             body_desc = f"[sent a file: {body}]" if body else "[sent a file]"
+            mxc_url = getattr(event, "url", "") or ""
+            if mxc_url:
+                eid = event.event_id[:8].lstrip("$")
+                filename = body or f"matrix_media_{eid}"
+                filename = f"{eid}_{filename}"
+                local_path = await self._download_mxc(mxc_url, filename)
+                if local_path:
+                    media_parts.append({
+                        "type": "file",
+                        "file_url": Path(local_path).as_uri(),
+                        "filename": body or filename,
+                    })
         elif isinstance(event, RoomMessageAudio):
             body_desc = f"[sent audio: {body}]" if body else "[sent audio]"
         elif isinstance(event, RoomMessageVideo):

--- a/copaw/src/copaw_worker/matrix_channel.py
+++ b/copaw/src/copaw_worker/matrix_channel.py
@@ -757,6 +757,18 @@ class MatrixChannel(BaseChannel):
                         })
         elif isinstance(event, RoomMessageFile):
             body_desc = f"[sent a file: {body}]" if body else "[sent a file]"
+            mxc_url = getattr(event, "url", "") or ""
+            if mxc_url:
+                eid = event.event_id[:8].lstrip("$")
+                filename = body or f"matrix_media_{eid}"
+                filename = f"{eid}_{filename}"
+                local_path = await self._download_mxc(mxc_url, filename)
+                if local_path:
+                    media_parts.append({
+                        "type": "file",
+                        "file_url": Path(local_path).as_uri(),
+                        "filename": body or filename,
+                    })
         elif isinstance(event, RoomMessageAudio):
             body_desc = f"[sent audio: {body}]" if body else "[sent audio]"
         elif isinstance(event, RoomMessageVideo):


### PR DESCRIPTION
## Summary
- `_record_media_history` 中 `RoomMessageFile` 分支缺少 `_download_mxc` 调用
- Group 房间中用户发送文件（未 mention worker）时，附件内容丢失，只记录了 `[sent a file: xxx]` 文本描述
- 补充下载逻辑，与 `RoomMessageImage` 保持一致
- 同时修复 CoPaw Worker 和 CoPaw Manager 两个 channel

## Test plan
- [x] ECS 上部署验证，group 房间发送文件附件，worker 能正确读取文件内容
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Summary
- Missing `_download_mxc` call in `RoomMessageFile` branch in `_record_media_history`
- When a user in the Group room sends a file (without mentioning the worker), the attachment content is lost, and only the text description of `[sent a file: xxx]` is recorded
- Supplement download logic, consistent with `RoomMessageImage`
- Fixed both CoPaw Worker and CoPaw Manager channels

## Test plan
- [x] Deployment verification on ECS, the group room sends file attachments, and the worker can correctly read the file content
