### PR TITLE
docs: add missing hyperlinks for key technologies across all README versions

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -20,13 +20,13 @@
 
 - 🧬 **Manager-Workers アーキテクチャ**: 個々の Worker Claw を人間が監視する必要がなくなり、Agent が Agent を管理することを実現します。
 
-- 🦞 **カスタマイズ可能な Agent**: 各 Agent は OpenClaw、Copaw、NanoClaw、ZeroClaw、企業独自の Agent など、柔軟な構成をサポートし、個別の「エビ養殖」からフルスケールの「エビ農場」運営まで対応します。
+- 🦞 **カスタマイズ可能な Agent**: 各 Agent は [OpenClaw](https://github.com/openclaw/openclaw)、[CoPaw](https://github.com/agentscope-ai/CoPaw)、NanoClaw、ZeroClaw、企業独自の Agent など、柔軟な構成をサポートし、個別の「エビ養殖」からフルスケールの「エビ農場」運営まで対応します。
 
-- 📦 **MinIO 共有ファイルシステム**: Agent 間の情報共有のための共有ファイルシステムを導入し、マルチエージェント連携シナリオにおけるトークン消費を大幅に削減します。
+- 📦 **[MinIO](https://min.io/) 共有ファイルシステム**: Agent 間の情報共有のための共有ファイルシステムを導入し、マルチエージェント連携シナリオにおけるトークン消費を大幅に削減します。
 
-- 🔐 **Higress AI ゲートウェイ**: トラフィック管理を一元化し、認証情報に関連するリスクを軽減します。ネイティブの Lobster フレームワークにおけるセキュリティ上の懸念を解消します。
+- 🔐 **[Higress AI ゲートウェイ](https://github.com/alibaba/higress)**: トラフィック管理を一元化し、認証情報に関連するリスクを軽減します。ネイティブの Lobster フレームワークにおけるセキュリティ上の懸念を解消します。
 
-- ☎️ **Element IM クライアント + Tuwunel IM サーバー（共に Matrix プロトコルベース）**: DingTalk/Lark 統合の手間や企業承認ワークフローを排除します。IM 環境でモデルサービスの「快適さ」を素早く体験でき、ネイティブの OpenClaw IM 統合との互換性も維持します。
+- ☎️ **[Element](https://element.io) IM クライアント + [Tuwunel](https://github.com/matrix-construct/tuwunel) IM サーバー（共に [Matrix](https://matrix.org) プロトコルベース）**: DingTalk/Lark 統合の手間や企業承認ワークフローを排除します。IM 環境でモデルサービスの「快適さ」を素早く体験でき、ネイティブの OpenClaw IM 統合との互換性も維持します。
 
 ## ニュース
 
@@ -77,7 +77,7 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; $wc=New-Object Net.WebClient; 
 
 ブラウザで http://127.0.0.1:18088 を開き、Element Web にログインしてください。Manager が挨拶し、最初の Worker の作成方法を説明してくれます。
 
-**モバイル**: 任意の Matrix クライアント（Element、FluffyChat）を使い、サーバーアドレスに接続してください。
+**モバイル**: 任意の Matrix クライアント（[Element](https://element.io)、[FluffyChat](https://fluffychat.im/)）を使い、サーバーアドレスに接続してください。
 
 **以上です。** ボットアプリケーション不要。外部サービス不要。AI チーム全体があなたのマシン上で動作します。
 
@@ -158,11 +158,11 @@ Alice: フロントエンドのバリデーションも更新しました。
 
 | コンポーネント | 役割 |
 |-----------|------|
-| Higress AI ゲートウェイ | LLM プロキシ、MCP Server ホスティング、認証情報管理 |
-| Tuwunel（Matrix） | すべての Agent + 人間のコミュニケーション用セルフホスト IM サーバー |
-| Element Web | ブラウザクライアント、ゼロ設定 |
-| MinIO | 一元化ファイルストレージ、Worker はステートレス |
-| OpenClaw | Matrix プラグインとスキルを備えた Agent ランタイム |
+| [Higress AI ゲートウェイ](https://github.com/alibaba/higress) | LLM プロキシ、MCP Server ホスティング、認証情報管理 |
+| [Tuwunel](https://github.com/matrix-construct/tuwunel)（[Matrix](https://matrix.org)） | すべての Agent + 人間のコミュニケーション用セルフホスト IM サーバー |
+| [Element Web](https://element.io) | ブラウザクライアント、ゼロ設定 |
+| [MinIO](https://min.io/) | 一元化ファイルストレージ、Worker はステートレス |
+| [OpenClaw](https://github.com/openclaw/openclaw) | Matrix プラグインとスキルを備えた Agent ランタイム |
 
 ## HiClaw vs OpenClaw ネイティブ
 
@@ -230,7 +230,7 @@ python scripts/export-debug-log.py --range 1h
 
 > "debug-log/ 内の JSONL ファイルを読み込み、Matrix メッセージログと Agent セッションログを合わせて分析してください。HiClaw のコードベースと照合し、[バグの内容を記述] の根本原因を特定してください。"
 
-AI の分析結果を [バグレポート](https://github.com/alibaba/hiclaw/issues/new?template=bug_report.yml) に含めてください。
+AI の分析結果を [バグレポート](https://github.com/agentscope-ai/HiClaw/issues/new?template=bug_report.yml) に含めてください。
 
 ## ビルド & テスト
 
@@ -251,7 +251,7 @@ make help
 ## コミュニティ
 
 - [Discord](https://discord.gg/NVjNA4BAVw)
-- [GitHub Issues](https://github.com/alibaba/hiclaw/issues)
+- [GitHub Issues](https://github.com/agentscope-ai/HiClaw/issues)
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ HiClaw does not compete with other xxClaw projects. Instead of implementing Agen
 
 - 🧬 **Manager-Workers Architecture**: Eliminates the need for human oversight of individual Worker Claws by enabling Agents to manage other Agents.
 
-- 🦞 **Customizable Agents**: Each Agent supports flexible configurations including OpenClaw, Copaw, NanoClaw, ZeroClaw, and enterprise-built Agents—scaling from individual "shrimp farming" to full-scale "shrimp farm" operations.HiClaw Provides Worker and Team template marketplaces.
+- 🦞 **Customizable Agents**: Each Agent supports flexible configurations including [OpenClaw](https://github.com/openclaw/openclaw), [CoPaw](https://github.com/agentscope-ai/CoPaw), NanoClaw, ZeroClaw, and enterprise-built Agents—scaling from individual "shrimp farming" to full-scale "shrimp farm" operations. HiClaw provides Worker and Team template marketplaces.
 
-- 📦 **MinIO Shared File System**: Introduces a shared file system for inter-Agent information exchange, significantly reducing token consumption in multi-Agent collaboration scenarios.
+- 📦 **[MinIO](https://min.io/) Shared File System**: Introduces a shared file system for inter-Agent information exchange, significantly reducing token consumption in multi-Agent collaboration scenarios.
 
-- 🔐 **Higress AI Gateway**: Centralizes traffic management and mitigates credential-related risks, alleviating user concerns about security vulnerabilities in the native Lobster framework.
+- 🔐 **[Higress AI Gateway](https://github.com/alibaba/higress)**: Centralizes traffic management and mitigates credential-related risks, alleviating user concerns about security vulnerabilities in the native Lobster framework.
 
-- ☎️ **Element IM Client + Tuwunel IM Server (both Matrix protocol-based)**: Eliminating DingTalk/Lark integration overhead and enterprise approval workflows. Enables rapid user onboarding to experience the "delight" of model services within an IM environment, while maintaining compatibility with native OpenClaw IM integration.
+- ☎️ **[Element](https://element.io) IM Client + [Tuwunel](https://github.com/matrix-construct/tuwunel) IM Server (both [Matrix](https://matrix.org) protocol-based)**: Eliminating DingTalk/Lark integration overhead and enterprise approval workflows. Enables rapid user onboarding to experience the "delight" of model services within an IM environment, while maintaining compatibility with native OpenClaw IM integration.
 
 ## News
 
@@ -77,7 +77,7 @@ The installer walks you through:
 
 Open http://127.0.0.1:18088 in your browser and log in to Element Web. The Manager will greet you and explain how to create your first Worker.
 
-**Mobile**: Use any Matrix client (Element, FluffyChat) and connect to your server address.
+**Mobile**: Use any Matrix client ([Element](https://element.io), [FluffyChat](https://fluffychat.im/)) and connect to your server address.
 
 **That's it.** No bot applications. No external services. Your AI team runs entirely on your machine.
 
@@ -158,11 +158,11 @@ No hidden agent-to-agent calls. Everything is visible and intervenable.
 
 | Component | Role |
 |-----------|------|
-| Higress AI Gateway | LLM proxy, MCP Server hosting, credential management |
-| Tuwunel (Matrix) | Self-hosted IM server for all Agent + Human communication |
-| Element Web | Browser client, zero setup |
-| MinIO | Centralized file storage, Workers are stateless |
-| OpenClaw | Agent runtime with Matrix plugin and skills |
+| [Higress AI Gateway](https://github.com/alibaba/higress) | LLM proxy, MCP Server hosting, credential management |
+| [Tuwunel](https://github.com/matrix-construct/tuwunel) ([Matrix](https://matrix.org)) | Self-hosted IM server for all Agent + Human communication |
+| [Element Web](https://element.io) | Browser client, zero setup |
+| [MinIO](https://min.io/) | Centralized file storage, Workers are stateless |
+| [OpenClaw](https://github.com/openclaw/openclaw) | Agent runtime with Matrix plugin and skills |
 
 ## HiClaw vs OpenClaw Native
 
@@ -230,7 +230,7 @@ Then open the HiClaw repo in Cursor, Claude Code, or similar AI tool and ask:
 
 > "Read the JSONL files in debug-log/. Analyze the Matrix message logs and agent session logs together. Cross-reference with the HiClaw codebase to identify the root cause of [describe your bug]."
 
-Include the AI's analysis in your [bug report](https://github.com/alibaba/hiclaw/issues/new?template=bug_report.yml).
+Include the AI's analysis in your [bug report](https://github.com/agentscope-ai/HiClaw/issues/new?template=bug_report.yml).
 
 You can also let the AI tool submit the issue or PR directly. Install [GitHub CLI](https://cli.github.com/), run `gh auth login` to authenticate in your browser, then add the [OpenClaw GitHub skill](https://github.com/openclaw/openclaw/blob/main/skills/github/SKILL.md) to your AI coding tool (Cursor, Claude Code, etc.). After that, just ask it to file the issue or open a PR based on its analysis.
 
@@ -253,7 +253,7 @@ make help
 ## Community
 
 - [Discord](https://discord.gg/NVjNA4BAVw)
-- [GitHub Issues](https://github.com/alibaba/hiclaw/issues)
+- [GitHub Issues](https://github.com/agentscope-ai/HiClaw/issues)
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,10 +16,10 @@
 
 HiClaw 并不和其他 xxClaw 对标，自己不实现 Agent 逻辑，而是编排和管理多个 Agent 容器（Manager 和众多 Workers）。
 - 🧑‍💻 **设计了 Manger-Workers 架构**：不用真人去管理每个干活的 Worker Claw，实现由 Agent 管理 Agents。
-- 🦞 **每个 Agent 支持自定义**：OpenClaw、Copaw、NanoClaw、ZeroClaw 以及企业自建的 Agent，从养虾到开虾场，提供 worker 和 Team 模板市场。
-- 📚 **引入 MinIO 共享文件系统**：用于 Agent 之间的信息共享，大幅降低多 Agent 协作带来的 Token 消耗。
-- ⛑️ **引入 Higress AI Gateway**：流量入口和各类凭证风险降低了，减少了用户对原生龙虾在安全上的顾虑。
-- 🎨 **使用 Element IM 客户端+Tuwunel IM 服务器（均基于 Matrix 实时通信协议）**：节省钉钉、飞书 IM 的接入和企业内的审批成本，方便用户快速体验在 IM 的交互环境中体验模型服务的"爽感"，同时支持以 OpenClaw 原生的方式接入 IM。
+- 🦞 **每个 Agent 支持自定义**：[OpenClaw](https://github.com/openclaw/openclaw)、[CoPaw](https://github.com/agentscope-ai/CoPaw)、NanoClaw、ZeroClaw 以及企业自建的 Agent，从养虾到开虾场，提供 worker 和 Team 模板市场。
+- 📚 **引入 [MinIO](https://min.io/) 共享文件系统**：用于 Agent 之间的信息共享，大幅降低多 Agent 协作带来的 Token 消耗。
+- ⛑️ **引入 [Higress AI Gateway](https://github.com/alibaba/higress)**：流量入口和各类凭证风险降低了，减少了用户对原生龙虾在安全上的顾虑。
+- 🎨 **使用 [Element](https://element.io) IM 客户端+[Tuwunel](https://github.com/matrix-construct/tuwunel) IM 服务器（均基于 [Matrix](https://matrix.org) 实时通信协议）**：节省钉钉、飞书 IM 的接入和企业内的审批成本，方便用户快速体验在 IM 的交互环境中体验模型服务的"爽感"，同时支持以 OpenClaw 原生的方式接入 IM。
 
 ![架构](https://img.alicdn.com/imgextra/i4/O1CN01c1VlDE1zYZ46EW3OA_!!6000000006726-49-tps-9895-8231.webp)
 
@@ -92,7 +92,7 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; $wc=New-Object Net.WebClient; 
 
 第十一步：等待安装。安装完成。登录密码是自动生成的。
 
-若希望通过移动端来访问和使用，则需要使用美区账号下载 FluffyChat/Element Mobile。（之所以采用这两个 IM，是因为他们是支持 Matrix 协议的）下载后，连接您的 Matrix 服务器地址，就能随时随地管理您的 Agent 团队。
+若希望通过移动端来访问和使用，则需要使用美区账号下载 [FluffyChat](https://fluffychat.im/)/[Element Mobile](https://element.io/)。（之所以采用这两个 IM，是因为他们是支持 Matrix 协议的）下载后，连接您的 Matrix 服务器地址，就能随时随地管理您的 Agent 团队。
 ![测试](https://img.alicdn.com/imgextra/i3/O1CN01Tl4T8q29HIHtPVSJL_!!6000000008042-2-tps-2372-1282.png)
 
 第十二步：浏览器中，输入 http://127.0.0.1:18088/#/login，登录 Element，输入用户名和密码，就可以玩龙虾了，告诉 Manager 创建 Worker 并分配任务。
@@ -199,11 +199,11 @@ Alice：前端校验也更新了。
 
 | 组件 | 职责 |
 |------|------|
-| Higress AI 网关 | LLM 代理、MCP Server 托管、凭证集中管理 |
-| Tuwunel（Matrix） | 所有 Agent 与人类通信的 IM 服务器 |
-| Element Web | 浏览器客户端，零配置 |
-| MinIO | 集中式文件存储，Worker 无状态 |
-| OpenClaw | 带 Matrix 插件和技能系统的 Agent 运行时 |
+| [Higress AI 网关](https://github.com/alibaba/higress) | LLM 代理、MCP Server 托管、凭证集中管理 |
+| [Tuwunel](https://github.com/matrix-construct/tuwunel)（[Matrix](https://matrix.org)） | 所有 Agent 与人类通信的 IM 服务器 |
+| [Element Web](https://element.io) | 浏览器客户端，零配置 |
+| [MinIO](https://min.io/) | 集中式文件存储，Worker 无状态 |
+| [OpenClaw](https://github.com/openclaw/openclaw) | 带 Matrix 插件和技能系统的 Agent 运行时 |
 
 ## 常见问题
 
@@ -228,11 +228,11 @@ python scripts/export-debug-log.py --range 1h
 
 > "读取 debug-log/ 下的 JSONL 文件，同时分析 Matrix 消息日志和 Agent 会话日志。结合 HiClaw 代码库，定位 [描述你的 bug] 的根因。重点关注 Agent 交互流程、工具调用失败和错误模式。"
 
-将 AI 的分析结果贴到 [Bug Report](https://github.com/alibaba/hiclaw/issues/new?template=bug_report.yml) 中。
+将 AI 的分析结果贴到 [Bug Report](https://github.com/agentscope-ai/HiClaw/issues/new?template=bug_report.yml) 中。
 
 你也可以让 AI 工具直接提交 Issue 或 PR。先安装 [GitHub CLI](https://cli.github.com/)，执行 `gh auth login` 在浏览器中完成登录，然后将 [OpenClaw GitHub skill](https://github.com/openclaw/openclaw/blob/main/skills/github/SKILL.md) 配置到你的 AI 编程工具（Cursor、Claude Code 等）中。之后直接让它根据分析结果提交 Issue 或 PR 即可。
 
-欢迎[提交 Issue](https://github.com/alibaba/hiclaw/issues)，或在 [Discord](https://discord.gg/n6mV8xEYUF) / 钉钉群里随时提问。
+欢迎[提交 Issue](https://github.com/agentscope-ai/HiClaw/issues)，或在 [Discord](https://discord.com/invite/NVjNA4BAVw) / 钉钉群里随时提问。
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary

All three language READMEs (English / 中文 / 日本語) were updated consistently.

### Links added

| Technology | Link |
|---|---|
| OpenClaw | https://github.com/openclaw/openclaw |
| CoPaw | https://github.com/agentscope-ai/CoPaw |
| Higress AI Gateway | https://github.com/alibaba/higress |
| MinIO | https://min.io/ |
| Tuwunel | https://github.com/matrix-construct/tuwunel |
| Matrix (protocol) | https://matrix.org |
| Element | https://element.io |
| FluffyChat | https://fluffychat.im/ |

Links appear on first mention in the feature bullets, architecture component table, and mobile access section. Later mentions in the same document are left as plain text to avoid cluttering the reading experience.

### Bugs fixed

- **Stale repo URLs**: `github.com/alibaba/hiclaw` → `github.com/agentscope-ai/HiClaw` in bug report and community links (affected all three READMEs)
- **Inconsistent Discord invite** (zh-CN only): `discord.gg/n6mV8xEYUF` → `discord.com/invite/NVjNA4BAVw` to match the badge and community section