### PR TITLE
feat: add qwen3.6-plus model support with 1M context window

### DIFF
--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -389,8 +389,10 @@ msg() {
         "llm.codingplan.model.kimi.en") text="  3) kimi-k2.5  - Moonshot Kimi K2.5" ;;
         "llm.codingplan.model.minimax.zh") text="  4) MiniMax-M2.5  - MiniMax M2.5" ;;
         "llm.codingplan.model.minimax.en") text="  4) MiniMax-M2.5  - MiniMax M2.5" ;;
-        "llm.codingplan.model.select.zh") text="选择模型 [1/2/3/4]" ;;
-        "llm.codingplan.model.select.en") text="Select model [1/2/3/4]" ;;
+        "llm.codingplan.model.qwen36plus.zh") text="  5) qwen3.6-plus  - 千问 3.6（100万上下文，适合长文档）" ;;
+        "llm.codingplan.model.qwen36plus.en") text="  5) qwen3.6-plus  - Qwen 3.6 (1M context, ideal for long documents)" ;;
+        "llm.codingplan.model.select.zh") text="选择模型 [1/2/3/4/5]" ;;
+        "llm.codingplan.model.select.en") text="Select model [1/2/3/4/5]" ;;
         "llm.provider.selected_codingplan.zh") text="  提供商: 阿里云百炼 CodingPlan" ;;
         "llm.provider.selected_codingplan.en") text="  Provider: Alibaba Cloud CodingPlan" ;;
         "llm.provider.selected_qwen.zh") text="  提供商: 阿里云百炼" ;;
@@ -926,7 +928,7 @@ resolve_docker_proxy_image() {
 # ============================================================
 # Known models list — used to detect custom models during install
 # ============================================================
-KNOWN_MODELS="gpt-5.4 gpt-5.3-codex gpt-5-mini gpt-5-nano claude-opus-4-6 claude-sonnet-4-6 claude-haiku-4-5 qwen3.5-plus deepseek-chat deepseek-reasoner kimi-k2.5 glm-5 MiniMax-M2.7 MiniMax-M2.7-highspeed MiniMax-M2.5"
+KNOWN_MODELS="gpt-5.4 gpt-5.3-codex gpt-5-mini gpt-5-nano claude-opus-4-6 claude-sonnet-4-6 claude-haiku-4-5 qwen3.5-plus qwen3.6-plus deepseek-chat deepseek-reasoner kimi-k2.5 glm-5 MiniMax-M2.7 MiniMax-M2.7-highspeed MiniMax-M2.5"
 
 is_known_model() {
     local model="$1"
@@ -1605,6 +1607,7 @@ step_llm() {
                     2|glm-5)        HICLAW_DEFAULT_MODEL="glm-5" ;;
                     3|kimi-k2.5)    HICLAW_DEFAULT_MODEL="kimi-k2.5" ;;
                     4|MiniMax-M2.5) HICLAW_DEFAULT_MODEL="MiniMax-M2.5" ;;
+                    5|qwen3.6-plus) HICLAW_DEFAULT_MODEL="qwen3.6-plus" ;;
                     *)              HICLAW_DEFAULT_MODEL="qwen3.5-plus" ;;
                 esac
                 log "$(msg llm.provider.selected_codingplan)"
@@ -1659,6 +1662,7 @@ step_llm() {
                             2|glm-5)        HICLAW_DEFAULT_MODEL="glm-5" ;;
                             3|kimi-k2.5)    HICLAW_DEFAULT_MODEL="kimi-k2.5" ;;
                             4|MiniMax-M2.5) HICLAW_DEFAULT_MODEL="MiniMax-M2.5" ;;
+                            5|qwen3.6-plus) HICLAW_DEFAULT_MODEL="qwen3.6-plus" ;;
                             *)              HICLAW_DEFAULT_MODEL="qwen3.5-plus" ;;
                         esac
                         log "$(msg llm.provider.selected_codingplan)"

--- a/manager/configs/known-models.json
+++ b/manager/configs/known-models.json
@@ -7,11 +7,12 @@
   { "id": "claude-sonnet-4-6", "name": "claude-sonnet-4-6", "reasoning": true,  "contextWindow": 1000000, "maxTokens": 64000,  "input": ["text", "image"] },
   { "id": "claude-haiku-4-5",  "name": "claude-haiku-4-5",  "reasoning": true,  "contextWindow": 200000,  "maxTokens": 64000,  "input": ["text", "image"] },
   { "id": "qwen3.5-plus",      "name": "qwen3.5-plus",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 64000,  "input": ["text", "image"] },
+  { "id": "qwen3.6-plus",      "name": "qwen3.6-plus",      "reasoning": true,  "contextWindow": 1000000, "maxTokens": 128000, "input": ["text"] },
   { "id": "deepseek-chat",     "name": "deepseek-chat",     "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text"] },
