### PR TITLE
fix(controller): auto-recreate pod when deleted while CR is still Running

### DIFF
--- a/hiclaw-controller/internal/controller/manager_controller.go
+++ b/hiclaw-controller/internal/controller/manager_controller.go
@@ -345,10 +345,11 @@ func (r *ManagerReconciler) failManagerUpdate(ctx context.Context, m *v1beta1.Ma
 // --- Desired state reconciliation ---
 
 func (r *ManagerReconciler) reconcileDesiredState(ctx context.Context, m *v1beta1.Manager, desired string) (reconcile.Result, error) {
-	// If current phase already matches desired state, nothing to do.
-	// This also avoids calling backend Status/Stop/Delete for Managers
-	// in Docker mode, where the container name ("hiclaw-manager") doesn't
-	// include the backend's worker prefix ("hiclaw-worker-").
+	// When phase matches desired "Running", verify the pod/container still exists.
+	if m.Status.Phase == desired && desired == "Running" {
+		return r.ensureManagerPodExists(ctx, m)
+	}
+
 	if m.Status.Phase == desired {
 		return reconcile.Result{}, nil
 	}
@@ -367,6 +368,28 @@ func (r *ManagerReconciler) reconcileDesiredState(ctx context.Context, m *v1beta
 		logger.Info("unknown desired state, ignoring", "state", desired)
 		return reconcile.Result{}, nil
 	}
+}
+
+// ensureManagerPodExists checks if the manager's pod/container still exists.
+func (r *ManagerReconciler) ensureManagerPodExists(ctx context.Context, m *v1beta1.Manager) (reconcile.Result, error) {
+	wb := r.managerBackend(ctx)
+	if wb == nil {
+		return reconcile.Result{}, nil
+	}
+
+	containerName := managerContainerName(m.Name)
+	result, err := wb.Status(ctx, containerName)
+	if err != nil {
+		return reconcile.Result{RequeueAfter: reconcileRetryDelay}, nil
+	}
+
+	if result.Status == backend.StatusRunning || result.Status == backend.StatusStarting {
+		return reconcile.Result{}, nil
+	}
+
+	logger := log.FromContext(ctx)
+	logger.Info("pod missing for Running manager, recreating", "name", m.Name, "backendStatus", result.Status)
+	return r.ensureManagerRunning(ctx, m)
 }
 
 // managerBackend returns the WorkerBackend with Docker's container prefix cleared.

--- a/hiclaw-controller/internal/controller/worker_controller.go
+++ b/hiclaw-controller/internal/controller/worker_controller.go
@@ -400,8 +400,13 @@ func (r *WorkerReconciler) failUpdate(ctx context.Context, w *v1beta1.Worker, ms
 // reconcileDesiredState compares the desired lifecycle state (spec.state) with
 // the actual backend state and takes corrective action when drift is detected.
 func (r *WorkerReconciler) reconcileDesiredState(ctx context.Context, w *v1beta1.Worker, desired string) (reconcile.Result, error) {
-	// If current phase already matches desired state, nothing to do.
-	// This also avoids unnecessary backend Status calls on every reconcile.
+	// When phase matches desired "Running", verify the pod/container still exists.
+	// It may have been deleted externally (kubectl delete pod, node eviction, OOM, etc.)
+	// while the CR status still shows Running.
+	if w.Status.Phase == desired && desired == "Running" {
+		return r.ensurePodExists(ctx, w)
+	}
+
 	if w.Status.Phase == desired {
 		return reconcile.Result{}, nil
 	}
@@ -420,6 +425,31 @@ func (r *WorkerReconciler) reconcileDesiredState(ctx context.Context, w *v1beta1
 		logger.Info("unknown desired state, ignoring", "state", desired)
 		return reconcile.Result{}, nil
 	}
+}
+
+// ensurePodExists checks if the worker's pod/container still exists when the
+// CR status is Running. If the pod was deleted externally, triggers recreation.
+func (r *WorkerReconciler) ensurePodExists(ctx context.Context, w *v1beta1.Worker) (reconcile.Result, error) {
+	if r.Backend == nil {
+		return reconcile.Result{}, nil
+	}
+	wb := r.Backend.DetectWorkerBackend(ctx)
+	if wb == nil {
+		return reconcile.Result{}, nil
+	}
+
+	result, err := wb.Status(ctx, w.Name)
+	if err != nil {
+		return reconcile.Result{RequeueAfter: reconcileRetryDelay}, nil
+	}
+
+	if result.Status == backend.StatusRunning || result.Status == backend.StatusStarting {
+		return reconcile.Result{}, nil
+	}
+
+	logger := log.FromContext(ctx)
+	logger.Info("pod missing for Running worker, recreating", "name", w.Name, "backendStatus", result.Status)
+	return r.ensureWorkerRunning(ctx, w)
 }
 
 // ensureWorkerRunning wakes a worker from Sleeping or Stopped state.


### PR DESCRIPTION
# fix(controller): auto-recreate pod when deleted while CR is still Running

## Problem

When a Worker or Manager pod is deleted externally (e.g. `kubectl delete pod`, node eviction, OOM kill) while the CR status is still `Running`, the reconciler skips reconciliation because `observedGeneration == generation` and `phase == desired`. The pod is never recreated, leaving the CR in a stale `Running` state with no backing pod.

## Fix

In `reconcileDesiredState` for both `WorkerReconciler` and `ManagerReconciler`, when `phase == desired == "Running"`, check the backend for actual pod/container status. If the pod is missing, trigger recreation via the existing `ensureWorkerRunning` / `ensureManagerRunning` methods which already handle pod recreation.

Detection runs on the existing 5-minute `reconcileInterval`, so a deleted pod is recreated within 5 minutes.

## Files Changed

- `hiclaw-controller/internal/controller/worker_controller.go` — add `ensurePodExists`, call it from `reconcileDesiredState`
- `hiclaw-controller/internal/controller/manager_controller.go` — add `ensureManagerPodExists`, same pattern
