### PR TITLE
fix(copaw-worker): bump copaw dep to >=1.0.2 to resolve agentscope pre-release conflict

### DIFF
--- a/copaw/pyproject.toml
+++ b/copaw/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "copaw-worker"
-version = "0.1.12"
+version = "0.1.13"
 description = "Lightweight HiClaw Worker runtime based on CoPaw"
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 dependencies = [
-    "copaw==0.0.5",
+    "copaw>=1.0.2",
     "matrix-nio[e2e]>=0.24.0",
     "markdown-it-py>=3.0",
     "linkify-it-py>=2.0",


### PR DESCRIPTION
## Problem

Fixes #598

`copaw-worker==0.1.12` depends on `copaw==0.0.5` (exact pin). That version of `copaw` on PyPI requires `agentscope==1.0.16.dev0` — a pre-release. By default, `uv` (and recent `pip`) refuse to install pre-release packages, so users get an unsatisfiable dependency error:

```
agentscope==1.0.16.dev0 and copaw==0.0.5 depends on agentscope==1.0.16.dev0 ... requirements are unsatisfiable
```

The only workaround was `--prerelease=allow`, which is non-obvious and undesirable.

## Root Cause

`copaw==0.0.5` is an old release. `copaw>=1.0.2` is already on PyPI and depends on `agentscope==1.0.18` (stable). The `copaw-worker` package was never updated to track the new copaw major version.

## Fix

- `copaw==0.0.5` → `copaw>=1.0.2` in `copaw/pyproject.toml`
- Bump `copaw-worker` version `0.1.12` → `0.1.13`

No code changes needed — `matrix_channel.py` already uses the copaw 1.x API (`BaseChannel`, `_enqueue`, `resolve_session_id`, `get_to_handle_from_request`, etc.), which was verified against `CoPaw/src/copaw/app/channels/base.py`.

## After this fix

```bash
# Works without --prerelease=allow
uv pip install copaw-worker
```