### PR TITLE
refactor(copaw-manager): simplify _apply_mention to match worker

### DIFF
--- a/copaw/src/copaw_manager/app/channels/matrix/channel.py
+++ b/copaw/src/copaw_manager/app/channels/matrix/channel.py
@@ -206,23 +206,6 @@ class MatrixChannelConfig:
             0,
             raw.get("history_limit", DEFAULT_HISTORY_LIMIT),
         )
-        # When True (default), outbound text/media with meta.sender_id call
-        # _apply_mention: m.mentions + HTML pill. Plain body stays the original
-        # text (no leading display name) to avoid duplicate @ in clients.
-        # Set False or use meta skip_structured_mention if a manager-style bot
-        # loops on structured mentions.
-        self.outbound_structured_mentions: bool = raw.get(
-            "outbound_structured_mentions",
-            True,
-        )
-        # When True, prepend the HTML pill (clickable mention link) to
-        # formatted_body. Default is False: m.mentions is always set for push
-        # notifications, but the visible pill prefix is omitted from the
-        # rendered message to avoid duplicate @-mentions in rich clients.
-        self.mention_pill_in_body: bool = raw.get(
-            "mention_pill_in_body",
-            False,
-        )
         # matrix-nio sync long-poll timeout (ms); typical 30s
         self.sync_timeout_ms: int = raw.get("sync_timeout_ms", 30000)
 
@@ -1902,110 +1885,35 @@ class MatrixChannel(BaseChannel):
         return meta.get("room_id", getattr(request, "user_id", ""))
 
     # ------------------------------------------------------------------
-    # Mention helper — spec-compliant Matrix mention (m.mentions + HTML pill)
-    # outbound m.mentions (P0) + formatted_body pill
-    # for push + Element-style render; display name from room state (§12–§13).
+    # Mention helper — MSC3952 m.mentions from body text scan
     # ------------------------------------------------------------------
 
