### PR TITLE
refactor: remove unused worker/manager ClusterRoles and RoleBindings

### DIFF
--- a/helm/hiclaw/templates/controller/rbac.yaml
+++ b/helm/hiclaw/templates/controller/rbac.yaml
@@ -25,9 +25,6 @@ rules:
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["get", "list", "create", "delete"]
-  - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["roles", "rolebindings"]
-    verbs: ["get", "list", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
@@ -56,29 +53,6 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "hiclaw.controller.serviceAccountName" . }}
     namespace: {{ include "hiclaw.namespace" . }}
----
-{{- /*
-  ClusterRole for worker ServiceAccounts.
-  Workers authenticate to the controller via projected SA tokens (HTTP bearer),
-  not directly via the K8s API. This ClusterRole exists so that per-worker
-  RoleBindings created by the controller have a valid RoleRef.
-*/}}
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: hiclaw-worker
-  labels:
-    {{- include "hiclaw.component.labels" (dict "root" . "component" "controller") | nindent 4 }}
-rules: []
----
-{{- /* ClusterRole for Manager ServiceAccount (same pattern as hiclaw-worker). */}}
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: hiclaw-manager
-  labels:
-    {{- include "hiclaw.component.labels" (dict "root" . "component" "controller") | nindent 4 }}
-rules: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/hiclaw-controller/go.mod
+++ b/hiclaw-controller/go.mod
@@ -22,6 +22,7 @@ require (
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/Rican7/retry v0.3.1 // indirect
+	github.com/alibabacloud-go/alibabacloud-gateway-pop v0.0.8 // indirect
 	github.com/alibabacloud-go/alibabacloud-gateway-spi v0.0.5 // indirect
 	github.com/alibabacloud-go/debug v1.0.1 // indirect
 	github.com/alibabacloud-go/tea-utils/v2 v2.0.7 // indirect

--- a/hiclaw-controller/go.sum
+++ b/hiclaw-controller/go.sum
@@ -6,8 +6,9 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Rican7/retry v0.3.1 h1:scY4IbO8swckzoA/11HgBwaZRJEyY9vaNJshcdhp1Mc=
 github.com/Rican7/retry v0.3.1/go.mod h1:CxSDrhAyXmTMeEuRAnArMu1FHu48vtfjLREWqVl7Vw0=
-github.com/alibabacloud-go/alibabacloud-gateway-pop v0.0.6 h1:eIf+iGJxdU4U9ypaUfbtOWCsZSbTb8AUHvyPrxu6mAA=
 github.com/alibabacloud-go/alibabacloud-gateway-pop v0.0.6/go.mod h1:4EUIoxs/do24zMOGGqYVWgw0s9NtiylnJglOeEB5UJo=
+github.com/alibabacloud-go/alibabacloud-gateway-pop v0.0.8 h1:ViQyUFKBVnhzsODcNzJK/uz1WXqzX+3xeQsEDy610PA=
+github.com/alibabacloud-go/alibabacloud-gateway-pop v0.0.8/go.mod h1:e3etxyckfZ4sHJsmA2uBz07BUMKQWyPeZNP0dqi/5kw=
 github.com/alibabacloud-go/alibabacloud-gateway-spi v0.0.4/go.mod h1:sCavSAvdzOjul4cEqeVtvlSaSScfNsTQ+46HwlTL1hc=
 github.com/alibabacloud-go/alibabacloud-gateway-spi v0.0.5 h1:zE8vH9C7JiZLNJJQ5OwjU9mSi4T9ef9u3BURT6LCLC8=
 github.com/alibabacloud-go/alibabacloud-gateway-spi v0.0.5/go.mod h1:tWnyE9AjF8J8qqLk645oUmVUnFybApTQWklQmi5tY6g=
@@ -32,8 +33,9 @@ github.com/alibabacloud-go/debug v1.0.1 h1:MsW9SmUtbb1Fnt3ieC6NNZi6aEwrXfDksD4QA
 github.com/alibabacloud-go/debug v1.0.1/go.mod h1:8gfgZCCAC3+SCzjWtY053FrOcd4/qlH6IHTI4QyICOc=
 github.com/alibabacloud-go/endpoint-util v1.1.0 h1:r/4D3VSw888XGaeNpP994zDUaxdgTSHBbVfZlzf6b5Q=
 github.com/alibabacloud-go/endpoint-util v1.1.0/go.mod h1:O5FuCALmCKs2Ff7JFJMudHs0I5EBgecXXxZRyswlEjE=
-github.com/alibabacloud-go/openapi-util v0.1.0 h1:0z75cIULkDrdEhkLWgi9tnLe+KhAFE/r5Pb3312/eAY=
 github.com/alibabacloud-go/openapi-util v0.1.0/go.mod h1:sQuElr4ywwFRlCCberQwKRFhRzIyG4QTP/P4y1CJ6Ws=
+github.com/alibabacloud-go/openapi-util v0.1.1 h1:ujGErJjG8ncRW6XtBBMphzHTvCxn4DjrVw4m04HsS28=
+github.com/alibabacloud-go/openapi-util v0.1.1/go.mod h1:/UehBSE2cf1gYT43GV4E+RxTdLRzURImCYY0aRmlXpw=
 github.com/alibabacloud-go/sae-20190506/v4 v4.11.5 h1:UXZ7qgJW/E7LIYrLpmUl7riMt+gf0EQTnAz+B0P44FQ=
 github.com/alibabacloud-go/sae-20190506/v4 v4.11.5/go.mod h1:6g/gfr1piYjVZWKmnX6OqnVOiQK21Dxi1ra11Y5xuRM=
 github.com/alibabacloud-go/tea v1.1.0/go.mod h1:IkGyUSX4Ba1V+k4pCtJUc6jDpZLFph9QMy2VUPTwukg=
@@ -45,9 +47,9 @@ github.com/alibabacloud-go/tea v1.1.20/go.mod h1:nXxjm6CIFkBhwW4FQkNrolwbfon8Svy
 github.com/alibabacloud-go/tea v1.2.2/go.mod h1:CF3vOzEMAG+bR4WOql8gc2G9H3EkH3ZLAQdpmpXMgwk=
 github.com/alibabacloud-go/tea v1.3.13 h1:WhGy6LIXaMbBM6VBYcsDCz6K/TPsT1Ri2hPmmZffZ94=
 github.com/alibabacloud-go/tea v1.3.13/go.mod h1:A560v/JTQ1n5zklt2BEpurJzZTI8TUT+Psg2drWlxRg=
-github.com/alibabacloud-go/tea-utils v1.3.1 h1:iWQeRzRheqCMuiF3+XkfybB3kTgUXkXX+JMrqfLeB2I=
 github.com/alibabacloud-go/tea-utils v1.3.1/go.mod h1:EI/o33aBfj3hETm4RLiAxF/ThQdSngxrpF8rKUDJjPE=
 github.com/alibabacloud-go/tea-utils/v2 v2.0.5/go.mod h1:dL6vbUT35E4F4bFTHL845eUloqaerYBYPsdWR2/jhe4=
+github.com/alibabacloud-go/tea-utils/v2 v2.0.6/go.mod h1:qxn986l+q33J5VkialKMqT/TTs3E+U9MJpd001iWQ9I=
 github.com/alibabacloud-go/tea-utils/v2 v2.0.7 h1:WDx5qW3Xa5ZgJ1c8NfqJkF6w+AU5wB8835UdhPr6Ax0=
 github.com/alibabacloud-go/tea-utils/v2 v2.0.7/go.mod h1:qxn986l+q33J5VkialKMqT/TTs3E+U9MJpd001iWQ9I=
 github.com/aliyun/credentials-go v1.1.2/go.mod h1:ozcZaMR5kLM7pwtCMEpVmQ242suV6qTJya2bDq4X1Tw=

--- a/hiclaw-controller/internal/service/provisioner_sa.go
+++ b/hiclaw-controller/internal/service/provisioner_sa.go
@@ -7,14 +7,13 @@ import (
 	authpkg "github.com/hiclaw/hiclaw-controller/internal/auth"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // --- ServiceAccount Management ---
 
-// EnsureServiceAccount creates a SA + RoleBinding for the worker if it doesn't exist.
+// EnsureServiceAccount creates a ServiceAccount for the worker if it doesn't exist.
 func (p *Provisioner) EnsureServiceAccount(ctx context.Context, workerName string) error {
 	if p.k8sClient == nil {
 		return nil
@@ -46,37 +45,10 @@ func (p *Provisioner) EnsureServiceAccount(ctx context.Context, workerName strin
 		}
 	}
 
-	rbName := saName + "-rb"
-	rb := &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      rbName,
-			Namespace: ns,
-			Labels: map[string]string{
-				"app":              "hiclaw-worker",
-				"hiclaw.io/worker": workerName,
-			},
-		},
-		Subjects: []rbacv1.Subject{{
-			Kind:      "ServiceAccount",
-			Name:      saName,
-			Namespace: ns,
-		}},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
-			Name:     "hiclaw-worker",
-		},
-	}
-	if _, err := p.k8sClient.RbacV1().RoleBindings(ns).Create(ctx, rb, metav1.CreateOptions{}); err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("create RoleBinding %s: %w", rbName, err)
-		}
-	}
-
 	return nil
 }
 
