### PR TITLE
refactor: declarative convergence rewrite for Worker Reconciler with integration tests

### DIFF
--- a/.github/workflows/test-controller.yml
+++ b/.github/workflows/test-controller.yml
@@ -1,4 +1,4 @@
-name: Controller Tests
+name: HiClaw Controller Tests
 
 on:
   pull_request:

--- a/.github/workflows/test-controller.yml
+++ b/.github/workflows/test-controller.yml
@@ -1,0 +1,32 @@
+name: Controller Tests
+
+on:
+  pull_request:
+    paths:
+      - 'hiclaw-controller/**'
+      - '.github/workflows/test-controller.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'hiclaw-controller/**'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: hiclaw-controller/go.mod
+          cache-dependency-path: hiclaw-controller/go.sum
+
+      - name: Unit tests
+        working-directory: hiclaw-controller
+        run: make test-unit
+
+      - name: Integration tests (envtest)
+        working-directory: hiclaw-controller
+        run: make test-integration

--- a/hiclaw-controller/Makefile
+++ b/hiclaw-controller/Makefile
@@ -1,4 +1,6 @@
-.PHONY: build build-controller build-cli clean
+.PHONY: build build-controller build-cli clean test test-unit test-integration test-all
+
+# --- Build ---
 
 build: build-controller build-cli
 
@@ -11,5 +13,36 @@ build-cli:
 clean:
 	rm -rf bin/
 
-test:
-	go test ./...
+# --- Test ---
+
+GOBIN ?= $(shell go env GOPATH)/bin
+ENVTEST ?= $(GOBIN)/setup-envtest
+ENVTEST_K8S_VERSION ?= 1.31.0
+
+# Detect architecture for envtest binaries
+UNAME_ARCH := $(shell uname -m)
+ifeq ($(UNAME_ARCH),arm64)
+  ENVTEST_ARCH ?= arm64
+else
+  ENVTEST_ARCH ?= amd64
+endif
+
+KUBEBUILDER_ASSETS ?= $(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --arch=$(ENVTEST_ARCH) -p path 2>/dev/null)
+
+test: test-unit
+
+test-unit:
+	go test ./internal/... ./cmd/...
+
+test-integration: setup-envtest
+	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" \
+	go test -tags=integration -count=1 -v -timeout=120s ./test/integration/...
+
+test-all: test-unit test-integration
+
+# --- Tools ---
+
+setup-envtest:
+	@test -x $(ENVTEST) || go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	@$(ENVTEST) use $(ENVTEST_K8S_VERSION) --arch=$(ENVTEST_ARCH) -p path >/dev/null 2>&1 || \
+		$(ENVTEST) use $(ENVTEST_K8S_VERSION) --arch=$(ENVTEST_ARCH)

--- a/hiclaw-controller/Makefile
+++ b/hiclaw-controller/Makefile
@@ -36,7 +36,7 @@ test-unit:
 
 test-integration: setup-envtest
 	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" \
-	go test -tags=integration -count=1 -v -timeout=120s ./test/integration/...
+	go test -tags=integration -race -count=1 -v -timeout=120s ./test/integration/...
 
 test-all: test-unit test-integration
 

--- a/hiclaw-controller/go.mod
+++ b/hiclaw-controller/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/alibabacloud-go/debug v1.0.1 // indirect
 	github.com/alibabacloud-go/tea-utils/v2 v2.0.7 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/canonical/go-dqlite v1.5.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/hiclaw-controller/internal/controller/manager_controller.go
+++ b/hiclaw-controller/internal/controller/manager_controller.go
@@ -589,7 +589,10 @@ func (r *ManagerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 						return nil
 					}
 					return []reconcile.Request{
-						{NamespacedName: client.ObjectKey{Name: managerName}},
+						{NamespacedName: client.ObjectKey{
+							Name:      managerName,
+							Namespace: obj.GetNamespace(),
+						}},
 					}
 				}),
 			)

--- a/hiclaw-controller/internal/controller/worker_controller.go
+++ b/hiclaw-controller/internal/controller/worker_controller.go
@@ -111,6 +111,14 @@ func (r *WorkerReconciler) reconcileNormal(ctx context.Context, s *workerScope) 
 	r.reconcileExpose(ctx, s)
 	r.reconcileLegacy(ctx, s)
 
+	w := s.worker
+	logger := log.FromContext(ctx)
+	if w.Status.ObservedGeneration == 0 {
+		logger.Info("worker created", "name", w.Name, "roomID", w.Status.RoomID)
+	} else if w.Generation != w.Status.ObservedGeneration {
+		logger.Info("worker updated", "name", w.Name)
+	}
+
 	return reconcile.Result{RequeueAfter: reconcileInterval}, nil
 }
 
@@ -176,7 +184,10 @@ func (r *WorkerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 						return nil
 					}
 					return []reconcile.Request{
-						{NamespacedName: client.ObjectKey{Name: workerName}},
+						{NamespacedName: client.ObjectKey{
+							Name:      workerName,
+							Namespace: obj.GetNamespace(),
+						}},
 					}
 				}),
 				builder.WithPredicates(podLifecyclePredicates()),

--- a/hiclaw-controller/internal/controller/worker_controller.go
+++ b/hiclaw-controller/internal/controller/worker_controller.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
@@ -46,7 +45,7 @@ func (r *WorkerReconciler) Reconcile(ctx context.Context, req reconcile.Request)
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
-	patchBase := client.MergeFromWithOptions(worker.DeepCopy(), client.MergeFromWithOptimisticLock{})
+	patchBase := client.MergeFrom(worker.DeepCopy())
 
 	s := &workerScope{
 		worker:    &worker,
@@ -233,6 +232,3 @@ func roleForAnnotations(role, teamLeaderName string) string {
 	}
 	return "standalone"
 }
-
-// Suppress unused import for fmt (used by sub-reconcilers in other files).
-var _ = fmt.Errorf

--- a/hiclaw-controller/internal/controller/worker_controller.go
+++ b/hiclaw-controller/internal/controller/worker_controller.go
@@ -2,20 +2,22 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
-	authpkg "github.com/hiclaw/hiclaw-controller/internal/auth"
 	"github.com/hiclaw/hiclaw-controller/internal/backend"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -36,7 +38,7 @@ type WorkerReconciler struct {
 	Legacy      *service.LegacyCompat // nil in incluster mode
 }
 
-func (r *WorkerReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+func (r *WorkerReconciler) Reconcile(ctx context.Context, req reconcile.Request) (retres reconcile.Result, reterr error) {
 	logger := log.FromContext(ctx)
 
 	var worker v1beta1.Worker
@@ -44,22 +46,45 @@ func (r *WorkerReconciler) Reconcile(ctx context.Context, req reconcile.Request)
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// Handle deletion with finalizer
+	patchBase := client.MergeFromWithOptions(worker.DeepCopy(), client.MergeFromWithOptimisticLock{})
+
+	s := &workerScope{
+		worker:    &worker,
+		patchBase: patchBase,
+	}
+
+	// Unified status patch at the end of every reconcile.
+	// ObservedGeneration is only written when reconcile succeeds, preventing
+	// the infinite-loop bug where a failed status write triggered re-reconcile
+	// with Generation != ObservedGeneration.
+	defer func() {
+		if !worker.DeletionTimestamp.IsZero() {
+			return
+		}
+
+		worker.Status.Phase = computePhase(&worker, reterr)
+		if reterr == nil {
+			worker.Status.ObservedGeneration = worker.Generation
+			worker.Status.Message = ""
+		} else {
+			worker.Status.Message = reterr.Error()
+		}
+
+		if err := r.Status().Patch(ctx, &worker, patchBase); err != nil {
+			logger.Error(err, "failed to patch worker status")
+			reterr = kerrors.NewAggregate([]error{reterr, err})
+		}
+	}()
+
+	// Handle deletion
 	if !worker.DeletionTimestamp.IsZero() {
 		if controllerutil.ContainsFinalizer(&worker, finalizerName) {
-			if err := r.handleDelete(ctx, &worker); err != nil {
-				logger.Error(err, "failed to delete worker", "name", worker.Name)
-				return reconcile.Result{RequeueAfter: 30 * time.Second}, err
-			}
-			controllerutil.RemoveFinalizer(&worker, finalizerName)
-			if err := r.Update(ctx, &worker); err != nil {
-				return reconcile.Result{}, err
-			}
+			return r.reconcileDelete(ctx, s)
 		}
 		return reconcile.Result{}, nil
 	}
 
-	// Add finalizer if not present
+	// Add finalizer
 	if !controllerutil.ContainsFinalizer(&worker, finalizerName) {
 		controllerutil.AddFinalizer(&worker, finalizerName)
 		if err := r.Update(ctx, &worker); err != nil {
@@ -67,519 +92,84 @@ func (r *WorkerReconciler) Reconcile(ctx context.Context, req reconcile.Request)
 		}
 	}
 
-	// Reconcile based on current phase
-	switch worker.Status.Phase {
-	case "", "Failed":
-		return r.handleCreate(ctx, &worker)
-	case "Pending":
-		if worker.Status.Message != "" {
-			return r.handleCreate(ctx, &worker)
-		}
-		return reconcile.Result{}, nil
-	default:
-		// For provisioned workers, reconcile desired lifecycle state
-		desired := worker.Spec.DesiredState()
-		result, err := r.reconcileDesiredState(ctx, &worker, desired)
-		if err != nil || result.RequeueAfter > 0 {
-			return result, err
-		}
-
-		if worker.Generation == worker.Status.ObservedGeneration {
-			return reconcile.Result{RequeueAfter: reconcileInterval}, nil
-		}
-		return r.handleUpdate(ctx, &worker)
-	}
+	return r.reconcileNormal(ctx, s)
 }
 
-func (r *WorkerReconciler) handleCreate(ctx context.Context, w *v1beta1.Worker) (reconcile.Result, error) {
-	logger := log.FromContext(ctx)
-	logger.Info("creating worker", "name", w.Name)
-
-	w.Status.Phase = "Pending"
-	if err := r.Status().Update(ctx, w); err != nil {
-		return reconcile.Result{}, err
+// reconcileNormal runs the declarative convergence loop: infrastructure,
+// config, container, expose, legacy. Critical-path phases are serial with
+// early return on error; non-critical phases log errors without failing.
+func (r *WorkerReconciler) reconcileNormal(ctx context.Context, s *workerScope) (reconcile.Result, error) {
+	if res, err := r.reconcileInfrastructure(ctx, s); err != nil || res.RequeueAfter > 0 {
+		return res, err
+	}
+	if res, err := r.reconcileConfig(ctx, s); err != nil || res.RequeueAfter > 0 {
+		return res, err
+	}
+	if res, err := r.reconcileContainer(ctx, s); err != nil || res.RequeueAfter > 0 {
+		return res, err
 	}
 
-	workerName := w.Name
+	r.reconcileExpose(ctx, s)
+	r.reconcileLegacy(ctx, s)
+
+	return reconcile.Result{RequeueAfter: reconcileInterval}, nil
+}
+
+// reconcileExpose reconciles port exposure via the gateway. Non-critical.
+func (r *WorkerReconciler) reconcileExpose(ctx context.Context, s *workerScope) {
+	w := s.worker
+	if len(w.Spec.Expose) == 0 && len(w.Status.ExposedPorts) == 0 {
+		return
+	}
+	exposedPorts, err := r.Provisioner.ReconcileExpose(ctx, w.Name, w.Spec.Expose, w.Status.ExposedPorts)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed to reconcile exposed ports (non-fatal)")
+		return
+	}
+	w.Status.ExposedPorts = exposedPorts
+}
+
+// reconcileLegacy updates the legacy workers registry. Non-critical.
+func (r *WorkerReconciler) reconcileLegacy(ctx context.Context, s *workerScope) {
+	w := s.worker
+	if r.Legacy == nil || !r.Legacy.Enabled() {
+		return
+	}
+	logger := log.FromContext(ctx)
+
 	role := w.Annotations["hiclaw.io/role"]
 	teamName := w.Annotations["hiclaw.io/team"]
 	teamLeaderName := w.Annotations["hiclaw.io/team-leader"]
-	teamAdminMatrixID := w.Annotations["hiclaw.io/team-admin-id"]
 	isTeamWorker := teamLeaderName != ""
 
-	// --- Phase 1: Package + inline configs ---
-	if err := r.Deployer.DeployPackage(ctx, workerName, w.Spec.Package, false); err != nil {
-		return r.failCreate(ctx, w, err.Error())
-	}
-	if err := r.Deployer.WriteInlineConfigs(workerName, w.Spec); err != nil {
-		return r.failCreate(ctx, w, fmt.Sprintf("write inline configs failed: %v", err))
+	if !isTeamWorker && s.provResult != nil {
+		if err := r.Legacy.UpdateManagerGroupAllowFrom(s.provResult.MatrixUserID, true); err != nil {
+			logger.Error(err, "failed to update Manager groupAllowFrom (non-fatal)")
+		}
 	}
 
-	// --- Phase 2: Provision infrastructure ---
-	provResult, err := r.Provisioner.ProvisionWorker(ctx, service.WorkerProvisionRequest{
-		Name:           workerName,
-		Role:           roleForAnnotations(role, teamLeaderName),
-		TeamName:       teamName,
-		TeamLeaderName: teamLeaderName,
-		McpServers:     w.Spec.McpServers,
-	})
-	if err != nil {
-		return r.failCreate(ctx, w, err.Error())
-	}
-
-	// --- Phase 3: Deploy configuration ---
-	if err := r.Deployer.DeployWorkerConfig(ctx, service.WorkerDeployRequest{
-		Name:              workerName,
-		Spec:              w.Spec,
-		Role:              roleForAnnotations(role, teamLeaderName),
-		TeamName:          teamName,
-		TeamLeaderName:    teamLeaderName,
-		MatrixToken:       provResult.MatrixToken,
-		GatewayKey:        provResult.GatewayKey,
-		MatrixPassword:    provResult.MatrixPassword,
-		AuthorizedMCPs:    provResult.AuthorizedMCPs,
-		TeamAdminMatrixID: teamAdminMatrixID,
+	if err := r.Legacy.UpdateWorkersRegistry(service.WorkerRegistryEntry{
+		Name:         w.Name,
+		MatrixUserID: r.Provisioner.MatrixUserID(w.Name),
+		RoomID:       w.Status.RoomID,
+		Runtime:      w.Spec.Runtime,
+		Deployment:   "local",
+		Skills:       w.Spec.Skills,
+		Role:         role,
+		TeamID:       nilIfEmpty(teamName),
+		Image:        nilIfEmpty(w.Spec.Image),
 	}); err != nil {
-		return r.failCreate(ctx, w, err.Error())
+		logger.Error(err, "registry update failed (non-fatal)")
 	}
-
-	// --- Phase 4: Legacy compat ---
-	if r.Legacy != nil && r.Legacy.Enabled() {
-		if !isTeamWorker {
-			if err := r.Legacy.UpdateManagerGroupAllowFrom(provResult.MatrixUserID, true); err != nil {
-				logger.Error(err, "failed to update Manager groupAllowFrom (non-fatal)")
-			}
-		}
-		if err := r.Legacy.UpdateWorkersRegistry(service.WorkerRegistryEntry{
-			Name:         workerName,
-			MatrixUserID: provResult.MatrixUserID,
-			RoomID:       provResult.RoomID,
-			Runtime:      w.Spec.Runtime,
-			Deployment:   "local",
-			Skills:       w.Spec.Skills,
-			Role:         role,
-			TeamID:       nilIfEmpty(teamName),
-			Image:        nilIfEmpty(w.Spec.Image),
-		}); err != nil {
-			logger.Error(err, "registry update failed (non-fatal)")
-		}
-	}
-
-	// --- Phase 5: On-demand skills ---
-	if err := r.Deployer.PushOnDemandSkills(ctx, workerName, w.Spec.Skills); err != nil {
-		logger.Error(err, "skill push failed (non-fatal)")
-	}
-
-	// --- Phase 6: ServiceAccount + Container start ---
-	logger.Info("ensuring service account", "name", workerName)
-	if err := r.Provisioner.EnsureServiceAccount(ctx, workerName); err != nil {
-		return r.failCreate(ctx, w, fmt.Sprintf("ServiceAccount creation failed: %v", err))
-	}
-
-	logger.Info("starting worker container", "name", workerName)
-	if r.Backend != nil {
-		if wb := r.Backend.DetectWorkerBackend(ctx); wb != nil {
-			workerEnv := r.EnvBuilder.Build(workerName, provResult)
-			saName := authpkg.SAName(authpkg.RoleWorker, workerName)
-			createReq := backend.CreateRequest{
-				Name:               workerName,
-				Image:              w.Spec.Image,
-				Runtime:            w.Spec.Runtime,
-				Env:                workerEnv,
-				ServiceAccountName: saName,
-			}
-			if wb.Name() != "k8s" {
-				token, err := r.Provisioner.RequestSAToken(ctx, workerName)
-				if err != nil {
-					logger.Error(err, "failed to request SA token (non-fatal, worker auth will fail)")
-				}
-				createReq.AuthToken = token
-			}
-			if _, err := wb.Create(ctx, createReq); err != nil {
-				logger.Error(err, "worker container creation failed (non-fatal, worker can be started manually)")
-			}
-		} else {
-			logger.Info("no worker backend available, worker needs manual start")
-		}
-	}
-
-	// --- Phase 7: Expose + Status ---
-	var exposedPorts []v1beta1.ExposedPortStatus
-	if len(w.Spec.Expose) > 0 {
-		var exposeErr error
-		exposedPorts, exposeErr = r.Provisioner.ReconcileExpose(ctx, workerName, w.Spec.Expose, nil)
-		if exposeErr != nil {
-			logger.Error(exposeErr, "failed to expose ports (non-fatal)")
-		}
-	}
-
-	if err := r.Get(ctx, client.ObjectKeyFromObject(w), w); err != nil {
-		return reconcile.Result{}, err
-	}
-	w.Status.ObservedGeneration = w.Generation
-	w.Status.Phase = "Running"
-	w.Status.MatrixUserID = provResult.MatrixUserID
-	w.Status.RoomID = provResult.RoomID
-	w.Status.Message = ""
-	w.Status.ExposedPorts = exposedPorts
-	if err := r.Status().Update(ctx, w); err != nil {
-		logger.Error(err, "failed to update status after create (non-fatal)")
-	}
-
-	logger.Info("worker created", "name", workerName, "roomID", provResult.RoomID)
-	return reconcile.Result{}, nil
-}
-
-func (r *WorkerReconciler) handleUpdate(ctx context.Context, w *v1beta1.Worker) (reconcile.Result, error) {
-	logger := log.FromContext(ctx)
-	logger.Info("worker spec changed, updating configuration", "name", w.Name)
-	workerName := w.Name
-	consumerName := "worker-" + workerName
-	role := w.Annotations["hiclaw.io/role"]
-	teamName := w.Annotations["hiclaw.io/team"]
-	teamLeaderName := w.Annotations["hiclaw.io/team-leader"]
-	teamAdminMatrixID := w.Annotations["hiclaw.io/team-admin-id"]
-
-	w.Status.Phase = "Updating"
-	w.Status.Message = "Updating worker configuration (memory preserved, skills merged)"
-	if err := r.Status().Update(ctx, w); err != nil {
-		return reconcile.Result{}, err
-	}
-
-	// --- Phase 1: Package + inline configs ---
-	if err := r.Deployer.DeployPackage(ctx, workerName, w.Spec.Package, true); err != nil {
-		return r.failUpdate(ctx, w, err.Error())
-	}
-	if err := r.Deployer.WriteInlineConfigs(workerName, w.Spec); err != nil {
-		return r.failUpdate(ctx, w, fmt.Sprintf("write inline configs failed: %v", err))
-	}
-
-	// --- Phase 2: Refresh credentials + MCP auth ---
-	refreshResult, err := r.Provisioner.RefreshCredentials(ctx, workerName)
-	if err != nil {
-		return r.failUpdate(ctx, w, err.Error())
-	}
-
-	var authorizedMCPs []string
-	if len(w.Spec.McpServers) > 0 {
-		authorizedMCPs, err = r.Provisioner.ReconcileMCPAuth(ctx, consumerName, w.Spec.McpServers)
-		if err != nil {
-			logger.Error(err, "MCP reauthorization failed (non-fatal)")
-		}
-	}
-
-	// --- Phase 3: Deploy configuration ---
-	if err := r.Deployer.DeployWorkerConfig(ctx, service.WorkerDeployRequest{
-		Name:              workerName,
-		Spec:              w.Spec,
-		Role:              roleForAnnotations(role, teamLeaderName),
-		TeamName:          teamName,
-		TeamLeaderName:    teamLeaderName,
-		MatrixToken:       refreshResult.MatrixToken,
-		GatewayKey:        refreshResult.GatewayKey,
-		MatrixPassword:    refreshResult.MatrixPassword,
-		AuthorizedMCPs:    authorizedMCPs,
-		TeamAdminMatrixID: teamAdminMatrixID,
-		IsUpdate:          true,
-	}); err != nil {
-		return r.failUpdate(ctx, w, err.Error())
-	}
-
-	// --- Phase 4: On-demand skills ---
-	if err := r.Deployer.PushOnDemandSkills(ctx, workerName, w.Spec.Skills); err != nil {
-		logger.Error(err, "skill push failed (non-fatal)")
-	}
-
-	// --- Phase 5: Legacy compat ---
-	if r.Legacy != nil && r.Legacy.Enabled() {
-		_ = r.Legacy.UpdateWorkersRegistry(service.WorkerRegistryEntry{
-			Name:         workerName,
-			MatrixUserID: r.Provisioner.MatrixUserID(workerName),
-			RoomID:       w.Status.RoomID,
-			Runtime:      w.Spec.Runtime,
-			Deployment:   "local",
-			Skills:       w.Spec.Skills,
-			Role:         role,
-			TeamID:       nilIfEmpty(teamName),
-			Image:        nilIfEmpty(w.Spec.Image),
-		})
-	}
-
-	// --- Phase 6: Expose + Status ---
-	exposedPorts, exposeErr := r.Provisioner.ReconcileExpose(ctx, workerName, w.Spec.Expose, w.Status.ExposedPorts)
-	if exposeErr != nil {
-		logger.Error(exposeErr, "failed to reconcile exposed ports (non-fatal)")
-	}
-
-	_ = r.Get(ctx, client.ObjectKeyFromObject(w), w)
-	w.Status.ObservedGeneration = w.Generation
-	w.Status.Phase = "Running"
-	w.Status.Message = "Configuration updated (memory preserved, skills merged)"
-	w.Status.ExposedPorts = exposedPorts
-	if err := r.Status().Update(ctx, w); err != nil {
-		logger.Error(err, "failed to update status after update (non-fatal)")
-	}
-
-	logger.Info("worker updated", "name", workerName)
-	return reconcile.Result{}, nil
-}
-
-func (r *WorkerReconciler) handleDelete(ctx context.Context, w *v1beta1.Worker) error {
-	logger := log.FromContext(ctx)
-	logger.Info("deleting worker", "name", w.Name)
-
-	workerName := w.Name
-	isTeamWorker := w.Annotations["hiclaw.io/team-leader"] != ""
-
-	// --- Phase 1: Deprovision infrastructure ---
-	if err := r.Provisioner.DeprovisionWorker(ctx, service.WorkerDeprovisionRequest{
-		Name:         workerName,
-		IsTeamWorker: isTeamWorker,
-		McpServers:   w.Spec.McpServers,
-		ExposedPorts: w.Status.ExposedPorts,
-		ExposeSpec:   w.Spec.Expose,
-	}); err != nil {
-		logger.Error(err, "deprovision failed (non-fatal)")
-	}
-
-	// --- Phase 2: Delete worker container ---
-	if r.Backend != nil {
-		if wb := r.Backend.DetectWorkerBackend(ctx); wb != nil {
-			if err := wb.Delete(ctx, workerName); err != nil {
-				logger.Error(err, "failed to delete worker container (may already be removed)")
-			}
-		}
-	}
-
-	// --- Phase 3: Legacy compat ---
-	if r.Legacy != nil && r.Legacy.Enabled() {
-		workerMatrixID := r.Provisioner.MatrixUserID(workerName)
-		if !isTeamWorker {
-			if err := r.Legacy.UpdateManagerGroupAllowFrom(workerMatrixID, false); err != nil {
-				logger.Error(err, "failed to update Manager groupAllowFrom (non-fatal)")
-			}
-		}
-		if err := r.Legacy.RemoveFromWorkersRegistry(workerName); err != nil {
-			logger.Error(err, "failed to remove from workers registry (non-fatal)")
-		}
-	}
-
-	// --- Phase 4: Clean up OSS + credentials + SA ---
-	if err := r.Deployer.CleanupOSSData(ctx, workerName); err != nil {
-		logger.Error(err, "failed to clean up OSS agent data (non-fatal)")
-	}
-	if err := r.Provisioner.DeleteCredentials(ctx, workerName); err != nil {
-		logger.Error(err, "failed to delete credentials (non-fatal)")
-	}
-	if err := r.Provisioner.DeleteServiceAccount(ctx, workerName); err != nil {
-		logger.Error(err, "failed to delete ServiceAccount (non-fatal)")
-	}
-
-	logger.Info("worker deleted", "name", workerName)
-	return nil
-}
-
-func (r *WorkerReconciler) failCreate(ctx context.Context, w *v1beta1.Worker, msg string) (reconcile.Result, error) {
-	_ = r.Get(ctx, client.ObjectKeyFromObject(w), w)
-	w.Status.Phase = "Failed"
-	w.Status.Message = msg
-	r.Status().Update(ctx, w)
-	return reconcile.Result{RequeueAfter: time.Minute}, fmt.Errorf("%s", msg)
-}
-
-func (r *WorkerReconciler) failUpdate(ctx context.Context, w *v1beta1.Worker, msg string) (reconcile.Result, error) {
-	_ = r.Get(ctx, client.ObjectKeyFromObject(w), w)
-	w.Status.Phase = "Running"
-	w.Status.Message = msg
-	r.Status().Update(ctx, w)
-	return reconcile.Result{RequeueAfter: time.Minute}, fmt.Errorf("%s", msg)
-}
-
-// --- Desired state reconciliation ---
-
-// reconcileDesiredState compares the desired lifecycle state (spec.state) with
-// the actual backend state and takes corrective action when drift is detected.
-func (r *WorkerReconciler) reconcileDesiredState(ctx context.Context, w *v1beta1.Worker, desired string) (reconcile.Result, error) {
-	// If current phase already matches desired state, nothing to do.
-	// This also avoids unnecessary backend Status calls on every reconcile.
-	if w.Status.Phase == desired {
-		return reconcile.Result{}, nil
-	}
-
-	logger := log.FromContext(ctx)
-	logger.Info("reconciling desired state", "name", w.Name, "current", w.Status.Phase, "desired", desired)
-
-	switch desired {
-	case "Running":
-		return r.ensureWorkerRunning(ctx, w)
-	case "Sleeping":
-		return r.ensureWorkerSleeping(ctx, w)
-	case "Stopped":
-		return r.ensureWorkerStopped(ctx, w)
-	default:
-		logger.Info("unknown desired state, ignoring", "state", desired)
-		return reconcile.Result{}, nil
-	}
-}
-
-// ensureWorkerRunning wakes a worker from Sleeping or Stopped state.
-func (r *WorkerReconciler) ensureWorkerRunning(ctx context.Context, w *v1beta1.Worker) (reconcile.Result, error) {
-	logger := log.FromContext(ctx)
-
-	if r.Backend == nil {
-		return reconcile.Result{}, nil
-	}
-	wb := r.Backend.DetectWorkerBackend(ctx)
-	if wb == nil {
-		return reconcile.Result{}, nil
-	}
-
-	result, err := wb.Status(ctx, w.Name)
-	if err != nil {
-		logger.Error(err, "failed to check backend status")
-		return reconcile.Result{RequeueAfter: reconcileRetryDelay}, nil
-	}
-
-	switch {
-	case result.Status == backend.StatusRunning || result.Status == backend.StatusStarting:
-		// Already running — just update status.phase
-	case result.Status == backend.StatusStopped && wb.Name() == "docker":
-		// Docker Sleeping: container exists but stopped → docker start
-		if err := wb.Start(ctx, w.Name); err != nil {
-			return r.failLifecycle(ctx, w, fmt.Sprintf("start failed: %v", err))
-		}
-	default:
-		// Container removed (Docker Stopped) or pod deleted (K8s) → recreate
-		if err := r.recreateWorkerContainer(ctx, w, wb); err != nil {
-			return r.failLifecycle(ctx, w, fmt.Sprintf("recreate failed: %v", err))
-		}
-	}
-
-	_ = r.Get(ctx, client.ObjectKeyFromObject(w), w)
-	w.Status.Phase = "Running"
-	w.Status.Message = ""
-	r.Status().Update(ctx, w)
-
-	logger.Info("worker running", "name", w.Name)
-	return reconcile.Result{}, nil
-}
-
-// ensureWorkerSleeping stops a worker: docker stop (container kept) or delete pod (K8s).
-func (r *WorkerReconciler) ensureWorkerSleeping(ctx context.Context, w *v1beta1.Worker) (reconcile.Result, error) {
-	logger := log.FromContext(ctx)
-
-	if r.Backend == nil {
-		return reconcile.Result{}, nil
-	}
-	wb := r.Backend.DetectWorkerBackend(ctx)
-	if wb == nil {
-		return reconcile.Result{}, nil
-	}
-
-	if err := wb.Stop(ctx, w.Name); err != nil && !errors.Is(err, backend.ErrNotFound) {
-		return r.failLifecycle(ctx, w, fmt.Sprintf("sleep failed: %v", err))
-	}
-
-	_ = r.Get(ctx, client.ObjectKeyFromObject(w), w)
-	w.Status.Phase = "Sleeping"
-	w.Status.Message = ""
-	r.Status().Update(ctx, w)
-
-	logger.Info("worker sleeping", "name", w.Name)
-	return reconcile.Result{}, nil
-}
-
-// ensureWorkerStopped stops and removes a worker: docker stop+rm or delete pod (K8s).
-func (r *WorkerReconciler) ensureWorkerStopped(ctx context.Context, w *v1beta1.Worker) (reconcile.Result, error) {
-	logger := log.FromContext(ctx)
-
-	if r.Backend == nil {
-		return reconcile.Result{}, nil
-	}
-	wb := r.Backend.DetectWorkerBackend(ctx)
-	if wb == nil {
-		return reconcile.Result{}, nil
-	}
-
-	_ = wb.Stop(ctx, w.Name) // best-effort stop first
-	if err := wb.Delete(ctx, w.Name); err != nil && !errors.Is(err, backend.ErrNotFound) {
-		return r.failLifecycle(ctx, w, fmt.Sprintf("stop failed: %v", err))
-	}
-
-	_ = r.Get(ctx, client.ObjectKeyFromObject(w), w)
-	w.Status.Phase = "Stopped"
-	w.Status.Message = ""
-	r.Status().Update(ctx, w)
-
-	logger.Info("worker stopped", "name", w.Name)
-	return reconcile.Result{}, nil
-}
-
-// recreateWorkerContainer rebuilds a worker container/pod from the Worker CR spec
-// and stored credentials. Used when waking from Stopped (container removed) or
-// K8s (pod deleted).
-func (r *WorkerReconciler) recreateWorkerContainer(ctx context.Context, w *v1beta1.Worker, wb backend.WorkerBackend) error {
-	logger := log.FromContext(ctx)
-	workerName := w.Name
-
-	// Refresh credentials from persisted store
-	refreshResult, err := r.Provisioner.RefreshCredentials(ctx, workerName)
-	if err != nil {
-		return fmt.Errorf("refresh credentials: %w", err)
-	}
-
-	// Ensure ServiceAccount still exists
-	if err := r.Provisioner.EnsureServiceAccount(ctx, workerName); err != nil {
-		logger.Error(err, "ServiceAccount ensure during recreate (non-fatal)")
-	}
-
-	// Build env from stored credentials
-	workerEnv := r.EnvBuilder.Build(workerName, &service.WorkerProvisionResult{
-		MatrixToken:    refreshResult.MatrixToken,
-		GatewayKey:     refreshResult.GatewayKey,
-		MinIOPassword:  refreshResult.MinIOPassword,
-		MatrixPassword: refreshResult.MatrixPassword,
-	})
-
-	// Build create request
-	saName := authpkg.SAName(authpkg.RoleWorker, workerName)
-	createReq := backend.CreateRequest{
-		Name:               workerName,
-		Image:              w.Spec.Image,
-		Runtime:            w.Spec.Runtime,
-		Env:                workerEnv,
-		ServiceAccountName: saName,
-	}
-	if wb.Name() != "k8s" {
-		token, err := r.Provisioner.RequestSAToken(ctx, workerName)
-		if err != nil {
-			logger.Error(err, "SA token request during recreate (non-fatal)")
-		}
-		createReq.AuthToken = token
-	}
-
-	if _, err := wb.Create(ctx, createReq); err != nil {
-		return fmt.Errorf("container recreate: %w", err)
-	}
-	return nil
-}
-
-func (r *WorkerReconciler) failLifecycle(ctx context.Context, w *v1beta1.Worker, msg string) (reconcile.Result, error) {
-	_ = r.Get(ctx, client.ObjectKeyFromObject(w), w)
-	w.Status.Message = msg
-	r.Status().Update(ctx, w)
-	return reconcile.Result{RequeueAfter: time.Minute}, fmt.Errorf("%s", msg)
 }
 
 func (r *WorkerReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	builder := ctrl.NewControllerManagedBy(mgr).
+	bldr := ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.Worker{})
 
-	// In-cluster mode: watch Pod events with hiclaw.io/worker label,
-	// map to corresponding Worker CR for immediate reconcile on pod failure/deletion.
 	if r.Backend != nil {
 		if wb := r.Backend.DetectWorkerBackend(context.Background()); wb != nil && wb.Name() == "k8s" {
-			builder = builder.Watches(
+			bldr = bldr.Watches(
 				&corev1.Pod{},
 				handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
 					workerName := obj.GetLabels()["hiclaw.io/worker"]
@@ -590,11 +180,39 @@ func (r *WorkerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 						{NamespacedName: client.ObjectKey{Name: workerName}},
 					}
 				}),
+				builder.WithPredicates(podLifecyclePredicates()),
 			)
 		}
 	}
 
-	return builder.Complete(r)
+	return bldr.Complete(r)
+}
+
+// podLifecyclePredicates filters Pod events to only trigger reconciliation
+// on create, delete, or phase transitions (not every status update).
+func podLifecyclePredicates() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object.GetLabels()["hiclaw.io/worker"] != ""
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return e.Object.GetLabels()["hiclaw.io/worker"] != ""
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectNew.GetLabels()["hiclaw.io/worker"] == "" {
+				return false
+			}
+			oldPod, ok1 := e.ObjectOld.(*corev1.Pod)
+			newPod, ok2 := e.ObjectNew.(*corev1.Pod)
+			if !ok1 || !ok2 {
+				return true
+			}
+			return oldPod.Status.Phase != newPod.Status.Phase
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
 }
 
 // --- Package-level helpers ---
@@ -615,3 +233,6 @@ func roleForAnnotations(role, teamLeaderName string) string {
 	}
 	return "standalone"
 }
+
+// Suppress unused import for fmt (used by sub-reconcilers in other files).
+var _ = fmt.Errorf

--- a/hiclaw-controller/internal/controller/worker_controller.go
+++ b/hiclaw-controller/internal/controller/worker_controller.go
@@ -29,10 +29,10 @@ const (
 type WorkerReconciler struct {
 	client.Client
 
-	Provisioner *service.Provisioner
-	Deployer    *service.Deployer
+	Provisioner service.WorkerProvisioner
+	Deployer    service.WorkerDeployer
 	Backend     *backend.Registry
-	EnvBuilder  *service.WorkerEnvBuilder
+	EnvBuilder  service.WorkerEnvBuilderI
 	Legacy      *service.LegacyCompat // nil in incluster mode
 }
 

--- a/hiclaw-controller/internal/controller/worker_reconcile_config.go
+++ b/hiclaw-controller/internal/controller/worker_reconcile_config.go
@@ -1,0 +1,70 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hiclaw/hiclaw-controller/internal/service"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// reconcileConfig ensures all configuration (package, inline configs, openclaw.json,
+// SOUL.md, mcporter config, AGENTS.md, builtin skills) is deployed to OSS.
+// Idempotent: safe to re-run; OSS writes overwrite existing files.
+func (r *WorkerReconciler) reconcileConfig(ctx context.Context, s *workerScope) (reconcile.Result, error) {
+	if s.provResult == nil {
+		return reconcile.Result{}, nil
+	}
+
+	w := s.worker
+	logger := log.FromContext(ctx)
+	workerName := w.Name
+	role := w.Annotations["hiclaw.io/role"]
+	teamName := w.Annotations["hiclaw.io/team"]
+	teamLeaderName := w.Annotations["hiclaw.io/team-leader"]
+	teamAdminMatrixID := w.Annotations["hiclaw.io/team-admin-id"]
+	consumerName := "worker-" + workerName
+
+	isUpdate := w.Status.Phase != "" && w.Status.Phase != "Pending" && w.Status.Phase != "Failed"
+
+	if err := r.Deployer.DeployPackage(ctx, workerName, w.Spec.Package, isUpdate); err != nil {
+		return reconcile.Result{}, fmt.Errorf("deploy package: %w", err)
+	}
+	if err := r.Deployer.WriteInlineConfigs(workerName, w.Spec); err != nil {
+		return reconcile.Result{}, fmt.Errorf("write inline configs: %w", err)
+	}
+
+	var authorizedMCPs []string
+	if isUpdate && len(w.Spec.McpServers) > 0 {
+		var err error
+		authorizedMCPs, err = r.Provisioner.ReconcileMCPAuth(ctx, consumerName, w.Spec.McpServers)
+		if err != nil {
+			logger.Error(err, "MCP reauthorization failed (non-fatal)")
+		}
+	} else {
+		authorizedMCPs = s.provResult.AuthorizedMCPs
+	}
+
+	if err := r.Deployer.DeployWorkerConfig(ctx, service.WorkerDeployRequest{
+		Name:              workerName,
+		Spec:              w.Spec,
+		Role:              roleForAnnotations(role, teamLeaderName),
+		TeamName:          teamName,
+		TeamLeaderName:    teamLeaderName,
+		MatrixToken:       s.provResult.MatrixToken,
+		GatewayKey:        s.provResult.GatewayKey,
+		MatrixPassword:    s.provResult.MatrixPassword,
+		AuthorizedMCPs:    authorizedMCPs,
+		TeamAdminMatrixID: teamAdminMatrixID,
+		IsUpdate:          isUpdate,
+	}); err != nil {
+		return reconcile.Result{}, fmt.Errorf("deploy worker config: %w", err)
+	}
+
+	if err := r.Deployer.PushOnDemandSkills(ctx, workerName, w.Spec.Skills); err != nil {
+		logger.Error(err, "skill push failed (non-fatal)")
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/hiclaw-controller/internal/controller/worker_reconcile_container.go
+++ b/hiclaw-controller/internal/controller/worker_reconcile_container.go
@@ -51,30 +51,47 @@ func (r *WorkerReconciler) ensureContainerPresent(ctx context.Context, s *worker
 
 	logger := log.FromContext(ctx)
 	result, err := wb.Status(ctx, w.Name)
-	if err == nil {
-		switch result.Status {
-		case backend.StatusRunning, backend.StatusStarting, backend.StatusReady:
-			if w.Generation != w.Status.ObservedGeneration {
-				logger.Info("spec changed, recreating container",
-					"generation", w.Generation,
-					"observedGeneration", w.Status.ObservedGeneration)
-				if err := wb.Delete(ctx, w.Name); err != nil && !errors.Is(err, backend.ErrNotFound) {
-					return reconcile.Result{}, fmt.Errorf("delete container for recreate: %w", err)
-				}
-				return r.createWorkerContainer(ctx, s, wb)
-			}
-			return reconcile.Result{}, nil
-		case backend.StatusStopped:
-			if wb.Name() == "docker" {
-				if err := wb.Start(ctx, w.Name); err != nil {
-					return reconcile.Result{}, fmt.Errorf("start container: %w", err)
-				}
-				return reconcile.Result{}, nil
-			}
-		}
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("query container status: %w", err)
 	}
 
-	return r.createWorkerContainer(ctx, s, wb)
+	specChanged := w.Generation != w.Status.ObservedGeneration
+
+	switch result.Status {
+	case backend.StatusRunning, backend.StatusStarting, backend.StatusReady:
+		if !specChanged {
+			return reconcile.Result{}, nil
+		}
+		logger.Info("spec changed, recreating container",
+			"generation", w.Generation,
+			"observedGeneration", w.Status.ObservedGeneration)
+		if err := wb.Delete(ctx, w.Name); err != nil && !errors.Is(err, backend.ErrNotFound) {
+			return reconcile.Result{}, fmt.Errorf("delete container for recreate: %w", err)
+		}
+		return r.createWorkerContainer(ctx, s, wb)
+
+	case backend.StatusStopped:
+		if wb.Name() == "docker" && !specChanged {
+			if err := wb.Start(ctx, w.Name); err != nil {
+				return reconcile.Result{}, fmt.Errorf("start container: %w", err)
+			}
+			return reconcile.Result{}, nil
+		}
+		if err := wb.Delete(ctx, w.Name); err != nil && !errors.Is(err, backend.ErrNotFound) {
+			return reconcile.Result{}, fmt.Errorf("delete stale container: %w", err)
+		}
+		return r.createWorkerContainer(ctx, s, wb)
+
+	case backend.StatusNotFound:
+		return r.createWorkerContainer(ctx, s, wb)
+
+	default:
+		logger.Info("container in unexpected state, recreating", "status", result.Status)
+		if err := wb.Delete(ctx, w.Name); err != nil && !errors.Is(err, backend.ErrNotFound) {
+			return reconcile.Result{}, fmt.Errorf("delete container in unknown state: %w", err)
+		}
+		return r.createWorkerContainer(ctx, s, wb)
+	}
 }
 
 // ensureContainerAbsent ensures a worker container is not running.
@@ -92,7 +109,6 @@ func (r *WorkerReconciler) ensureContainerAbsent(ctx context.Context, s *workerS
 	}
 
 	if remove {
-		_ = wb.Stop(ctx, w.Name)
 		if err := wb.Delete(ctx, w.Name); err != nil && !errors.Is(err, backend.ErrNotFound) {
 			return reconcile.Result{}, fmt.Errorf("delete container: %w", err)
 		}

--- a/hiclaw-controller/internal/controller/worker_reconcile_container.go
+++ b/hiclaw-controller/internal/controller/worker_reconcile_container.go
@@ -34,8 +34,10 @@ func (r *WorkerReconciler) reconcileContainer(ctx context.Context, s *workerScop
 }
 
 // ensureContainerPresent ensures a worker container is running. If the
-// container does not exist or was deleted, it is (re)created. If it exists
-// but is stopped (Docker), it is started.
+// container does not exist or was deleted, it is (re)created. If the spec
+// has changed (Generation != ObservedGeneration) while the container is
+// running, the old container is deleted and a new one created so the worker
+// picks up the latest configuration on startup.
 func (r *WorkerReconciler) ensureContainerPresent(ctx context.Context, s *workerScope) (reconcile.Result, error) {
 	w := s.worker
 	if r.Backend == nil {
@@ -47,10 +49,20 @@ func (r *WorkerReconciler) ensureContainerPresent(ctx context.Context, s *worker
 		return reconcile.Result{}, nil
 	}
 
+	logger := log.FromContext(ctx)
 	result, err := wb.Status(ctx, w.Name)
 	if err == nil {
 		switch result.Status {
 		case backend.StatusRunning, backend.StatusStarting, backend.StatusReady:
+			if w.Generation != w.Status.ObservedGeneration {
+				logger.Info("spec changed, recreating container",
+					"generation", w.Generation,
+					"observedGeneration", w.Status.ObservedGeneration)
+				if err := wb.Delete(ctx, w.Name); err != nil && !errors.Is(err, backend.ErrNotFound) {
+					return reconcile.Result{}, fmt.Errorf("delete container for recreate: %w", err)
+				}
+				return r.createWorkerContainer(ctx, s, wb)
+			}
 			return reconcile.Result{}, nil
 		case backend.StatusStopped:
 			if wb.Name() == "docker" {

--- a/hiclaw-controller/internal/controller/worker_reconcile_container.go
+++ b/hiclaw-controller/internal/controller/worker_reconcile_container.go
@@ -1,0 +1,143 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	authpkg "github.com/hiclaw/hiclaw-controller/internal/auth"
+	"github.com/hiclaw/hiclaw-controller/internal/backend"
+	"github.com/hiclaw/hiclaw-controller/internal/service"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// reconcileContainer ensures the worker container/pod matches the desired
+// lifecycle state (Running/Sleeping/Stopped). Idempotent: checks actual
+// backend state before acting.
+func (r *WorkerReconciler) reconcileContainer(ctx context.Context, s *workerScope) (reconcile.Result, error) {
+	if s.provResult == nil {
+		return reconcile.Result{}, nil
+	}
+
+	w := s.worker
+	desired := w.Spec.DesiredState()
+
+	switch desired {
+	case "Stopped":
+		return r.ensureContainerAbsent(ctx, s, true)
+	case "Sleeping":
+		return r.ensureContainerAbsent(ctx, s, false)
+	default:
+		return r.ensureContainerPresent(ctx, s)
+	}
+}
+
+// ensureContainerPresent ensures a worker container is running. If the
+// container does not exist or was deleted, it is (re)created. If it exists
+// but is stopped (Docker), it is started.
+func (r *WorkerReconciler) ensureContainerPresent(ctx context.Context, s *workerScope) (reconcile.Result, error) {
+	w := s.worker
+	if r.Backend == nil {
+		return reconcile.Result{}, nil
+	}
+	wb := r.Backend.DetectWorkerBackend(ctx)
+	if wb == nil {
+		log.FromContext(ctx).Info("no worker backend available, worker needs manual start")
+		return reconcile.Result{}, nil
+	}
+
+	result, err := wb.Status(ctx, w.Name)
+	if err == nil {
+		switch result.Status {
+		case backend.StatusRunning, backend.StatusStarting, backend.StatusReady:
+			return reconcile.Result{}, nil
+		case backend.StatusStopped:
+			if wb.Name() == "docker" {
+				if err := wb.Start(ctx, w.Name); err != nil {
+					return reconcile.Result{}, fmt.Errorf("start container: %w", err)
+				}
+				return reconcile.Result{}, nil
+			}
+		}
+	}
+
+	return r.createWorkerContainer(ctx, s, wb)
+}
+
+// ensureContainerAbsent ensures a worker container is not running.
+// If remove is true (Stopped), the container is deleted entirely.
+// If remove is false (Sleeping), the container is stopped but kept (Docker)
+// or deleted (K8s, which has no stop-without-delete).
+func (r *WorkerReconciler) ensureContainerAbsent(ctx context.Context, s *workerScope, remove bool) (reconcile.Result, error) {
+	w := s.worker
+	if r.Backend == nil {
+		return reconcile.Result{}, nil
+	}
+	wb := r.Backend.DetectWorkerBackend(ctx)
+	if wb == nil {
+		return reconcile.Result{}, nil
+	}
+
+	if remove {
+		_ = wb.Stop(ctx, w.Name)
+		if err := wb.Delete(ctx, w.Name); err != nil && !errors.Is(err, backend.ErrNotFound) {
+			return reconcile.Result{}, fmt.Errorf("delete container: %w", err)
+		}
+	} else {
+		if err := wb.Stop(ctx, w.Name); err != nil && !errors.Is(err, backend.ErrNotFound) {
+			return reconcile.Result{}, fmt.Errorf("stop container: %w", err)
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// createWorkerContainer builds and issues a backend Create request.
+// ErrConflict (container already exists) is treated as success for idempotency.
+func (r *WorkerReconciler) createWorkerContainer(ctx context.Context, s *workerScope, wb backend.WorkerBackend) (reconcile.Result, error) {
+	w := s.worker
+	logger := log.FromContext(ctx)
+
+	prov := s.provResult
+	if prov.MatrixToken == "" {
+		refreshResult, err := r.Provisioner.RefreshCredentials(ctx, w.Name)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("refresh credentials for container: %w", err)
+		}
+		prov = &service.WorkerProvisionResult{
+			MatrixUserID:   w.Status.MatrixUserID,
+			MatrixToken:    refreshResult.MatrixToken,
+			RoomID:         w.Status.RoomID,
+			GatewayKey:     refreshResult.GatewayKey,
+			MinIOPassword:  refreshResult.MinIOPassword,
+			MatrixPassword: refreshResult.MatrixPassword,
+		}
+	}
+
+	workerEnv := r.EnvBuilder.Build(w.Name, prov)
+	saName := authpkg.SAName(authpkg.RoleWorker, w.Name)
+	createReq := backend.CreateRequest{
+		Name:               w.Name,
+		Image:              w.Spec.Image,
+		Runtime:            w.Spec.Runtime,
+		Env:                workerEnv,
+		ServiceAccountName: saName,
+	}
+	if wb.Name() != "k8s" {
+		token, err := r.Provisioner.RequestSAToken(ctx, w.Name)
+		if err != nil {
+			logger.Error(err, "SA token request failed (non-fatal, worker auth will fail)")
+		}
+		createReq.AuthToken = token
+	}
+
+	if _, err := wb.Create(ctx, createReq); err != nil {
+		if errors.Is(err, backend.ErrConflict) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("create container: %w", err)
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/hiclaw-controller/internal/controller/worker_reconcile_delete.go
+++ b/hiclaw-controller/internal/controller/worker_reconcile_delete.go
@@ -17,6 +17,10 @@ func (r *WorkerReconciler) reconcileDelete(ctx context.Context, s *workerScope) 
 	workerName := w.Name
 	isTeamWorker := w.Annotations["hiclaw.io/team-leader"] != ""
 
+	if err := r.Provisioner.DeactivateMatrixUser(ctx, workerName); err != nil {
+		logger.Error(err, "matrix user deactivation failed (non-fatal)")
+	}
+
 	if err := r.Provisioner.DeprovisionWorker(ctx, service.WorkerDeprovisionRequest{
 		Name:         workerName,
 		IsTeamWorker: isTeamWorker,

--- a/hiclaw-controller/internal/controller/worker_reconcile_delete.go
+++ b/hiclaw-controller/internal/controller/worker_reconcile_delete.go
@@ -1,0 +1,67 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/hiclaw/hiclaw-controller/internal/service"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func (r *WorkerReconciler) reconcileDelete(ctx context.Context, s *workerScope) (reconcile.Result, error) {
+	logger := log.FromContext(ctx)
+	w := s.worker
+	logger.Info("deleting worker", "name", w.Name)
+
+	workerName := w.Name
+	isTeamWorker := w.Annotations["hiclaw.io/team-leader"] != ""
+
+	if err := r.Provisioner.DeprovisionWorker(ctx, service.WorkerDeprovisionRequest{
+		Name:         workerName,
+		IsTeamWorker: isTeamWorker,
+		McpServers:   w.Spec.McpServers,
+		ExposedPorts: w.Status.ExposedPorts,
+		ExposeSpec:   w.Spec.Expose,
+	}); err != nil {
+		logger.Error(err, "deprovision failed (non-fatal)")
+	}
+
+	if r.Backend != nil {
+		if wb := r.Backend.DetectWorkerBackend(ctx); wb != nil {
+			if err := wb.Delete(ctx, workerName); err != nil {
+				logger.Error(err, "failed to delete worker container (may already be removed)")
+			}
+		}
+	}
+
+	if r.Legacy != nil && r.Legacy.Enabled() {
+		workerMatrixID := r.Provisioner.MatrixUserID(workerName)
+		if !isTeamWorker {
+			if err := r.Legacy.UpdateManagerGroupAllowFrom(workerMatrixID, false); err != nil {
+				logger.Error(err, "failed to update Manager groupAllowFrom (non-fatal)")
+			}
+		}
+		if err := r.Legacy.RemoveFromWorkersRegistry(workerName); err != nil {
+			logger.Error(err, "failed to remove from workers registry (non-fatal)")
+		}
+	}
+
+	if err := r.Deployer.CleanupOSSData(ctx, workerName); err != nil {
+		logger.Error(err, "failed to clean up OSS agent data (non-fatal)")
+	}
+	if err := r.Provisioner.DeleteCredentials(ctx, workerName); err != nil {
+		logger.Error(err, "failed to delete credentials (non-fatal)")
+	}
+	if err := r.Provisioner.DeleteServiceAccount(ctx, workerName); err != nil {
+		logger.Error(err, "failed to delete ServiceAccount (non-fatal)")
+	}
+
+	controllerutil.RemoveFinalizer(w, finalizerName)
+	if err := r.Update(ctx, w); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	logger.Info("worker deleted", "name", workerName)
+	return reconcile.Result{}, nil
+}

--- a/hiclaw-controller/internal/controller/worker_reconcile_infra.go
+++ b/hiclaw-controller/internal/controller/worker_reconcile_infra.go
@@ -1,0 +1,61 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hiclaw/hiclaw-controller/internal/service"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// reconcileInfrastructure ensures Matrix account, Gateway consumer, MinIO user,
+// Matrix room, and credentials are provisioned. Idempotent: if already
+// provisioned (MatrixUserID set), it refreshes credentials from the persisted store.
+func (r *WorkerReconciler) reconcileInfrastructure(ctx context.Context, s *workerScope) (reconcile.Result, error) {
+	w := s.worker
+
+	if w.Status.MatrixUserID != "" {
+		refreshResult, err := r.Provisioner.RefreshCredentials(ctx, w.Name)
+		if err != nil {
+			return reconcile.Result{RequeueAfter: time.Minute}, fmt.Errorf("refresh credentials: %w", err)
+		}
+		s.provResult = &service.WorkerProvisionResult{
+			MatrixUserID:   w.Status.MatrixUserID,
+			MatrixToken:    refreshResult.MatrixToken,
+			RoomID:         w.Status.RoomID,
+			GatewayKey:     refreshResult.GatewayKey,
+			MinIOPassword:  refreshResult.MinIOPassword,
+			MatrixPassword: refreshResult.MatrixPassword,
+		}
+		return reconcile.Result{}, nil
+	}
+
+	logger := log.FromContext(ctx)
+	logger.Info("provisioning worker infrastructure", "name", w.Name)
+
+	role := w.Annotations["hiclaw.io/role"]
+	teamLeaderName := w.Annotations["hiclaw.io/team-leader"]
+
+	provResult, err := r.Provisioner.ProvisionWorker(ctx, service.WorkerProvisionRequest{
+		Name:           w.Name,
+		Role:           roleForAnnotations(role, teamLeaderName),
+		TeamName:       w.Annotations["hiclaw.io/team"],
+		TeamLeaderName: teamLeaderName,
+		McpServers:     w.Spec.McpServers,
+	})
+	if err != nil {
+		return reconcile.Result{RequeueAfter: time.Minute}, fmt.Errorf("provision worker: %w", err)
+	}
+
+	w.Status.MatrixUserID = provResult.MatrixUserID
+	w.Status.RoomID = provResult.RoomID
+	s.provResult = provResult
+
+	if err := r.Provisioner.EnsureServiceAccount(ctx, w.Name); err != nil {
+		return reconcile.Result{RequeueAfter: time.Minute}, fmt.Errorf("ServiceAccount creation: %w", err)
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/hiclaw-controller/internal/controller/worker_reconcile_infra.go
+++ b/hiclaw-controller/internal/controller/worker_reconcile_infra.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -19,7 +18,7 @@ func (r *WorkerReconciler) reconcileInfrastructure(ctx context.Context, s *worke
 	if w.Status.MatrixUserID != "" {
 		refreshResult, err := r.Provisioner.RefreshCredentials(ctx, w.Name)
 		if err != nil {
-			return reconcile.Result{RequeueAfter: time.Minute}, fmt.Errorf("refresh credentials: %w", err)
+			return reconcile.Result{}, fmt.Errorf("refresh credentials: %w", err)
 		}
 		s.provResult = &service.WorkerProvisionResult{
 			MatrixUserID:   w.Status.MatrixUserID,
@@ -46,7 +45,7 @@ func (r *WorkerReconciler) reconcileInfrastructure(ctx context.Context, s *worke
 		McpServers:     w.Spec.McpServers,
 	})
 	if err != nil {
-		return reconcile.Result{RequeueAfter: time.Minute}, fmt.Errorf("provision worker: %w", err)
+		return reconcile.Result{}, fmt.Errorf("provision worker: %w", err)
 	}
 
 	w.Status.MatrixUserID = provResult.MatrixUserID
@@ -54,7 +53,7 @@ func (r *WorkerReconciler) reconcileInfrastructure(ctx context.Context, s *worke
 	s.provResult = provResult
 
 	if err := r.Provisioner.EnsureServiceAccount(ctx, w.Name); err != nil {
-		return reconcile.Result{RequeueAfter: time.Minute}, fmt.Errorf("ServiceAccount creation: %w", err)
+		return reconcile.Result{}, fmt.Errorf("ServiceAccount creation: %w", err)
 	}
 
 	return reconcile.Result{}, nil

--- a/hiclaw-controller/internal/controller/worker_scope.go
+++ b/hiclaw-controller/internal/controller/worker_scope.go
@@ -1,0 +1,26 @@
+package controller
+
+import (
+	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	"github.com/hiclaw/hiclaw-controller/internal/service"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type workerScope struct {
+	worker     *v1beta1.Worker
+	provResult *service.WorkerProvisionResult
+	patchBase  client.Patch
+}
+
+// computePhase determines the Worker status phase based on reconcile outcome.
+// When reconcile succeeds, phase reflects the desired lifecycle state.
+// When reconcile fails, phase depends on whether infrastructure was provisioned.
+func computePhase(w *v1beta1.Worker, reconcileErr error) string {
+	if reconcileErr != nil {
+		if w.Status.MatrixUserID == "" {
+			return "Failed"
+		}
+		return w.Status.Phase
+	}
+	return w.Spec.DesiredState()
+}

--- a/hiclaw-controller/internal/controller/worker_scope.go
+++ b/hiclaw-controller/internal/controller/worker_scope.go
@@ -20,6 +20,11 @@ func computePhase(w *v1beta1.Worker, reconcileErr error) string {
 		if w.Status.MatrixUserID == "" {
 			return "Failed"
 		}
+		// TODO: Introduce Status.Conditions (Ready/Provisioned) to surface
+		// transient errors without flipping Phase away from Running. Currently
+		// we keep the old Phase to avoid marking a healthy worker as Failed on
+		// a temporary config-deploy or OSS failure; the error is recorded in
+		// Status.Message instead.
 		return w.Status.Phase
 	}
 	return w.Spec.DesiredState()

--- a/hiclaw-controller/internal/matrix/client.go
+++ b/hiclaw-controller/internal/matrix/client.go
@@ -34,6 +34,11 @@ type Client interface {
 	// Login obtains an access token for an existing user.
 	Login(ctx context.Context, username, password string) (string, error)
 
+	// DeactivateUser permanently deactivates a Matrix account via the
+	// Synapse Admin API. The user will no longer be able to log in.
+	// Message history is preserved (erase=false).
+	DeactivateUser(ctx context.Context, username string) error
+
 	// UserID builds a full Matrix user ID from a localpart.
 	UserID(localpart string) string
 }
@@ -268,6 +273,29 @@ func (c *TuwunelClient) SendMessage(ctx context.Context, roomID, token, body str
 	}
 	if statusCode != http.StatusOK && statusCode != http.StatusCreated {
 		return fmt.Errorf("send message to %s: HTTP %d", roomID, statusCode)
+	}
+	return nil
+}
+
+func (c *TuwunelClient) DeactivateUser(ctx context.Context, username string) error {
+	token, err := c.ensureAdminToken(ctx)
+	if err != nil {
+		return fmt.Errorf("deactivate user %s: %w", username, err)
+	}
+	userID := c.UserID(username)
+	body := map[string]interface{}{"erase": false}
+
+	statusCode, err := c.doJSON(ctx, http.MethodPost,
+		fmt.Sprintf("/_synapse/admin/v1/deactivate/%s", encodeRoomID(userID)),
+		token, body, nil)
+	if err != nil {
+		return fmt.Errorf("deactivate user %s: %w", username, err)
+	}
+	if statusCode == http.StatusNotFound {
+		return nil
+	}
+	if statusCode != http.StatusOK {
+		return fmt.Errorf("deactivate user %s: HTTP %d", username, statusCode)
 	}
 	return nil
 }

--- a/hiclaw-controller/internal/service/interfaces.go
+++ b/hiclaw-controller/internal/service/interfaces.go
@@ -18,6 +18,7 @@ type WorkerProvisioner interface {
 	DeleteServiceAccount(ctx context.Context, workerName string) error
 	DeleteCredentials(ctx context.Context, workerName string) error
 	RequestSAToken(ctx context.Context, workerName string) (string, error)
+	DeactivateMatrixUser(ctx context.Context, workerName string) error
 	MatrixUserID(name string) string
 }
 

--- a/hiclaw-controller/internal/service/interfaces.go
+++ b/hiclaw-controller/internal/service/interfaces.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"context"
+
+	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+)
+
+// WorkerProvisioner defines the provisioning operations used by WorkerReconciler.
+// Implemented by *Provisioner; extracted for testability.
+type WorkerProvisioner interface {
+	ProvisionWorker(ctx context.Context, req WorkerProvisionRequest) (*WorkerProvisionResult, error)
+	DeprovisionWorker(ctx context.Context, req WorkerDeprovisionRequest) error
+	RefreshCredentials(ctx context.Context, workerName string) (*RefreshResult, error)
+	ReconcileMCPAuth(ctx context.Context, consumerName string, mcpServers []string) ([]string, error)
+	ReconcileExpose(ctx context.Context, workerName string, desired []v1beta1.ExposePort, current []v1beta1.ExposedPortStatus) ([]v1beta1.ExposedPortStatus, error)
+	EnsureServiceAccount(ctx context.Context, workerName string) error
+	DeleteServiceAccount(ctx context.Context, workerName string) error
+	DeleteCredentials(ctx context.Context, workerName string) error
+	RequestSAToken(ctx context.Context, workerName string) (string, error)
+	MatrixUserID(name string) string
+}
+
+// WorkerDeployer defines the deployment operations used by WorkerReconciler.
+// Implemented by *Deployer; extracted for testability.
+type WorkerDeployer interface {
+	DeployPackage(ctx context.Context, name, uri string, isUpdate bool) error
+	WriteInlineConfigs(name string, spec v1beta1.WorkerSpec) error
+	DeployWorkerConfig(ctx context.Context, req WorkerDeployRequest) error
+	PushOnDemandSkills(ctx context.Context, workerName string, skills []string) error
+	CleanupOSSData(ctx context.Context, workerName string) error
+}
+
+// WorkerEnvBuilderI defines env map construction for worker containers.
+// Implemented by *WorkerEnvBuilder; extracted for testability.
+type WorkerEnvBuilderI interface {
+	Build(workerName string, prov *WorkerProvisionResult) map[string]string
+}
+
+// Compile-time interface satisfaction checks.
+var (
+	_ WorkerProvisioner = (*Provisioner)(nil)
+	_ WorkerDeployer    = (*Deployer)(nil)
+	_ WorkerEnvBuilderI = (*WorkerEnvBuilder)(nil)
+)

--- a/hiclaw-controller/internal/service/provisioner.go
+++ b/hiclaw-controller/internal/service/provisioner.go
@@ -130,6 +130,10 @@ func (p *Provisioner) MatrixUserID(name string) string {
 	return p.matrix.UserID(name)
 }
 
+func (p *Provisioner) DeactivateMatrixUser(ctx context.Context, workerName string) error {
+	return p.matrix.DeactivateUser(ctx, workerName)
+}
+
 // ProvisionWorker executes the full infrastructure setup for a new worker:
 // credentials, Matrix account, MinIO user, Matrix room, Gateway consumer.
 func (p *Provisioner) ProvisionWorker(ctx context.Context, req WorkerProvisionRequest) (*WorkerProvisionResult, error) {

--- a/hiclaw-controller/internal/service/worker_env.go
+++ b/hiclaw-controller/internal/service/worker_env.go
@@ -47,8 +47,6 @@ func (b *WorkerEnvBuilder) BuildManager(managerName string, prov *ManagerProvisi
 		"HICLAW_MANAGER_PASSWORD":    prov.MatrixPassword,
 		"HICLAW_FS_ACCESS_KEY":       managerName,
 		"HICLAW_FS_SECRET_KEY":       prov.MinIOPassword,
-		"HICLAW_MINIO_ACCESS_KEY":    managerName,
-		"HICLAW_MINIO_SECRET_KEY":    prov.MinIOPassword,
 		"OPENCLAW_DISABLE_BONJOUR":   "1",
 		"OPENCLAW_MDNS_HOSTNAME":     "hiclaw-manager",
 		"HOME":                       "/root/manager-workspace",
@@ -84,7 +82,6 @@ func (b *WorkerEnvBuilder) applyClusterDefaults(env map[string]string) {
 	for k, v := range map[string]string{
 		"HICLAW_MATRIX_DOMAIN":   b.defaults.MatrixDomain,
 		"HICLAW_FS_ENDPOINT":     b.defaults.FSEndpoint,
-		"HICLAW_MINIO_ENDPOINT":  b.defaults.FSEndpoint,
 		"HICLAW_FS_BUCKET":       b.defaults.FSBucket,
 		"HICLAW_STORAGE_PREFIX":  b.defaults.StoragePrefix,
 		"HICLAW_CONTROLLER_URL":  b.defaults.ControllerURL,

--- a/hiclaw-controller/test/integration/controller/suite_test.go
+++ b/hiclaw-controller/test/integration/controller/suite_test.go
@@ -1,0 +1,136 @@
+//go:build integration
+
+package controller_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	"github.com/hiclaw/hiclaw-controller/internal/backend"
+	"github.com/hiclaw/hiclaw-controller/internal/controller"
+	"github.com/hiclaw/hiclaw-controller/test/testutil"
+	"github.com/hiclaw/hiclaw-controller/test/testutil/mocks"
+	"go.uber.org/zap/zapcore"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+const (
+	timeout  = 30 * time.Second
+	interval = 250 * time.Millisecond
+)
+
+var (
+	testEnv   *envtest.Environment
+	k8sClient client.Client
+	ctx       context.Context
+	cancel    context.CancelFunc
+
+	mockProv    *mocks.MockProvisioner
+	mockDeploy  *mocks.MockDeployer
+	mockBackend *mocks.MockWorkerBackend
+	mockEnv     *mocks.MockEnvBuilder
+)
+
+func TestMain(m *testing.M) {
+	testEnv = testutil.NewTestEnv()
+	scheme := testutil.Scheme()
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		panic(fmt.Sprintf("failed to start envtest: %v", err))
+	}
+
+	ctx, cancel = context.WithCancel(context.Background())
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true), zap.Level(zapcore.InfoLevel)))
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0", // disable metrics server in tests
+		},
+	})
+	if err != nil {
+		panic(fmt.Sprintf("failed to create manager: %v", err))
+	}
+
+	// Create a cacheless client so tests always read the latest state.
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		panic(fmt.Sprintf("failed to create k8s client: %v", err))
+	}
+
+	// Wire up mocks
+	mockProv = mocks.NewMockProvisioner()
+	mockDeploy = mocks.NewMockDeployer()
+	mockBackend = mocks.NewMockWorkerBackend()
+	mockEnv = mocks.NewMockEnvBuilder()
+
+	backendRegistry := backend.NewRegistry(
+		[]backend.WorkerBackend{mockBackend},
+		nil,
+	)
+
+	reconciler := &controller.WorkerReconciler{
+		Client:      mgr.GetClient(),
+		Provisioner: mockProv,
+		Deployer:    mockDeploy,
+		Backend:     backendRegistry,
+		EnvBuilder:  mockEnv,
+		Legacy:      nil,
+	}
+	if err := reconciler.SetupWithManager(mgr); err != nil {
+		panic(fmt.Sprintf("failed to setup WorkerReconciler: %v", err))
+	}
+
+	go func() {
+		if err := mgr.Start(ctx); err != nil {
+			panic(fmt.Sprintf("failed to start manager: %v", err))
+		}
+	}()
+
+	// Wait for manager cache to sync
+	if !mgr.GetCache().WaitForCacheSync(ctx) {
+		panic("cache sync failed")
+	}
+
+	code := m.Run()
+
+	cancel()
+	if err := testEnv.Stop(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to stop envtest: %v\n", err)
+	}
+
+	os.Exit(code)
+}
+
+// resetMocks resets all mock call records between tests.
+func resetMocks() {
+	mockProv.Calls.ProvisionWorker = nil
+	mockProv.Calls.DeprovisionWorker = nil
+	mockProv.Calls.RefreshCredentials = nil
+	mockDeploy.Calls.DeployPackage = nil
+	mockDeploy.Calls.DeployWorkerConfig = nil
+	mockDeploy.Calls.CleanupOSSData = nil
+	mockBackend.Calls.Create = nil
+	mockBackend.Calls.Delete = nil
+
+	// Reset function overrides to defaults
+	mockProv.ProvisionWorkerFn = nil
+	mockProv.DeprovisionWorkerFn = nil
+	mockProv.RefreshCredentialsFn = nil
+	mockDeploy.DeployPackageFn = nil
+	mockDeploy.DeployWorkerConfigFn = nil
+	mockBackend.CreateFn = nil
+	mockBackend.DeleteFn = nil
+}
+
+// suppress unused import for v1beta1
+var _ = v1beta1.GroupName

--- a/hiclaw-controller/test/integration/controller/suite_test.go
+++ b/hiclaw-controller/test/integration/controller/suite_test.go
@@ -111,25 +111,12 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-// resetMocks resets all mock call records between tests.
+// resetMocks resets all mock call records and Fn overrides between tests.
 func resetMocks() {
-	mockProv.Calls.ProvisionWorker = nil
-	mockProv.Calls.DeprovisionWorker = nil
-	mockProv.Calls.RefreshCredentials = nil
-	mockDeploy.Calls.DeployPackage = nil
-	mockDeploy.Calls.DeployWorkerConfig = nil
-	mockDeploy.Calls.CleanupOSSData = nil
-	mockBackend.Calls.Create = nil
-	mockBackend.Calls.Delete = nil
-
-	// Reset function overrides to defaults
-	mockProv.ProvisionWorkerFn = nil
-	mockProv.DeprovisionWorkerFn = nil
-	mockProv.RefreshCredentialsFn = nil
-	mockDeploy.DeployPackageFn = nil
-	mockDeploy.DeployWorkerConfigFn = nil
-	mockBackend.CreateFn = nil
-	mockBackend.DeleteFn = nil
+	mockProv.Reset()
+	mockDeploy.Reset()
+	mockBackend.Reset()
+	mockEnv.Reset()
 }
 
 // suppress unused import for v1beta1

--- a/hiclaw-controller/test/integration/controller/worker_test.go
+++ b/hiclaw-controller/test/integration/controller/worker_test.go
@@ -15,6 +15,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ---------------------------------------------------------------------------
+// Existing tests (Phase 1-3)
+// ---------------------------------------------------------------------------
+
 func TestWorkerCreate_HappyPath(t *testing.T) {
 	resetMocks()
 
@@ -28,7 +32,6 @@ func TestWorkerCreate_HappyPath(t *testing.T) {
 		_ = k8sClient.Delete(ctx, worker)
 	})
 
-	// Eventually: phase should become Running
 	assertEventually(t, func() error {
 		var w v1beta1.Worker
 		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
@@ -40,7 +43,6 @@ func TestWorkerCreate_HappyPath(t *testing.T) {
 		return nil
 	})
 
-	// Verify final state
 	var w v1beta1.Worker
 	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
 		t.Fatalf("failed to get Worker: %v", err)
@@ -55,8 +57,6 @@ func TestWorkerCreate_HappyPath(t *testing.T) {
 	if w.Status.RoomID == "" {
 		t.Error("RoomID should be set after creation")
 	}
-
-	// Verify service layer was called
 	if len(mockProv.Calls.ProvisionWorker) == 0 {
 		t.Error("ProvisionWorker should have been called")
 	}
@@ -107,30 +107,15 @@ func TestWorkerDelete_CleansUpAll(t *testing.T) {
 		t.Fatalf("failed to create Worker CR: %v", err)
 	}
 
-	// Wait for Running
-	assertEventually(t, func() error {
-		var w v1beta1.Worker
-		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
-			return err
-		}
-		if w.Status.Phase != "Running" {
-			return fmt.Errorf("phase=%q message=%q gen=%d obsGen=%d, want Running",
-				w.Status.Phase, w.Status.Message, w.Generation, w.Status.ObservedGeneration)
-		}
-		return nil
-	})
+	waitForRunning(t, worker)
 
-	// Reset call counters after create
-	mockProv.Calls.DeprovisionWorker = nil
-	mockProv.Calls.DeactivateMatrixUser = nil
-	mockDeploy.Calls.CleanupOSSData = nil
+	mockProv.ClearCalls()
+	mockDeploy.ClearCalls()
 
-	// Delete
 	if err := k8sClient.Delete(ctx, worker); err != nil {
 		t.Fatalf("failed to delete Worker CR: %v", err)
 	}
 
-	// Eventually: Worker should be gone
 	assertEventually(t, func() error {
 		var w v1beta1.Worker
 		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w)
@@ -140,7 +125,6 @@ func TestWorkerDelete_CleansUpAll(t *testing.T) {
 		return client.IgnoreNotFound(err)
 	})
 
-	// Verify deprovision was called
 	if len(mockProv.Calls.DeactivateMatrixUser) == 0 {
 		t.Error("DeactivateMatrixUser should have been called")
 	}
@@ -192,36 +176,19 @@ func TestWorkerUpdate_SpecChange_RecreatesPod(t *testing.T) {
 		_ = k8sClient.Delete(ctx, worker)
 	})
 
-	// Wait for Running
-	assertEventually(t, func() error {
-		var w v1beta1.Worker
-		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
-			return err
-		}
-		if w.Status.Phase != "Running" {
-			return fmt.Errorf("phase=%q, want Running", w.Status.Phase)
-		}
-		return nil
-	})
+	waitForRunning(t, worker)
 
-	// Reset mock calls so we only observe the update path
+	// Reset fully: clear state so we can use StatusFn to simulate pre-existing pod.
+	// This test predates stateful mock; keep using StatusFn for explicit control.
 	mockBackend.Reset()
-	// Restore default StatusFn to return Running (simulates existing pod)
 	mockBackend.StatusFn = func(_ context.Context, _ string) (*backend.WorkerResult, error) {
 		return &backend.WorkerResult{Status: backend.StatusRunning}, nil
 	}
 
-	// Update spec — change model to trigger Generation increment
-	assertEventually(t, func() error {
-		var w v1beta1.Worker
-		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
-			return err
-		}
+	updateSpecField(t, worker, func(w *v1beta1.Worker) {
 		w.Spec.Model = "claude-sonnet-4-20250514"
-		return k8sClient.Update(ctx, &w)
 	})
 
-	// Eventually: ObservedGeneration should catch up (meaning reconcile completed)
 	assertEventually(t, func() error {
 		var w v1beta1.Worker
 		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
@@ -233,7 +200,6 @@ func TestWorkerUpdate_SpecChange_RecreatesPod(t *testing.T) {
 		return nil
 	})
 
-	// Verify: backend should have deleted the old pod and created a new one
 	creates, deletes, _, _, _ := mockBackend.CallSnapshot()
 	if len(deletes) == 0 {
 		t.Error("backend.Delete should have been called to remove old container")
@@ -243,7 +209,448 @@ func TestWorkerUpdate_SpecChange_RecreatesPod(t *testing.T) {
 	}
 }
 
-// --- Test helpers ---
+// ---------------------------------------------------------------------------
+// Phase 4: Lifecycle state change tests
+// ---------------------------------------------------------------------------
+
+func TestWorkerStateChange_StopAndResume(t *testing.T) {
+	resetMocks()
+
+	workerName := fixtures.UniqueName("test-stop-resume")
+	worker := fixtures.NewTestWorker(workerName)
+
+	if err := k8sClient.Create(ctx, worker); err != nil {
+		t.Fatalf("failed to create Worker CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, worker)
+	})
+
+	waitForRunning(t, worker)
+
+	// --- Running → Stopped ---
+	mockBackend.ClearCalls()
+
+	updateSpecField(t, worker, func(w *v1beta1.Worker) {
+		w.Spec.State = ptrString("Stopped")
+	})
+
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+			return err
+		}
+		if w.Status.Phase != "Stopped" {
+			return fmt.Errorf("phase=%q, want Stopped", w.Status.Phase)
+		}
+		return nil
+	})
+
+	_, deletes, _, stops, _ := mockBackend.CallSnapshot()
+	if len(stops)+len(deletes) == 0 {
+		t.Error("backend.Stop or Delete should have been called when transitioning to Stopped")
+	}
+
+	// --- Stopped → Running ---
+	mockBackend.ClearCalls()
+
+	updateSpecField(t, worker, func(w *v1beta1.Worker) {
+		w.Spec.State = nil
+	})
+
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+			return err
+		}
+		if w.Status.Phase != "Running" {
+			return fmt.Errorf("phase=%q, want Running", w.Status.Phase)
+		}
+		return nil
+	})
+
+	creates, _, _, _, _ := mockBackend.CallSnapshot()
+	if len(creates) == 0 {
+		t.Error("backend.Create should have been called when resuming from Stopped")
+	}
+}
+
+func TestWorkerStateChange_SleepAndWake(t *testing.T) {
+	resetMocks()
+
+	workerName := fixtures.UniqueName("test-sleep-wake")
+	worker := fixtures.NewTestWorker(workerName)
+
+	if err := k8sClient.Create(ctx, worker); err != nil {
+		t.Fatalf("failed to create Worker CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, worker)
+	})
+
+	waitForRunning(t, worker)
+
+	// --- Running → Sleeping ---
+	mockBackend.ClearCalls()
+
+	updateSpecField(t, worker, func(w *v1beta1.Worker) {
+		w.Spec.State = ptrString("Sleeping")
+	})
+
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+			return err
+		}
+		if w.Status.Phase != "Sleeping" {
+			return fmt.Errorf("phase=%q, want Sleeping", w.Status.Phase)
+		}
+		return nil
+	})
+
+	_, _, _, stops, _ := mockBackend.CallSnapshot()
+	if len(stops) == 0 {
+		t.Error("backend.Stop should have been called when transitioning to Sleeping")
+	}
+
+	// --- Sleeping → Running ---
+	mockBackend.ClearCalls()
+
+	updateSpecField(t, worker, func(w *v1beta1.Worker) {
+		w.Spec.State = nil
+	})
+
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+			return err
+		}
+		if w.Status.Phase != "Running" {
+			return fmt.Errorf("phase=%q, want Running", w.Status.Phase)
+		}
+		return nil
+	})
+
+	creates, _, _, _, _ := mockBackend.CallSnapshot()
+	if len(creates) == 0 {
+		t.Error("backend.Create should have been called when waking from Sleeping")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4: Pod resilience tests
+// ---------------------------------------------------------------------------
+
+func TestWorkerPodDeleted_Recreates(t *testing.T) {
+	resetMocks()
+
+	workerName := fixtures.UniqueName("test-pod-deleted")
+	worker := fixtures.NewTestWorker(workerName)
+
+	if err := k8sClient.Create(ctx, worker); err != nil {
+		t.Fatalf("failed to create Worker CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, worker)
+	})
+
+	waitForRunning(t, worker)
+
+	// Simulate external pod deletion
+	mockBackend.SimulatePodDeletion(workerName)
+	mockBackend.ClearCalls()
+
+	triggerReconcile(t, worker)
+
+	assertEventually(t, func() error {
+		creates, _, _, _, _ := mockBackend.CallSnapshot()
+		if len(creates) == 0 {
+			return fmt.Errorf("waiting for backend.Create to be called (pod recreation)")
+		}
+		return nil
+	})
+
+	// Phase should still be Running after recreation
+	var w v1beta1.Worker
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+		t.Fatalf("failed to get Worker: %v", err)
+	}
+	if w.Status.Phase != "Running" {
+		t.Errorf("phase=%q after pod recreation, want Running", w.Status.Phase)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4: Idempotency and convergence tests
+// ---------------------------------------------------------------------------
+
+func TestWorkerCreate_Idempotent_NoDoubleProvision(t *testing.T) {
+	resetMocks()
+
+	workerName := fixtures.UniqueName("test-idempotent")
+	worker := fixtures.NewTestWorker(workerName)
+
+	if err := k8sClient.Create(ctx, worker); err != nil {
+		t.Fatalf("failed to create Worker CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, worker)
+	})
+
+	waitForRunning(t, worker)
+
+	provCountBefore := len(mockProv.Calls.ProvisionWorker)
+	refreshCountBefore := len(mockProv.Calls.RefreshCredentials)
+
+	// Trigger another reconcile via annotation update (no spec change)
+	triggerReconcile(t, worker)
+
+	// Wait for the new reconcile to complete — RefreshCredentials count increases
+	assertEventually(t, func() error {
+		if len(mockProv.Calls.RefreshCredentials) <= refreshCountBefore {
+			return fmt.Errorf("RefreshCredentials count=%d, want >%d (reconcile not triggered yet)",
+				len(mockProv.Calls.RefreshCredentials), refreshCountBefore)
+		}
+		return nil
+	})
+
+	if len(mockProv.Calls.ProvisionWorker) != provCountBefore {
+		t.Errorf("ProvisionWorker called %d times, want %d (should not re-provision after Running)",
+			len(mockProv.Calls.ProvisionWorker), provCountBefore)
+	}
+}
+
+func TestWorkerUpdate_NoInfiniteRecreate(t *testing.T) {
+	resetMocks()
+
+	workerName := fixtures.UniqueName("test-no-loop")
+	worker := fixtures.NewTestWorker(workerName)
+
+	if err := k8sClient.Create(ctx, worker); err != nil {
+		t.Fatalf("failed to create Worker CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, worker)
+	})
+
+	waitForRunning(t, worker)
+
+	mockBackend.ClearCalls()
+
+	updateSpecField(t, worker, func(w *v1beta1.Worker) {
+		w.Spec.Model = "gpt-4o-mini"
+	})
+
+	// Wait for reconcile to complete
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+			return err
+		}
+		if w.Status.ObservedGeneration != w.Generation {
+			return fmt.Errorf("ObservedGeneration=%d, want %d", w.Status.ObservedGeneration, w.Generation)
+		}
+		return nil
+	})
+
+	// Wait a grace period — if there's an infinite loop, Creates will keep growing
+	time.Sleep(3 * time.Second)
+
+	creates, _, _, _, _ := mockBackend.CallSnapshot()
+	// Expect exactly 1 Create from the update (delete old + create new).
+	// With stateful mock, after the recreate cycle Status returns Running,
+	// Generation == ObservedGeneration, so no further Creates should occur.
+	if len(creates) == 0 {
+		t.Error("expected at least 1 Create from spec update")
+	}
+	if len(creates) > 2 {
+		t.Errorf("Create called %d times — possible infinite recreate loop (want <=2)", len(creates))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4: Simultaneous state + spec change
+// ---------------------------------------------------------------------------
+
+func TestWorkerStateChange_SimultaneousSpecAndState(t *testing.T) {
+	resetMocks()
+
+	workerName := fixtures.UniqueName("test-simul")
+	worker := fixtures.NewTestWorker(workerName)
+
+	if err := k8sClient.Create(ctx, worker); err != nil {
+		t.Fatalf("failed to create Worker CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, worker)
+	})
+
+	waitForRunning(t, worker)
+
+	// --- Simultaneously change state to Stopped AND model ---
+	mockBackend.ClearCalls()
+
+	updateSpecField(t, worker, func(w *v1beta1.Worker) {
+		w.Spec.State = ptrString("Stopped")
+		w.Spec.Model = "claude-sonnet-4-20250514"
+	})
+
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+			return err
+		}
+		if w.Status.Phase != "Stopped" {
+			return fmt.Errorf("phase=%q, want Stopped", w.Status.Phase)
+		}
+		return nil
+	})
+
+	// While Stopped, no new pod should be created despite model change
+	creates, _, _, _, _ := mockBackend.CallSnapshot()
+	if len(creates) > 0 {
+		t.Errorf("backend.Create called %d times while Stopped — should not create pod in Stopped state", len(creates))
+	}
+
+	// --- Resume to Running with new config ---
+	mockBackend.ClearCalls()
+
+	updateSpecField(t, worker, func(w *v1beta1.Worker) {
+		w.Spec.State = nil
+	})
+
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+			return err
+		}
+		if w.Status.Phase != "Running" {
+			return fmt.Errorf("phase=%q, want Running", w.Status.Phase)
+		}
+		return nil
+	})
+
+	creates, _, _, _, _ = mockBackend.CallSnapshot()
+	if len(creates) == 0 {
+		t.Error("backend.Create should have been called when resuming with new config")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4: Deletion of a failed worker
+// ---------------------------------------------------------------------------
+
+func TestWorkerDelete_ProvisionFailed_StillCleans(t *testing.T) {
+	resetMocks()
+
+	mockProv.ProvisionWorkerFn = func(_ context.Context, _ service.WorkerProvisionRequest) (*service.WorkerProvisionResult, error) {
+		return nil, fmt.Errorf("simulated provision failure")
+	}
+
+	workerName := fixtures.UniqueName("test-del-fail")
+	worker := fixtures.NewTestWorker(workerName)
+
+	if err := k8sClient.Create(ctx, worker); err != nil {
+		t.Fatalf("failed to create Worker CR: %v", err)
+	}
+
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+			return err
+		}
+		if w.Status.Phase != "Failed" {
+			return fmt.Errorf("phase=%q, want Failed", w.Status.Phase)
+		}
+		return nil
+	})
+
+	mockProv.ClearCalls()
+	mockDeploy.ClearCalls()
+
+	if err := k8sClient.Delete(ctx, worker); err != nil {
+		t.Fatalf("failed to delete Worker CR: %v", err)
+	}
+
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w)
+		if err == nil {
+			return fmt.Errorf("worker still exists (phase=%q)", w.Status.Phase)
+		}
+		return client.IgnoreNotFound(err)
+	})
+
+	if len(mockProv.Calls.DeprovisionWorker) == 0 {
+		t.Error("DeprovisionWorker should have been called even for a failed worker")
+	}
+	if len(mockDeploy.Calls.CleanupOSSData) == 0 {
+		t.Error("CleanupOSSData should have been called even for a failed worker")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func ptrString(s string) *string {
+	return &s
+}
+
+// clearAllCalls resets call records on all mocks without clearing Fn overrides or state.
+func clearAllCalls() {
+	mockProv.ClearCalls()
+	mockDeploy.ClearCalls()
+	mockBackend.ClearCalls()
+	mockEnv.ClearCalls()
+}
+
+// waitForRunning blocks until the Worker reaches Phase "Running".
+func waitForRunning(t *testing.T, worker *v1beta1.Worker) {
+	t.Helper()
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+			return err
+		}
+		if w.Status.Phase != "Running" {
+			return fmt.Errorf("phase=%q message=%q gen=%d obsGen=%d, want Running",
+				w.Status.Phase, w.Status.Message, w.Generation, w.Status.ObservedGeneration)
+		}
+		return nil
+	})
+}
+
+// updateSpecField performs a read-modify-write on the Worker spec using the
+// given mutator function. Retries on conflict (stale resourceVersion).
+func updateSpecField(t *testing.T, worker *v1beta1.Worker, mutate func(w *v1beta1.Worker)) {
+	t.Helper()
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+			return err
+		}
+		mutate(&w)
+		return k8sClient.Update(ctx, &w)
+	})
+}
+
+// triggerReconcile forces a reconcile by adding/updating an annotation.
+// This does NOT increment Generation (metadata-only change).
+func triggerReconcile(t *testing.T, worker *v1beta1.Worker) {
+	t.Helper()
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+			return err
+		}
+		if w.Annotations == nil {
+			w.Annotations = map[string]string{}
+		}
+		w.Annotations["hiclaw.io/reconcile-trigger"] = fmt.Sprintf("%d", time.Now().UnixNano())
+		return k8sClient.Update(ctx, &w)
+	})
+}
 
 // assertEventually polls condFn until it returns nil or the timeout expires.
 func assertEventually(t *testing.T, condFn func() error) {

--- a/hiclaw-controller/test/integration/controller/worker_test.go
+++ b/hiclaw-controller/test/integration/controller/worker_test.go
@@ -57,10 +57,12 @@ func TestWorkerCreate_HappyPath(t *testing.T) {
 	if w.Status.RoomID == "" {
 		t.Error("RoomID should be set after creation")
 	}
-	if len(mockProv.Calls.ProvisionWorker) == 0 {
+	provCount, _, _, _ := mockProv.CallCounts()
+	if provCount == 0 {
 		t.Error("ProvisionWorker should have been called")
 	}
-	if len(mockDeploy.Calls.DeployWorkerConfig) == 0 {
+	_, _, deployConfigCount, _, _ := mockDeploy.CallCounts()
+	if deployConfigCount == 0 {
 		t.Error("DeployWorkerConfig should have been called")
 	}
 }
@@ -125,13 +127,15 @@ func TestWorkerDelete_CleansUpAll(t *testing.T) {
 		return client.IgnoreNotFound(err)
 	})
 
-	if len(mockProv.Calls.DeactivateMatrixUser) == 0 {
+	_, deprovCount, _, deactivateCount := mockProv.CallCounts()
+	if deactivateCount == 0 {
 		t.Error("DeactivateMatrixUser should have been called")
 	}
-	if len(mockProv.Calls.DeprovisionWorker) == 0 {
+	if deprovCount == 0 {
 		t.Error("DeprovisionWorker should have been called")
 	}
-	if len(mockDeploy.Calls.CleanupOSSData) == 0 {
+	_, _, _, _, cleanupCount := mockDeploy.CallCounts()
+	if cleanupCount == 0 {
 		t.Error("CleanupOSSData should have been called")
 	}
 }
@@ -399,24 +403,25 @@ func TestWorkerCreate_Idempotent_NoDoubleProvision(t *testing.T) {
 
 	waitForRunning(t, worker)
 
-	provCountBefore := len(mockProv.Calls.ProvisionWorker)
-	refreshCountBefore := len(mockProv.Calls.RefreshCredentials)
+	provCountBefore, _, refreshCountBefore, _ := mockProv.CallCounts()
 
 	// Trigger another reconcile via annotation update (no spec change)
 	triggerReconcile(t, worker)
 
 	// Wait for the new reconcile to complete — RefreshCredentials count increases
 	assertEventually(t, func() error {
-		if len(mockProv.Calls.RefreshCredentials) <= refreshCountBefore {
+		_, _, refreshCount, _ := mockProv.CallCounts()
+		if refreshCount <= refreshCountBefore {
 			return fmt.Errorf("RefreshCredentials count=%d, want >%d (reconcile not triggered yet)",
-				len(mockProv.Calls.RefreshCredentials), refreshCountBefore)
+				refreshCount, refreshCountBefore)
 		}
 		return nil
 	})
 
-	if len(mockProv.Calls.ProvisionWorker) != provCountBefore {
+	provCountAfter, _, _, _ := mockProv.CallCounts()
+	if provCountAfter != provCountBefore {
 		t.Errorf("ProvisionWorker called %d times, want %d (should not re-provision after Running)",
-			len(mockProv.Calls.ProvisionWorker), provCountBefore)
+			provCountAfter, provCountBefore)
 	}
 }
 
@@ -581,10 +586,12 @@ func TestWorkerDelete_ProvisionFailed_StillCleans(t *testing.T) {
 		return client.IgnoreNotFound(err)
 	})
 
-	if len(mockProv.Calls.DeprovisionWorker) == 0 {
+	_, deprovCount2, _, _ := mockProv.CallCounts()
+	if deprovCount2 == 0 {
 		t.Error("DeprovisionWorker should have been called even for a failed worker")
 	}
-	if len(mockDeploy.Calls.CleanupOSSData) == 0 {
+	_, _, _, _, cleanupCount2 := mockDeploy.CallCounts()
+	if cleanupCount2 == 0 {
 		t.Error("CleanupOSSData should have been called even for a failed worker")
 	}
 }

--- a/hiclaw-controller/test/integration/controller/worker_test.go
+++ b/hiclaw-controller/test/integration/controller/worker_test.go
@@ -1,0 +1,196 @@
+//go:build integration
+
+package controller_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	"github.com/hiclaw/hiclaw-controller/internal/service"
+	"github.com/hiclaw/hiclaw-controller/test/testutil/fixtures"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestWorkerCreate_HappyPath(t *testing.T) {
+	resetMocks()
+
+	workerName := fixtures.UniqueName("test-create")
+	worker := fixtures.NewTestWorker(workerName)
+
+	if err := k8sClient.Create(ctx, worker); err != nil {
+		t.Fatalf("failed to create Worker CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, worker)
+	})
+
+	// Eventually: phase should become Running
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+			return err
+		}
+		if w.Status.Phase != "Running" {
+			return fmt.Errorf("phase=%q, want Running", w.Status.Phase)
+		}
+		return nil
+	})
+
+	// Verify final state
+	var w v1beta1.Worker
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+		t.Fatalf("failed to get Worker: %v", err)
+	}
+
+	if w.Status.ObservedGeneration != w.Generation {
+		t.Errorf("ObservedGeneration=%d, want %d", w.Status.ObservedGeneration, w.Generation)
+	}
+	if w.Status.MatrixUserID == "" {
+		t.Error("MatrixUserID should be set after creation")
+	}
+	if w.Status.RoomID == "" {
+		t.Error("RoomID should be set after creation")
+	}
+
+	// Verify service layer was called
+	if len(mockProv.Calls.ProvisionWorker) == 0 {
+		t.Error("ProvisionWorker should have been called")
+	}
+	if len(mockDeploy.Calls.DeployWorkerConfig) == 0 {
+		t.Error("DeployWorkerConfig should have been called")
+	}
+}
+
+func TestWorkerCreate_ProvisionFailure_SetsFailedPhase(t *testing.T) {
+	// Known bug: failCreate ignores Status().Update errors, causing Phase to stay
+	// "Pending" instead of transitioning to "Failed". Will be fixed in Phase 2 reconciler refactor.
+	t.Skip("blocked on reconciler refactor: failCreate Status Update is unreliable (Phase 2)")
+
+	resetMocks()
+
+	mockProv.ProvisionWorkerFn = func(_ context.Context, _ service.WorkerProvisionRequest) (*service.WorkerProvisionResult, error) {
+		return nil, fmt.Errorf("simulated provision failure")
+	}
+
+	workerName := fixtures.UniqueName("test-fail")
+	worker := fixtures.NewTestWorker(workerName)
+
+	if err := k8sClient.Create(ctx, worker); err != nil {
+		t.Fatalf("failed to create Worker CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, worker)
+	})
+
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+			return err
+		}
+		if w.Status.Phase != "Failed" {
+			return fmt.Errorf("phase=%q, want Failed", w.Status.Phase)
+		}
+		if w.Status.Message == "" {
+			return fmt.Errorf("message should contain failure reason")
+		}
+		return nil
+	})
+}
+
+func TestWorkerDelete_CleansUpAll(t *testing.T) {
+	resetMocks()
+
+	workerName := fixtures.UniqueName("test-delete")
+	worker := fixtures.NewTestWorker(workerName)
+
+	if err := k8sClient.Create(ctx, worker); err != nil {
+		t.Fatalf("failed to create Worker CR: %v", err)
+	}
+
+	// Wait for Running
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+			return err
+		}
+		if w.Status.Phase != "Running" {
+			return fmt.Errorf("phase=%q message=%q gen=%d obsGen=%d, want Running",
+				w.Status.Phase, w.Status.Message, w.Generation, w.Status.ObservedGeneration)
+		}
+		return nil
+	})
+
+	// Reset call counters after create
+	mockProv.Calls.DeprovisionWorker = nil
+	mockDeploy.Calls.CleanupOSSData = nil
+
+	// Delete
+	if err := k8sClient.Delete(ctx, worker); err != nil {
+		t.Fatalf("failed to delete Worker CR: %v", err)
+	}
+
+	// Eventually: Worker should be gone
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w)
+		if err == nil {
+			return fmt.Errorf("worker still exists (phase=%q)", w.Status.Phase)
+		}
+		return client.IgnoreNotFound(err)
+	})
+
+	// Verify deprovision was called
+	if len(mockProv.Calls.DeprovisionWorker) == 0 {
+		t.Error("DeprovisionWorker should have been called")
+	}
+	if len(mockDeploy.Calls.CleanupOSSData) == 0 {
+		t.Error("CleanupOSSData should have been called")
+	}
+}
+
+func TestWorkerFinalizer_AddedOnCreate(t *testing.T) {
+	resetMocks()
+
+	workerName := fixtures.UniqueName("test-finalizer")
+	worker := fixtures.NewTestWorker(workerName)
+
+	if err := k8sClient.Create(ctx, worker); err != nil {
+		t.Fatalf("failed to create Worker CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, worker)
+	})
+
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+			return err
+		}
+		for _, f := range w.Finalizers {
+			if f == "hiclaw.io/cleanup" {
+				return nil
+			}
+		}
+		return fmt.Errorf("finalizer hiclaw.io/cleanup not found in %v", w.Finalizers)
+	})
+}
+
+// --- Test helpers ---
+
+// assertEventually polls condFn until it returns nil or the timeout expires.
+func assertEventually(t *testing.T, condFn func() error) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		lastErr = condFn()
+		if lastErr == nil {
+			return
+		}
+		time.Sleep(interval)
+	}
+	t.Fatalf("condition not met within %v: %v", timeout, lastErr)
+}

--- a/hiclaw-controller/test/integration/controller/worker_test.go
+++ b/hiclaw-controller/test/integration/controller/worker_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	"github.com/hiclaw/hiclaw-controller/internal/backend"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 	"github.com/hiclaw/hiclaw-controller/test/testutil/fixtures"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -65,10 +66,6 @@ func TestWorkerCreate_HappyPath(t *testing.T) {
 }
 
 func TestWorkerCreate_ProvisionFailure_SetsFailedPhase(t *testing.T) {
-	// Known bug: failCreate ignores Status().Update errors, causing Phase to stay
-	// "Pending" instead of transitioning to "Failed". Will be fixed in Phase 2 reconciler refactor.
-	t.Skip("blocked on reconciler refactor: failCreate Status Update is unreliable (Phase 2)")
-
 	resetMocks()
 
 	mockProv.ProvisionWorkerFn = func(_ context.Context, _ service.WorkerProvisionRequest) (*service.WorkerProvisionResult, error) {
@@ -125,6 +122,7 @@ func TestWorkerDelete_CleansUpAll(t *testing.T) {
 
 	// Reset call counters after create
 	mockProv.Calls.DeprovisionWorker = nil
+	mockProv.Calls.DeactivateMatrixUser = nil
 	mockDeploy.Calls.CleanupOSSData = nil
 
 	// Delete
@@ -143,6 +141,9 @@ func TestWorkerDelete_CleansUpAll(t *testing.T) {
 	})
 
 	// Verify deprovision was called
+	if len(mockProv.Calls.DeactivateMatrixUser) == 0 {
+		t.Error("DeactivateMatrixUser should have been called")
+	}
 	if len(mockProv.Calls.DeprovisionWorker) == 0 {
 		t.Error("DeprovisionWorker should have been called")
 	}
@@ -176,6 +177,70 @@ func TestWorkerFinalizer_AddedOnCreate(t *testing.T) {
 		}
 		return fmt.Errorf("finalizer hiclaw.io/cleanup not found in %v", w.Finalizers)
 	})
+}
+
+func TestWorkerUpdate_SpecChange_RecreatesPod(t *testing.T) {
+	resetMocks()
+
+	workerName := fixtures.UniqueName("test-update")
+	worker := fixtures.NewTestWorker(workerName)
+
+	if err := k8sClient.Create(ctx, worker); err != nil {
+		t.Fatalf("failed to create Worker CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, worker)
+	})
+
+	// Wait for Running
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+			return err
+		}
+		if w.Status.Phase != "Running" {
+			return fmt.Errorf("phase=%q, want Running", w.Status.Phase)
+		}
+		return nil
+	})
+
+	// Reset mock calls so we only observe the update path
+	mockBackend.Reset()
+	// Restore default StatusFn to return Running (simulates existing pod)
+	mockBackend.StatusFn = func(_ context.Context, _ string) (*backend.WorkerResult, error) {
+		return &backend.WorkerResult{Status: backend.StatusRunning}, nil
+	}
+
+	// Update spec — change model to trigger Generation increment
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+			return err
+		}
+		w.Spec.Model = "claude-sonnet-4-20250514"
+		return k8sClient.Update(ctx, &w)
+	})
+
+	// Eventually: ObservedGeneration should catch up (meaning reconcile completed)
+	assertEventually(t, func() error {
+		var w v1beta1.Worker
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(worker), &w); err != nil {
+			return err
+		}
+		if w.Status.ObservedGeneration != w.Generation {
+			return fmt.Errorf("ObservedGeneration=%d, want %d", w.Status.ObservedGeneration, w.Generation)
+		}
+		return nil
+	})
+
+	// Verify: backend should have deleted the old pod and created a new one
+	creates, deletes, _, _, _ := mockBackend.CallSnapshot()
+	if len(deletes) == 0 {
+		t.Error("backend.Delete should have been called to remove old container")
+	}
+	if len(creates) == 0 {
+		t.Error("backend.Create should have been called to create new container")
+	}
 }
 
 // --- Test helpers ---

--- a/hiclaw-controller/test/testutil/envtest.go
+++ b/hiclaw-controller/test/testutil/envtest.go
@@ -1,0 +1,34 @@
+package testutil
+
+import (
+	"path/filepath"
+	"runtime"
+
+	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+// Scheme returns a runtime.Scheme with all types needed for integration tests.
+func Scheme() *apiruntime.Scheme {
+	s := apiruntime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(v1beta1.AddToScheme(s))
+	return s
+}
+
+// CRDPath returns the absolute path to the CRD directory.
+func CRDPath() string {
+	_, thisFile, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "config", "crd")
+}
+
+// NewTestEnv creates a configured envtest.Environment with HiClaw CRDs loaded.
+func NewTestEnv() *envtest.Environment {
+	return &envtest.Environment{
+		CRDDirectoryPaths:     []string{CRDPath()},
+		ErrorIfCRDPathMissing: true,
+	}
+}

--- a/hiclaw-controller/test/testutil/fixtures/worker.go
+++ b/hiclaw-controller/test/testutil/fixtures/worker.go
@@ -1,0 +1,55 @@
+package fixtures
+
+import (
+	"fmt"
+	"math/rand"
+
+	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DefaultNamespace is used for test resources.
+const DefaultNamespace = "default"
+
+// NewTestWorker creates a minimal Worker CR for testing.
+func NewTestWorker(name string) *v1beta1.Worker {
+	return &v1beta1.Worker{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: DefaultNamespace,
+		},
+		Spec: v1beta1.WorkerSpec{
+			Model:   "gpt-4o",
+			Runtime: "openclaw",
+		},
+	}
+}
+
+// NewTestWorkerWithPhase creates a Worker CR with a pre-set status phase.
+func NewTestWorkerWithPhase(name, phase string) *v1beta1.Worker {
+	w := NewTestWorker(name)
+	w.Status.Phase = phase
+	return w
+}
+
+// NewTestWorkerWithAnnotations creates a Worker CR with annotations.
+func NewTestWorkerWithAnnotations(name string, annotations map[string]string) *v1beta1.Worker {
+	w := NewTestWorker(name)
+	w.Annotations = annotations
+	return w
+}
+
+// UniqueName returns a unique test name with a random suffix.
+func UniqueName(prefix string) string {
+	return fmt.Sprintf("%s-%s", prefix, randString(6))
+}
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+
+func randString(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}

--- a/hiclaw-controller/test/testutil/mocks/backend.go
+++ b/hiclaw-controller/test/testutil/mocks/backend.go
@@ -11,6 +11,8 @@ import (
 type MockWorkerBackend struct {
 	mu sync.Mutex
 
+	NameOverride string
+
 	CreateFn func(ctx context.Context, req backend.CreateRequest) (*backend.WorkerResult, error)
 	DeleteFn func(ctx context.Context, name string) error
 	StartFn  func(ctx context.Context, name string) error
@@ -21,6 +23,10 @@ type MockWorkerBackend struct {
 	Calls struct {
 		Create []string
 		Delete []string
+		Start  []string
+		Stop   []string
+		Status []string
+		List   int
 	}
 }
 
@@ -28,10 +34,35 @@ func NewMockWorkerBackend() *MockWorkerBackend {
 	return &MockWorkerBackend{}
 }
 
-func (m *MockWorkerBackend) Name() string           { return "mock" }
-func (m *MockWorkerBackend) DeploymentMode() string  { return backend.DeployLocal }
-func (m *MockWorkerBackend) Available(_ context.Context) bool { return true }
-func (m *MockWorkerBackend) NeedsCredentialInjection() bool  { return false }
+func (m *MockWorkerBackend) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Calls = struct {
+		Create []string
+		Delete []string
+		Start  []string
+		Stop   []string
+		Status []string
+		List   int
+	}{}
+	m.NameOverride = ""
+	m.CreateFn = nil
+	m.DeleteFn = nil
+	m.StartFn = nil
+	m.StopFn = nil
+	m.StatusFn = nil
+	m.ListFn = nil
+}
+
+func (m *MockWorkerBackend) Name() string {
+	if m.NameOverride != "" {
+		return m.NameOverride
+	}
+	return "mock"
+}
+func (m *MockWorkerBackend) DeploymentMode() string                { return backend.DeployLocal }
+func (m *MockWorkerBackend) Available(_ context.Context) bool      { return true }
+func (m *MockWorkerBackend) NeedsCredentialInjection() bool        { return false }
 
 func (m *MockWorkerBackend) Create(ctx context.Context, req backend.CreateRequest) (*backend.WorkerResult, error) {
 	m.mu.Lock()
@@ -42,7 +73,7 @@ func (m *MockWorkerBackend) Create(ctx context.Context, req backend.CreateReques
 	}
 	return &backend.WorkerResult{
 		Name:    req.Name,
-		Backend: "mock",
+		Backend: m.Name(),
 		Status:  backend.StatusStarting,
 	}, nil
 }
@@ -58,6 +89,9 @@ func (m *MockWorkerBackend) Delete(ctx context.Context, name string) error {
 }
 
 func (m *MockWorkerBackend) Start(ctx context.Context, name string) error {
+	m.mu.Lock()
+	m.Calls.Start = append(m.Calls.Start, name)
+	m.mu.Unlock()
 	if m.StartFn != nil {
 		return m.StartFn(ctx, name)
 	}
@@ -65,6 +99,9 @@ func (m *MockWorkerBackend) Start(ctx context.Context, name string) error {
 }
 
 func (m *MockWorkerBackend) Stop(ctx context.Context, name string) error {
+	m.mu.Lock()
+	m.Calls.Stop = append(m.Calls.Stop, name)
+	m.mu.Unlock()
 	if m.StopFn != nil {
 		return m.StopFn(ctx, name)
 	}
@@ -72,17 +109,23 @@ func (m *MockWorkerBackend) Stop(ctx context.Context, name string) error {
 }
 
 func (m *MockWorkerBackend) Status(ctx context.Context, name string) (*backend.WorkerResult, error) {
+	m.mu.Lock()
+	m.Calls.Status = append(m.Calls.Status, name)
+	m.mu.Unlock()
 	if m.StatusFn != nil {
 		return m.StatusFn(ctx, name)
 	}
 	return &backend.WorkerResult{
 		Name:    name,
-		Backend: "mock",
+		Backend: m.Name(),
 		Status:  backend.StatusRunning,
 	}, nil
 }
 
 func (m *MockWorkerBackend) List(ctx context.Context) ([]backend.WorkerResult, error) {
+	m.mu.Lock()
+	m.Calls.List++
+	m.mu.Unlock()
 	if m.ListFn != nil {
 		return m.ListFn(ctx)
 	}

--- a/hiclaw-controller/test/testutil/mocks/backend.go
+++ b/hiclaw-controller/test/testutil/mocks/backend.go
@@ -1,0 +1,92 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hiclaw/hiclaw-controller/internal/backend"
+)
+
+// MockWorkerBackend implements backend.WorkerBackend for testing.
+type MockWorkerBackend struct {
+	mu sync.Mutex
+
+	CreateFn func(ctx context.Context, req backend.CreateRequest) (*backend.WorkerResult, error)
+	DeleteFn func(ctx context.Context, name string) error
+	StartFn  func(ctx context.Context, name string) error
+	StopFn   func(ctx context.Context, name string) error
+	StatusFn func(ctx context.Context, name string) (*backend.WorkerResult, error)
+	ListFn   func(ctx context.Context) ([]backend.WorkerResult, error)
+
+	Calls struct {
+		Create []string
+		Delete []string
+	}
+}
+
+func NewMockWorkerBackend() *MockWorkerBackend {
+	return &MockWorkerBackend{}
+}
+
+func (m *MockWorkerBackend) Name() string           { return "mock" }
+func (m *MockWorkerBackend) DeploymentMode() string  { return backend.DeployLocal }
+func (m *MockWorkerBackend) Available(_ context.Context) bool { return true }
+func (m *MockWorkerBackend) NeedsCredentialInjection() bool  { return false }
+
+func (m *MockWorkerBackend) Create(ctx context.Context, req backend.CreateRequest) (*backend.WorkerResult, error) {
+	m.mu.Lock()
+	m.Calls.Create = append(m.Calls.Create, req.Name)
+	m.mu.Unlock()
+	if m.CreateFn != nil {
+		return m.CreateFn(ctx, req)
+	}
+	return &backend.WorkerResult{
+		Name:    req.Name,
+		Backend: "mock",
+		Status:  backend.StatusStarting,
+	}, nil
+}
+
+func (m *MockWorkerBackend) Delete(ctx context.Context, name string) error {
+	m.mu.Lock()
+	m.Calls.Delete = append(m.Calls.Delete, name)
+	m.mu.Unlock()
+	if m.DeleteFn != nil {
+		return m.DeleteFn(ctx, name)
+	}
+	return nil
+}
+
+func (m *MockWorkerBackend) Start(ctx context.Context, name string) error {
+	if m.StartFn != nil {
+		return m.StartFn(ctx, name)
+	}
+	return nil
+}
+
+func (m *MockWorkerBackend) Stop(ctx context.Context, name string) error {
+	if m.StopFn != nil {
+		return m.StopFn(ctx, name)
+	}
+	return nil
+}
+
+func (m *MockWorkerBackend) Status(ctx context.Context, name string) (*backend.WorkerResult, error) {
+	if m.StatusFn != nil {
+		return m.StatusFn(ctx, name)
+	}
+	return &backend.WorkerResult{
+		Name:    name,
+		Backend: "mock",
+		Status:  backend.StatusRunning,
+	}, nil
+}
+
+func (m *MockWorkerBackend) List(ctx context.Context) ([]backend.WorkerResult, error) {
+	if m.ListFn != nil {
+		return m.ListFn(ctx)
+	}
+	return nil, nil
+}
+
+var _ backend.WorkerBackend = (*MockWorkerBackend)(nil)

--- a/hiclaw-controller/test/testutil/mocks/backend.go
+++ b/hiclaw-controller/test/testutil/mocks/backend.go
@@ -60,9 +60,9 @@ func (m *MockWorkerBackend) Name() string {
 	}
 	return "mock"
 }
-func (m *MockWorkerBackend) DeploymentMode() string                { return backend.DeployLocal }
-func (m *MockWorkerBackend) Available(_ context.Context) bool      { return true }
-func (m *MockWorkerBackend) NeedsCredentialInjection() bool        { return false }
+func (m *MockWorkerBackend) DeploymentMode() string           { return backend.DeployLocal }
+func (m *MockWorkerBackend) Available(_ context.Context) bool { return true }
+func (m *MockWorkerBackend) NeedsCredentialInjection() bool   { return false }
 
 func (m *MockWorkerBackend) Create(ctx context.Context, req backend.CreateRequest) (*backend.WorkerResult, error) {
 	m.mu.Lock()
@@ -130,6 +130,18 @@ func (m *MockWorkerBackend) List(ctx context.Context) ([]backend.WorkerResult, e
 		return m.ListFn(ctx)
 	}
 	return nil, nil
+}
+
+// CallSnapshot returns a snapshot of call records safe for concurrent use.
+func (m *MockWorkerBackend) CallSnapshot() (creates, deletes, starts, stops, statuses []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	creates = append([]string{}, m.Calls.Create...)
+	deletes = append([]string{}, m.Calls.Delete...)
+	starts = append([]string{}, m.Calls.Start...)
+	stops = append([]string{}, m.Calls.Stop...)
+	statuses = append([]string{}, m.Calls.Status...)
+	return
 }
 
 var _ backend.WorkerBackend = (*MockWorkerBackend)(nil)

--- a/hiclaw-controller/test/testutil/mocks/backend.go
+++ b/hiclaw-controller/test/testutil/mocks/backend.go
@@ -8,6 +8,11 @@ import (
 )
 
 // MockWorkerBackend implements backend.WorkerBackend for testing.
+//
+// It tracks container lifecycle state automatically: Create sets a container
+// to Running, Delete removes it, Stop sets it to Stopped, Start sets it back
+// to Running. Status queries return the tracked state (or ErrNotFound if
+// no container exists). Fn overrides take precedence over tracked state.
 type MockWorkerBackend struct {
 	mu sync.Mutex
 
@@ -20,6 +25,8 @@ type MockWorkerBackend struct {
 	StatusFn func(ctx context.Context, name string) (*backend.WorkerResult, error)
 	ListFn   func(ctx context.Context) ([]backend.WorkerResult, error)
 
+	containerState map[string]backend.WorkerStatus
+
 	Calls struct {
 		Create []string
 		Delete []string
@@ -31,12 +38,34 @@ type MockWorkerBackend struct {
 }
 
 func NewMockWorkerBackend() *MockWorkerBackend {
-	return &MockWorkerBackend{}
+	return &MockWorkerBackend{
+		containerState: map[string]backend.WorkerStatus{},
+	}
 }
 
+// Reset clears all Fn overrides, call records, and tracked container state.
 func (m *MockWorkerBackend) Reset() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.clearCallsLocked()
+	m.containerState = map[string]backend.WorkerStatus{}
+	m.NameOverride = ""
+	m.CreateFn = nil
+	m.DeleteFn = nil
+	m.StartFn = nil
+	m.StopFn = nil
+	m.StatusFn = nil
+	m.ListFn = nil
+}
+
+// ClearCalls resets call records only, preserving Fn overrides and container state.
+func (m *MockWorkerBackend) ClearCalls() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.clearCallsLocked()
+}
+
+func (m *MockWorkerBackend) clearCallsLocked() {
 	m.Calls = struct {
 		Create []string
 		Delete []string
@@ -45,13 +74,15 @@ func (m *MockWorkerBackend) Reset() {
 		Status []string
 		List   int
 	}{}
-	m.NameOverride = ""
-	m.CreateFn = nil
-	m.DeleteFn = nil
-	m.StartFn = nil
-	m.StopFn = nil
-	m.StatusFn = nil
-	m.ListFn = nil
+}
+
+// SimulatePodDeletion removes a container from tracked state, simulating
+// an external deletion (e.g. kubectl delete pod). Subsequent Status calls
+// will return ErrNotFound (unless StatusFn is set).
+func (m *MockWorkerBackend) SimulatePodDeletion(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.containerState, name)
 }
 
 func (m *MockWorkerBackend) Name() string {
@@ -67,10 +98,22 @@ func (m *MockWorkerBackend) NeedsCredentialInjection() bool   { return false }
 func (m *MockWorkerBackend) Create(ctx context.Context, req backend.CreateRequest) (*backend.WorkerResult, error) {
 	m.mu.Lock()
 	m.Calls.Create = append(m.Calls.Create, req.Name)
+	fn := m.CreateFn
 	m.mu.Unlock()
-	if m.CreateFn != nil {
-		return m.CreateFn(ctx, req)
+
+	if fn != nil {
+		result, err := fn(ctx, req)
+		if err == nil {
+			m.mu.Lock()
+			m.containerState[req.Name] = backend.StatusRunning
+			m.mu.Unlock()
+		}
+		return result, err
 	}
+
+	m.mu.Lock()
+	m.containerState[req.Name] = backend.StatusRunning
+	m.mu.Unlock()
 	return &backend.WorkerResult{
 		Name:    req.Name,
 		Backend: m.Name(),
@@ -81,45 +124,87 @@ func (m *MockWorkerBackend) Create(ctx context.Context, req backend.CreateReques
 func (m *MockWorkerBackend) Delete(ctx context.Context, name string) error {
 	m.mu.Lock()
 	m.Calls.Delete = append(m.Calls.Delete, name)
+	fn := m.DeleteFn
 	m.mu.Unlock()
-	if m.DeleteFn != nil {
-		return m.DeleteFn(ctx, name)
+
+	if fn != nil {
+		err := fn(ctx, name)
+		if err == nil {
+			m.mu.Lock()
+			delete(m.containerState, name)
+			m.mu.Unlock()
+		}
+		return err
 	}
+
+	m.mu.Lock()
+	delete(m.containerState, name)
+	m.mu.Unlock()
 	return nil
 }
 
 func (m *MockWorkerBackend) Start(ctx context.Context, name string) error {
 	m.mu.Lock()
 	m.Calls.Start = append(m.Calls.Start, name)
+	fn := m.StartFn
 	m.mu.Unlock()
-	if m.StartFn != nil {
-		return m.StartFn(ctx, name)
+
+	if fn != nil {
+		err := fn(ctx, name)
+		if err == nil {
+			m.mu.Lock()
+			m.containerState[name] = backend.StatusRunning
+			m.mu.Unlock()
+		}
+		return err
 	}
+
+	m.mu.Lock()
+	m.containerState[name] = backend.StatusRunning
+	m.mu.Unlock()
 	return nil
 }
 
 func (m *MockWorkerBackend) Stop(ctx context.Context, name string) error {
 	m.mu.Lock()
 	m.Calls.Stop = append(m.Calls.Stop, name)
+	fn := m.StopFn
 	m.mu.Unlock()
-	if m.StopFn != nil {
-		return m.StopFn(ctx, name)
+
+	if fn != nil {
+		err := fn(ctx, name)
+		if err == nil {
+			m.mu.Lock()
+			m.containerState[name] = backend.StatusStopped
+			m.mu.Unlock()
+		}
+		return err
 	}
+
+	m.mu.Lock()
+	m.containerState[name] = backend.StatusStopped
+	m.mu.Unlock()
 	return nil
 }
 
 func (m *MockWorkerBackend) Status(ctx context.Context, name string) (*backend.WorkerResult, error) {
 	m.mu.Lock()
 	m.Calls.Status = append(m.Calls.Status, name)
+	fn := m.StatusFn
+	state, tracked := m.containerState[name]
 	m.mu.Unlock()
-	if m.StatusFn != nil {
-		return m.StatusFn(ctx, name)
+
+	if fn != nil {
+		return fn(ctx, name)
 	}
-	return &backend.WorkerResult{
-		Name:    name,
-		Backend: m.Name(),
-		Status:  backend.StatusRunning,
-	}, nil
+	if tracked {
+		return &backend.WorkerResult{
+			Name:    name,
+			Backend: m.Name(),
+			Status:  state,
+		}, nil
+	}
+	return nil, backend.ErrNotFound
 }
 
 func (m *MockWorkerBackend) List(ctx context.Context) ([]backend.WorkerResult, error) {

--- a/hiclaw-controller/test/testutil/mocks/backend.go
+++ b/hiclaw-controller/test/testutil/mocks/backend.go
@@ -204,7 +204,11 @@ func (m *MockWorkerBackend) Status(ctx context.Context, name string) (*backend.W
 			Status:  state,
 		}, nil
 	}
-	return nil, backend.ErrNotFound
+	return &backend.WorkerResult{
+		Name:    name,
+		Backend: m.Name(),
+		Status:  backend.StatusNotFound,
+	}, nil
 }
 
 func (m *MockWorkerBackend) List(ctx context.Context) ([]backend.WorkerResult, error) {

--- a/hiclaw-controller/test/testutil/mocks/deployer.go
+++ b/hiclaw-controller/test/testutil/mocks/deployer.go
@@ -110,4 +110,15 @@ func (m *MockDeployer) CleanupOSSData(ctx context.Context, workerName string) er
 	return nil
 }
 
+// CallCounts returns a snapshot of call counts safe for concurrent use.
+func (m *MockDeployer) CallCounts() (deployPkg, writeInline, deployConfig, pushSkills, cleanup int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.Calls.DeployPackage),
+		len(m.Calls.WriteInlineConfigs),
+		len(m.Calls.DeployWorkerConfig),
+		len(m.Calls.PushOnDemandSkills),
+		len(m.Calls.CleanupOSSData)
+}
+
 var _ service.WorkerDeployer = (*MockDeployer)(nil)

--- a/hiclaw-controller/test/testutil/mocks/deployer.go
+++ b/hiclaw-controller/test/testutil/mocks/deployer.go
@@ -12,16 +12,18 @@ import (
 type MockDeployer struct {
 	mu sync.Mutex
 
-	DeployPackageFn      func(ctx context.Context, name, uri string, isUpdate bool) error
-	WriteInlineConfigsFn func(name string, spec v1beta1.WorkerSpec) error
+	DeployPackageFn      func(ctx context.Context, workerName string, pkg string, isUpdate bool) error
+	WriteInlineConfigsFn func(workerName string, spec v1beta1.WorkerSpec) error
 	DeployWorkerConfigFn func(ctx context.Context, req service.WorkerDeployRequest) error
 	PushOnDemandSkillsFn func(ctx context.Context, workerName string, skills []string) error
 	CleanupOSSDataFn     func(ctx context.Context, workerName string) error
 
 	Calls struct {
-		DeployPackage     []string
-		DeployWorkerConfig []string
-		CleanupOSSData    []string
+		DeployPackage      []string
+		WriteInlineConfigs []string
+		DeployWorkerConfig []service.WorkerDeployRequest
+		PushOnDemandSkills []string
+		CleanupOSSData     []string
 	}
 }
 
@@ -29,26 +31,46 @@ func NewMockDeployer() *MockDeployer {
 	return &MockDeployer{}
 }
 
-func (m *MockDeployer) DeployPackage(ctx context.Context, name, uri string, isUpdate bool) error {
+func (m *MockDeployer) Reset() {
 	m.mu.Lock()
-	m.Calls.DeployPackage = append(m.Calls.DeployPackage, name)
+	defer m.mu.Unlock()
+	m.Calls = struct {
+		DeployPackage      []string
+		WriteInlineConfigs []string
+		DeployWorkerConfig []service.WorkerDeployRequest
+		PushOnDemandSkills []string
+		CleanupOSSData     []string
+	}{}
+	m.DeployPackageFn = nil
+	m.WriteInlineConfigsFn = nil
+	m.DeployWorkerConfigFn = nil
+	m.PushOnDemandSkillsFn = nil
+	m.CleanupOSSDataFn = nil
+}
+
+func (m *MockDeployer) DeployPackage(ctx context.Context, workerName string, pkg string, isUpdate bool) error {
+	m.mu.Lock()
+	m.Calls.DeployPackage = append(m.Calls.DeployPackage, workerName)
 	m.mu.Unlock()
 	if m.DeployPackageFn != nil {
-		return m.DeployPackageFn(ctx, name, uri, isUpdate)
+		return m.DeployPackageFn(ctx, workerName, pkg, isUpdate)
 	}
 	return nil
 }
 
-func (m *MockDeployer) WriteInlineConfigs(name string, spec v1beta1.WorkerSpec) error {
+func (m *MockDeployer) WriteInlineConfigs(workerName string, spec v1beta1.WorkerSpec) error {
+	m.mu.Lock()
+	m.Calls.WriteInlineConfigs = append(m.Calls.WriteInlineConfigs, workerName)
+	m.mu.Unlock()
 	if m.WriteInlineConfigsFn != nil {
-		return m.WriteInlineConfigsFn(name, spec)
+		return m.WriteInlineConfigsFn(workerName, spec)
 	}
 	return nil
 }
 
 func (m *MockDeployer) DeployWorkerConfig(ctx context.Context, req service.WorkerDeployRequest) error {
 	m.mu.Lock()
-	m.Calls.DeployWorkerConfig = append(m.Calls.DeployWorkerConfig, req.Name)
+	m.Calls.DeployWorkerConfig = append(m.Calls.DeployWorkerConfig, req)
 	m.mu.Unlock()
 	if m.DeployWorkerConfigFn != nil {
 		return m.DeployWorkerConfigFn(ctx, req)
@@ -57,6 +79,9 @@ func (m *MockDeployer) DeployWorkerConfig(ctx context.Context, req service.Worke
 }
 
 func (m *MockDeployer) PushOnDemandSkills(ctx context.Context, workerName string, skills []string) error {
+	m.mu.Lock()
+	m.Calls.PushOnDemandSkills = append(m.Calls.PushOnDemandSkills, workerName)
+	m.mu.Unlock()
 	if m.PushOnDemandSkillsFn != nil {
 		return m.PushOnDemandSkillsFn(ctx, workerName, skills)
 	}

--- a/hiclaw-controller/test/testutil/mocks/deployer.go
+++ b/hiclaw-controller/test/testutil/mocks/deployer.go
@@ -31,9 +31,26 @@ func NewMockDeployer() *MockDeployer {
 	return &MockDeployer{}
 }
 
+// Reset clears all Fn overrides and call records.
 func (m *MockDeployer) Reset() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.clearCallsLocked()
+	m.DeployPackageFn = nil
+	m.WriteInlineConfigsFn = nil
+	m.DeployWorkerConfigFn = nil
+	m.PushOnDemandSkillsFn = nil
+	m.CleanupOSSDataFn = nil
+}
+
+// ClearCalls resets call records only, preserving Fn overrides.
+func (m *MockDeployer) ClearCalls() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.clearCallsLocked()
+}
+
+func (m *MockDeployer) clearCallsLocked() {
 	m.Calls = struct {
 		DeployPackage      []string
 		WriteInlineConfigs []string
@@ -41,11 +58,6 @@ func (m *MockDeployer) Reset() {
 		PushOnDemandSkills []string
 		CleanupOSSData     []string
 	}{}
-	m.DeployPackageFn = nil
-	m.WriteInlineConfigsFn = nil
-	m.DeployWorkerConfigFn = nil
-	m.PushOnDemandSkillsFn = nil
-	m.CleanupOSSDataFn = nil
 }
 
 func (m *MockDeployer) DeployPackage(ctx context.Context, workerName string, pkg string, isUpdate bool) error {

--- a/hiclaw-controller/test/testutil/mocks/deployer.go
+++ b/hiclaw-controller/test/testutil/mocks/deployer.go
@@ -1,0 +1,76 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+
+	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	"github.com/hiclaw/hiclaw-controller/internal/service"
+)
+
+// MockDeployer implements service.WorkerDeployer for testing.
+type MockDeployer struct {
+	mu sync.Mutex
+
+	DeployPackageFn      func(ctx context.Context, name, uri string, isUpdate bool) error
+	WriteInlineConfigsFn func(name string, spec v1beta1.WorkerSpec) error
+	DeployWorkerConfigFn func(ctx context.Context, req service.WorkerDeployRequest) error
+	PushOnDemandSkillsFn func(ctx context.Context, workerName string, skills []string) error
+	CleanupOSSDataFn     func(ctx context.Context, workerName string) error
+
+	Calls struct {
+		DeployPackage     []string
+		DeployWorkerConfig []string
+		CleanupOSSData    []string
+	}
+}
+
+func NewMockDeployer() *MockDeployer {
+	return &MockDeployer{}
+}
+
+func (m *MockDeployer) DeployPackage(ctx context.Context, name, uri string, isUpdate bool) error {
+	m.mu.Lock()
+	m.Calls.DeployPackage = append(m.Calls.DeployPackage, name)
+	m.mu.Unlock()
+	if m.DeployPackageFn != nil {
+		return m.DeployPackageFn(ctx, name, uri, isUpdate)
+	}
+	return nil
+}
+
+func (m *MockDeployer) WriteInlineConfigs(name string, spec v1beta1.WorkerSpec) error {
+	if m.WriteInlineConfigsFn != nil {
+		return m.WriteInlineConfigsFn(name, spec)
+	}
+	return nil
+}
+
+func (m *MockDeployer) DeployWorkerConfig(ctx context.Context, req service.WorkerDeployRequest) error {
+	m.mu.Lock()
+	m.Calls.DeployWorkerConfig = append(m.Calls.DeployWorkerConfig, req.Name)
+	m.mu.Unlock()
+	if m.DeployWorkerConfigFn != nil {
+		return m.DeployWorkerConfigFn(ctx, req)
+	}
+	return nil
+}
+
+func (m *MockDeployer) PushOnDemandSkills(ctx context.Context, workerName string, skills []string) error {
+	if m.PushOnDemandSkillsFn != nil {
+		return m.PushOnDemandSkillsFn(ctx, workerName, skills)
+	}
+	return nil
+}
+
+func (m *MockDeployer) CleanupOSSData(ctx context.Context, workerName string) error {
+	m.mu.Lock()
+	m.Calls.CleanupOSSData = append(m.Calls.CleanupOSSData, workerName)
+	m.mu.Unlock()
+	if m.CleanupOSSDataFn != nil {
+		return m.CleanupOSSDataFn(ctx, workerName)
+	}
+	return nil
+}
+
+var _ service.WorkerDeployer = (*MockDeployer)(nil)

--- a/hiclaw-controller/test/testutil/mocks/env_builder.go
+++ b/hiclaw-controller/test/testutil/mocks/env_builder.go
@@ -1,19 +1,39 @@
 package mocks
 
 import (
+	"sync"
+
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 )
 
 // MockEnvBuilder implements service.WorkerEnvBuilderI for testing.
 type MockEnvBuilder struct {
+	mu sync.Mutex
+
 	BuildFn func(workerName string, prov *service.WorkerProvisionResult) map[string]string
+
+	Calls struct {
+		Build []string
+	}
 }
 
 func NewMockEnvBuilder() *MockEnvBuilder {
 	return &MockEnvBuilder{}
 }
 
+func (m *MockEnvBuilder) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Calls = struct {
+		Build []string
+	}{}
+	m.BuildFn = nil
+}
+
 func (m *MockEnvBuilder) Build(workerName string, prov *service.WorkerProvisionResult) map[string]string {
+	m.mu.Lock()
+	m.Calls.Build = append(m.Calls.Build, workerName)
+	m.mu.Unlock()
 	if m.BuildFn != nil {
 		return m.BuildFn(workerName, prov)
 	}

--- a/hiclaw-controller/test/testutil/mocks/env_builder.go
+++ b/hiclaw-controller/test/testutil/mocks/env_builder.go
@@ -1,0 +1,26 @@
+package mocks
+
+import (
+	"github.com/hiclaw/hiclaw-controller/internal/service"
+)
+
+// MockEnvBuilder implements service.WorkerEnvBuilderI for testing.
+type MockEnvBuilder struct {
+	BuildFn func(workerName string, prov *service.WorkerProvisionResult) map[string]string
+}
+
+func NewMockEnvBuilder() *MockEnvBuilder {
+	return &MockEnvBuilder{}
+}
+
+func (m *MockEnvBuilder) Build(workerName string, prov *service.WorkerProvisionResult) map[string]string {
+	if m.BuildFn != nil {
+		return m.BuildFn(workerName, prov)
+	}
+	return map[string]string{
+		"HICLAW_WORKER_NAME": workerName,
+		"MOCK_ENV":           "true",
+	}
+}
+
+var _ service.WorkerEnvBuilderI = (*MockEnvBuilder)(nil)

--- a/hiclaw-controller/test/testutil/mocks/env_builder.go
+++ b/hiclaw-controller/test/testutil/mocks/env_builder.go
@@ -21,13 +21,25 @@ func NewMockEnvBuilder() *MockEnvBuilder {
 	return &MockEnvBuilder{}
 }
 
+// Reset clears all Fn overrides and call records.
 func (m *MockEnvBuilder) Reset() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.clearCallsLocked()
+	m.BuildFn = nil
+}
+
+// ClearCalls resets call records only, preserving Fn overrides.
+func (m *MockEnvBuilder) ClearCalls() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.clearCallsLocked()
+}
+
+func (m *MockEnvBuilder) clearCallsLocked() {
 	m.Calls = struct {
 		Build []string
 	}{}
-	m.BuildFn = nil
 }
 
 func (m *MockEnvBuilder) Build(workerName string, prov *service.WorkerProvisionResult) map[string]string {

--- a/hiclaw-controller/test/testutil/mocks/provisioner.go
+++ b/hiclaw-controller/test/testutil/mocks/provisioner.go
@@ -201,4 +201,14 @@ func (m *MockProvisioner) MatrixUserID(name string) string {
 	return "@" + name + ":localhost"
 }
 
+// CallCounts returns a snapshot of call counts safe for concurrent use.
+func (m *MockProvisioner) CallCounts() (provision, deprovision, refresh, deactivate int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.Calls.ProvisionWorker),
+		len(m.Calls.DeprovisionWorker),
+		len(m.Calls.RefreshCredentials),
+		len(m.Calls.DeactivateMatrixUser)
+}
+
 var _ service.WorkerProvisioner = (*MockProvisioner)(nil)

--- a/hiclaw-controller/test/testutil/mocks/provisioner.go
+++ b/hiclaw-controller/test/testutil/mocks/provisioner.go
@@ -42,9 +42,32 @@ func NewMockProvisioner() *MockProvisioner {
 	return &MockProvisioner{}
 }
 
+// Reset clears all Fn overrides and call records.
 func (m *MockProvisioner) Reset() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.clearCallsLocked()
+	m.ProvisionWorkerFn = nil
+	m.DeprovisionWorkerFn = nil
+	m.RefreshCredentialsFn = nil
+	m.ReconcileMCPAuthFn = nil
+	m.ReconcileExposeFn = nil
+	m.EnsureServiceAccountFn = nil
+	m.DeleteServiceAccountFn = nil
+	m.DeleteCredentialsFn = nil
+	m.RequestSATokenFn = nil
+	m.DeactivateMatrixUserFn = nil
+	m.MatrixUserIDFn = nil
+}
+
+// ClearCalls resets call records only, preserving Fn overrides.
+func (m *MockProvisioner) ClearCalls() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.clearCallsLocked()
+}
+
+func (m *MockProvisioner) clearCallsLocked() {
 	m.Calls = struct {
 		ProvisionWorker      []service.WorkerProvisionRequest
 		DeprovisionWorker    []service.WorkerDeprovisionRequest
@@ -57,17 +80,6 @@ func (m *MockProvisioner) Reset() {
 		RequestSAToken       []string
 		DeactivateMatrixUser []string
 	}{}
-	m.ProvisionWorkerFn = nil
-	m.DeprovisionWorkerFn = nil
-	m.RefreshCredentialsFn = nil
-	m.ReconcileMCPAuthFn = nil
-	m.ReconcileExposeFn = nil
-	m.EnsureServiceAccountFn = nil
-	m.DeleteServiceAccountFn = nil
-	m.DeleteCredentialsFn = nil
-	m.RequestSATokenFn = nil
-	m.DeactivateMatrixUserFn = nil
-	m.MatrixUserIDFn = nil
 }
 
 func (m *MockProvisioner) ProvisionWorker(ctx context.Context, req service.WorkerProvisionRequest) (*service.WorkerProvisionResult, error) {

--- a/hiclaw-controller/test/testutil/mocks/provisioner.go
+++ b/hiclaw-controller/test/testutil/mocks/provisioner.go
@@ -12,11 +12,11 @@ import (
 type MockProvisioner struct {
 	mu sync.Mutex
 
-	ProvisionWorkerFn    func(ctx context.Context, req service.WorkerProvisionRequest) (*service.WorkerProvisionResult, error)
-	DeprovisionWorkerFn  func(ctx context.Context, req service.WorkerDeprovisionRequest) error
-	RefreshCredentialsFn func(ctx context.Context, workerName string) (*service.RefreshResult, error)
-	ReconcileMCPAuthFn   func(ctx context.Context, consumerName string, mcpServers []string) ([]string, error)
-	ReconcileExposeFn    func(ctx context.Context, workerName string, desired []v1beta1.ExposePort, current []v1beta1.ExposedPortStatus) ([]v1beta1.ExposedPortStatus, error)
+	ProvisionWorkerFn      func(ctx context.Context, req service.WorkerProvisionRequest) (*service.WorkerProvisionResult, error)
+	DeprovisionWorkerFn    func(ctx context.Context, req service.WorkerDeprovisionRequest) error
+	RefreshCredentialsFn   func(ctx context.Context, workerName string) (*service.RefreshResult, error)
+	ReconcileMCPAuthFn     func(ctx context.Context, consumerName string, mcpServers []string) ([]string, error)
+	ReconcileExposeFn      func(ctx context.Context, workerName string, desired []v1beta1.ExposePort, current []v1beta1.ExposedPortStatus) ([]v1beta1.ExposedPortStatus, error)
 	EnsureServiceAccountFn func(ctx context.Context, workerName string) error
 	DeleteServiceAccountFn func(ctx context.Context, workerName string) error
 	DeleteCredentialsFn    func(ctx context.Context, workerName string) error
@@ -24,14 +24,46 @@ type MockProvisioner struct {
 	MatrixUserIDFn         func(name string) string
 
 	Calls struct {
-		ProvisionWorker   []service.WorkerProvisionRequest
-		DeprovisionWorker []service.WorkerDeprovisionRequest
+		ProvisionWorker    []service.WorkerProvisionRequest
+		DeprovisionWorker  []service.WorkerDeprovisionRequest
 		RefreshCredentials []string
+		ReconcileMCPAuth   []string
+		ReconcileExpose    []string
+		EnsureServiceAccount []string
+		DeleteServiceAccount []string
+		DeleteCredentials  []string
+		RequestSAToken     []string
 	}
 }
 
 func NewMockProvisioner() *MockProvisioner {
 	return &MockProvisioner{}
+}
+
+func (m *MockProvisioner) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Calls = struct {
+		ProvisionWorker    []service.WorkerProvisionRequest
+		DeprovisionWorker  []service.WorkerDeprovisionRequest
+		RefreshCredentials []string
+		ReconcileMCPAuth   []string
+		ReconcileExpose    []string
+		EnsureServiceAccount []string
+		DeleteServiceAccount []string
+		DeleteCredentials  []string
+		RequestSAToken     []string
+	}{}
+	m.ProvisionWorkerFn = nil
+	m.DeprovisionWorkerFn = nil
+	m.RefreshCredentialsFn = nil
+	m.ReconcileMCPAuthFn = nil
+	m.ReconcileExposeFn = nil
+	m.EnsureServiceAccountFn = nil
+	m.DeleteServiceAccountFn = nil
+	m.DeleteCredentialsFn = nil
+	m.RequestSATokenFn = nil
+	m.MatrixUserIDFn = nil
 }
 
 func (m *MockProvisioner) ProvisionWorker(ctx context.Context, req service.WorkerProvisionRequest) (*service.WorkerProvisionResult, error) {
@@ -77,6 +109,9 @@ func (m *MockProvisioner) RefreshCredentials(ctx context.Context, workerName str
 }
 
 func (m *MockProvisioner) ReconcileMCPAuth(ctx context.Context, consumerName string, mcpServers []string) ([]string, error) {
+	m.mu.Lock()
+	m.Calls.ReconcileMCPAuth = append(m.Calls.ReconcileMCPAuth, consumerName)
+	m.mu.Unlock()
 	if m.ReconcileMCPAuthFn != nil {
 		return m.ReconcileMCPAuthFn(ctx, consumerName, mcpServers)
 	}
@@ -84,6 +119,9 @@ func (m *MockProvisioner) ReconcileMCPAuth(ctx context.Context, consumerName str
 }
 
 func (m *MockProvisioner) ReconcileExpose(ctx context.Context, workerName string, desired []v1beta1.ExposePort, current []v1beta1.ExposedPortStatus) ([]v1beta1.ExposedPortStatus, error) {
+	m.mu.Lock()
+	m.Calls.ReconcileExpose = append(m.Calls.ReconcileExpose, workerName)
+	m.mu.Unlock()
 	if m.ReconcileExposeFn != nil {
 		return m.ReconcileExposeFn(ctx, workerName, desired, current)
 	}
@@ -91,6 +129,9 @@ func (m *MockProvisioner) ReconcileExpose(ctx context.Context, workerName string
 }
 
 func (m *MockProvisioner) EnsureServiceAccount(ctx context.Context, workerName string) error {
+	m.mu.Lock()
+	m.Calls.EnsureServiceAccount = append(m.Calls.EnsureServiceAccount, workerName)
+	m.mu.Unlock()
 	if m.EnsureServiceAccountFn != nil {
 		return m.EnsureServiceAccountFn(ctx, workerName)
 	}
@@ -98,6 +139,9 @@ func (m *MockProvisioner) EnsureServiceAccount(ctx context.Context, workerName s
 }
 
 func (m *MockProvisioner) DeleteServiceAccount(ctx context.Context, workerName string) error {
+	m.mu.Lock()
+	m.Calls.DeleteServiceAccount = append(m.Calls.DeleteServiceAccount, workerName)
+	m.mu.Unlock()
 	if m.DeleteServiceAccountFn != nil {
 		return m.DeleteServiceAccountFn(ctx, workerName)
 	}
@@ -105,6 +149,9 @@ func (m *MockProvisioner) DeleteServiceAccount(ctx context.Context, workerName s
 }
 
 func (m *MockProvisioner) DeleteCredentials(ctx context.Context, workerName string) error {
+	m.mu.Lock()
+	m.Calls.DeleteCredentials = append(m.Calls.DeleteCredentials, workerName)
+	m.mu.Unlock()
 	if m.DeleteCredentialsFn != nil {
 		return m.DeleteCredentialsFn(ctx, workerName)
 	}
@@ -112,6 +159,9 @@ func (m *MockProvisioner) DeleteCredentials(ctx context.Context, workerName stri
 }
 
 func (m *MockProvisioner) RequestSAToken(ctx context.Context, workerName string) (string, error) {
+	m.mu.Lock()
+	m.Calls.RequestSAToken = append(m.Calls.RequestSAToken, workerName)
+	m.mu.Unlock()
 	if m.RequestSATokenFn != nil {
 		return m.RequestSATokenFn(ctx, workerName)
 	}

--- a/hiclaw-controller/test/testutil/mocks/provisioner.go
+++ b/hiclaw-controller/test/testutil/mocks/provisioner.go
@@ -21,18 +21,20 @@ type MockProvisioner struct {
 	DeleteServiceAccountFn func(ctx context.Context, workerName string) error
 	DeleteCredentialsFn    func(ctx context.Context, workerName string) error
 	RequestSATokenFn       func(ctx context.Context, workerName string) (string, error)
+	DeactivateMatrixUserFn func(ctx context.Context, workerName string) error
 	MatrixUserIDFn         func(name string) string
 
 	Calls struct {
-		ProvisionWorker    []service.WorkerProvisionRequest
-		DeprovisionWorker  []service.WorkerDeprovisionRequest
-		RefreshCredentials []string
-		ReconcileMCPAuth   []string
-		ReconcileExpose    []string
+		ProvisionWorker      []service.WorkerProvisionRequest
+		DeprovisionWorker    []service.WorkerDeprovisionRequest
+		RefreshCredentials   []string
+		ReconcileMCPAuth     []string
+		ReconcileExpose      []string
 		EnsureServiceAccount []string
 		DeleteServiceAccount []string
-		DeleteCredentials  []string
-		RequestSAToken     []string
+		DeleteCredentials    []string
+		RequestSAToken       []string
+		DeactivateMatrixUser []string
 	}
 }
 
@@ -44,15 +46,16 @@ func (m *MockProvisioner) Reset() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.Calls = struct {
-		ProvisionWorker    []service.WorkerProvisionRequest
-		DeprovisionWorker  []service.WorkerDeprovisionRequest
-		RefreshCredentials []string
-		ReconcileMCPAuth   []string
-		ReconcileExpose    []string
+		ProvisionWorker      []service.WorkerProvisionRequest
+		DeprovisionWorker    []service.WorkerDeprovisionRequest
+		RefreshCredentials   []string
+		ReconcileMCPAuth     []string
+		ReconcileExpose      []string
 		EnsureServiceAccount []string
 		DeleteServiceAccount []string
-		DeleteCredentials  []string
-		RequestSAToken     []string
+		DeleteCredentials    []string
+		RequestSAToken       []string
+		DeactivateMatrixUser []string
 	}{}
 	m.ProvisionWorkerFn = nil
 	m.DeprovisionWorkerFn = nil
@@ -63,6 +66,7 @@ func (m *MockProvisioner) Reset() {
 	m.DeleteServiceAccountFn = nil
 	m.DeleteCredentialsFn = nil
 	m.RequestSATokenFn = nil
+	m.DeactivateMatrixUserFn = nil
 	m.MatrixUserIDFn = nil
 }
 
@@ -166,6 +170,16 @@ func (m *MockProvisioner) RequestSAToken(ctx context.Context, workerName string)
 		return m.RequestSATokenFn(ctx, workerName)
 	}
 	return "mock-sa-token-" + workerName, nil
+}
+
+func (m *MockProvisioner) DeactivateMatrixUser(ctx context.Context, workerName string) error {
+	m.mu.Lock()
+	m.Calls.DeactivateMatrixUser = append(m.Calls.DeactivateMatrixUser, workerName)
+	m.mu.Unlock()
+	if m.DeactivateMatrixUserFn != nil {
+		return m.DeactivateMatrixUserFn(ctx, workerName)
+	}
+	return nil
 }
 
 func (m *MockProvisioner) MatrixUserID(name string) string {

--- a/hiclaw-controller/test/testutil/mocks/provisioner.go
+++ b/hiclaw-controller/test/testutil/mocks/provisioner.go
@@ -1,0 +1,128 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+
+	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	"github.com/hiclaw/hiclaw-controller/internal/service"
+)
+
+// MockProvisioner implements service.WorkerProvisioner for testing.
+type MockProvisioner struct {
+	mu sync.Mutex
+
+	ProvisionWorkerFn    func(ctx context.Context, req service.WorkerProvisionRequest) (*service.WorkerProvisionResult, error)
+	DeprovisionWorkerFn  func(ctx context.Context, req service.WorkerDeprovisionRequest) error
+	RefreshCredentialsFn func(ctx context.Context, workerName string) (*service.RefreshResult, error)
+	ReconcileMCPAuthFn   func(ctx context.Context, consumerName string, mcpServers []string) ([]string, error)
+	ReconcileExposeFn    func(ctx context.Context, workerName string, desired []v1beta1.ExposePort, current []v1beta1.ExposedPortStatus) ([]v1beta1.ExposedPortStatus, error)
+	EnsureServiceAccountFn func(ctx context.Context, workerName string) error
+	DeleteServiceAccountFn func(ctx context.Context, workerName string) error
+	DeleteCredentialsFn    func(ctx context.Context, workerName string) error
+	RequestSATokenFn       func(ctx context.Context, workerName string) (string, error)
+	MatrixUserIDFn         func(name string) string
+
+	Calls struct {
+		ProvisionWorker   []service.WorkerProvisionRequest
+		DeprovisionWorker []service.WorkerDeprovisionRequest
+		RefreshCredentials []string
+	}
+}
+
+func NewMockProvisioner() *MockProvisioner {
+	return &MockProvisioner{}
+}
+
+func (m *MockProvisioner) ProvisionWorker(ctx context.Context, req service.WorkerProvisionRequest) (*service.WorkerProvisionResult, error) {
+	m.mu.Lock()
+	m.Calls.ProvisionWorker = append(m.Calls.ProvisionWorker, req)
+	m.mu.Unlock()
+	if m.ProvisionWorkerFn != nil {
+		return m.ProvisionWorkerFn(ctx, req)
+	}
+	return &service.WorkerProvisionResult{
+		MatrixUserID:   "@" + req.Name + ":localhost",
+		MatrixToken:    "mock-token-" + req.Name,
+		RoomID:         "!room-" + req.Name + ":localhost",
+		GatewayKey:     "mock-gw-key-" + req.Name,
+		MinIOPassword:  "mock-minio-pw",
+		MatrixPassword: "mock-matrix-pw",
+	}, nil
+}
+
+func (m *MockProvisioner) DeprovisionWorker(ctx context.Context, req service.WorkerDeprovisionRequest) error {
+	m.mu.Lock()
+	m.Calls.DeprovisionWorker = append(m.Calls.DeprovisionWorker, req)
+	m.mu.Unlock()
+	if m.DeprovisionWorkerFn != nil {
+		return m.DeprovisionWorkerFn(ctx, req)
+	}
+	return nil
+}
+
+func (m *MockProvisioner) RefreshCredentials(ctx context.Context, workerName string) (*service.RefreshResult, error) {
+	m.mu.Lock()
+	m.Calls.RefreshCredentials = append(m.Calls.RefreshCredentials, workerName)
+	m.mu.Unlock()
+	if m.RefreshCredentialsFn != nil {
+		return m.RefreshCredentialsFn(ctx, workerName)
+	}
+	return &service.RefreshResult{
+		MatrixToken:    "mock-token-" + workerName,
+		GatewayKey:     "mock-gw-key-" + workerName,
+		MinIOPassword:  "mock-minio-pw",
+		MatrixPassword: "mock-matrix-pw",
+	}, nil
+}
+
+func (m *MockProvisioner) ReconcileMCPAuth(ctx context.Context, consumerName string, mcpServers []string) ([]string, error) {
+	if m.ReconcileMCPAuthFn != nil {
+		return m.ReconcileMCPAuthFn(ctx, consumerName, mcpServers)
+	}
+	return mcpServers, nil
+}
+
+func (m *MockProvisioner) ReconcileExpose(ctx context.Context, workerName string, desired []v1beta1.ExposePort, current []v1beta1.ExposedPortStatus) ([]v1beta1.ExposedPortStatus, error) {
+	if m.ReconcileExposeFn != nil {
+		return m.ReconcileExposeFn(ctx, workerName, desired, current)
+	}
+	return nil, nil
+}
+
+func (m *MockProvisioner) EnsureServiceAccount(ctx context.Context, workerName string) error {
+	if m.EnsureServiceAccountFn != nil {
+		return m.EnsureServiceAccountFn(ctx, workerName)
+	}
+	return nil
+}
+
+func (m *MockProvisioner) DeleteServiceAccount(ctx context.Context, workerName string) error {
+	if m.DeleteServiceAccountFn != nil {
+		return m.DeleteServiceAccountFn(ctx, workerName)
+	}
+	return nil
+}
+
+func (m *MockProvisioner) DeleteCredentials(ctx context.Context, workerName string) error {
+	if m.DeleteCredentialsFn != nil {
+		return m.DeleteCredentialsFn(ctx, workerName)
+	}
+	return nil
+}
+
+func (m *MockProvisioner) RequestSAToken(ctx context.Context, workerName string) (string, error) {
+	if m.RequestSATokenFn != nil {
+		return m.RequestSATokenFn(ctx, workerName)
+	}
+	return "mock-sa-token-" + workerName, nil
+}
+
+func (m *MockProvisioner) MatrixUserID(name string) string {
+	if m.MatrixUserIDFn != nil {
+		return m.MatrixUserIDFn(name)
+	}
+	return "@" + name + ":localhost"
+}
+
+var _ service.WorkerProvisioner = (*MockProvisioner)(nil)


### PR DESCRIPTION
## Summary

### 问题背景

Worker Controller Reconciler 存在严重的结构性问题，不符合 K8s 控制器最佳实践：

1. **反模式：过程式编排** — `handleCreate` 和 `handleUpdate` 是线性管道（Phase 1→2→3→...→7），任何中间步骤失败后 requeue 从头执行，违反幂等性原则
2. **handleUpdate 无限循环（CRITICAL）** — `ObservedGeneration` 写入失败被标记为 non-fatal，导致 `Generation != ObservedGeneration` 永远成立，不断重入 handleUpdate，涉及 pod 重建时会无限 delete+create
3. **Status Update 不可靠** — `failCreate`、`failUpdate`、`failLifecycle` 中的 `r.Status().Update()` 返回值全部被丢弃
4. **handleCreate 不幂等** — Phase 7 status update 失败后重入会重复执行 ProvisionWorker，pod 已存在时触发 ErrConflict
5. **Pod 创建失败仍标记 Running** — `wb.Create()` 失败是 non-fatal，但 Phase 7 无条件设置 `Phase=Running`
6. **handleDelete 不清理 Matrix 用户** — 删除 Worker CR 后重建同名 Worker 时，新密码不匹配已存在的 Matrix 用户，Login 会 403
7. **reconcileDesiredState + handleUpdate 竞争** — 同时修改 state 和 model 时，两条路径没有协调
8. **Pod Watch 过于宽泛** — 没有 predicates 过滤，Pod 任何字段变化都触发 reconcile
9. **零测试覆盖** — 没有任何 controller 集成测试

### 改动结构

#### 阶段 1：测试基础设施搭建
- 提取 Service 层接口（`internal/service/interfaces.go`）：`WorkerProvisioner`、`WorkerDeployer`、`WorkerEnvBuilderI`
- 修改 `WorkerReconciler` 字段从具体类型改为接口类型，支持 mock 注入
- 建立独立测试目录结构（`test/integration/`、`test/testutil/`、`test/e2e/`），使用 Go build tags 分层控制
- 创建手写 mock（MockProvisioner、MockDeployer、MockWorkerBackend、MockEnvBuilder）
- 搭建 envtest 集成测试框架（suite_test.go + TestMain）

#### 阶段 2：Reconciler 核心重构
- 引入 `workerScope` 上下文对象，统一管理 reconcile 生命周期
- 采用声明式收敛模式，拆分为独立的子资源收敛函数：
  - `reconcileInfrastructure`（幂等 ensure Matrix + Gateway + MinIO）
  - `reconcileConfig`（幂等 ensure config files）
  - `reconcileContainer`（基于 spec.state 管理 pod 生命周期）
- 使用 `defer` + `patchBase` 统一 status 写入，`ObservedGeneration` 原子性写入，失败必须返回 error
- 引入 `podSpecHash` annotation 机制区分 config-only 变更和 pod-rebuild 变更
- 优化 Pod Watch predicates，只关注 pod phase 变化

#### 阶段 3：Matrix Deactivation + Delete 修复
- Matrix Client 接口新增 `DeactivateUser` 方法（Synapse Admin API）
- Provisioner 新增 `DeactivateMatrixUser`，在 `reconcileDelete` 中调用
- 修复删除后重建同名 Worker 的 403 问题

#### 阶段 4：集成测试完善
- 覆盖 15 个关键场景：创建/失败/幂等重入/config-only 更新/image 变更重建/ObservedGeneration/无限循环防护/删除清理/状态切换/Pod 意外删除/Finalizer 等

### 文件结构

```
hiclaw-controller/
├── internal/controller/
│   ├── worker_controller.go            # 重构后的 reconcile 入口
│   ├── worker_reconcile_infra.go       # 基础设施收敛
│   ├── worker_reconcile_config.go      # 配置收敛
│   ├── worker_reconcile_container.go   # 容器生命周期收敛
│   ├── worker_reconcile_delete.go      # 删除处理
│   └── worker_scope.go                 # reconcile 上下文
├── internal/service/interfaces.go      # Service 层接口定义
├── test/
│   ├── integration/controller/         # envtest 集成测试
│   ├── testutil/mocks/                 # 共享 mock
│   ├── testutil/fixtures/              # 测试数据构造器
│   └── testutil/envtest.go             # envtest 共享启动逻辑
```

> 注：Manager Reconciler 存在完全相同的结构性问题，将在后续 PR 中同模式重构。

## Test plan

- [x] `make test-unit` 通过，现有 unit test 无 regression
- [x] `make test-integration` 通过，15 个集成测试用例全部通过
- [x] Worker 创建 → Phase 从 "" 到 Running
- [x] Worker 删除 → finalizer 清理 + Matrix 用户 deactivation
- [x] Spec 变更 → pod 重建
- [x] Status update conflict → 不进入无限循环
- [x] Pod 意外删除 → reconcile 重建