### PR TITLE
fix: test-20/21 failures, team storage init, consumer sync race

### DIFF
--- a/hiclaw-controller/internal/agentconfig/agents_merge.go
+++ b/hiclaw-controller/internal/agentconfig/agents_merge.go
@@ -21,8 +21,8 @@ func MergeBuiltinSection(target, source string) string {
 		return wrapWithMarkers(source, userContent)
 	}
 
-	// Legacy file without markers — wrap source with markers
-	return wrapWithMarkers(source, "")
+	// Legacy file without markers — wrap source with markers, preserve target as user content
+	return wrapWithMarkers(source, target)
 }
 
 // ExtractFrontmatter separates YAML frontmatter from the body.

--- a/hiclaw-controller/internal/controller/team_controller.go
+++ b/hiclaw-controller/internal/controller/team_controller.go
@@ -158,7 +158,12 @@ func (r *TeamReconciler) handleCreate(ctx context.Context, t *v1beta1.Team) (rec
 		}
 	}
 
-	// --- Step 6: Legacy teams-registry + Manager groupAllowFrom ---
+	// --- Step 6: Team shared storage ---
+	if err := r.Deployer.EnsureTeamStorage(ctx, t.Name); err != nil {
+		logger.Error(err, "team shared storage init failed (non-fatal)")
+	}
+
+	// --- Step 7: Legacy teams-registry + Manager groupAllowFrom ---
 	if r.Legacy != nil && r.Legacy.Enabled() {
 		if err := r.Legacy.UpdateTeamsRegistry(service.TeamRegistryEntry{
 			Name:           t.Name,

--- a/hiclaw-controller/internal/gateway/higress.go
+++ b/hiclaw-controller/internal/gateway/higress.go
@@ -121,10 +121,29 @@ func (c *HigressClient) EnsureConsumer(ctx context.Context, req ConsumerRequest)
 		return nil, fmt.Errorf("ensure consumer %s: HTTP %d", req.Name, statusCode)
 	}
 
+	// Wait for consumer to be fully synced into WASM key-auth config.
+	// Without this, AuthorizeAIRoutes may trigger a config update that
+	// races with the consumer creation, causing 401 errors.
+	if status == "created" {
+		c.waitForConsumer(ctx, req.Name)
+	}
+
 	return &ConsumerResult{
 		Status: status,
 		APIKey: req.CredentialKey,
 	}, nil
+}
+
+// waitForConsumer polls until the consumer is visible via GET, ensuring
+// the Higress config has been fully synced before proceeding.
+func (c *HigressClient) waitForConsumer(ctx context.Context, name string) {
+	for i := 0; i < 10; i++ {
+		_, sc, err := c.doJSON(ctx, http.MethodGet, "/v1/consumers/"+name, nil)
+		if err == nil && sc == http.StatusOK {
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
 }
 
 func (c *HigressClient) DeleteConsumer(ctx context.Context, name string) error {

--- a/hiclaw-controller/internal/service/deployer.go
+++ b/hiclaw-controller/internal/service/deployer.go
@@ -268,6 +268,17 @@ func (d *Deployer) CleanupOSSData(ctx context.Context, workerName string) error 
 	return d.oss.DeletePrefix(ctx, agentPrefix)
 }
 
+// EnsureTeamStorage creates the shared storage directories for a team.
+func (d *Deployer) EnsureTeamStorage(ctx context.Context, teamName string) error {
+	prefix := fmt.Sprintf("teams/%s/", teamName)
+	for _, subdir := range []string{"shared/tasks/", "shared/projects/", "shared/knowledge/"} {
+		if err := d.oss.PutObject(ctx, prefix+subdir+".keep", []byte("")); err != nil {
+			return fmt.Errorf("create %s%s: %w", prefix, subdir, err)
+		}
+	}
+	return nil
+}
+
 // --- Manager Config Deployment ---
 
 // ManagerDeployRequest describes a Manager config deployment (create or update).


### PR DESCRIPTION
## Summary

- Fix `MergeBuiltinSection` to preserve inline AGENTS.md content when no builtin markers exist (test-20)
- Add `EnsureTeamStorage` to create shared/tasks, shared/projects, shared/knowledge .keep files on team creation (test-21)
- Wait for consumer to be fully synced before authorizing AI routes, preventing WASM key-auth race condition that caused 401 errors

## Test plan

- [x] `make test-embedded` — verify test-20 inline config and test-21 team storage pass
- [x] Verify no 401 errors on fresh install with openai-compat provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)