### PR TITLE
feat(install): add uninstall subcommand to hiclaw-install.sh and hiclaw-install.ps1

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -91,6 +91,20 @@ bash <(curl -sSL https://higress.ai/hiclaw/install.sh)
 HICLAW_VERSION=v1.0.5 bash <(curl -sSL https://higress.ai/hiclaw/install.sh)
 ```
 
+## アンインストール
+
+**macOS / Linux:**
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/higress-group/hiclaw/main/install/hiclaw-install.sh) uninstall
+```
+
+**Windows (PowerShell):**
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process -Force; $wc=New-Object Net.WebClient; $wc.Encoding=[Text.Encoding]::UTF8; $s=$wc.DownloadString('https://raw.githubusercontent.com/higress-group/hiclaw/main/install/hiclaw-install.ps1'); & ([scriptblock]::Create($s)) uninstall
+```
+
+すべての HiClaw コンテナ（Manager、Worker、docker-proxy）、Docker ボリューム、ネットワーク、env ファイル、ワークスペースディレクトリ、インストールログが削除されます。
+
 ## 仕組み
 
 ### Manager — あなたの AI チーフオブスタッフ

--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ bash <(curl -sSL https://higress.ai/hiclaw/install.sh)
 HICLAW_VERSION=v1.0.5 bash <(curl -sSL https://higress.ai/hiclaw/install.sh)
 ```
 
+## Uninstall
+
+**macOS / Linux:**
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/higress-group/hiclaw/main/install/hiclaw-install.sh) uninstall
+```
+
+**Windows (PowerShell):**
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process -Force; $wc=New-Object Net.WebClient; $wc.Encoding=[Text.Encoding]::UTF8; $s=$wc.DownloadString('https://raw.githubusercontent.com/higress-group/hiclaw/main/install/hiclaw-install.ps1'); & ([scriptblock]::Create($s)) uninstall
+```
+
+This removes all HiClaw containers (Manager, Workers, docker-proxy), Docker volume, network, env file, workspace directory, and install log.
+
 ## How It Works
 
 ### Manager as Your AI Chief of Staff

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -117,6 +117,20 @@ HICLAW_VERSION=v1.0.5 bash <(curl -sSL https://higress.ai/hiclaw/install.sh)
 ```
 
 
+## 卸载
+
+**macOS / Linux:**
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/higress-group/hiclaw/main/install/hiclaw-install.sh) uninstall
+```
+
+**Windows (PowerShell):**
+```powershell
+Set-ExecutionPolicy Bypass -Scope Process -Force; $wc=New-Object Net.WebClient; $wc.Encoding=[Text.Encoding]::UTF8; $s=$wc.DownloadString('https://raw.githubusercontent.com/higress-group/hiclaw/main/install/hiclaw-install.ps1'); & ([scriptblock]::Create($s)) uninstall
+```
+
+将移除所有 HiClaw 容器（Manager、Worker、docker-proxy）、Docker 卷、网络、env 文件、工作空间目录和安装日志。
+
 ## 工作方式
 
 ### Manager 是你的 AI 管家

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -319,3 +319,15 @@ You have successfully completed all 10 verification steps for HiClaw. Your Agent
 - Centralized credential management
 - MCP-based external tool integration
 - Dynamic permission control
+
+--
+
+## Uninstall
+
+To completely remove HiClaw and all its data:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/higress-group/hiclaw/main/install/hiclaw-install.sh) uninstall
+```
+
+This removes all containers (Manager, Workers, docker-proxy), Docker volume, network, env file, workspace directory, and install log.

--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -580,8 +580,11 @@ $script:Messages = @{
     "uninstall.removed" = @{ zh = "  已移除: {0}"; en = "  Removed: {0}" }
     "uninstall.removing_volume" = @{ zh = "正在移除 Docker 卷: hiclaw-data"; en = "Removing Docker volume: hiclaw-data" }
     "uninstall.removing_env" = @{ zh = "正在移除 env 文件: {0}"; en = "Removing env file: {0}" }
+    "uninstall.removing_proxy" = @{ zh = "正在停止并移除 Docker API 代理容器: hiclaw-docker-proxy"; en = "Stopping and removing Docker API proxy container: hiclaw-docker-proxy" }
+    "uninstall.removing_network" = @{ zh = "正在移除 Docker 网络: hiclaw-net"; en = "Removing Docker network: hiclaw-net" }
+    "uninstall.removing_workspace" = @{ zh = "正在移除工作空间目录: {0}"; en = "Removing workspace directory: {0}" }
+    "uninstall.removing_log" = @{ zh = "正在移除日志文件: {0}"; en = "Removing log file: {0}" }
     "uninstall.done" = @{ zh = "HiClaw 已卸载。"; en = "HiClaw has been uninstalled." }
-    "uninstall.workspace_note" = @{ zh = "注意: Manager 工作空间目录已保留。如需删除请手动操作。"; en = "Note: Manager workspace directory was preserved. Remove manually if desired." }
 }
 
 # Get-Msg: look up message by key, with -f style argument substitution.
@@ -2529,11 +2532,49 @@ function Uninstall-HiClaw {
         }
     }
 
-    # Remove Docker volume
-    $volume = docker volume ls -q 2>$null | Select-String "^hiclaw-data$"
+    # Stop and remove docker-proxy
+    $proxy = docker ps -a --format "{{.Names}}" 2>$null | Select-String "^hiclaw-docker-proxy$"
+    if ($proxy) {
+        Write-Log (Get-Msg "uninstall.removing_proxy")
+        docker stop hiclaw-docker-proxy *>$null
+        docker rm hiclaw-docker-proxy *>$null
+    }
+
+    # Remove Docker volume (read custom name from env file if available)
+    $dataVolume = "hiclaw-data"
+    if (Test-Path $script:HICLAW_ENV_FILE) {
+        $envContent = Get-Content $script:HICLAW_ENV_FILE -ErrorAction SilentlyContinue
+        $dataLine = $envContent | Select-String "^HICLAW_DATA_DIR="
+        if ($dataLine) {
+            $parsed = ($dataLine -split "=", 2)[1]
+            if ($parsed) { $dataVolume = $parsed }
+        }
+    }
+    $volume = docker volume ls -q 2>$null | Select-String "^${dataVolume}$"
     if ($volume) {
         Write-Log (Get-Msg "uninstall.removing_volume")
-        docker volume rm hiclaw-data *>$null
+        docker volume rm $dataVolume *>$null
+    }
+
+    # Remove Docker network
+    $network = docker network ls --format "{{.Name}}" 2>$null | Select-String "^hiclaw-net$"
+    if ($network) {
+        Write-Log (Get-Msg "uninstall.removing_network")
+        docker network rm hiclaw-net *>$null
+    }
+
+    # Remove workspace directory
+    $workspaceDir = "$env:USERPROFILE\hiclaw-manager"
+    if (Test-Path $script:HICLAW_ENV_FILE) {
+        $envContent = Get-Content $script:HICLAW_ENV_FILE -ErrorAction SilentlyContinue
+        $wsLine = $envContent | Select-String "^HICLAW_WORKSPACE_DIR="
+        if ($wsLine) {
+            $workspaceDir = ($wsLine -split "=", 2)[1]
+        }
+    }
+    if ($workspaceDir -and (Test-Path $workspaceDir)) {
+        Write-Log (Get-Msg "uninstall.removing_workspace" -f $workspaceDir)
+        Remove-Item -Recurse -Force $workspaceDir -ErrorAction SilentlyContinue
     }
 
     # Remove env file
@@ -2542,9 +2583,15 @@ function Uninstall-HiClaw {
         Remove-Item -Force $script:HICLAW_ENV_FILE
     }
 
+    # Remove install log (stop transcript first to release the file)
+    if (Test-Path $script:HICLAW_LOG_FILE) {
+        Write-Log (Get-Msg "uninstall.removing_log" -f $script:HICLAW_LOG_FILE)
+        try { Stop-Transcript *>$null } catch {}
+        Remove-Item -Force $script:HICLAW_LOG_FILE -ErrorAction SilentlyContinue
+    }
+
     Write-Log ""
     Write-Log (Get-Msg "uninstall.done")
-    Write-Log (Get-Msg "uninstall.workspace_note")
 }
 
 # ============================================================

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -5,6 +5,7 @@
 #   ./hiclaw-install.sh                  # Interactive installation (choose Quick Start or Manual)
 #   ./hiclaw-install.sh manager          # Same as above (explicit)
 #   ./hiclaw-install.sh worker --name <name> ...  # Worker installation
+#   ./hiclaw-install.sh uninstall        # Stop and remove Manager + all Workers
 #
 # Onboarding Modes:
 #   Quick Start  - Fast installation with all default values (recommended)
@@ -59,18 +60,20 @@ STEP_RESULT=""  # Used by state machine to signal "back" navigation
 
 HICLAW_LOG_FILE="${HOME}/hiclaw-install.log"
 
-# Redirect all output (stdout and stderr) to both terminal and log file
-exec > >(tee -a "${HICLAW_LOG_FILE}") 2>&1
+if [ "${1:-}" != "uninstall" ]; then
+    # Redirect all output (stdout and stderr) to both terminal and log file
+    exec > >(tee -a "${HICLAW_LOG_FILE}") 2>&1
 
-echo ""
-echo "========================================"
-echo "HiClaw Installation Log"
-echo "Started: $(date)"
-echo "User: $(whoami)"
-echo "System: $(uname -a)"
-echo "Log file: ${HICLAW_LOG_FILE}"
-echo "========================================"
-echo ""
+    echo ""
+    echo "========================================"
+    echo "HiClaw Installation Log"
+    echo "Started: $(date)"
+    echo "User: $(whoami)"
+    echo "System: $(uname -a)"
+    echo "Log file: ${HICLAW_LOG_FILE}"
+    echo "========================================"
+    echo ""
+fi
 
 # ============================================================
 # Utility functions (needed early for timezone detection)
@@ -825,6 +828,31 @@ msg() {
         "lang.option_en.en") text="  2) English" ;;
         "lang.prompt.zh") text="请选择 / Enter choice" ;;
         "lang.prompt.en") text="请选择 / Enter choice" ;;
+        # --- Uninstall messages ---
+        "uninstall.title.zh") text="正在卸载 HiClaw..." ;;
+        "uninstall.title.en") text="Uninstalling HiClaw..." ;;
+        "uninstall.stopping_manager.zh") text="正在停止并移除 hiclaw-manager..." ;;
+        "uninstall.stopping_manager.en") text="Stopping and removing hiclaw-manager..." ;;
+        "uninstall.stopping_workers.zh") text="正在停止并移除 Worker 容器..." ;;
+        "uninstall.stopping_workers.en") text="Stopping and removing worker containers..." ;;
+        "uninstall.removed.zh") text="  已移除: %s" ;;
+        "uninstall.removed.en") text="  Removed: %s" ;;
+        "uninstall.removing_volume.zh") text="正在移除 Docker 卷: %s" ;;
+        "uninstall.removing_volume.en") text="Removing Docker volume: %s" ;;
+        "uninstall.removing_env.zh") text="正在移除 env 文件: %s" ;;
+        "uninstall.removing_env.en") text="Removing env file: %s" ;;
+        "uninstall.removing_proxy.zh") text="正在停止并移除 Docker API 代理容器: hiclaw-docker-proxy" ;;
+        "uninstall.removing_proxy.en") text="Stopping and removing Docker API proxy container: hiclaw-docker-proxy" ;;
+        "uninstall.removing_network.zh") text="正在移除 Docker 网络: hiclaw-net" ;;
+        "uninstall.removing_network.en") text="Removing Docker network: hiclaw-net" ;;
+        "uninstall.removing_workspace.zh") text="正在移除工作空间目录: %s" ;;
+        "uninstall.removing_workspace.en") text="Removing workspace directory: %s" ;;
+        "uninstall.removing_workspace_elevated.zh") text="  工作空间包含 root 文件，通过容器清理..." ;;
+        "uninstall.removing_workspace_elevated.en") text="  Workspace contains root-owned files, cleaning via container..." ;;
+        "uninstall.removing_log.zh") text="正在移除日志文件: %s" ;;
+        "uninstall.removing_log.en") text="Removing log file: %s" ;;
+        "uninstall.done.zh") text="HiClaw 已卸载。" ;;
+        "uninstall.done.en") text="HiClaw has been uninstalled." ;;
         # --- Error messages ---
         "error.name_required.zh") text="--name 是必需的" ;;
         "error.name_required.en") text="--name is required" ;;
@@ -2762,6 +2790,98 @@ test_embedding_connectivity() {
 }
 
 # ============================================================
+# Uninstall
+# ============================================================
+
+uninstall_hiclaw() {
+    log "$(msg uninstall.title)"
+
+    # Capture manager image before removing (needed for workspace cleanup on Linux)
+    local manager_image=""
+    manager_image=$(${DOCKER_CMD} inspect hiclaw-manager --format '{{.Config.Image}}' 2>/dev/null || true)
+
+    # Stop and remove manager
+    if ${DOCKER_CMD} ps -a --format '{{.Names}}' 2>/dev/null | grep -q "^hiclaw-manager$"; then
+        log "$(msg uninstall.stopping_manager)"
+        ${DOCKER_CMD} stop hiclaw-manager >/dev/null 2>&1 || true
+        ${DOCKER_CMD} rm hiclaw-manager >/dev/null 2>&1 || true
+    fi
+
+    # Stop and remove workers
+    local workers
+    workers=$(${DOCKER_CMD} ps -a --filter "name=hiclaw-worker-" --format '{{.Names}}' 2>/dev/null || true)
+    if [ -n "${workers}" ]; then
+        log "$(msg uninstall.stopping_workers)"
+        echo "${workers}" | while read -r w; do
+            ${DOCKER_CMD} rm -f "${w}" >/dev/null 2>&1 || true
+            log "$(msg uninstall.removed "${w}")"
+        done
+    fi
+
+    # Stop and remove docker-proxy
+    if ${DOCKER_CMD} ps -a --format '{{.Names}}' 2>/dev/null | grep -q "^hiclaw-docker-proxy$"; then
+        log "$(msg uninstall.removing_proxy)"
+        ${DOCKER_CMD} stop hiclaw-docker-proxy >/dev/null 2>&1 || true
+        ${DOCKER_CMD} rm hiclaw-docker-proxy >/dev/null 2>&1 || true
+    fi
+
+    # Read env file for data/workspace info before removing
+    local env_file="${HICLAW_ENV_FILE:-${HOME}/hiclaw-manager.env}"
+    [ ! -f "${env_file}" ] && [ -f "./hiclaw-manager.env" ] && env_file="./hiclaw-manager.env"
+
+    local data_dir="" workspace_dir=""
+    if [ -f "${env_file}" ]; then
+        data_dir=$(grep '^HICLAW_DATA_DIR=' "${env_file}" 2>/dev/null | cut -d= -f2- || true)
+        workspace_dir=$(grep '^HICLAW_WORKSPACE_DIR=' "${env_file}" 2>/dev/null | cut -d= -f2- || true)
+    fi
+
+    # Remove Docker volume
+    local vol="${data_dir:-hiclaw-data}"
+    if ${DOCKER_CMD} volume inspect "${vol}" >/dev/null 2>&1; then
+        log "$(msg uninstall.removing_volume "${vol}")"
+        ${DOCKER_CMD} volume rm "${vol}" >/dev/null 2>&1 || true
+    fi
+
+    # Remove Docker network
+    if ${DOCKER_CMD} network ls --format '{{.Name}}' 2>/dev/null | grep -q "^hiclaw-net$"; then
+        log "$(msg uninstall.removing_network)"
+        ${DOCKER_CMD} network rm hiclaw-net >/dev/null 2>&1 || true
+    fi
+
+    # Remove workspace directory
+    if [ -n "${workspace_dir}" ] && [ -d "${workspace_dir}" ]; then
+        log "$(msg uninstall.removing_workspace "${workspace_dir}")"
+        rm -rf "${workspace_dir}" 2>/dev/null || true
+        if [ -d "${workspace_dir}" ]; then
+            log "$(msg uninstall.removing_workspace_elevated)"
+            local _parent _base
+            _parent=$(dirname "${workspace_dir}")
+            _base=$(basename "${workspace_dir}")
+            local _rm_image="${manager_image:-busybox}"
+            ${DOCKER_CMD} run --rm --entrypoint sh \
+                -v "${_parent}:/host-parent" \
+                "${_rm_image}" \
+                -c "rm -rf /host-parent/${_base}" 2>/dev/null || true
+        fi
+    fi
+
+    # Remove env file
+    if [ -f "${env_file}" ]; then
+        log "$(msg uninstall.removing_env "${env_file}")"
+        rm -f "${env_file}"
+    fi
+
+    # Remove install log
+    if [ -f "${HOME}/hiclaw-install.log" ]; then
+        log "$(msg uninstall.removing_log "${HOME}/hiclaw-install.log")"
+        rm -f "${HOME}/hiclaw-install.log"
+    fi
+
+    echo ""
+    log "$(msg uninstall.done)"
+}
+
+# ============================================================
 # Check container runtime (docker or podman)
 # ============================================================
 
@@ -2786,20 +2906,23 @@ check_container_runtime
 
 case "${1:-}" in
     manager|"")
-        # Default to manager installation if no argument or explicit "manager"
         install_manager
         ;;
     worker)
         shift
         install_worker "$@"
         ;;
+    uninstall)
+        uninstall_hiclaw
+        ;;
     *)
-        echo "Usage: $0 [manager|worker [options]]"
+        echo "Usage: $0 [manager|worker [options]|uninstall]"
         echo ""
         echo "Commands:"
         echo "  manager              Interactive Manager installation (default)"
         echo "                       Choose Quick Start (all defaults) or Manual mode"
         echo "  worker               Worker installation (requires --name and connection params)"
+        echo "  uninstall            Stop and remove Manager + all Worker containers"
         echo ""
         echo "Quick Start (fastest):"
         echo "  $0"


### PR DESCRIPTION
Add `uninstall` subcommand to both install scripts. Performs complete cleanup: all containers (manager, workers, docker-proxy), Docker volume (`hiclaw-data`), network (`hiclaw-net`), env file (`~/hiclaw-manager.env`), workspace directory (`~/hiclaw-manager`), and install log (`~/hiclaw-install.log`) — leaving no residual data on the host.

```bash
./hiclaw-install.sh uninstall

========================================
HiClaw Installation Log
Started: Fri Apr 10 22:18:01 CST 2026
User: sevenc
System: Darwin sevenc-mlt 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:51:28 PST 2026; root:xnu-12377.91.3~2/RELEASE_ARM64_T6041 arm64
Log file: /Users/sevenc/hiclaw-install.log
========================================

[HiClaw] 正在卸载 HiClaw...
[HiClaw] 正在停止并移除 hiclaw-manager...
[HiClaw] 正在停止并移除 Worker 容器...
[HiClaw]   已移除: hiclaw-worker-reviewer
[HiClaw]   已移除: hiclaw-worker-coder
[HiClaw] 正在停止并移除 Docker API 代理容器: hiclaw-docker-proxy
[HiClaw] 正在移除 Docker 卷: hiclaw-data
[HiClaw] 正在移除 Docker 网络: hiclaw-net
[HiClaw] 正在移除工作空间目录: /Users/sevenc/hiclaw-manager
[HiClaw] 正在移除 env 文件: /Users/sevenc/hiclaw-manager.env
[HiClaw] 正在移除日志文件: /Users/sevenc/hiclaw-install.log

[HiClaw] HiClaw 已卸载。
```

## Changes
### install/hiclaw-install.sh
- Add `uninstall_hiclaw()` function with full cleanup logic and bilingual i18n messages (zh/en)
- Add `uninstall` case to the main command dispatcher and usage help
- Delete workspace (`~/hiclaw-manager`) directory

### install/hiclaw-install.ps1
- Add `hiclaw-docker-proxy` container and `hiclaw-net` network cleanup to `Uninstall-HiClaw` (was missing)
- Delete workspace (`~/hiclaw-manager`) directory and install log
- Read `HICLAW_DATA_DIR` / `HICLAW_WORKSPACE_DIR` from env file for custom path support

### Documentation
- README.md, README.zh-CN.md, README.ja-JP.md: add Uninstall section with both bash and PowerShell commands
- docs/quickstart.md: add Uninstall step