-  { "id": "deepseek-reasoner", "name": "deepseek-reasoner", "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text"] },
+  { "id": "deepseek-reasoner", "name": "deepseek-reasoner", "reasoning": true,  "contextWindow": 256000, "maxTokens": 128000, "input": ["text"] },
   { "id": "kimi-k2.5",         "name": "kimi-k2.5",         "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text", "image"] },
   { "id": "glm-5",             "name": "glm-5",             "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
   { "id": "MiniMax-M2.7",      "name": "MiniMax-M2.7",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
-  { "id": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed", "reasoning": true, "contextWindow": 200000, "maxTokens": 128000, "input": ["text"] },
+  { "id": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed", "reasoning": true,  "contextWindow": 200000, "maxTokens": 128000, "input": ["text"] },
   { "id": "MiniMax-M2.5",      "name": "MiniMax-M2.5",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] }
 ]

--- a/manager/configs/manager-openclaw.json.tmpl
+++ b/manager/configs/manager-openclaw.json.tmpl
@@ -49,15 +49,16 @@
           { "id": "gpt-5-nano",        "name": "gpt-5-nano",        "reasoning": true,  "contextWindow": 400000,  "maxTokens": 128000, "input": ["text", "image"] },
           { "id": "claude-opus-4-6",   "name": "claude-opus-4-6",   "reasoning": true,  "contextWindow": 1000000, "maxTokens": 128000, "input": ["text", "image"] },
           { "id": "claude-sonnet-4-6", "name": "claude-sonnet-4-6", "reasoning": true,  "contextWindow": 1000000, "maxTokens": 64000,  "input": ["text", "image"] },
-          { "id": "claude-haiku-4-5",  "name": "claude-haiku-4-5",  "reasoning": true,  "contextWindow": 200000,  "maxTokens": 64000,  "input": ["text", "image"] },
+          { "id": "claude-haiku-4-5",  "name": "claude-haiku-4-5",  "reasoning": true,  "contextWindow": 200000, "maxTokens": 64000,  "input": ["text", "image"] },
           { "id": "qwen3.5-plus",      "name": "qwen3.5-plus",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 64000,  "input": ["text", "image"] },
+          { "id": "qwen3.6-plus",      "name": "qwen3.6-plus",      "reasoning": true,  "contextWindow": 1000000, "maxTokens": 128000, "input": ["text"] },
           { "id": "deepseek-chat",     "name": "deepseek-chat",     "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text"] },
           { "id": "deepseek-reasoner", "name": "deepseek-reasoner", "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text"] },
-          { "id": "kimi-k2.5",         "name": "kimi-k2.5",         "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text", "image"] },
+          { "id": "kimi-k2.5",         "name": "kimi-k2.5",         "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000,  "input": ["text", "image"] },
           { "id": "glm-5",             "name": "glm-5",             "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
           { "id": "MiniMax-M2.7",      "name": "MiniMax-M2.7",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
-          { "id": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed", "reasoning": true, "contextWindow": 200000, "maxTokens": 128000, "input": ["text"] },
-          { "id": "MiniMax-M2.5",      "name": "MiniMax-M2.5",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] }
+          { "id": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed", "reasoning": true,  "contextWindow": 200000, "maxTokens": 128000, "input": ["text"] },
+          { "id": "MiniMax-M2.5",      "name": "MiniMax-M2.5",      "reasoning": true,  "contextWindow": 200000, "maxTokens": 128000, "input": ["text"] }
         ]
       }
     }
@@ -79,6 +80,7 @@
         "hiclaw-gateway/claude-sonnet-4-6": { "alias": "claude-sonnet-4-6" },
         "hiclaw-gateway/claude-haiku-4-5":  { "alias": "claude-haiku-4-5" },
         "hiclaw-gateway/qwen3.5-plus":      { "alias": "qwen3.5-plus" },
+        "hiclaw-gateway/qwen3.6-plus":      { "alias": "qwen3.6-plus" },
         "hiclaw-gateway/deepseek-chat":     { "alias": "deepseek-chat" },
         "hiclaw-gateway/deepseek-reasoner": { "alias": "deepseek-reasoner" },
         "hiclaw-gateway/kimi-k2.5":         { "alias": "kimi-k2.5" },


### PR DESCRIPTION
## Changes

This PR adds support for the qwen3.6-plus model with a 1M token context window.

### Modified Files

1. **install/hiclaw-install.sh**
   - Add `qwen3.6-plus` to `KNOWN_MODELS` list
   - Add CodingPlan model selection option 5 for qwen3.6-plus
   - Add i18n strings (Chinese: "千问 3.6（100万上下文，适合长文档）", English: "Qwen 3.6 (1M context, ideal for long documents)"")
   - Update model select prompt from `[1/2/3/4]` to `[1/2/3/4/5]`

2. **manager/configs/known-models.json**
   - Add qwen3.6-plus model definition:
     - `contextWindow: 1000000` (1M tokens)
     - `maxTokens: 128000`
     - `reasoning: true`
     - `input: ["text"]`

3. **manager/configs/manager-openclaw.json.tmpl**
   - Add qwen3.6-plus to models array
   - Add alias mapping for hiclaw-gateway/qwen3.6-plus

### Testing

The changes allow users to select qwen3.6-plus as the default model during HiClaw installation, enabling support for long documents with the 1M context window.

---

Submitted by @nillikechatchat