-// DeleteServiceAccount removes the SA + RoleBinding for the worker.
+// DeleteServiceAccount removes the ServiceAccount for the worker.
 func (p *Provisioner) DeleteServiceAccount(ctx context.Context, workerName string) error {
 	if p.k8sClient == nil {
 		return nil
@@ -84,8 +56,6 @@ func (p *Provisioner) DeleteServiceAccount(ctx context.Context, workerName strin
 	saName := authpkg.SAName(authpkg.RoleWorker, workerName)
 	ns := p.namespace
 
-	rbName := saName + "-rb"
-	_ = p.k8sClient.RbacV1().RoleBindings(ns).Delete(ctx, rbName, metav1.DeleteOptions{})
 	err := p.k8sClient.CoreV1().ServiceAccounts(ns).Delete(ctx, saName, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		return nil
@@ -93,7 +63,7 @@ func (p *Provisioner) DeleteServiceAccount(ctx context.Context, workerName strin
 	return err
 }
 
-// EnsureManagerServiceAccount creates a SA + RoleBinding for the Manager if it doesn't exist.
+// EnsureManagerServiceAccount creates a ServiceAccount for the Manager if it doesn't exist.
 func (p *Provisioner) EnsureManagerServiceAccount(ctx context.Context, managerName string) error {
 	if p.k8sClient == nil {
 		return nil
@@ -125,37 +95,10 @@ func (p *Provisioner) EnsureManagerServiceAccount(ctx context.Context, managerNa
 		}
 	}
 
-	rbName := saName + "-rb"
-	rb := &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      rbName,
-			Namespace: ns,
-			Labels: map[string]string{
-				"app":               "hiclaw-manager",
-				"hiclaw.io/manager": managerName,
-			},
-		},
-		Subjects: []rbacv1.Subject{{
-			Kind:      "ServiceAccount",
-			Name:      saName,
-			Namespace: ns,
-		}},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "ClusterRole",
-			Name:     "hiclaw-manager",
-		},
-	}
-	if _, err := p.k8sClient.RbacV1().RoleBindings(ns).Create(ctx, rb, metav1.CreateOptions{}); err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("create RoleBinding %s: %w", rbName, err)
-		}
-	}
-
 	return nil
 }
 
