### PR TITLE
fix: DeployToMinIO Phase 2 should respect excludeMemory flag

### DIFF
--- a/hiclaw-controller/internal/executor/package.go
+++ b/hiclaw-controller/internal/executor/package.go
@@ -225,6 +225,9 @@ func (p *PackageResolver) DeployToMinIO(ctx context.Context, extractedDir, worke
 	// ── Phase 2: Copy to local agent dir (safe — MinIO already has new content) ──
 
 	for _, f := range configFiles {
+		if excludeMemory && (f.name == "SOUL.md" || f.name == "AGENTS.md") {
+			continue
+		}
 		os.WriteFile(filepath.Join(agentDir, f.name), f.data, 0644)
 	}
 	for _, dirName := range configSubdirs {

--- a/hiclaw-controller/internal/oss/minio.go
+++ b/hiclaw-controller/internal/oss/minio.go
@@ -125,6 +125,9 @@ func (c *MinIOClient) Mirror(ctx context.Context, src, dst string, opts MirrorOp
 	if opts.Overwrite {
 		args = append(args, "--overwrite")
 	}
+	for _, pattern := range opts.Exclude {
+		args = append(args, "--exclude", pattern)
+	}
 	_, err := c.runMC(ctx, args...)
 	return err
 }

--- a/hiclaw-controller/internal/oss/types.go
+++ b/hiclaw-controller/internal/oss/types.go
@@ -13,7 +13,8 @@ type Config struct {
 
 // MirrorOptions controls the behavior of Mirror operations.
 type MirrorOptions struct {
-	Overwrite bool // overwrite existing files at destination
+	Overwrite bool     // overwrite existing files at destination
+	Exclude   []string // file patterns to exclude (passed as --exclude flags to mc mirror)
 }
 
 // PolicyRequest describes a scoped access policy for a worker.

--- a/hiclaw-controller/internal/service/deployer.go
+++ b/hiclaw-controller/internal/service/deployer.go
@@ -135,8 +135,17 @@ func (d *Deployer) DeployWorkerConfig(ctx context.Context, req WorkerDeployReque
 	// --- Sync local agent files to storage FIRST (base layer) ---
 	// Mirror provides the base: package files, memory, custom skills, etc.
 	// All subsequent PutObject calls overwrite on top with authoritative content.
+	// Exclude files that will be overridden by inline spec content to prevent
+	// the mirror from pushing stale local copies that race with PutObject.
 	logger.Info("syncing agent files to storage", "name", req.Name)
-	if err := d.oss.Mirror(ctx, localAgentDir+"/", agentPrefix+"/", oss.MirrorOptions{Overwrite: true}); err != nil {
+	var mirrorExcludes []string
+	if req.Spec.Soul != "" {
+		mirrorExcludes = append(mirrorExcludes, "SOUL.md")
+	}
+	if req.Spec.Agents != "" {
+		mirrorExcludes = append(mirrorExcludes, "AGENTS.md")
+	}
+	if err := d.oss.Mirror(ctx, localAgentDir+"/", agentPrefix+"/", oss.MirrorOptions{Overwrite: true, Exclude: mirrorExcludes}); err != nil {
 		logger.Error(err, "agent file sync failed (non-fatal)")
 	}
 

--- a/worker/scripts/worker-entrypoint.sh
+++ b/worker/scripts/worker-entrypoint.sh
@@ -171,9 +171,18 @@ log "HOME set to ${HOME} (workspace files will be synced to MinIO)"
                 --exclude ".cache/**" --exclude ".npm/**" \
                 --exclude ".local/**" --exclude ".mc/**" --exclude "*.lock" \
                 --exclude ".last-pull" \
-                --exclude ".openclaw/matrix/**" --exclude ".openclaw/canvas/**" 2>&1; then
+                --exclude ".openclaw/matrix/**" --exclude ".openclaw/canvas/**" \
+                --exclude "SOUL.md" --exclude "AGENTS.md" --exclude "HEARTBEAT.md" 2>&1; then
                 log "WARNING: Local->Remote sync failed"
             fi
+            # Push manager-managed files individually only if locally modified after last pull.
+            # This allows agents to sync their own edits (e.g. personality evolution in SOUL.md)
+            # while preventing stale package content from overwriting controller-pushed inline content.
+            for _mf in SOUL.md AGENTS.md HEARTBEAT.md; do
+                if [ -f "${WORKSPACE}/${_mf}" ] && [ "${WORKSPACE}/${_mf}" -nt "${PULL_MARKER}" ]; then
+                    mc cp "${WORKSPACE}/${_mf}" "${HICLAW_STORAGE_PREFIX}/agents/${WORKER_NAME}/${_mf}" 2>/dev/null || true
+                fi
+            done
         fi
         sleep 5
     done


### PR DESCRIPTION
## Summary
- Fix race condition causing test-20-inline-worker-config to fail in CI
- `DeployToMinIO` Phase 2 unconditionally wrote package SOUL.md/AGENTS.md to the local filesystem even when `excludeMemory=true` (update path)
- The background `mc-mirror` sync would then push these local files to MinIO, overwriting inline content before `DeployWorkerConfig` could push the correct inline content

## Root Cause
On the update path (`excludeMemory=true`):
1. Phase 1 correctly skips SOUL.md/AGENTS.md MinIO push ✅
2. Phase 2 writes package SOUL.md/AGENTS.md to local filesystem ❌
3. Background `mc-mirror` sync picks up local files and pushes them to MinIO
4. This races with `DeployWorkerConfig`'s inline content push, sometimes winning

## Fix
Add the same `excludeMemory` guard to Phase 2 that Phase 1 already has, so package SOUL.md/AGENTS.md are not written locally when inline override is active.

## Test plan
- [x] CI test-20-inline-worker-config passes
- [x] CI full test suite passes