### PR TITLE
fix(crd): move subresources.status to correct level in teams CRD

### DIFF
--- a/hiclaw-controller/config/crd/teams.hiclaw.io.yaml
+++ b/hiclaw-controller/config/crd/teams.hiclaw.io.yaml
@@ -169,6 +169,7 @@ spec:
                   type: object
                   description: Exposed ports per worker name
                   x-kubernetes-preserve-unknown-fields: true
+      subresources:
         status: {}
       additionalPrinterColumns:
         - name: Leader


### PR DESCRIPTION
The status: {} field was placed inside schema.openAPIV3Schema instead of as a sibling of schema under versions[]. This caused kubectl apply to fail with a strict decoding error when deploying against a real K8s cluster:

  strict decoding error: unknown field "spec.versions[0].schema.status"

Move it under the correct subresources key so the Team status subresource is properly enabled.

Closes #572