-// DeleteManagerServiceAccount removes the SA + RoleBinding for the Manager.
+// DeleteManagerServiceAccount removes the ServiceAccount for the Manager.
 func (p *Provisioner) DeleteManagerServiceAccount(ctx context.Context, managerName string) error {
 	if p.k8sClient == nil {
 		return nil
@@ -163,8 +106,6 @@ func (p *Provisioner) DeleteManagerServiceAccount(ctx context.Context, managerNa
 	saName := authpkg.SAName(authpkg.RoleManager, managerName)
 	ns := p.namespace
 
-	rbName := saName + "-rb"
-	_ = p.k8sClient.RbacV1().RoleBindings(ns).Delete(ctx, rbName, metav1.DeleteOptions{})
 	err := p.k8sClient.CoreV1().ServiceAccounts(ns).Delete(ctx, saName, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		return nil


### PR DESCRIPTION
## Summary

- Remove empty `hiclaw-worker` and `hiclaw-manager` ClusterRoles and their per-entity RoleBindings
- Remove `roles/rolebindings` RBAC permissions from the controller Role (no longer needed)
- Clean up `rbacv1` import and RoleBinding creation/deletion code in `provisioner_sa.go`

Worker/manager SA tokens are used solely for HTTP bearer auth to the controller via TokenReview, not for K8s API access. The empty ClusterRoles and RoleBindings served no functional purpose.

## Test plan

- [x] `go build ./...` passes
- [x] Deployed to kind cluster via `make local-k8s-up`
- [x] Verified ClusterRoles `hiclaw-worker`/`hiclaw-manager` no longer exist
- [x] Verified no worker/manager RoleBindings created
- [x] ServiceAccounts created successfully for both worker and manager
- [x] Worker and manager pods running with token auth working

🤖 Generated with [Claude Code](https://claude.com/claude-code)