### PR TITLE
fix(install): user can specify which docker.sock to mount when run install script

### DIFF
--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -3097,7 +3097,9 @@ EOF
         if [ "${DOCKER_CMD:-}" = "podman" ]; then
             ensure_podman_socket
         fi
-        CONTAINER_SOCK=$(detect_socket)
+        if [ -z "${CONTAINER_SOCK}" ]; then
+            CONTAINER_SOCK=$(detect_socket)
+        fi
         if [ -n "${CONTAINER_SOCK}" ]; then
             log "$(msg install.socket_detected "${CONTAINER_SOCK}")"
             SOCKET_MOUNT_ARGS="-v ${CONTAINER_SOCK}:/var/run/docker.sock --security-opt label=disable"

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -2530,7 +2530,9 @@ EOF
     # Detect container runtime socket
     SOCKET_MOUNT_ARGS=""
     if [ "${HICLAW_MOUNT_SOCKET}" = "1" ]; then
-        CONTAINER_SOCK=$(detect_socket)
+        if [ -z "${CONTAINER_SOCK}" ]; then
+            CONTAINER_SOCK=$(detect_socket)
+        fi
         if [ -n "${CONTAINER_SOCK}" ]; then
             log "$(msg install.socket_detected "${CONTAINER_SOCK}")"
             SOCKET_MOUNT_ARGS="-v ${CONTAINER_SOCK}:/var/run/docker.sock --security-opt label=disable"


### PR DESCRIPTION
fix #552 (install.sh choose a wrong docker.sock on macos machine which uses colima managed docker)