-    def _strip_lead_echo_of_ping_target(
-        self,
-        body: str,
-        user_id: str,
-        room_id: str,
-    ) -> str:
-        """Drop a leading display name / MXID that duplicates the HTML pill.
+    # Regex to match Matrix user IDs: @localpart:domain (with optional port)
+    _MATRIX_USER_ID_RE = re.compile(
+        r"@[a-zA-Z0-9._=+/\-]+:[a-zA-Z0-9.\-]+(?::\d+)?",
+    )
 
-        Manager/worker pipelines often prefix replies with the target's room
-        display name (e.g. ``manager 💕 TASK: ...``).  We still prepend a pill
-        in ``formatted_body``; without stripping, rich clients show the name
-        twice (pill + markdown HTML).
-        """
-        if not body.strip():
-            return body
-        display_name = self._resolve_display_name(user_id, room_id)
-        stripped = body.lstrip()
-        for prefix in (display_name, user_id):
-            if not prefix or not stripped.startswith(prefix):
-                continue
-            tail = stripped[len(prefix) :].lstrip(" \t:：，,、\n\r-—")
-            return tail if tail.strip() else body
-        return body
+    def _extract_mentions_from_text(self, text: str) -> list[str]:
+        """Extract all @user:domain Matrix IDs from message text."""
+        matches = self._MATRIX_USER_ID_RE.findall(text)
+        return list(dict.fromkeys(matches))  # dedupe, preserve order
 
     def _apply_mention(
         self,
         content: dict[str, Any],
         user_id: str,
         room_id: str,
-        meta: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Add a full Matrix mention to an outgoing event content dict.
+        """Add Matrix mentions to an outgoing event content dict.
 
-        Sets ``m.mentions`` (for push notifications) and optionally adds a
-        ``formatted_body`` with an HTML pill so clients render the
-        mention visually (controlled by ``mention_pill_in_body`` config).
-
-        Plain ``body`` is not prefixed with the display name (that duplicated
-        @).  If the upstream ``body`` already starts with the same display
-        name or MXID as the pill, that lead is stripped and HTML is rebuilt
-        so the rich client does not show the name twice.
-
-        Args:
-            content: The Matrix event content dict to modify in place.
-            user_id: The MXID to mention (e.g. "@user:server").
-            room_id: The room where this event will be sent.
-            meta: Optional message metadata; supports overrides:
-                - ``skip_mention_pill``: If True, omit HTML pill even if config
-                  enables it.
-                - ``force_mention_pill``: If True, include HTML pill even if
-                  config disables it.
+        Scans the message body for @user:domain patterns and populates
+        ``m.mentions.user_ids`` (MSC3952). Only includes user IDs that
+        actually appear in the text. Does NOT modify the body text.
         """
-        # Always set m.mentions for push notification delivery
-        content["m.mentions"] = {"user_ids": [user_id]}
-
         body = content.get("body", "")
-        body = self._strip_lead_echo_of_ping_target(body, user_id, room_id)
-
-        # Convert body to HTML
-        html_body = _md_to_html(body)
-        content["format"] = "org.matrix.custom.html"
-
-        # Determine whether to show HTML pill (config + meta overrides)
-        show_pill = self._should_show_mention_pill(meta)
-
-        # Conditionally prepend HTML pill
-        if show_pill:
-            display_name = self._resolve_display_name(user_id, room_id)
-            pill = (
-                f'<a href="https://matrix.to/#/{user_id}">'
-                f"{display_name}</a>"
-            )
-            content["formatted_body"] = (
-                f"{pill} {html_body}" if html_body else pill
-            )
-        else:
-            # No pill prefix, just the converted HTML body
-            content["formatted_body"] = html_body
-
-        if body.strip():
-            content["body"] = body
-        else:
-            display_name = self._resolve_display_name(user_id, room_id)
-            content["body"] = display_name
-
-    def _should_show_mention_pill(
-        self,
-        meta: Optional[Dict[str, Any]],
-    ) -> bool:
-        """Determine whether to prepend HTML pill to formatted_body.
-
-        Checks meta overrides first, then falls back to config default.
-        """
-        m = meta or {}
-        if m.get("skip_mention_pill"):
-            return False
-        if m.get("force_mention_pill"):
-            return True
-        return bool(self._cfg.mention_pill_in_body)
+        mentioned_ids = self._extract_mentions_from_text(body)
+        if mentioned_ids:
+            content["m.mentions"] = {"user_ids": mentioned_ids}
 
     def _resolve_display_name(self, user_id: str, room_id: str) -> str:
         """Best-effort display name for *user_id* in *room_id*."""
@@ -2072,8 +1980,8 @@ class MatrixChannel(BaseChannel):
         sender_id = (meta or {}).get("sender_id") or (meta or {}).get(
             "user_id",
         )
-        if sender_id and self._should_apply_outbound_mention(meta):
-            self._apply_mention(content, sender_id, room_id, meta)
+        if sender_id:
+            self._apply_mention(content, sender_id, room_id)
 
         try:
             await self._client.room_send(
@@ -2091,22 +1999,8 @@ class MatrixChannel(BaseChannel):
         finally:
             await self._send_typing(room_id, False)
 
-    def _should_apply_outbound_mention(
-        self,
-        meta: Optional[Dict[str, Any]],
-    ) -> bool:
-        """Whether to set m.mentions + pill on this outbound event."""
-        m = meta or {}
-        if m.get("skip_structured_mention"):
-            return False
-        if m.get("force_structured_mention"):
-            return True
-        return bool(self._cfg.outbound_structured_mentions)
-
     # ------------------------------------------------------------------
     # Outgoing send — media
-    # _upload_file then room_send; optional _apply_mention (see
-    # outbound_structured_mentions and meta overrides; §13).
     # ------------------------------------------------------------------
 
     async def send_media(
@@ -2177,8 +2071,8 @@ class MatrixChannel(BaseChannel):
             sender_id = (meta or {}).get("sender_id") or (meta or {}).get(
                 "user_id",
             )
-            if sender_id and self._should_apply_outbound_mention(meta):
-                self._apply_mention(event_content, sender_id, room_id, meta)
+            if sender_id:
+                self._apply_mention(event_content, sender_id, room_id)
 
             await self._client.room_send(
                 room_id,

--- a/copaw/src/copaw_manager/config/config.py
+++ b/copaw/src/copaw_manager/config/config.py
@@ -164,11 +164,6 @@ class MatrixConfig(BaseChannelConfig):
     device_name: str = "copaw-worker"
     # matrix-nio sync long-poll timeout (ms); typical 30s
     sync_timeout_ms: int = Field(default=30000, ge=5000, le=300000)
-    # When True, prepend HTML pill to formatted_body for outbound mentions.
-    # Default False: m.mentions is always set for push, but pill is omitted.
-    mention_pill_in_body: bool = True
-    # When True, apply m.mentions + optional pill on outbound messages.
-    outbound_structured_mentions: bool = True
 
 
 class VoiceChannelConfig(BaseChannelConfig):


### PR DESCRIPTION
## Summary
- Simplify CoPaw Manager's `_apply_mention` outbound mention logic to match Worker's text-scan approach
- Remove helper methods (`_strip_lead_echo_of_ping_target`, `_should_show_mention_pill`, `_should_apply_outbound_mention`) and config fields (`outbound_structured_mentions`, `mention_pill_in_body`)
- New implementation scans body for `@user:domain` MXIDs and populates `m.mentions` (MSC3952), without modifying body text

## Changes
| File | Change |
|------|--------|
| `copaw/src/copaw_manager/app/channels/matrix/channel.py` | Replaced complex mention logic with Worker-aligned scan approach (-126 lines) |
| `copaw/src/copaw_manager/config/config.py` | Removed `mention_pill_in_body` and `outbound_structured_mentions` fields (-5 lines) |

**Net: +20/-131 lines**

## Test plan
- [x] Built CoPaw Manager image (`make build-manager-copaw`) on ECS
- [x] Deployed and verified 6/6 health checks pass (Tuwunel, MinIO, Higress Gateway, Higress Console, Manager API, Manager Agent)
- [x] Verified mention functionality: `_apply_mention` extracts MXIDs from body → sets `m.mentions` → `_was_mentioned` reads `m.mentions` on receive

🤖 Generated with [Claude Code](https://claude.com/claude-code)