### PR TITLE
refactor: modularize Manager reconciler with phase-based lifecycle and integration tests

### DIFF
--- a/hiclaw-controller/internal/backend/kubernetes.go
+++ b/hiclaw-controller/internal/backend/kubernetes.go
@@ -90,6 +90,16 @@ func NewK8sBackendWithClient(client K8sCoreClient, config K8sConfig, containerPr
 	}
 }
 
+// WithPrefix returns a shallow copy of the backend with a different container name prefix.
+// The returned backend shares the same client (safe — K8sCoreClient is stateless).
+// Use WithPrefix("") to disable prefix for containers that already have full names
+// (e.g. Manager containers named "hiclaw-manager" rather than "hiclaw-worker-X").
+func (k *K8sBackend) WithPrefix(prefix string) *K8sBackend {
+	cp := *k
+	cp.containerPrefix = prefix
+	return &cp
+}
+
 func (k *K8sBackend) Name() string                   { return "k8s" }
 func (k *K8sBackend) DeploymentMode() string         { return DeployCloud }
 func (k *K8sBackend) NeedsCredentialInjection() bool { return true }

--- a/hiclaw-controller/internal/backend/kubernetes_test.go
+++ b/hiclaw-controller/internal/backend/kubernetes_test.go
@@ -307,3 +307,93 @@ func TestBuildHostAliases(t *testing.T) {
 		t.Fatalf("expected 2 hostnames, got %d", len(aliases[0].Hostnames))
 	}
 }
+
+func TestK8sWithPrefix(t *testing.T) {
+	managerPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hiclaw-manager",
+			Namespace: "hiclaw",
+			Labels: map[string]string{
+				"app":               "hiclaw-manager",
+				"hiclaw.io/manager": "default",
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	b := newTestK8sBackend(managerPod)
+
+	// Original backend (prefix "hiclaw-worker-") should NOT find the manager pod
+	result, err := b.Status(context.Background(), "hiclaw-manager")
+	if err != nil {
+		t.Fatalf("Status failed: %v", err)
+	}
+	if result.Status != StatusNotFound {
+		t.Fatalf("expected not_found with worker prefix, got %s", result.Status)
+	}
+
+	// WithPrefix("") should find it by exact name
+	mb := b.WithPrefix("")
+	result, err = mb.Status(context.Background(), "hiclaw-manager")
+	if err != nil {
+		t.Fatalf("Status failed: %v", err)
+	}
+	if result.Status != StatusRunning {
+		t.Fatalf("expected running with empty prefix, got %s", result.Status)
+	}
+
+	// WithPrefix does not mutate the original backend
+	if b.containerPrefix != "hiclaw-worker-" {
+		t.Fatalf("original prefix mutated: %q", b.containerPrefix)
+	}
+	if mb.containerPrefix != "" {
+		t.Fatalf("new prefix not empty: %q", mb.containerPrefix)
+	}
+}
+
+func TestK8sWithPrefixDelete(t *testing.T) {
+	managerPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hiclaw-manager",
+			Namespace: "hiclaw",
+		},
+	}
+	b := newTestK8sBackend(managerPod)
+	mb := b.WithPrefix("")
+
+	if err := mb.Delete(context.Background(), "hiclaw-manager"); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	result, err := mb.Status(context.Background(), "hiclaw-manager")
+	if err != nil {
+		t.Fatalf("Status after delete failed: %v", err)
+	}
+	if result.Status != StatusNotFound {
+		t.Fatalf("expected not_found after delete, got %s", result.Status)
+	}
+}
+
+func TestK8sWithPrefixStop(t *testing.T) {
+	managerPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hiclaw-manager",
+			Namespace: "hiclaw",
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	b := newTestK8sBackend(managerPod)
+	mb := b.WithPrefix("")
+
+	// Stop on K8s backend is equivalent to Delete
+	if err := mb.Stop(context.Background(), "hiclaw-manager"); err != nil {
+		t.Fatalf("Stop failed: %v", err)
+	}
+
+	result, err := mb.Status(context.Background(), "hiclaw-manager")
+	if err != nil {
+		t.Fatalf("Status after stop failed: %v", err)
+	}
+	if result.Status != StatusNotFound {
+		t.Fatalf("expected not_found after stop, got %s", result.Status)
+	}
+}

--- a/hiclaw-controller/internal/controller/manager_controller.go
+++ b/hiclaw-controller/internal/controller/manager_controller.go
@@ -2,16 +2,14 @@ package controller
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"time"
 
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
-	authpkg "github.com/hiclaw/hiclaw-controller/internal/auth"
 	"github.com/hiclaw/hiclaw-controller/internal/backend"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -52,7 +50,7 @@ type ManagerReconciler struct {
 	EmbeddedConfig   *ManagerEmbeddedConfig // non-nil in embedded mode only
 }
 
-func (r *ManagerReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+func (r *ManagerReconciler) Reconcile(ctx context.Context, req reconcile.Request) (retres reconcile.Result, reterr error) {
 	logger := log.FromContext(ctx)
 
 	var mgr v1beta1.Manager
@@ -60,16 +58,38 @@ func (r *ManagerReconciler) Reconcile(ctx context.Context, req reconcile.Request
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
+	patchBase := client.MergeFrom(mgr.DeepCopy())
+
+	s := &managerScope{
+		manager:   &mgr,
+		patchBase: patchBase,
+	}
+
+	defer func() {
+		if !mgr.DeletionTimestamp.IsZero() {
+			return
+		}
+
+		mgr.Status.Phase = computeManagerPhase(&mgr, reterr)
+		if reterr == nil {
+			mgr.Status.ObservedGeneration = mgr.Generation
+			mgr.Status.Message = ""
+		} else {
+			mgr.Status.Message = reterr.Error()
+		}
+		if mgr.Spec.Image != "" {
+			mgr.Status.Version = mgr.Spec.Image
+		}
+
+		if err := r.Status().Patch(ctx, &mgr, patchBase); err != nil {
+			logger.Error(err, "failed to patch manager status")
+			reterr = kerrors.NewAggregate([]error{reterr, err})
+		}
+	}()
+
 	if !mgr.DeletionTimestamp.IsZero() {
 		if controllerutil.ContainsFinalizer(&mgr, finalizerName) {
-			if err := r.handleDelete(ctx, &mgr); err != nil {
-				logger.Error(err, "failed to delete manager", "name", mgr.Name)
-				return reconcile.Result{RequeueAfter: 30 * time.Second}, err
-			}
-			controllerutil.RemoveFinalizer(&mgr, finalizerName)
-			if err := r.Update(ctx, &mgr); err != nil {
-				return reconcile.Result{}, err
-			}
+			return r.reconcileManagerDelete(ctx, s)
 		}
 		return reconcile.Result{}, nil
 	}
@@ -81,508 +101,40 @@ func (r *ManagerReconciler) Reconcile(ctx context.Context, req reconcile.Request
 		}
 	}
 
-	switch mgr.Status.Phase {
-	case "", "Failed":
-		return r.handleCreate(ctx, &mgr)
-	case "Pending":
-		if mgr.Status.Message != "" {
-			return r.handleCreate(ctx, &mgr)
-		}
-		return reconcile.Result{}, nil
-	default:
-		// For provisioned managers, reconcile desired lifecycle state
-		desired := mgr.Spec.DesiredState()
-		result, err := r.reconcileDesiredState(ctx, &mgr, desired)
-		if err != nil || result.RequeueAfter > 0 {
-			return result, err
-		}
-
-		if mgr.Generation == mgr.Status.ObservedGeneration {
-			return reconcile.Result{RequeueAfter: reconcileInterval}, nil
-		}
-		return r.handleUpdate(ctx, &mgr)
-	}
+	return r.reconcileManagerNormal(ctx, s)
 }
 
-func (r *ManagerReconciler) handleCreate(ctx context.Context, m *v1beta1.Manager) (reconcile.Result, error) {
+// reconcileManagerNormal runs the declarative convergence loop: infrastructure,
+// config, container. Critical-path phases are serial with early return on error.
+func (r *ManagerReconciler) reconcileManagerNormal(ctx context.Context, s *managerScope) (reconcile.Result, error) {
+	if res, err := r.reconcileManagerInfrastructure(ctx, s); err != nil || res.RequeueAfter > 0 {
+		return res, err
+	}
+	if res, err := r.reconcileManagerConfig(ctx, s); err != nil || res.RequeueAfter > 0 {
+		return res, err
+	}
+	if res, err := r.reconcileManagerContainer(ctx, s); err != nil || res.RequeueAfter > 0 {
+		return res, err
+	}
+
+	m := s.manager
 	logger := log.FromContext(ctx)
-	logger.Info("creating manager", "name", m.Name)
-
-	m.Status.Phase = "Pending"
-	if err := r.Status().Update(ctx, m); err != nil {
-		return reconcile.Result{}, err
+	if m.Status.ObservedGeneration == 0 {
+		logger.Info("manager created", "name", m.Name, "roomID", m.Status.RoomID)
+	} else if m.Generation != m.Status.ObservedGeneration {
+		logger.Info("manager updated", "name", m.Name)
 	}
 
-	managerName := m.Name
-
-	// --- Phase 1: Package (if any) ---
-	if err := r.Deployer.DeployPackage(ctx, managerName, m.Spec.Package, false); err != nil {
-		return r.failManager(ctx, m, err.Error())
-	}
-
-	// --- Phase 2: Provision infrastructure ---
-	provResult, err := r.Provisioner.ProvisionManager(ctx, service.ManagerProvisionRequest{
-		Name:       managerName,
-		McpServers: m.Spec.McpServers,
-	})
-	if err != nil {
-		return r.failManager(ctx, m, err.Error())
-	}
-
-	// --- Phase 3: Deploy configuration to OSS ---
-	if err := r.Deployer.DeployManagerConfig(ctx, service.ManagerDeployRequest{
-		Name:           managerName,
-		Spec:           m.Spec,
-		MatrixToken:    provResult.MatrixToken,
-		GatewayKey:     provResult.GatewayKey,
-		MatrixPassword: provResult.MatrixPassword,
-		AuthorizedMCPs: provResult.AuthorizedMCPs,
-	}); err != nil {
-		return r.failManager(ctx, m, err.Error())
-	}
-
-	// --- Phase 4: On-demand skills ---
-	if err := r.Deployer.PushOnDemandSkills(ctx, managerName, m.Spec.Skills); err != nil {
-		logger.Error(err, "skill push failed (non-fatal)")
-	}
-
-	// --- Phase 5: ServiceAccount ---
-	logger.Info("ensuring manager service account", "name", managerName)
-	if err := r.Provisioner.EnsureManagerServiceAccount(ctx, managerName); err != nil {
-		return r.failManager(ctx, m, fmt.Sprintf("ServiceAccount creation failed: %v", err))
-	}
-
-	// --- Phase 6: Container start ---
-	logger.Info("starting manager container", "name", managerName)
-	if r.Backend != nil {
-		if wb := r.Backend.DetectWorkerBackend(ctx); wb != nil {
-			managerEnv := r.EnvBuilder.BuildManager(managerName, provResult, m.Spec)
-			saName := authpkg.SAName(authpkg.RoleManager, managerName)
-			createReq := backend.CreateRequest{
-				Name:               managerName,
-				ContainerName:      managerContainerName(managerName),
-				Image:              m.Spec.Image,
-				Runtime:            m.Spec.Runtime,
-				Env:                managerEnv,
-				ServiceAccountName: saName,
-				Resources:          r.ManagerResources,
-				Labels: map[string]string{
-					"app":               "hiclaw-manager",
-					"hiclaw.io/manager": managerName,
-				},
-			}
-			if wb.Name() != "k8s" {
-				token, err := r.Provisioner.RequestManagerSAToken(ctx, managerName)
-				if err != nil {
-					logger.Error(err, "failed to request manager SA token (non-fatal, auth will fail)")
-				}
-				createReq.AuthToken = token
-			}
-
-			// Embedded (Docker) mode: inject host volume mounts and extra env
-			if wb.Name() == "docker" && r.EmbeddedConfig != nil {
-				if r.EmbeddedConfig.WorkspaceDir != "" {
-					createReq.Volumes = append(createReq.Volumes, backend.VolumeMount{
-						HostPath:      r.EmbeddedConfig.WorkspaceDir,
-						ContainerPath: "/root/manager-workspace",
-					})
-				}
-				if r.EmbeddedConfig.HostShareDir != "" {
-					createReq.Volumes = append(createReq.Volumes, backend.VolumeMount{
-						HostPath:      r.EmbeddedConfig.HostShareDir,
-						ContainerPath: "/host-share",
-					})
-				}
-				createReq.RestartPolicy = "unless-stopped"
-				// Map manager console port to host (18799 is the UI console for both runtimes)
-				consoleHostPort := r.EmbeddedConfig.ManagerConsolePort
-				if consoleHostPort == "" {
-					consoleHostPort = "18888"
-				}
-				createReq.Ports = append(createReq.Ports, backend.PortMapping{
-					HostIP:        "127.0.0.1",
-					HostPort:      consoleHostPort,
-					ContainerPort: "18799",
-				})
-				for k, v := range r.EmbeddedConfig.ExtraEnv {
-					if _, exists := createReq.Env[k]; !exists {
-						createReq.Env[k] = v
-					}
-				}
-			}
-
-			if _, err := wb.Create(ctx, createReq); err != nil {
-				logger.Error(err, "manager container creation failed (non-fatal, can be started manually)")
-			}
-		} else {
-			logger.Info("no worker backend available, manager needs manual start")
-		}
-	}
-
-	// --- Phase 7: Status ---
-	if err := r.Get(ctx, client.ObjectKeyFromObject(m), m); err != nil {
-		return reconcile.Result{}, err
-	}
-	m.Status.ObservedGeneration = m.Generation
-	m.Status.Phase = "Running"
-	m.Status.MatrixUserID = provResult.MatrixUserID
-	m.Status.RoomID = provResult.RoomID
-	m.Status.Message = ""
-	if m.Spec.Image != "" {
-		m.Status.Version = m.Spec.Image
-	}
-	if err := r.Status().Update(ctx, m); err != nil {
-		logger.Error(err, "failed to update status after create (non-fatal)")
-	}
-
-	logger.Info("manager created", "name", managerName, "roomID", provResult.RoomID)
-	return reconcile.Result{}, nil
-}
-
-func (r *ManagerReconciler) handleUpdate(ctx context.Context, m *v1beta1.Manager) (reconcile.Result, error) {
-	logger := log.FromContext(ctx)
-	logger.Info("manager spec changed, updating configuration", "name", m.Name)
-	managerName := m.Name
-
-	m.Status.Phase = "Updating"
-	m.Status.Message = "Updating manager configuration"
-	if err := r.Status().Update(ctx, m); err != nil {
-		return reconcile.Result{}, err
-	}
-
-	// Refresh credentials
-	refreshResult, err := r.Provisioner.RefreshCredentials(ctx, managerName)
-	if err != nil {
-		return r.failManagerUpdate(ctx, m, err.Error())
-	}
-
-	// Reconcile MCP auth
-	var authorizedMCPs []string
-	if len(m.Spec.McpServers) > 0 {
-		authorizedMCPs, err = r.Provisioner.ReconcileMCPAuth(ctx, "manager", m.Spec.McpServers)
-		if err != nil {
-			logger.Error(err, "MCP reauthorization failed (non-fatal)")
-		}
-	}
-
-	// Redeploy configuration
-	if err := r.Deployer.DeployManagerConfig(ctx, service.ManagerDeployRequest{
-		Name:           managerName,
-		Spec:           m.Spec,
-		MatrixToken:    refreshResult.MatrixToken,
-		GatewayKey:     refreshResult.GatewayKey,
-		MatrixPassword: refreshResult.MatrixPassword,
-		AuthorizedMCPs: authorizedMCPs,
-		IsUpdate:       true,
-	}); err != nil {
-		return r.failManagerUpdate(ctx, m, err.Error())
-	}
-
-	// On-demand skills
-	if err := r.Deployer.PushOnDemandSkills(ctx, managerName, m.Spec.Skills); err != nil {
-		logger.Error(err, "skill push failed (non-fatal)")
-	}
-
-	_ = r.Get(ctx, client.ObjectKeyFromObject(m), m)
-	m.Status.ObservedGeneration = m.Generation
-	m.Status.Phase = "Running"
-	m.Status.Message = "Configuration updated"
-	if m.Spec.Image != "" {
-		m.Status.Version = m.Spec.Image
-	}
-	if err := r.Status().Update(ctx, m); err != nil {
-		logger.Error(err, "failed to update status after update (non-fatal)")
-	}
-
-	logger.Info("manager updated", "name", managerName)
-	return reconcile.Result{}, nil
-}
-
-func (r *ManagerReconciler) handleDelete(ctx context.Context, m *v1beta1.Manager) error {
-	logger := log.FromContext(ctx)
-	logger.Info("deleting manager", "name", m.Name)
-
-	managerName := m.Name
-
-	// Deprovision infrastructure
-	if err := r.Provisioner.DeprovisionManager(ctx, managerName, m.Spec.McpServers); err != nil {
-		logger.Error(err, "deprovision failed (non-fatal)")
-	}
-
-	// Delete manager container/pod via backend (WithPrefix("") ensures correct name)
-	if wb := r.managerBackend(ctx); wb != nil {
-		containerName := managerContainerName(managerName)
-		if err := wb.Delete(ctx, containerName); err != nil && !errors.Is(err, backend.ErrNotFound) {
-			logger.Error(err, "failed to delete manager container (may already be removed)")
-		}
-	}
-
-	// Clean up OSS data
-	if err := r.Deployer.CleanupOSSData(ctx, managerName); err != nil {
-		logger.Error(err, "failed to clean up OSS agent data (non-fatal)")
-	}
-
-	// Delete credentials
-	if err := r.Provisioner.DeleteCredentials(ctx, managerName); err != nil {
-		logger.Error(err, "failed to delete credentials (non-fatal)")
-	}
-
-	// Delete ServiceAccount
-	if err := r.Provisioner.DeleteManagerServiceAccount(ctx, managerName); err != nil {
-		logger.Error(err, "failed to delete ServiceAccount (non-fatal)")
-	}
-
-	logger.Info("manager deleted", "name", managerName)
-	return nil
-}
-
-func (r *ManagerReconciler) failManager(ctx context.Context, m *v1beta1.Manager, msg string) (reconcile.Result, error) {
-	_ = r.Get(ctx, client.ObjectKeyFromObject(m), m)
-	m.Status.Phase = "Failed"
-	m.Status.Message = msg
-	r.Status().Update(ctx, m)
-	return reconcile.Result{RequeueAfter: time.Minute}, fmt.Errorf("%s", msg)
-}
-
-func (r *ManagerReconciler) failManagerUpdate(ctx context.Context, m *v1beta1.Manager, msg string) (reconcile.Result, error) {
-	_ = r.Get(ctx, client.ObjectKeyFromObject(m), m)
-	m.Status.Phase = "Running"
-	m.Status.Message = msg
-	r.Status().Update(ctx, m)
-	return reconcile.Result{RequeueAfter: time.Minute}, fmt.Errorf("%s", msg)
-}
-
-// --- Desired state reconciliation ---
-
-func (r *ManagerReconciler) reconcileDesiredState(ctx context.Context, m *v1beta1.Manager, desired string) (reconcile.Result, error) {
-	// For Running state, always verify the container exists (it may have been
-	// removed externally, e.g. by an upgrade install script).
-	// For other states, skip if phase already matches.
-	if m.Status.Phase == desired && desired != "Running" {
-		return reconcile.Result{}, nil
-	}
-
-	logger := log.FromContext(ctx)
-	logger.Info("reconciling desired state", "name", m.Name, "current", m.Status.Phase, "desired", desired)
-
-	switch desired {
-	case "Running":
-		return r.ensureManagerRunning(ctx, m)
-	case "Sleeping":
-		return r.ensureManagerSleeping(ctx, m)
-	case "Stopped":
-		return r.ensureManagerStopped(ctx, m)
-	default:
-		logger.Info("unknown desired state, ignoring", "state", desired)
-		return reconcile.Result{}, nil
-	}
-}
-
-// managerBackend returns the WorkerBackend with the container prefix cleared.
-// Manager containers use explicit full names (e.g. "hiclaw-manager") rather than
-// the default worker prefix ("hiclaw-worker-"), so we need WithPrefix("") to
-// ensure Status/Stop/Delete/Start operate on the correct container/pod name.
-func (r *ManagerReconciler) managerBackend(ctx context.Context) backend.WorkerBackend {
-	if r.Backend == nil {
-		return nil
-	}
-	wb := r.Backend.DetectWorkerBackend(ctx)
-	if wb == nil {
-		return nil
-	}
-	switch b := wb.(type) {
-	case *backend.DockerBackend:
-		return b.WithPrefix("")
-	case *backend.K8sBackend:
-		return b.WithPrefix("")
-	default:
-		return wb
-	}
-}
-
-func (r *ManagerReconciler) ensureManagerRunning(ctx context.Context, m *v1beta1.Manager) (reconcile.Result, error) {
-	logger := log.FromContext(ctx)
-
-	wb := r.managerBackend(ctx)
-	if wb == nil {
-		return reconcile.Result{}, nil
-	}
-
-	containerName := managerContainerName(m.Name)
-	result, err := wb.Status(ctx, containerName)
-	if err != nil {
-		logger.Error(err, "failed to check backend status")
-		return reconcile.Result{RequeueAfter: reconcileRetryDelay}, nil
-	}
-
-	switch {
-	case result.Status == backend.StatusRunning || result.Status == backend.StatusStarting:
-		// Already running
-	case result.Status == backend.StatusStopped && wb.Name() == "docker":
-		if err := wb.Start(ctx, containerName); err != nil {
-			return r.failManagerLifecycle(ctx, m, fmt.Sprintf("start failed: %v", err))
-		}
-	default:
-		if err := r.recreateManagerContainer(ctx, m, wb); err != nil {
-			return r.failManagerLifecycle(ctx, m, fmt.Sprintf("recreate failed: %v", err))
-		}
-	}
-
-	_ = r.Get(ctx, client.ObjectKeyFromObject(m), m)
-	m.Status.Phase = "Running"
-	m.Status.Message = ""
-	r.Status().Update(ctx, m)
-
-	logger.Info("manager running", "name", m.Name)
-	return reconcile.Result{}, nil
-}
-
-func (r *ManagerReconciler) ensureManagerSleeping(ctx context.Context, m *v1beta1.Manager) (reconcile.Result, error) {
-	logger := log.FromContext(ctx)
-
-	wb := r.managerBackend(ctx)
-	if wb == nil {
-		return reconcile.Result{}, nil
-	}
-
-	containerName := managerContainerName(m.Name)
-	if err := wb.Stop(ctx, containerName); err != nil && !errors.Is(err, backend.ErrNotFound) {
-		return r.failManagerLifecycle(ctx, m, fmt.Sprintf("sleep failed: %v", err))
-	}
-
-	_ = r.Get(ctx, client.ObjectKeyFromObject(m), m)
-	m.Status.Phase = "Sleeping"
-	m.Status.Message = ""
-	r.Status().Update(ctx, m)
-
-	logger.Info("manager sleeping", "name", m.Name)
-	return reconcile.Result{}, nil
-}
-
-func (r *ManagerReconciler) ensureManagerStopped(ctx context.Context, m *v1beta1.Manager) (reconcile.Result, error) {
-	logger := log.FromContext(ctx)
-
-	wb := r.managerBackend(ctx)
-	if wb == nil {
-		return reconcile.Result{}, nil
-	}
-
-	containerName := managerContainerName(m.Name)
-	_ = wb.Stop(ctx, containerName) // best-effort stop first
-	if err := wb.Delete(ctx, containerName); err != nil && !errors.Is(err, backend.ErrNotFound) {
-		return r.failManagerLifecycle(ctx, m, fmt.Sprintf("stop failed: %v", err))
-	}
-
-	_ = r.Get(ctx, client.ObjectKeyFromObject(m), m)
-	m.Status.Phase = "Stopped"
-	m.Status.Message = ""
-	r.Status().Update(ctx, m)
-
-	logger.Info("manager stopped", "name", m.Name)
-	return reconcile.Result{}, nil
-}
-
-func (r *ManagerReconciler) recreateManagerContainer(ctx context.Context, m *v1beta1.Manager, wb backend.WorkerBackend) error {
-	logger := log.FromContext(ctx)
-	managerName := m.Name
-
-	// Manager CR name is "default" but Matrix username is always "manager"
-	refreshResult, err := r.Provisioner.RefreshManagerCredentials(ctx, managerName)
-	if err != nil {
-		return fmt.Errorf("refresh credentials: %w", err)
-	}
-
-	// Ensure gateway consumer is authorized on AI routes (may have been lost after upgrade)
-	if err := r.Provisioner.EnsureManagerGatewayAuth(ctx, managerName, refreshResult.GatewayKey); err != nil {
-		logger.Error(err, "gateway auth during recreate (non-fatal)")
-	}
-
-	_ = r.Provisioner.EnsureManagerServiceAccount(ctx, managerName)
-
-	managerEnv := r.EnvBuilder.BuildManager(managerName, &service.ManagerProvisionResult{
-		MatrixToken:    refreshResult.MatrixToken,
-		GatewayKey:     refreshResult.GatewayKey,
-		MinIOPassword:  refreshResult.MinIOPassword,
-		MatrixPassword: refreshResult.MatrixPassword,
-	}, m.Spec)
-
-	containerName := managerContainerName(managerName)
-	saName := authpkg.SAName(authpkg.RoleManager, managerName)
-	createReq := backend.CreateRequest{
-		Name:               managerName,
-		ContainerName:      containerName,
-		Image:              m.Spec.Image,
-		Runtime:            m.Spec.Runtime,
-		Env:                managerEnv,
-		ServiceAccountName: saName,
-		Resources:          r.ManagerResources,
-		Labels: map[string]string{
-			"app":               "hiclaw-manager",
-			"hiclaw.io/manager": managerName,
-		},
-	}
-	if wb.Name() != "k8s" {
-		token, err := r.Provisioner.RequestManagerSAToken(ctx, managerName)
-		if err != nil {
-			logger.Error(err, "SA token request during recreate (non-fatal)")
-		}
-		createReq.AuthToken = token
-	}
-
-	// Embedded (Docker) mode: inject host volume mounts and extra env
-	if wb.Name() == "docker" && r.EmbeddedConfig != nil {
-		if r.EmbeddedConfig.WorkspaceDir != "" {
-			createReq.Volumes = append(createReq.Volumes, backend.VolumeMount{
-				HostPath:      r.EmbeddedConfig.WorkspaceDir,
-				ContainerPath: "/root/manager-workspace",
-			})
-		}
-		if r.EmbeddedConfig.HostShareDir != "" {
-			createReq.Volumes = append(createReq.Volumes, backend.VolumeMount{
-				HostPath:      r.EmbeddedConfig.HostShareDir,
-				ContainerPath: "/host-share",
-			})
-		}
-		createReq.RestartPolicy = "unless-stopped"
-		// Map manager console port to host (18799 is the UI console for both runtimes)
-		consoleHostPort := r.EmbeddedConfig.ManagerConsolePort
-		if consoleHostPort == "" {
-			consoleHostPort = "18888"
-		}
-		createReq.Ports = append(createReq.Ports, backend.PortMapping{
-			HostIP:        "127.0.0.1",
-			HostPort:      consoleHostPort,
-			ContainerPort: "18799",
-		})
-		for k, v := range r.EmbeddedConfig.ExtraEnv {
-			if _, exists := createReq.Env[k]; !exists {
-				createReq.Env[k] = v
-			}
-		}
-	}
-
-	if _, err := wb.Create(ctx, createReq); err != nil {
-		return fmt.Errorf("container recreate: %w", err)
-	}
-	return nil
-}
-
-func (r *ManagerReconciler) failManagerLifecycle(ctx context.Context, m *v1beta1.Manager, msg string) (reconcile.Result, error) {
-	_ = r.Get(ctx, client.ObjectKeyFromObject(m), m)
-	m.Status.Message = msg
-	r.Status().Update(ctx, m)
-	return reconcile.Result{RequeueAfter: time.Minute}, fmt.Errorf("%s", msg)
+	return reconcile.Result{RequeueAfter: reconcileInterval}, nil
 }
 
 func (r *ManagerReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	builder := ctrl.NewControllerManagedBy(mgr).
+	bldr := ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.Manager{})
 
-	// In-cluster mode: watch Pod events with hiclaw.io/manager label,
-	// map to corresponding Manager CR for immediate reconcile on pod failure/deletion.
 	if r.Backend != nil {
 		if wb := r.Backend.DetectWorkerBackend(context.Background()); wb != nil && wb.Name() == "k8s" {
-			builder = builder.Watches(
+			bldr = bldr.Watches(
 				&corev1.Pod{},
 				handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
 					managerName := obj.GetLabels()["hiclaw.io/manager"]
@@ -596,9 +148,10 @@ func (r *ManagerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 						}},
 					}
 				}),
+				builder.WithPredicates(podLifecyclePredicates("hiclaw.io/manager")),
 			)
 		}
 	}
 
-	return builder.Complete(r)
+	return bldr.Complete(r)
 }

--- a/hiclaw-controller/internal/controller/manager_controller.go
+++ b/hiclaw-controller/internal/controller/manager_controller.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hiclaw/hiclaw-controller/internal/backend"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -310,12 +309,12 @@ func (r *ManagerReconciler) handleDelete(ctx context.Context, m *v1beta1.Manager
 		logger.Error(err, "deprovision failed (non-fatal)")
 	}
 
-	// Delete manager pod by exact name (bypasses backend's default worker prefix)
-	managerPod := &corev1.Pod{}
-	managerPod.Name = managerContainerName(managerName)
-	managerPod.Namespace = m.Namespace
-	if err := r.Delete(ctx, managerPod); err != nil && !apierrors.IsNotFound(err) {
-		logger.Error(err, "failed to delete manager pod (may already be removed)")
+	// Delete manager container/pod via backend (WithPrefix("") ensures correct name)
+	if wb := r.managerBackend(ctx); wb != nil {
+		containerName := managerContainerName(managerName)
+		if err := wb.Delete(ctx, containerName); err != nil && !errors.Is(err, backend.ErrNotFound) {
+			logger.Error(err, "failed to delete manager container (may already be removed)")
+		}
 	}
 
 	// Clean up OSS data
@@ -379,10 +378,10 @@ func (r *ManagerReconciler) reconcileDesiredState(ctx context.Context, m *v1beta
 	}
 }
 
-// managerBackend returns the WorkerBackend with Docker's container prefix cleared.
-// Manager containers are created with ContainerName override (e.g. "hiclaw-manager"),
-// which doesn't include the default worker prefix ("hiclaw-worker-").  Without this
-// adjustment, Docker backend's Status/Stop/Delete/Start would look for the wrong name.
+// managerBackend returns the WorkerBackend with the container prefix cleared.
+// Manager containers use explicit full names (e.g. "hiclaw-manager") rather than
+// the default worker prefix ("hiclaw-worker-"), so we need WithPrefix("") to
+// ensure Status/Stop/Delete/Start operate on the correct container/pod name.
 func (r *ManagerReconciler) managerBackend(ctx context.Context) backend.WorkerBackend {
 	if r.Backend == nil {
 		return nil
@@ -391,12 +390,14 @@ func (r *ManagerReconciler) managerBackend(ctx context.Context) backend.WorkerBa
 	if wb == nil {
 		return nil
 	}
-	// Docker backend always prepends containerPrefix to name parameters.
-	// Manager containers use a different naming scheme, so strip the prefix.
-	if docker, ok := wb.(*backend.DockerBackend); ok {
-		return docker.WithPrefix("")
+	switch b := wb.(type) {
+	case *backend.DockerBackend:
+		return b.WithPrefix("")
+	case *backend.K8sBackend:
+		return b.WithPrefix("")
+	default:
+		return wb
 	}
-	return wb
 }
 
 func (r *ManagerReconciler) ensureManagerRunning(ctx context.Context, m *v1beta1.Manager) (reconcile.Result, error) {

--- a/hiclaw-controller/internal/controller/manager_controller.go
+++ b/hiclaw-controller/internal/controller/manager_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
 	"github.com/hiclaw/hiclaw-controller/internal/backend"
@@ -109,6 +110,9 @@ func (r *ManagerReconciler) Reconcile(ctx context.Context, req reconcile.Request
 func (r *ManagerReconciler) reconcileManagerNormal(ctx context.Context, s *managerScope) (reconcile.Result, error) {
 	if res, err := r.reconcileManagerInfrastructure(ctx, s); err != nil || res.RequeueAfter > 0 {
 		return res, err
+	}
+	if err := r.Provisioner.EnsureManagerServiceAccount(ctx, s.manager.Name); err != nil {
+		return reconcile.Result{}, fmt.Errorf("ServiceAccount: %w", err)
 	}
 	if res, err := r.reconcileManagerConfig(ctx, s); err != nil || res.RequeueAfter > 0 {
 		return res, err

--- a/hiclaw-controller/internal/controller/manager_controller.go
+++ b/hiclaw-controller/internal/controller/manager_controller.go
@@ -44,10 +44,10 @@ type ManagerEmbeddedConfig struct {
 type ManagerReconciler struct {
 	client.Client
 
-	Provisioner      *service.Provisioner
-	Deployer         *service.Deployer
+	Provisioner      service.ManagerProvisioner
+	Deployer         service.ManagerDeployer
 	Backend          *backend.Registry
-	EnvBuilder       *service.WorkerEnvBuilder
+	EnvBuilder       service.ManagerEnvBuilderI
 	ManagerResources *backend.ResourceRequirements
 	EmbeddedConfig   *ManagerEmbeddedConfig // non-nil in embedded mode only
 }

--- a/hiclaw-controller/internal/controller/manager_reconcile_config.go
+++ b/hiclaw-controller/internal/controller/manager_reconcile_config.go
@@ -1,0 +1,56 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hiclaw/hiclaw-controller/internal/service"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// reconcileManagerConfig ensures all configuration (package, manager config,
+// on-demand skills) is deployed to OSS. Idempotent: safe to re-run; OSS writes
+// overwrite existing files.
+func (r *ManagerReconciler) reconcileManagerConfig(ctx context.Context, s *managerScope) (reconcile.Result, error) {
+	if s.provResult == nil {
+		return reconcile.Result{}, nil
+	}
+
+	m := s.manager
+	logger := log.FromContext(ctx)
+	isUpdate := m.Status.Phase != "" && m.Status.Phase != "Pending" && m.Status.Phase != "Failed"
+
+	if err := r.Deployer.DeployPackage(ctx, m.Name, m.Spec.Package, isUpdate); err != nil {
+		return reconcile.Result{}, fmt.Errorf("deploy package: %w", err)
+	}
+
+	var authorizedMCPs []string
+	if isUpdate && len(m.Spec.McpServers) > 0 {
+		var err error
+		authorizedMCPs, err = r.Provisioner.ReconcileMCPAuth(ctx, "manager", m.Spec.McpServers)
+		if err != nil {
+			logger.Error(err, "MCP reauthorization failed (non-fatal)")
+		}
+	} else {
+		authorizedMCPs = s.provResult.AuthorizedMCPs
+	}
+
+	if err := r.Deployer.DeployManagerConfig(ctx, service.ManagerDeployRequest{
+		Name:           m.Name,
+		Spec:           m.Spec,
+		MatrixToken:    s.provResult.MatrixToken,
+		GatewayKey:     s.provResult.GatewayKey,
+		MatrixPassword: s.provResult.MatrixPassword,
+		AuthorizedMCPs: authorizedMCPs,
+		IsUpdate:       isUpdate,
+	}); err != nil {
+		return reconcile.Result{}, fmt.Errorf("deploy manager config: %w", err)
+	}
+
+	if err := r.Deployer.PushOnDemandSkills(ctx, m.Name, m.Spec.Skills); err != nil {
+		logger.Error(err, "skill push failed (non-fatal)")
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/hiclaw-controller/internal/controller/manager_reconcile_container.go
+++ b/hiclaw-controller/internal/controller/manager_reconcile_container.go
@@ -52,6 +52,12 @@ func (r *ManagerReconciler) ensureManagerContainerPresent(ctx context.Context, s
 		return reconcile.Result{}, fmt.Errorf("query container status: %w", err)
 	}
 
+	// TODO(hot-reload): All spec changes trigger container recreation because
+	// agents only load config at startup (no hot-reload). When agent-side config
+	// hot-reload is implemented (file watcher / Matrix reload command / webhook),
+	// introduce a podSpecHash annotation to distinguish pod-affecting fields
+	// (Image, Runtime, Model) from config-only fields (Skills, McpServers, Soul,
+	// Agents, Package) and skip recreation for config-only changes.
 	specChanged := m.Generation != m.Status.ObservedGeneration
 
 	switch result.Status {

--- a/hiclaw-controller/internal/controller/manager_reconcile_container.go
+++ b/hiclaw-controller/internal/controller/manager_reconcile_container.go
@@ -1,0 +1,236 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	authpkg "github.com/hiclaw/hiclaw-controller/internal/auth"
+	"github.com/hiclaw/hiclaw-controller/internal/backend"
+	"github.com/hiclaw/hiclaw-controller/internal/service"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// reconcileManagerContainer ensures the manager container/pod matches the desired
+// lifecycle state (Running/Sleeping/Stopped). Idempotent: checks actual backend
+// state before acting.
+func (r *ManagerReconciler) reconcileManagerContainer(ctx context.Context, s *managerScope) (reconcile.Result, error) {
+	if s.provResult == nil {
+		return reconcile.Result{}, nil
+	}
+
+	m := s.manager
+	desired := m.Spec.DesiredState()
+
+	switch desired {
+	case "Stopped":
+		return r.ensureManagerContainerAbsent(ctx, s, true)
+	case "Sleeping":
+		return r.ensureManagerContainerAbsent(ctx, s, false)
+	default:
+		return r.ensureManagerContainerPresent(ctx, s)
+	}
+}
+
+// ensureManagerContainerPresent ensures the manager container is running. If the
+// container does not exist or was deleted, it is (re)created. If the spec has
+// changed (Generation != ObservedGeneration) while the container is running, the
+// old container is deleted and a new one created.
+func (r *ManagerReconciler) ensureManagerContainerPresent(ctx context.Context, s *managerScope) (reconcile.Result, error) {
+	m := s.manager
+	wb := r.managerBackend(ctx)
+	if wb == nil {
+		log.FromContext(ctx).Info("no worker backend available, manager needs manual start")
+		return reconcile.Result{}, nil
+	}
+
+	logger := log.FromContext(ctx)
+	containerName := managerContainerName(m.Name)
+	result, err := wb.Status(ctx, containerName)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("query container status: %w", err)
+	}
+
+	specChanged := m.Generation != m.Status.ObservedGeneration
+
+	switch result.Status {
+	case backend.StatusRunning, backend.StatusStarting, backend.StatusReady:
+		if !specChanged {
+			return reconcile.Result{}, nil
+		}
+		logger.Info("spec changed, recreating manager container",
+			"generation", m.Generation,
+			"observedGeneration", m.Status.ObservedGeneration)
+		if err := wb.Delete(ctx, containerName); err != nil && !errors.Is(err, backend.ErrNotFound) {
+			return reconcile.Result{}, fmt.Errorf("delete container for recreate: %w", err)
+		}
+		return r.createManagerContainer(ctx, s, wb)
+
+	case backend.StatusStopped:
+		if wb.Name() == "docker" && !specChanged {
+			if err := wb.Start(ctx, containerName); err != nil {
+				return reconcile.Result{}, fmt.Errorf("start container: %w", err)
+			}
+			return reconcile.Result{}, nil
+		}
+		if err := wb.Delete(ctx, containerName); err != nil && !errors.Is(err, backend.ErrNotFound) {
+			return reconcile.Result{}, fmt.Errorf("delete stale container: %w", err)
+		}
+		return r.createManagerContainer(ctx, s, wb)
+
+	case backend.StatusNotFound:
+		return r.createManagerContainer(ctx, s, wb)
+
+	default:
+		logger.Info("container in unexpected state, recreating", "status", result.Status)
+		if err := wb.Delete(ctx, containerName); err != nil && !errors.Is(err, backend.ErrNotFound) {
+			return reconcile.Result{}, fmt.Errorf("delete container in unknown state: %w", err)
+		}
+		return r.createManagerContainer(ctx, s, wb)
+	}
+}
+
+// ensureManagerContainerAbsent ensures the manager container is not running.
+// If remove is true (Stopped), the container is deleted entirely.
+// If remove is false (Sleeping), the container is stopped but kept (Docker)
+// or deleted (K8s, which has no stop-without-delete).
+func (r *ManagerReconciler) ensureManagerContainerAbsent(ctx context.Context, s *managerScope, remove bool) (reconcile.Result, error) {
+	wb := r.managerBackend(ctx)
+	if wb == nil {
+		return reconcile.Result{}, nil
+	}
+
+	containerName := managerContainerName(s.manager.Name)
+	if remove {
+		_ = wb.Stop(ctx, containerName)
+		if err := wb.Delete(ctx, containerName); err != nil && !errors.Is(err, backend.ErrNotFound) {
+			return reconcile.Result{}, fmt.Errorf("delete container: %w", err)
+		}
+	} else {
+		if err := wb.Stop(ctx, containerName); err != nil && !errors.Is(err, backend.ErrNotFound) {
+			return reconcile.Result{}, fmt.Errorf("stop container: %w", err)
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// createManagerContainer builds and issues a backend Create request for the manager.
+// ErrConflict (container already exists) is treated as success for idempotency.
+func (r *ManagerReconciler) createManagerContainer(ctx context.Context, s *managerScope, wb backend.WorkerBackend) (reconcile.Result, error) {
+	m := s.manager
+	logger := log.FromContext(ctx)
+
+	prov := s.provResult
+	if prov.MatrixToken == "" {
+		refreshResult, err := r.Provisioner.RefreshManagerCredentials(ctx, m.Name)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("refresh credentials for container: %w", err)
+		}
+		prov = &service.ManagerProvisionResult{
+			MatrixUserID:   m.Status.MatrixUserID,
+			MatrixToken:    refreshResult.MatrixToken,
+			RoomID:         m.Status.RoomID,
+			GatewayKey:     refreshResult.GatewayKey,
+			MinIOPassword:  refreshResult.MinIOPassword,
+			MatrixPassword: refreshResult.MatrixPassword,
+		}
+	}
+
+	managerEnv := r.EnvBuilder.BuildManager(m.Name, prov, m.Spec)
+	containerName := managerContainerName(m.Name)
+	saName := authpkg.SAName(authpkg.RoleManager, m.Name)
+	createReq := backend.CreateRequest{
+		Name:               m.Name,
+		ContainerName:      containerName,
+		Image:              m.Spec.Image,
+		Runtime:            m.Spec.Runtime,
+		Env:                managerEnv,
+		ServiceAccountName: saName,
+		Resources:          r.ManagerResources,
+		Labels: map[string]string{
+			"app":               "hiclaw-manager",
+			"hiclaw.io/manager": m.Name,
+		},
+	}
+	if wb.Name() != "k8s" {
+		token, err := r.Provisioner.RequestManagerSAToken(ctx, m.Name)
+		if err != nil {
+			logger.Error(err, "SA token request failed (non-fatal, manager auth will fail)")
+		}
+		createReq.AuthToken = token
+	}
+
+	r.applyEmbeddedConfig(&createReq, wb)
+
+	if _, err := wb.Create(ctx, createReq); err != nil {
+		if errors.Is(err, backend.ErrConflict) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("create container: %w", err)
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// applyEmbeddedConfig injects Docker-mode host volume mounts, port mapping,
+// restart policy, and extra env into the CreateRequest when running in embedded mode.
+func (r *ManagerReconciler) applyEmbeddedConfig(req *backend.CreateRequest, wb backend.WorkerBackend) {
+	if wb.Name() != "docker" || r.EmbeddedConfig == nil {
+		return
+	}
+
+	if r.EmbeddedConfig.WorkspaceDir != "" {
+		req.Volumes = append(req.Volumes, backend.VolumeMount{
+			HostPath:      r.EmbeddedConfig.WorkspaceDir,
+			ContainerPath: "/root/manager-workspace",
+		})
+	}
+	if r.EmbeddedConfig.HostShareDir != "" {
+		req.Volumes = append(req.Volumes, backend.VolumeMount{
+			HostPath:      r.EmbeddedConfig.HostShareDir,
+			ContainerPath: "/host-share",
+		})
+	}
+
+	req.RestartPolicy = "unless-stopped"
+
+	consoleHostPort := r.EmbeddedConfig.ManagerConsolePort
+	if consoleHostPort == "" {
+		consoleHostPort = "18888"
+	}
+	req.Ports = append(req.Ports, backend.PortMapping{
+		HostIP:        "127.0.0.1",
+		HostPort:      consoleHostPort,
+		ContainerPort: "18799",
+	})
+
+	for k, v := range r.EmbeddedConfig.ExtraEnv {
+		if _, exists := req.Env[k]; !exists {
+			req.Env[k] = v
+		}
+	}
+}
+
+// managerBackend returns the WorkerBackend with the container prefix cleared.
+// Manager containers use explicit full names (e.g. "hiclaw-manager") rather than
+// the default worker prefix ("hiclaw-worker-"), so we need WithPrefix("") to
+// ensure Status/Stop/Delete/Start operate on the correct container/pod name.
+func (r *ManagerReconciler) managerBackend(ctx context.Context) backend.WorkerBackend {
+	if r.Backend == nil {
+		return nil
+	}
+	wb := r.Backend.DetectWorkerBackend(ctx)
+	if wb == nil {
+		return nil
+	}
+	switch b := wb.(type) {
+	case *backend.DockerBackend:
+		return b.WithPrefix("")
+	case *backend.K8sBackend:
+		return b.WithPrefix("")
+	default:
+		return wb
+	}
+}

--- a/hiclaw-controller/internal/controller/manager_reconcile_delete.go
+++ b/hiclaw-controller/internal/controller/manager_reconcile_delete.go
@@ -1,0 +1,52 @@
+package controller
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hiclaw/hiclaw-controller/internal/backend"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func (r *ManagerReconciler) reconcileManagerDelete(ctx context.Context, s *managerScope) (reconcile.Result, error) {
+	logger := log.FromContext(ctx)
+	m := s.manager
+	logger.Info("deleting manager", "name", m.Name)
+
+	managerName := m.Name
+
+	if err := r.Provisioner.DeactivateMatrixUser(ctx, "manager"); err != nil {
+		logger.Error(err, "matrix user deactivation failed (non-fatal)")
+	}
+
+	if err := r.Provisioner.DeprovisionManager(ctx, managerName, m.Spec.McpServers); err != nil {
+		logger.Error(err, "deprovision failed (non-fatal)")
+	}
+
+	if wb := r.managerBackend(ctx); wb != nil {
+		containerName := managerContainerName(managerName)
+		if err := wb.Delete(ctx, containerName); err != nil && !errors.Is(err, backend.ErrNotFound) {
+			logger.Error(err, "failed to delete manager container (may already be removed)")
+		}
+	}
+
+	if err := r.Deployer.CleanupOSSData(ctx, managerName); err != nil {
+		logger.Error(err, "failed to clean up OSS agent data (non-fatal)")
+	}
+	if err := r.Provisioner.DeleteCredentials(ctx, managerName); err != nil {
+		logger.Error(err, "failed to delete credentials (non-fatal)")
+	}
+	if err := r.Provisioner.DeleteManagerServiceAccount(ctx, managerName); err != nil {
+		logger.Error(err, "failed to delete ServiceAccount (non-fatal)")
+	}
+
+	controllerutil.RemoveFinalizer(m, finalizerName)
+	if err := r.Update(ctx, m); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	logger.Info("manager deleted", "name", managerName)
+	return reconcile.Result{}, nil
+}

--- a/hiclaw-controller/internal/controller/manager_reconcile_infra.go
+++ b/hiclaw-controller/internal/controller/manager_reconcile_infra.go
@@ -51,9 +51,5 @@ func (r *ManagerReconciler) reconcileManagerInfrastructure(ctx context.Context, 
 	m.Status.RoomID = provResult.RoomID
 	s.provResult = provResult
 
-	if err := r.Provisioner.EnsureManagerServiceAccount(ctx, m.Name); err != nil {
-		return reconcile.Result{}, fmt.Errorf("ServiceAccount creation: %w", err)
-	}
-
 	return reconcile.Result{}, nil
 }

--- a/hiclaw-controller/internal/controller/manager_reconcile_infra.go
+++ b/hiclaw-controller/internal/controller/manager_reconcile_infra.go
@@ -1,0 +1,59 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hiclaw/hiclaw-controller/internal/service"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// reconcileManagerInfrastructure ensures Matrix account, Gateway consumer, MinIO user,
+// Matrix room, and credentials are provisioned for the Manager. Idempotent: if already
+// provisioned (MatrixUserID set), it refreshes credentials and restores gateway auth.
+func (r *ManagerReconciler) reconcileManagerInfrastructure(ctx context.Context, s *managerScope) (reconcile.Result, error) {
+	m := s.manager
+
+	if m.Status.MatrixUserID != "" {
+		refreshResult, err := r.Provisioner.RefreshManagerCredentials(ctx, m.Name)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("refresh credentials: %w", err)
+		}
+
+		if err := r.Provisioner.EnsureManagerGatewayAuth(ctx, m.Name, refreshResult.GatewayKey); err != nil {
+			log.FromContext(ctx).Error(err, "gateway auth restore failed (non-fatal)")
+		}
+
+		s.provResult = &service.ManagerProvisionResult{
+			MatrixUserID:   m.Status.MatrixUserID,
+			MatrixToken:    refreshResult.MatrixToken,
+			RoomID:         m.Status.RoomID,
+			GatewayKey:     refreshResult.GatewayKey,
+			MinIOPassword:  refreshResult.MinIOPassword,
+			MatrixPassword: refreshResult.MatrixPassword,
+		}
+		return reconcile.Result{}, nil
+	}
+
+	logger := log.FromContext(ctx)
+	logger.Info("provisioning manager infrastructure", "name", m.Name)
+
+	provResult, err := r.Provisioner.ProvisionManager(ctx, service.ManagerProvisionRequest{
+		Name:       m.Name,
+		McpServers: m.Spec.McpServers,
+	})
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("provision manager: %w", err)
+	}
+
+	m.Status.MatrixUserID = provResult.MatrixUserID
+	m.Status.RoomID = provResult.RoomID
+	s.provResult = provResult
+
+	if err := r.Provisioner.EnsureManagerServiceAccount(ctx, m.Name); err != nil {
+		return reconcile.Result{}, fmt.Errorf("ServiceAccount creation: %w", err)
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/hiclaw-controller/internal/controller/manager_scope.go
+++ b/hiclaw-controller/internal/controller/manager_scope.go
@@ -20,6 +20,9 @@ func computeManagerPhase(m *v1beta1.Manager, reconcileErr error) string {
 		if m.Status.MatrixUserID == "" {
 			return "Failed"
 		}
+		if m.Status.Phase == "" {
+			return "Pending"
+		}
 		return m.Status.Phase
 	}
 	return m.Spec.DesiredState()

--- a/hiclaw-controller/internal/controller/manager_scope.go
+++ b/hiclaw-controller/internal/controller/manager_scope.go
@@ -1,0 +1,26 @@
+package controller
+
+import (
+	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	"github.com/hiclaw/hiclaw-controller/internal/service"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type managerScope struct {
+	manager    *v1beta1.Manager
+	provResult *service.ManagerProvisionResult
+	patchBase  client.Patch
+}
+
+// computeManagerPhase determines the Manager status phase based on reconcile outcome.
+// When reconcile succeeds, phase reflects the desired lifecycle state.
+// When reconcile fails, phase depends on whether infrastructure was provisioned.
+func computeManagerPhase(m *v1beta1.Manager, reconcileErr error) string {
+	if reconcileErr != nil {
+		if m.Status.MatrixUserID == "" {
+			return "Failed"
+		}
+		return m.Status.Phase
+	}
+	return m.Spec.DesiredState()
+}

--- a/hiclaw-controller/internal/controller/worker_controller.go
+++ b/hiclaw-controller/internal/controller/worker_controller.go
@@ -190,7 +190,7 @@ func (r *WorkerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 						}},
 					}
 				}),
-				builder.WithPredicates(podLifecyclePredicates()),
+				builder.WithPredicates(podLifecyclePredicates("hiclaw.io/worker")),
 			)
 		}
 	}
@@ -200,16 +200,18 @@ func (r *WorkerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // podLifecyclePredicates filters Pod events to only trigger reconciliation
 // on create, delete, or phase transitions (not every status update).
-func podLifecyclePredicates() predicate.Predicate {
+// labelKey is the pod label used to identify which CR owns the pod
+// (e.g. "hiclaw.io/worker" or "hiclaw.io/manager").
+func podLifecyclePredicates(labelKey string) predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			return e.Object.GetLabels()["hiclaw.io/worker"] != ""
+			return e.Object.GetLabels()[labelKey] != ""
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return e.Object.GetLabels()["hiclaw.io/worker"] != ""
+			return e.Object.GetLabels()[labelKey] != ""
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			if e.ObjectNew.GetLabels()["hiclaw.io/worker"] == "" {
+			if e.ObjectNew.GetLabels()[labelKey] == "" {
 				return false
 			}
 			oldPod, ok1 := e.ObjectOld.(*corev1.Pod)

--- a/hiclaw-controller/internal/controller/worker_controller.go
+++ b/hiclaw-controller/internal/controller/worker_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
@@ -100,6 +101,9 @@ func (r *WorkerReconciler) Reconcile(ctx context.Context, req reconcile.Request)
 func (r *WorkerReconciler) reconcileNormal(ctx context.Context, s *workerScope) (reconcile.Result, error) {
 	if res, err := r.reconcileInfrastructure(ctx, s); err != nil || res.RequeueAfter > 0 {
 		return res, err
+	}
+	if err := r.Provisioner.EnsureServiceAccount(ctx, s.worker.Name); err != nil {
+		return reconcile.Result{}, fmt.Errorf("ServiceAccount: %w", err)
 	}
 	if res, err := r.reconcileConfig(ctx, s); err != nil || res.RequeueAfter > 0 {
 		return res, err

--- a/hiclaw-controller/internal/controller/worker_reconcile_container.go
+++ b/hiclaw-controller/internal/controller/worker_reconcile_container.go
@@ -55,6 +55,12 @@ func (r *WorkerReconciler) ensureContainerPresent(ctx context.Context, s *worker
 		return reconcile.Result{}, fmt.Errorf("query container status: %w", err)
 	}
 
+	// TODO(hot-reload): All spec changes trigger container recreation because
+	// agents only load config at startup (no hot-reload). When agent-side config
+	// hot-reload is implemented (file watcher / Matrix reload command / webhook),
+	// introduce a podSpecHash annotation to distinguish pod-affecting fields
+	// (Image, Runtime, Model) from config-only fields (Skills, McpServers, Soul,
+	// Agents, Package) and skip recreation for config-only changes.
 	specChanged := w.Generation != w.Status.ObservedGeneration
 
 	switch result.Status {

--- a/hiclaw-controller/internal/controller/worker_reconcile_infra.go
+++ b/hiclaw-controller/internal/controller/worker_reconcile_infra.go
@@ -52,9 +52,5 @@ func (r *WorkerReconciler) reconcileInfrastructure(ctx context.Context, s *worke
 	w.Status.RoomID = provResult.RoomID
 	s.provResult = provResult
 
-	if err := r.Provisioner.EnsureServiceAccount(ctx, w.Name); err != nil {
-		return reconcile.Result{}, fmt.Errorf("ServiceAccount creation: %w", err)
-	}
-
 	return reconcile.Result{}, nil
 }

--- a/hiclaw-controller/internal/controller/worker_scope.go
+++ b/hiclaw-controller/internal/controller/worker_scope.go
@@ -20,6 +20,9 @@ func computePhase(w *v1beta1.Worker, reconcileErr error) string {
 		if w.Status.MatrixUserID == "" {
 			return "Failed"
 		}
+		if w.Status.Phase == "" {
+			return "Pending"
+		}
 		// TODO: Introduce Status.Conditions (Ready/Provisioned) to surface
 		// transient errors without flipping Phase away from Running. Currently
 		// we keep the old Phase to avoid marking a healthy worker as Failed on

--- a/hiclaw-controller/internal/service/interfaces.go
+++ b/hiclaw-controller/internal/service/interfaces.go
@@ -38,9 +38,48 @@ type WorkerEnvBuilderI interface {
 	Build(workerName string, prov *WorkerProvisionResult) map[string]string
 }
 
+// ManagerProvisioner defines the provisioning operations used by ManagerReconciler.
+// Implemented by *Provisioner; extracted for testability.
+//
+// NOTE: RefreshCredentials is included because the current handleUpdate calls it
+// (likely a bug — should be RefreshManagerCredentials). Phase 2 reconciler rewrite
+// will unify to RefreshManagerCredentials only.
+type ManagerProvisioner interface {
+	ProvisionManager(ctx context.Context, req ManagerProvisionRequest) (*ManagerProvisionResult, error)
+	DeprovisionManager(ctx context.Context, name string, mcpServers []string) error
+	RefreshCredentials(ctx context.Context, name string) (*RefreshResult, error)
+	RefreshManagerCredentials(ctx context.Context, managerName string) (*RefreshResult, error)
+	EnsureManagerGatewayAuth(ctx context.Context, managerName, gatewayKey string) error
+	ReconcileMCPAuth(ctx context.Context, consumerName string, mcpServers []string) ([]string, error)
+	EnsureManagerServiceAccount(ctx context.Context, managerName string) error
+	DeleteManagerServiceAccount(ctx context.Context, managerName string) error
+	DeleteCredentials(ctx context.Context, name string) error
+	RequestManagerSAToken(ctx context.Context, managerName string) (string, error)
+	DeactivateMatrixUser(ctx context.Context, name string) error
+}
+
+// ManagerDeployer defines the deployment operations used by ManagerReconciler.
+// Implemented by *Deployer; extracted for testability.
+type ManagerDeployer interface {
+	DeployPackage(ctx context.Context, name, uri string, isUpdate bool) error
+	DeployManagerConfig(ctx context.Context, req ManagerDeployRequest) error
+	PushOnDemandSkills(ctx context.Context, name string, skills []string) error
+	CleanupOSSData(ctx context.Context, name string) error
+}
+
+// ManagerEnvBuilderI defines env map construction for manager containers.
+// Implemented by *WorkerEnvBuilder; extracted for testability.
+type ManagerEnvBuilderI interface {
+	BuildManager(managerName string, prov *ManagerProvisionResult, spec v1beta1.ManagerSpec) map[string]string
+}
+
 // Compile-time interface satisfaction checks.
 var (
 	_ WorkerProvisioner = (*Provisioner)(nil)
 	_ WorkerDeployer    = (*Deployer)(nil)
 	_ WorkerEnvBuilderI = (*WorkerEnvBuilder)(nil)
+
+	_ ManagerProvisioner = (*Provisioner)(nil)
+	_ ManagerDeployer    = (*Deployer)(nil)
+	_ ManagerEnvBuilderI = (*WorkerEnvBuilder)(nil)
 )

--- a/hiclaw-controller/test/integration/controller/manager_test.go
+++ b/hiclaw-controller/test/integration/controller/manager_test.go
@@ -1,0 +1,477 @@
+//go:build integration
+
+package controller_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	"github.com/hiclaw/hiclaw-controller/internal/backend"
+	"github.com/hiclaw/hiclaw-controller/internal/service"
+	"github.com/hiclaw/hiclaw-controller/test/testutil/fixtures"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ---------------------------------------------------------------------------
+// Manager Create tests
+// ---------------------------------------------------------------------------
+
+func TestManagerCreate_HappyPath(t *testing.T) {
+	resetManagerMocks()
+
+	mgrName := fixtures.UniqueName("test-mgr-create")
+	mgr := fixtures.NewTestManager(mgrName)
+
+	if err := k8sClient.Create(ctx, mgr); err != nil {
+		t.Fatalf("failed to create Manager CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, mgr)
+	})
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		if m.Status.Phase != "Running" {
+			return fmt.Errorf("phase=%q, want Running", m.Status.Phase)
+		}
+		return nil
+	})
+
+	var m v1beta1.Manager
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+		t.Fatalf("failed to get Manager: %v", err)
+	}
+
+	if m.Status.ObservedGeneration != m.Generation {
+		t.Errorf("ObservedGeneration=%d, want %d", m.Status.ObservedGeneration, m.Generation)
+	}
+	if m.Status.MatrixUserID == "" {
+		t.Error("MatrixUserID should be set after creation")
+	}
+	if m.Status.RoomID == "" {
+		t.Error("RoomID should be set after creation")
+	}
+	provCount, _, _, _ := mockMgrProv.CallCounts()
+	if provCount == 0 {
+		t.Error("ProvisionManager should have been called")
+	}
+	_, deployConfigCount, _, _ := mockMgrDeploy.CallCounts()
+	if deployConfigCount == 0 {
+		t.Error("DeployManagerConfig should have been called")
+	}
+}
+
+func TestManagerCreate_ProvisionFailure_SetsFailedPhase(t *testing.T) {
+	resetManagerMocks()
+
+	mockMgrProv.ProvisionManagerFn = func(_ context.Context, _ service.ManagerProvisionRequest) (*service.ManagerProvisionResult, error) {
+		return nil, fmt.Errorf("simulated provision failure")
+	}
+
+	mgrName := fixtures.UniqueName("test-mgr-fail")
+	mgr := fixtures.NewTestManager(mgrName)
+
+	if err := k8sClient.Create(ctx, mgr); err != nil {
+		t.Fatalf("failed to create Manager CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, mgr)
+	})
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		if m.Status.Phase != "Failed" {
+			return fmt.Errorf("phase=%q, want Failed", m.Status.Phase)
+		}
+		if m.Status.Message == "" {
+			return fmt.Errorf("message should contain failure reason")
+		}
+		return nil
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Manager Delete tests
+// ---------------------------------------------------------------------------
+
+func TestManagerDelete_CleansUpAll(t *testing.T) {
+	resetManagerMocks()
+
+	mgrName := fixtures.UniqueName("test-mgr-delete")
+	mgr := fixtures.NewTestManager(mgrName)
+
+	if err := k8sClient.Create(ctx, mgr); err != nil {
+		t.Fatalf("failed to create Manager CR: %v", err)
+	}
+
+	waitForManagerRunning(t, mgr)
+
+	mockMgrProv.ClearCalls()
+	mockMgrDeploy.ClearCalls()
+
+	if err := k8sClient.Delete(ctx, mgr); err != nil {
+		t.Fatalf("failed to delete Manager CR: %v", err)
+	}
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m)
+		if err == nil {
+			return fmt.Errorf("manager still exists (phase=%q)", m.Status.Phase)
+		}
+		return client.IgnoreNotFound(err)
+	})
+
+	_, deprovCount, _, deactivateCount := mockMgrProv.CallCounts()
+	if deactivateCount == 0 {
+		t.Error("DeactivateMatrixUser should have been called")
+	}
+	if deprovCount == 0 {
+		t.Error("DeprovisionManager should have been called")
+	}
+	_, _, _, cleanupCount := mockMgrDeploy.CallCounts()
+	if cleanupCount == 0 {
+		t.Error("CleanupOSSData should have been called")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Manager Finalizer test
+// ---------------------------------------------------------------------------
+
+func TestManagerFinalizer_AddedOnCreate(t *testing.T) {
+	resetManagerMocks()
+
+	mgrName := fixtures.UniqueName("test-mgr-fin")
+	mgr := fixtures.NewTestManager(mgrName)
+
+	if err := k8sClient.Create(ctx, mgr); err != nil {
+		t.Fatalf("failed to create Manager CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, mgr)
+	})
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		for _, f := range m.Finalizers {
+			if f == "hiclaw.io/cleanup" {
+				return nil
+			}
+		}
+		return fmt.Errorf("finalizer hiclaw.io/cleanup not found in %v", m.Finalizers)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Manager Update test
+// ---------------------------------------------------------------------------
+
+func TestManagerUpdate_SpecChange_RecreatesContainer(t *testing.T) {
+	resetManagerMocks()
+
+	mgrName := fixtures.UniqueName("test-mgr-update")
+	mgr := fixtures.NewTestManager(mgrName)
+
+	if err := k8sClient.Create(ctx, mgr); err != nil {
+		t.Fatalf("failed to create Manager CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, mgr)
+	})
+
+	waitForManagerRunning(t, mgr)
+
+	mockMgrBackend.Reset()
+	mockMgrBackend.StatusFn = func(_ context.Context, _ string) (*backend.WorkerResult, error) {
+		return &backend.WorkerResult{Status: backend.StatusRunning}, nil
+	}
+
+	updateManagerSpecField(t, mgr, func(m *v1beta1.Manager) {
+		m.Spec.Model = "claude-sonnet-4-20250514"
+	})
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		if m.Status.ObservedGeneration != m.Generation {
+			return fmt.Errorf("ObservedGeneration=%d, want %d", m.Status.ObservedGeneration, m.Generation)
+		}
+		return nil
+	})
+
+	creates, deletes, _, _, _ := mockMgrBackend.CallSnapshot()
+	if len(deletes) == 0 {
+		t.Error("backend.Delete should have been called to remove old container")
+	}
+	if len(creates) == 0 {
+		t.Error("backend.Create should have been called to create new container")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Manager Idempotency test
+// ---------------------------------------------------------------------------
+
+func TestManagerCreate_Idempotent_NoDoubleProvision(t *testing.T) {
+	resetManagerMocks()
+
+	mgrName := fixtures.UniqueName("test-mgr-idemp")
+	mgr := fixtures.NewTestManager(mgrName)
+
+	if err := k8sClient.Create(ctx, mgr); err != nil {
+		t.Fatalf("failed to create Manager CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, mgr)
+	})
+
+	waitForManagerRunning(t, mgr)
+
+	provCountBefore, _, refreshCountBefore, _ := mockMgrProv.CallCounts()
+
+	triggerManagerReconcile(t, mgr)
+
+	assertEventually(t, func() error {
+		_, _, refreshCount, _ := mockMgrProv.CallCounts()
+		if refreshCount <= refreshCountBefore {
+			return fmt.Errorf("RefreshManagerCredentials count=%d, want >%d",
+				refreshCount, refreshCountBefore)
+		}
+		return nil
+	})
+
+	provCountAfter, _, _, _ := mockMgrProv.CallCounts()
+	if provCountAfter != provCountBefore {
+		t.Errorf("ProvisionManager called %d times, want %d (should not re-provision after Running)",
+			provCountAfter, provCountBefore)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Manager Lifecycle state change tests
+// ---------------------------------------------------------------------------
+
+func TestManagerStateChange_StopAndResume(t *testing.T) {
+	resetManagerMocks()
+
+	mgrName := fixtures.UniqueName("test-mgr-stop")
+	mgr := fixtures.NewTestManager(mgrName)
+
+	if err := k8sClient.Create(ctx, mgr); err != nil {
+		t.Fatalf("failed to create Manager CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, mgr)
+	})
+
+	waitForManagerRunning(t, mgr)
+
+	// Running -> Stopped
+	mockMgrBackend.ClearCalls()
+
+	updateManagerSpecField(t, mgr, func(m *v1beta1.Manager) {
+		m.Spec.State = ptrString("Stopped")
+	})
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		if m.Status.Phase != "Stopped" {
+			return fmt.Errorf("phase=%q, want Stopped", m.Status.Phase)
+		}
+		return nil
+	})
+
+	_, deletes, _, stops, _ := mockMgrBackend.CallSnapshot()
+	if len(stops)+len(deletes) == 0 {
+		t.Error("backend.Stop or Delete should have been called when transitioning to Stopped")
+	}
+
+	// Stopped -> Running
+	mockMgrBackend.ClearCalls()
+
+	updateManagerSpecField(t, mgr, func(m *v1beta1.Manager) {
+		m.Spec.State = nil
+	})
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		if m.Status.Phase != "Running" {
+			return fmt.Errorf("phase=%q, want Running", m.Status.Phase)
+		}
+		return nil
+	})
+
+	creates, _, _, _, _ := mockMgrBackend.CallSnapshot()
+	if len(creates) == 0 {
+		t.Error("backend.Create should have been called when resuming from Stopped")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Manager Delete of failed manager
+// ---------------------------------------------------------------------------
+
+func TestManagerDelete_ProvisionFailed_StillCleans(t *testing.T) {
+	resetManagerMocks()
+
+	mockMgrProv.ProvisionManagerFn = func(_ context.Context, _ service.ManagerProvisionRequest) (*service.ManagerProvisionResult, error) {
+		return nil, fmt.Errorf("simulated provision failure")
+	}
+
+	mgrName := fixtures.UniqueName("test-mgr-delfail")
+	mgr := fixtures.NewTestManager(mgrName)
+
+	if err := k8sClient.Create(ctx, mgr); err != nil {
+		t.Fatalf("failed to create Manager CR: %v", err)
+	}
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		if m.Status.Phase != "Failed" {
+			return fmt.Errorf("phase=%q, want Failed", m.Status.Phase)
+		}
+		return nil
+	})
+
+	mockMgrProv.ClearCalls()
+	mockMgrDeploy.ClearCalls()
+
+	if err := k8sClient.Delete(ctx, mgr); err != nil {
+		t.Fatalf("failed to delete Manager CR: %v", err)
+	}
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m)
+		if err == nil {
+			return fmt.Errorf("manager still exists (phase=%q)", m.Status.Phase)
+		}
+		return client.IgnoreNotFound(err)
+	})
+
+	_, deprovCount, _, _ := mockMgrProv.CallCounts()
+	if deprovCount == 0 {
+		t.Error("DeprovisionManager should have been called even for a failed manager")
+	}
+	_, _, _, cleanupCount := mockMgrDeploy.CallCounts()
+	if cleanupCount == 0 {
+		t.Error("CleanupOSSData should have been called even for a failed manager")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Manager no infinite recreate loop
+// ---------------------------------------------------------------------------
+
+func TestManagerUpdate_NoInfiniteRecreate(t *testing.T) {
+	resetManagerMocks()
+
+	mgrName := fixtures.UniqueName("test-mgr-noloop")
+	mgr := fixtures.NewTestManager(mgrName)
+
+	if err := k8sClient.Create(ctx, mgr); err != nil {
+		t.Fatalf("failed to create Manager CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, mgr)
+	})
+
+	waitForManagerRunning(t, mgr)
+
+	mockMgrBackend.ClearCalls()
+
+	updateManagerSpecField(t, mgr, func(m *v1beta1.Manager) {
+		m.Spec.Model = "gpt-4o-mini"
+	})
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		if m.Status.ObservedGeneration != m.Generation {
+			return fmt.Errorf("ObservedGeneration=%d, want %d", m.Status.ObservedGeneration, m.Generation)
+		}
+		return nil
+	})
+
+	time.Sleep(3 * time.Second)
+
+	creates, _, _, _, _ := mockMgrBackend.CallSnapshot()
+	if len(creates) == 0 {
+		t.Error("expected at least 1 Create from spec update")
+	}
+	if len(creates) > 2 {
+		t.Errorf("Create called %d times -- possible infinite recreate loop (want <=2)", len(creates))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Manager test helpers
+// ---------------------------------------------------------------------------
+
+func waitForManagerRunning(t *testing.T, mgr *v1beta1.Manager) {
+	t.Helper()
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		if m.Status.Phase != "Running" {
+			return fmt.Errorf("phase=%q message=%q gen=%d obsGen=%d, want Running",
+				m.Status.Phase, m.Status.Message, m.Generation, m.Status.ObservedGeneration)
+		}
+		return nil
+	})
+}
+
+func updateManagerSpecField(t *testing.T, mgr *v1beta1.Manager, mutate func(m *v1beta1.Manager)) {
+	t.Helper()
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		mutate(&m)
+		return k8sClient.Update(ctx, &m)
+	})
+}
+
+func triggerManagerReconcile(t *testing.T, mgr *v1beta1.Manager) {
+	t.Helper()
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		if m.Annotations == nil {
+			m.Annotations = map[string]string{}
+		}
+		m.Annotations["hiclaw.io/reconcile-trigger"] = fmt.Sprintf("%d", time.Now().UnixNano())
+		return k8sClient.Update(ctx, &m)
+	})
+}

--- a/hiclaw-controller/test/integration/controller/manager_test.go
+++ b/hiclaw-controller/test/integration/controller/manager_test.go
@@ -503,14 +503,6 @@ func TestManagerStateChange_SleepAndWake(t *testing.T) {
 func TestManagerPodDeleted_Recreates(t *testing.T) {
 	resetManagerMocks()
 
-	// Use StatusFn to simulate container presence. Manager's containerName
-	// differs from req.Name (managerContainerName mapping), so the mock's
-	// automatic state tracking doesn't work for Manager. We use StatusFn to
-	// control the simulation explicitly.
-	mockMgrBackend.StatusFn = func(_ context.Context, _ string) (*backend.WorkerResult, error) {
-		return &backend.WorkerResult{Status: backend.StatusRunning}, nil
-	}
-
 	mgrName := fixtures.UniqueName("test-mgr-poddel")
 	mgr := fixtures.NewTestManager(mgrName)
 
@@ -518,17 +510,17 @@ func TestManagerPodDeleted_Recreates(t *testing.T) {
 		t.Fatalf("failed to create Manager CR: %v", err)
 	}
 	t.Cleanup(func() {
-		mockMgrBackend.StatusFn = nil
 		_ = k8sClient.Delete(ctx, mgr)
 	})
 
 	waitForManagerRunning(t, mgr)
 
-	// Simulate external pod deletion: switch Status to NotFound
+	// Simulate external pod deletion via the mock's automatic state tracking.
+	// The ContainerName alias (Issue #1 fix) means "hiclaw-manager" is tracked
+	// alongside req.Name, so SimulatePodDeletion works for Manager now.
+	containerName := managerContainerName(mgrName)
+	mockMgrBackend.SimulatePodDeletion(containerName)
 	mockMgrBackend.ClearCalls()
-	mockMgrBackend.StatusFn = func(_ context.Context, _ string) (*backend.WorkerResult, error) {
-		return &backend.WorkerResult{Status: backend.StatusNotFound}, nil
-	}
 
 	triggerManagerReconcile(t, mgr)
 
@@ -656,10 +648,8 @@ func TestManagerCreate_ConfigDeployFailure_KeepsPhase(t *testing.T) {
 	if m.Status.MatrixUserID == "" {
 		t.Error("MatrixUserID should be set (provision succeeded before config failure)")
 	}
-	// computeManagerPhase: MatrixUserID != "" + err → keeps original Phase (empty on first create)
-	// Phase should NOT be "Failed" because infrastructure was provisioned
-	if m.Status.Phase == "Failed" {
-		t.Error("Phase should not be Failed when infrastructure was successfully provisioned")
+	if m.Status.Phase != "Pending" {
+		t.Errorf("Phase=%q, want Pending (infra provisioned but config failed)", m.Status.Phase)
 	}
 	if m.Status.ObservedGeneration != 0 {
 		t.Errorf("ObservedGeneration=%d, want 0 (should not be written on error)", m.Status.ObservedGeneration)
@@ -707,19 +697,16 @@ func TestManagerCreate_ContainerCreateFailure_ReturnsError(t *testing.T) {
 	}
 }
 
-func TestManagerCreate_ServiceAccountFailure_SelfHeals(t *testing.T) {
-	// SA creation failure during initial provisioning doesn't permanently
-	// block the Manager. After the first reconcile writes MatrixUserID to
-	// status, subsequent reconciles take the refresh path, bypassing SA
-	// creation entirely. The Manager reaches Running despite the SA never
-	// being successfully created.
-	//
-	// Known Issue: SA is never retried after recovery. If the SA is
-	// actually required for operation, the Manager runs without it.
+func TestManagerCreate_ServiceAccountFailure_RetriesOnNextReconcile(t *testing.T) {
 	resetManagerMocks()
 
+	saCallCount := 0
 	mockMgrProv.EnsureManagerServiceAccountFn = func(_ context.Context, _ string) error {
-		return fmt.Errorf("simulated SA creation failure")
+		saCallCount++
+		if saCallCount <= 1 {
+			return fmt.Errorf("simulated SA creation failure")
+		}
+		return nil
 	}
 
 	mgrName := fixtures.UniqueName("test-mgr-safail")
@@ -732,17 +719,12 @@ func TestManagerCreate_ServiceAccountFailure_SelfHeals(t *testing.T) {
 		_ = k8sClient.Delete(ctx, mgr)
 	})
 
-	// Manager self-heals: first reconcile fails at SA but writes
-	// MatrixUserID; second reconcile takes refresh path and succeeds.
+	// SA fails on first reconcile, succeeds on retry → Manager reaches Running.
 	waitForManagerRunning(t, mgr)
 
-	provCount, _, _, _ := mockMgrProv.CallCounts()
-	if provCount == 0 {
-		t.Error("ProvisionManager should have been called")
-	}
 	ensureSA, _ := mockMgrProv.ServiceAccountCallCounts()
-	if ensureSA == 0 {
-		t.Error("EnsureManagerServiceAccount should have been attempted at least once")
+	if ensureSA < 2 {
+		t.Errorf("EnsureManagerServiceAccount called %d times, want >=2 (initial failure + retry)", ensureSA)
 	}
 }
 
@@ -875,6 +857,14 @@ func TestManagerUpdate_MCPServersChange_TriggersReauth(t *testing.T) {
 // ---------------------------------------------------------------------------
 // Manager test helpers
 // ---------------------------------------------------------------------------
+
+// managerContainerName mirrors the controller's naming logic for tests.
+func managerContainerName(name string) string {
+	if name == "default" {
+		return "hiclaw-manager"
+	}
+	return "hiclaw-manager-" + name
+}
 
 func waitForManagerRunning(t *testing.T, mgr *v1beta1.Manager) {
 	t.Helper()

--- a/hiclaw-controller/test/integration/controller/manager_test.go
+++ b/hiclaw-controller/test/integration/controller/manager_test.go
@@ -431,6 +431,448 @@ func TestManagerUpdate_NoInfiniteRecreate(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Manager Sleeping lifecycle test
+// ---------------------------------------------------------------------------
+
+func TestManagerStateChange_SleepAndWake(t *testing.T) {
+	resetManagerMocks()
+
+	mgrName := fixtures.UniqueName("test-mgr-sleep")
+	mgr := fixtures.NewTestManager(mgrName)
+
+	if err := k8sClient.Create(ctx, mgr); err != nil {
+		t.Fatalf("failed to create Manager CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, mgr)
+	})
+
+	waitForManagerRunning(t, mgr)
+
+	// --- Running -> Sleeping ---
+	mockMgrBackend.ClearCalls()
+
+	updateManagerSpecField(t, mgr, func(m *v1beta1.Manager) {
+		m.Spec.State = ptrString("Sleeping")
+	})
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		if m.Status.Phase != "Sleeping" {
+			return fmt.Errorf("phase=%q, want Sleeping", m.Status.Phase)
+		}
+		return nil
+	})
+
+	_, _, _, stops, _ := mockMgrBackend.CallSnapshot()
+	if len(stops) == 0 {
+		t.Error("backend.Stop should have been called when transitioning to Sleeping")
+	}
+
+	// --- Sleeping -> Running ---
+	mockMgrBackend.ClearCalls()
+
+	updateManagerSpecField(t, mgr, func(m *v1beta1.Manager) {
+		m.Spec.State = nil
+	})
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		if m.Status.Phase != "Running" {
+			return fmt.Errorf("phase=%q, want Running", m.Status.Phase)
+		}
+		return nil
+	})
+
+	creates, _, _, _, _ := mockMgrBackend.CallSnapshot()
+	if len(creates) == 0 {
+		t.Error("backend.Create should have been called when waking from Sleeping")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Manager Pod deleted recreates test
+// ---------------------------------------------------------------------------
+
+func TestManagerPodDeleted_Recreates(t *testing.T) {
+	resetManagerMocks()
+
+	// Use StatusFn to simulate container presence. Manager's containerName
+	// differs from req.Name (managerContainerName mapping), so the mock's
+	// automatic state tracking doesn't work for Manager. We use StatusFn to
+	// control the simulation explicitly.
+	mockMgrBackend.StatusFn = func(_ context.Context, _ string) (*backend.WorkerResult, error) {
+		return &backend.WorkerResult{Status: backend.StatusRunning}, nil
+	}
+
+	mgrName := fixtures.UniqueName("test-mgr-poddel")
+	mgr := fixtures.NewTestManager(mgrName)
+
+	if err := k8sClient.Create(ctx, mgr); err != nil {
+		t.Fatalf("failed to create Manager CR: %v", err)
+	}
+	t.Cleanup(func() {
+		mockMgrBackend.StatusFn = nil
+		_ = k8sClient.Delete(ctx, mgr)
+	})
+
+	waitForManagerRunning(t, mgr)
+
+	// Simulate external pod deletion: switch Status to NotFound
+	mockMgrBackend.ClearCalls()
+	mockMgrBackend.StatusFn = func(_ context.Context, _ string) (*backend.WorkerResult, error) {
+		return &backend.WorkerResult{Status: backend.StatusNotFound}, nil
+	}
+
+	triggerManagerReconcile(t, mgr)
+
+	assertEventually(t, func() error {
+		creates, _, _, _, _ := mockMgrBackend.CallSnapshot()
+		if len(creates) == 0 {
+			return fmt.Errorf("waiting for backend.Create to be called (pod recreation)")
+		}
+		return nil
+	})
+
+	var m v1beta1.Manager
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+		t.Fatalf("failed to get Manager: %v", err)
+	}
+	if m.Status.Phase != "Running" {
+		t.Errorf("phase=%q after pod recreation, want Running", m.Status.Phase)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Manager simultaneous spec + state change test
+// ---------------------------------------------------------------------------
+
+func TestManagerStateChange_SimultaneousSpecAndState(t *testing.T) {
+	resetManagerMocks()
+
+	mgrName := fixtures.UniqueName("test-mgr-simul")
+	mgr := fixtures.NewTestManager(mgrName)
+
+	if err := k8sClient.Create(ctx, mgr); err != nil {
+		t.Fatalf("failed to create Manager CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, mgr)
+	})
+
+	waitForManagerRunning(t, mgr)
+
+	// --- Simultaneously change state to Stopped AND model ---
+	mockMgrBackend.ClearCalls()
+
+	updateManagerSpecField(t, mgr, func(m *v1beta1.Manager) {
+		m.Spec.State = ptrString("Stopped")
+		m.Spec.Model = "claude-sonnet-4-20250514"
+	})
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		if m.Status.Phase != "Stopped" {
+			return fmt.Errorf("phase=%q, want Stopped", m.Status.Phase)
+		}
+		return nil
+	})
+
+	creates, _, _, _, _ := mockMgrBackend.CallSnapshot()
+	if len(creates) > 0 {
+		t.Errorf("backend.Create called %d times while Stopped -- should not create in Stopped state", len(creates))
+	}
+
+	// --- Resume to Running with new config ---
+	mockMgrBackend.ClearCalls()
+
+	updateManagerSpecField(t, mgr, func(m *v1beta1.Manager) {
+		m.Spec.State = nil
+	})
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		if m.Status.Phase != "Running" {
+			return fmt.Errorf("phase=%q, want Running", m.Status.Phase)
+		}
+		return nil
+	})
+
+	creates, _, _, _, _ = mockMgrBackend.CallSnapshot()
+	if len(creates) == 0 {
+		t.Error("backend.Create should have been called when resuming with new config")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Manager error path tests
+// ---------------------------------------------------------------------------
+
+func TestManagerCreate_ConfigDeployFailure_KeepsPhase(t *testing.T) {
+	resetManagerMocks()
+
+	mockMgrDeploy.DeployManagerConfigFn = func(_ context.Context, _ service.ManagerDeployRequest) error {
+		return fmt.Errorf("simulated config deploy failure")
+	}
+
+	mgrName := fixtures.UniqueName("test-mgr-cfgfail")
+	mgr := fixtures.NewTestManager(mgrName)
+
+	if err := k8sClient.Create(ctx, mgr); err != nil {
+		t.Fatalf("failed to create Manager CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, mgr)
+	})
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		if m.Status.Message == "" {
+			return fmt.Errorf("message should contain failure reason")
+		}
+		return nil
+	})
+
+	var m v1beta1.Manager
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+		t.Fatalf("failed to get Manager: %v", err)
+	}
+
+	if m.Status.MatrixUserID == "" {
+		t.Error("MatrixUserID should be set (provision succeeded before config failure)")
+	}
+	// computeManagerPhase: MatrixUserID != "" + err → keeps original Phase (empty on first create)
+	// Phase should NOT be "Failed" because infrastructure was provisioned
+	if m.Status.Phase == "Failed" {
+		t.Error("Phase should not be Failed when infrastructure was successfully provisioned")
+	}
+	if m.Status.ObservedGeneration != 0 {
+		t.Errorf("ObservedGeneration=%d, want 0 (should not be written on error)", m.Status.ObservedGeneration)
+	}
+}
+
+func TestManagerCreate_ContainerCreateFailure_ReturnsError(t *testing.T) {
+	resetManagerMocks()
+
+	mockMgrBackend.CreateFn = func(_ context.Context, _ backend.CreateRequest) (*backend.WorkerResult, error) {
+		return nil, fmt.Errorf("simulated container create failure")
+	}
+
+	mgrName := fixtures.UniqueName("test-mgr-ctrfail")
+	mgr := fixtures.NewTestManager(mgrName)
+
+	if err := k8sClient.Create(ctx, mgr); err != nil {
+		t.Fatalf("failed to create Manager CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, mgr)
+	})
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		if m.Status.Message == "" {
+			return fmt.Errorf("message should contain failure reason")
+		}
+		return nil
+	})
+
+	var m v1beta1.Manager
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+		t.Fatalf("failed to get Manager: %v", err)
+	}
+
+	if m.Status.MatrixUserID == "" {
+		t.Error("MatrixUserID should be set (infra+config succeeded before container failure)")
+	}
+	if m.Status.Phase == "Running" {
+		t.Error("Phase should not be Running when container creation failed")
+	}
+}
+
+func TestManagerCreate_ServiceAccountFailure_SelfHeals(t *testing.T) {
+	// SA creation failure during initial provisioning doesn't permanently
+	// block the Manager. After the first reconcile writes MatrixUserID to
+	// status, subsequent reconciles take the refresh path, bypassing SA
+	// creation entirely. The Manager reaches Running despite the SA never
+	// being successfully created.
+	//
+	// Known Issue: SA is never retried after recovery. If the SA is
+	// actually required for operation, the Manager runs without it.
+	resetManagerMocks()
+
+	mockMgrProv.EnsureManagerServiceAccountFn = func(_ context.Context, _ string) error {
+		return fmt.Errorf("simulated SA creation failure")
+	}
+
+	mgrName := fixtures.UniqueName("test-mgr-safail")
+	mgr := fixtures.NewTestManager(mgrName)
+
+	if err := k8sClient.Create(ctx, mgr); err != nil {
+		t.Fatalf("failed to create Manager CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, mgr)
+	})
+
+	// Manager self-heals: first reconcile fails at SA but writes
+	// MatrixUserID; second reconcile takes refresh path and succeeds.
+	waitForManagerRunning(t, mgr)
+
+	provCount, _, _, _ := mockMgrProv.CallCounts()
+	if provCount == 0 {
+		t.Error("ProvisionManager should have been called")
+	}
+	ensureSA, _ := mockMgrProv.ServiceAccountCallCounts()
+	if ensureSA == 0 {
+		t.Error("EnsureManagerServiceAccount should have been attempted at least once")
+	}
+}
+
+func TestManagerUpdate_RefreshCredentialsFail_KeepsPhase(t *testing.T) {
+	resetManagerMocks()
+
+	mgrName := fixtures.UniqueName("test-mgr-reffail")
+	mgr := fixtures.NewTestManager(mgrName)
+
+	if err := k8sClient.Create(ctx, mgr); err != nil {
+		t.Fatalf("failed to create Manager CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, mgr)
+	})
+
+	waitForManagerRunning(t, mgr)
+
+	// Switch RefreshManagerCredentials to fail
+	mockMgrProv.RefreshManagerCredentialsFn = func(_ context.Context, _ string) (*service.RefreshResult, error) {
+		return nil, fmt.Errorf("simulated refresh failure")
+	}
+
+	triggerManagerReconcile(t, mgr)
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		if m.Status.Message == "" {
+			return fmt.Errorf("message should contain refresh failure")
+		}
+		return nil
+	})
+
+	var m v1beta1.Manager
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+		t.Fatalf("failed to get Manager: %v", err)
+	}
+
+	if m.Status.Phase != "Running" {
+		t.Errorf("Phase=%q, want Running (should keep original phase on refresh failure)", m.Status.Phase)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Manager delete resilience test
+// ---------------------------------------------------------------------------
+
+func TestManagerDelete_PartialFailure_StillCompletes(t *testing.T) {
+	resetManagerMocks()
+
+	mgrName := fixtures.UniqueName("test-mgr-delprt")
+	mgr := fixtures.NewTestManager(mgrName)
+
+	if err := k8sClient.Create(ctx, mgr); err != nil {
+		t.Fatalf("failed to create Manager CR: %v", err)
+	}
+
+	waitForManagerRunning(t, mgr)
+
+	// Make cleanup operations fail
+	mockMgrProv.DeprovisionManagerFn = func(_ context.Context, _ string, _ []string) error {
+		return fmt.Errorf("simulated deprovision failure")
+	}
+	mockMgrDeploy.CleanupOSSDataFn = func(_ context.Context, _ string) error {
+		return fmt.Errorf("simulated OSS cleanup failure")
+	}
+	mockMgrProv.DeleteCredentialsFn = func(_ context.Context, _ string) error {
+		return fmt.Errorf("simulated credential delete failure")
+	}
+
+	if err := k8sClient.Delete(ctx, mgr); err != nil {
+		t.Fatalf("failed to delete Manager CR: %v", err)
+	}
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m)
+		if err == nil {
+			return fmt.Errorf("manager still exists (phase=%q)", m.Status.Phase)
+		}
+		return client.IgnoreNotFound(err)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Manager MCP reauthorization test
+// ---------------------------------------------------------------------------
+
+func TestManagerUpdate_MCPServersChange_TriggersReauth(t *testing.T) {
+	resetManagerMocks()
+
+	mgrName := fixtures.UniqueName("test-mgr-mcp")
+	mgr := fixtures.NewTestManagerWithMCPServers(mgrName, []string{"mcp-server-1"})
+
+	if err := k8sClient.Create(ctx, mgr); err != nil {
+		t.Fatalf("failed to create Manager CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, mgr)
+	})
+
+	waitForManagerRunning(t, mgr)
+
+	mockMgrProv.ClearCalls()
+
+	updateManagerSpecField(t, mgr, func(m *v1beta1.Manager) {
+		m.Spec.McpServers = []string{"mcp-server-1", "mcp-server-2"}
+	})
+
+	assertEventually(t, func() error {
+		var m v1beta1.Manager
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(mgr), &m); err != nil {
+			return err
+		}
+		if m.Status.ObservedGeneration != m.Generation {
+			return fmt.Errorf("ObservedGeneration=%d, want %d", m.Status.ObservedGeneration, m.Generation)
+		}
+		return nil
+	})
+
+	mcpCount := mockMgrProv.MCPAuthCallCount()
+	if mcpCount == 0 {
+		t.Error("ReconcileMCPAuth should have been called after McpServers change")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Manager test helpers
 // ---------------------------------------------------------------------------
 

--- a/hiclaw-controller/test/integration/controller/suite_test.go
+++ b/hiclaw-controller/test/integration/controller/suite_test.go
@@ -33,10 +33,17 @@ var (
 	ctx       context.Context
 	cancel    context.CancelFunc
 
+	// Worker mocks
 	mockProv    *mocks.MockProvisioner
 	mockDeploy  *mocks.MockDeployer
 	mockBackend *mocks.MockWorkerBackend
 	mockEnv     *mocks.MockEnvBuilder
+
+	// Manager mocks
+	mockMgrProv    *mocks.MockManagerProvisioner
+	mockMgrDeploy  *mocks.MockManagerDeployer
+	mockMgrBackend *mocks.MockWorkerBackend
+	mockMgrEnv     *mocks.MockManagerEnvBuilder
 )
 
 func TestMain(m *testing.M) {
@@ -67,27 +74,49 @@ func TestMain(m *testing.M) {
 		panic(fmt.Sprintf("failed to create k8s client: %v", err))
 	}
 
-	// Wire up mocks
+	// Wire up Worker mocks
 	mockProv = mocks.NewMockProvisioner()
 	mockDeploy = mocks.NewMockDeployer()
 	mockBackend = mocks.NewMockWorkerBackend()
 	mockEnv = mocks.NewMockEnvBuilder()
 
-	backendRegistry := backend.NewRegistry(
+	workerBackendRegistry := backend.NewRegistry(
 		[]backend.WorkerBackend{mockBackend},
 		nil,
 	)
 
-	reconciler := &controller.WorkerReconciler{
+	workerReconciler := &controller.WorkerReconciler{
 		Client:      mgr.GetClient(),
 		Provisioner: mockProv,
 		Deployer:    mockDeploy,
-		Backend:     backendRegistry,
+		Backend:     workerBackendRegistry,
 		EnvBuilder:  mockEnv,
 		Legacy:      nil,
 	}
-	if err := reconciler.SetupWithManager(mgr); err != nil {
+	if err := workerReconciler.SetupWithManager(mgr); err != nil {
 		panic(fmt.Sprintf("failed to setup WorkerReconciler: %v", err))
+	}
+
+	// Wire up Manager mocks
+	mockMgrProv = mocks.NewMockManagerProvisioner()
+	mockMgrDeploy = mocks.NewMockManagerDeployer()
+	mockMgrBackend = mocks.NewMockWorkerBackend()
+	mockMgrEnv = mocks.NewMockManagerEnvBuilder()
+
+	mgrBackendRegistry := backend.NewRegistry(
+		[]backend.WorkerBackend{mockMgrBackend},
+		nil,
+	)
+
+	managerReconciler := &controller.ManagerReconciler{
+		Client:      mgr.GetClient(),
+		Provisioner: mockMgrProv,
+		Deployer:    mockMgrDeploy,
+		Backend:     mgrBackendRegistry,
+		EnvBuilder:  mockMgrEnv,
+	}
+	if err := managerReconciler.SetupWithManager(mgr); err != nil {
+		panic(fmt.Sprintf("failed to setup ManagerReconciler: %v", err))
 	}
 
 	go func() {
@@ -117,6 +146,14 @@ func resetMocks() {
 	mockDeploy.Reset()
 	mockBackend.Reset()
 	mockEnv.Reset()
+}
+
+// resetManagerMocks resets all Manager mock call records and Fn overrides.
+func resetManagerMocks() {
+	mockMgrProv.Reset()
+	mockMgrDeploy.Reset()
+	mockMgrBackend.Reset()
+	mockMgrEnv.Reset()
 }
 
 // suppress unused import for v1beta1

--- a/hiclaw-controller/test/integration/controller/worker_test.go
+++ b/hiclaw-controller/test/integration/controller/worker_test.go
@@ -542,6 +542,41 @@ func TestWorkerStateChange_SimultaneousSpecAndState(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Phase 5: ServiceAccount retry test
+// ---------------------------------------------------------------------------
+
+func TestWorkerCreate_ServiceAccountFailure_RetriesOnNextReconcile(t *testing.T) {
+	resetMocks()
+
+	saCallCount := 0
+	mockProv.EnsureServiceAccountFn = func(_ context.Context, _ string) error {
+		saCallCount++
+		if saCallCount <= 1 {
+			return fmt.Errorf("simulated SA creation failure")
+		}
+		return nil
+	}
+
+	workerName := fixtures.UniqueName("test-sa-retry")
+	worker := fixtures.NewTestWorker(workerName)
+
+	if err := k8sClient.Create(ctx, worker); err != nil {
+		t.Fatalf("failed to create Worker CR: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = k8sClient.Delete(ctx, worker)
+	})
+
+	// SA fails on first reconcile, succeeds on retry -> Worker reaches Running.
+	waitForRunning(t, worker)
+
+	ensureSA, _ := mockProv.ServiceAccountCallCounts()
+	if ensureSA < 2 {
+		t.Errorf("EnsureServiceAccount called %d times, want >=2 (initial failure + retry)", ensureSA)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Phase 4: Deletion of a failed worker
 // ---------------------------------------------------------------------------
 

--- a/hiclaw-controller/test/testutil/fixtures/manager.go
+++ b/hiclaw-controller/test/testutil/fixtures/manager.go
@@ -1,0 +1,35 @@
+package fixtures
+
+import (
+	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewTestManager creates a minimal Manager CR for testing.
+func NewTestManager(name string) *v1beta1.Manager {
+	return &v1beta1.Manager{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: DefaultNamespace,
+		},
+		Spec: v1beta1.ManagerSpec{
+			Model:   "gpt-4o",
+			Runtime: "openclaw",
+			Image:   "hiclaw/manager:test",
+		},
+	}
+}
+
+// NewTestManagerWithPhase creates a Manager CR with a pre-set status phase.
+func NewTestManagerWithPhase(name, phase string) *v1beta1.Manager {
+	m := NewTestManager(name)
+	m.Status.Phase = phase
+	return m
+}
+
+// NewTestManagerWithMCPServers creates a Manager CR with MCP servers configured.
+func NewTestManagerWithMCPServers(name string, mcpServers []string) *v1beta1.Manager {
+	m := NewTestManager(name)
+	m.Spec.McpServers = mcpServers
+	return m
+}

--- a/hiclaw-controller/test/testutil/mocks/backend.go
+++ b/hiclaw-controller/test/testutil/mocks/backend.go
@@ -101,19 +101,24 @@ func (m *MockWorkerBackend) Create(ctx context.Context, req backend.CreateReques
 	fn := m.CreateFn
 	m.mu.Unlock()
 
+	setRunning := func() {
+		m.mu.Lock()
+		m.containerState[req.Name] = backend.StatusRunning
+		if req.ContainerName != "" && req.ContainerName != req.Name {
+			m.containerState[req.ContainerName] = backend.StatusRunning
+		}
+		m.mu.Unlock()
+	}
+
 	if fn != nil {
 		result, err := fn(ctx, req)
 		if err == nil {
-			m.mu.Lock()
-			m.containerState[req.Name] = backend.StatusRunning
-			m.mu.Unlock()
+			setRunning()
 		}
 		return result, err
 	}
 
-	m.mu.Lock()
-	m.containerState[req.Name] = backend.StatusRunning
-	m.mu.Unlock()
+	setRunning()
 	return &backend.WorkerResult{
 		Name:    req.Name,
 		Backend: m.Name(),
@@ -214,9 +219,10 @@ func (m *MockWorkerBackend) Status(ctx context.Context, name string) (*backend.W
 func (m *MockWorkerBackend) List(ctx context.Context) ([]backend.WorkerResult, error) {
 	m.mu.Lock()
 	m.Calls.List++
+	fn := m.ListFn
 	m.mu.Unlock()
-	if m.ListFn != nil {
-		return m.ListFn(ctx)
+	if fn != nil {
+		return fn(ctx)
 	}
 	return nil, nil
 }

--- a/hiclaw-controller/test/testutil/mocks/deployer.go
+++ b/hiclaw-controller/test/testutil/mocks/deployer.go
@@ -63,9 +63,10 @@ func (m *MockDeployer) clearCallsLocked() {
 func (m *MockDeployer) DeployPackage(ctx context.Context, workerName string, pkg string, isUpdate bool) error {
 	m.mu.Lock()
 	m.Calls.DeployPackage = append(m.Calls.DeployPackage, workerName)
+	fn := m.DeployPackageFn
 	m.mu.Unlock()
-	if m.DeployPackageFn != nil {
-		return m.DeployPackageFn(ctx, workerName, pkg, isUpdate)
+	if fn != nil {
+		return fn(ctx, workerName, pkg, isUpdate)
 	}
 	return nil
 }
@@ -73,9 +74,10 @@ func (m *MockDeployer) DeployPackage(ctx context.Context, workerName string, pkg
 func (m *MockDeployer) WriteInlineConfigs(workerName string, spec v1beta1.WorkerSpec) error {
 	m.mu.Lock()
 	m.Calls.WriteInlineConfigs = append(m.Calls.WriteInlineConfigs, workerName)
+	fn := m.WriteInlineConfigsFn
 	m.mu.Unlock()
-	if m.WriteInlineConfigsFn != nil {
-		return m.WriteInlineConfigsFn(workerName, spec)
+	if fn != nil {
+		return fn(workerName, spec)
 	}
 	return nil
 }
@@ -83,9 +85,10 @@ func (m *MockDeployer) WriteInlineConfigs(workerName string, spec v1beta1.Worker
 func (m *MockDeployer) DeployWorkerConfig(ctx context.Context, req service.WorkerDeployRequest) error {
 	m.mu.Lock()
 	m.Calls.DeployWorkerConfig = append(m.Calls.DeployWorkerConfig, req)
+	fn := m.DeployWorkerConfigFn
 	m.mu.Unlock()
-	if m.DeployWorkerConfigFn != nil {
-		return m.DeployWorkerConfigFn(ctx, req)
+	if fn != nil {
+		return fn(ctx, req)
 	}
 	return nil
 }
@@ -93,9 +96,10 @@ func (m *MockDeployer) DeployWorkerConfig(ctx context.Context, req service.Worke
 func (m *MockDeployer) PushOnDemandSkills(ctx context.Context, workerName string, skills []string) error {
 	m.mu.Lock()
 	m.Calls.PushOnDemandSkills = append(m.Calls.PushOnDemandSkills, workerName)
+	fn := m.PushOnDemandSkillsFn
 	m.mu.Unlock()
-	if m.PushOnDemandSkillsFn != nil {
-		return m.PushOnDemandSkillsFn(ctx, workerName, skills)
+	if fn != nil {
+		return fn(ctx, workerName, skills)
 	}
 	return nil
 }
@@ -103,9 +107,10 @@ func (m *MockDeployer) PushOnDemandSkills(ctx context.Context, workerName string
 func (m *MockDeployer) CleanupOSSData(ctx context.Context, workerName string) error {
 	m.mu.Lock()
 	m.Calls.CleanupOSSData = append(m.Calls.CleanupOSSData, workerName)
+	fn := m.CleanupOSSDataFn
 	m.mu.Unlock()
-	if m.CleanupOSSDataFn != nil {
-		return m.CleanupOSSDataFn(ctx, workerName)
+	if fn != nil {
+		return fn(ctx, workerName)
 	}
 	return nil
 }

--- a/hiclaw-controller/test/testutil/mocks/env_builder.go
+++ b/hiclaw-controller/test/testutil/mocks/env_builder.go
@@ -45,9 +45,10 @@ func (m *MockEnvBuilder) clearCallsLocked() {
 func (m *MockEnvBuilder) Build(workerName string, prov *service.WorkerProvisionResult) map[string]string {
 	m.mu.Lock()
 	m.Calls.Build = append(m.Calls.Build, workerName)
+	fn := m.BuildFn
 	m.mu.Unlock()
-	if m.BuildFn != nil {
-		return m.BuildFn(workerName, prov)
+	if fn != nil {
+		return fn(workerName, prov)
 	}
 	return map[string]string{
 		"HICLAW_WORKER_NAME": workerName,

--- a/hiclaw-controller/test/testutil/mocks/manager_deployer.go
+++ b/hiclaw-controller/test/testutil/mocks/manager_deployer.go
@@ -1,0 +1,106 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hiclaw/hiclaw-controller/internal/service"
+)
+
+// MockManagerDeployer implements service.ManagerDeployer for testing.
+type MockManagerDeployer struct {
+	mu sync.Mutex
+
+	DeployPackageFn       func(ctx context.Context, name, uri string, isUpdate bool) error
+	DeployManagerConfigFn func(ctx context.Context, req service.ManagerDeployRequest) error
+	PushOnDemandSkillsFn  func(ctx context.Context, name string, skills []string) error
+	CleanupOSSDataFn      func(ctx context.Context, name string) error
+
+	Calls struct {
+		DeployPackage       []string
+		DeployManagerConfig []service.ManagerDeployRequest
+		PushOnDemandSkills  []string
+		CleanupOSSData      []string
+	}
+}
+
+func NewMockManagerDeployer() *MockManagerDeployer {
+	return &MockManagerDeployer{}
+}
+
+func (m *MockManagerDeployer) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.clearCallsLocked()
+	m.DeployPackageFn = nil
+	m.DeployManagerConfigFn = nil
+	m.PushOnDemandSkillsFn = nil
+	m.CleanupOSSDataFn = nil
+}
+
+func (m *MockManagerDeployer) ClearCalls() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.clearCallsLocked()
+}
+
+func (m *MockManagerDeployer) clearCallsLocked() {
+	m.Calls = struct {
+		DeployPackage       []string
+		DeployManagerConfig []service.ManagerDeployRequest
+		PushOnDemandSkills  []string
+		CleanupOSSData      []string
+	}{}
+}
+
+func (m *MockManagerDeployer) DeployPackage(ctx context.Context, name, uri string, isUpdate bool) error {
+	m.mu.Lock()
+	m.Calls.DeployPackage = append(m.Calls.DeployPackage, name)
+	m.mu.Unlock()
+	if m.DeployPackageFn != nil {
+		return m.DeployPackageFn(ctx, name, uri, isUpdate)
+	}
+	return nil
+}
+
+func (m *MockManagerDeployer) DeployManagerConfig(ctx context.Context, req service.ManagerDeployRequest) error {
+	m.mu.Lock()
+	m.Calls.DeployManagerConfig = append(m.Calls.DeployManagerConfig, req)
+	m.mu.Unlock()
+	if m.DeployManagerConfigFn != nil {
+		return m.DeployManagerConfigFn(ctx, req)
+	}
+	return nil
+}
+
+func (m *MockManagerDeployer) PushOnDemandSkills(ctx context.Context, name string, skills []string) error {
+	m.mu.Lock()
+	m.Calls.PushOnDemandSkills = append(m.Calls.PushOnDemandSkills, name)
+	m.mu.Unlock()
+	if m.PushOnDemandSkillsFn != nil {
+		return m.PushOnDemandSkillsFn(ctx, name, skills)
+	}
+	return nil
+}
+
+func (m *MockManagerDeployer) CleanupOSSData(ctx context.Context, name string) error {
+	m.mu.Lock()
+	m.Calls.CleanupOSSData = append(m.Calls.CleanupOSSData, name)
+	m.mu.Unlock()
+	if m.CleanupOSSDataFn != nil {
+		return m.CleanupOSSDataFn(ctx, name)
+	}
+	return nil
+}
+
+// CallCounts returns a snapshot of call counts safe for concurrent use.
+func (m *MockManagerDeployer) CallCounts() (deployPkg, deployConfig, pushSkills, cleanup int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.Calls.DeployPackage),
+		len(m.Calls.DeployManagerConfig),
+		len(m.Calls.PushOnDemandSkills),
+		len(m.Calls.CleanupOSSData)
+}
+
+var _ service.ManagerDeployer = (*MockManagerDeployer)(nil)

--- a/hiclaw-controller/test/testutil/mocks/manager_deployer.go
+++ b/hiclaw-controller/test/testutil/mocks/manager_deployer.go
@@ -56,9 +56,10 @@ func (m *MockManagerDeployer) clearCallsLocked() {
 func (m *MockManagerDeployer) DeployPackage(ctx context.Context, name, uri string, isUpdate bool) error {
 	m.mu.Lock()
 	m.Calls.DeployPackage = append(m.Calls.DeployPackage, name)
+	fn := m.DeployPackageFn
 	m.mu.Unlock()
-	if m.DeployPackageFn != nil {
-		return m.DeployPackageFn(ctx, name, uri, isUpdate)
+	if fn != nil {
+		return fn(ctx, name, uri, isUpdate)
 	}
 	return nil
 }
@@ -66,9 +67,10 @@ func (m *MockManagerDeployer) DeployPackage(ctx context.Context, name, uri strin
 func (m *MockManagerDeployer) DeployManagerConfig(ctx context.Context, req service.ManagerDeployRequest) error {
 	m.mu.Lock()
 	m.Calls.DeployManagerConfig = append(m.Calls.DeployManagerConfig, req)
+	fn := m.DeployManagerConfigFn
 	m.mu.Unlock()
-	if m.DeployManagerConfigFn != nil {
-		return m.DeployManagerConfigFn(ctx, req)
+	if fn != nil {
+		return fn(ctx, req)
 	}
 	return nil
 }
@@ -76,9 +78,10 @@ func (m *MockManagerDeployer) DeployManagerConfig(ctx context.Context, req servi
 func (m *MockManagerDeployer) PushOnDemandSkills(ctx context.Context, name string, skills []string) error {
 	m.mu.Lock()
 	m.Calls.PushOnDemandSkills = append(m.Calls.PushOnDemandSkills, name)
+	fn := m.PushOnDemandSkillsFn
 	m.mu.Unlock()
-	if m.PushOnDemandSkillsFn != nil {
-		return m.PushOnDemandSkillsFn(ctx, name, skills)
+	if fn != nil {
+		return fn(ctx, name, skills)
 	}
 	return nil
 }
@@ -86,9 +89,10 @@ func (m *MockManagerDeployer) PushOnDemandSkills(ctx context.Context, name strin
 func (m *MockManagerDeployer) CleanupOSSData(ctx context.Context, name string) error {
 	m.mu.Lock()
 	m.Calls.CleanupOSSData = append(m.Calls.CleanupOSSData, name)
+	fn := m.CleanupOSSDataFn
 	m.mu.Unlock()
-	if m.CleanupOSSDataFn != nil {
-		return m.CleanupOSSDataFn(ctx, name)
+	if fn != nil {
+		return fn(ctx, name)
 	}
 	return nil
 }

--- a/hiclaw-controller/test/testutil/mocks/manager_env_builder.go
+++ b/hiclaw-controller/test/testutil/mocks/manager_env_builder.go
@@ -1,0 +1,57 @@
+package mocks
+
+import (
+	"sync"
+
+	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	"github.com/hiclaw/hiclaw-controller/internal/service"
+)
+
+// MockManagerEnvBuilder implements service.ManagerEnvBuilderI for testing.
+type MockManagerEnvBuilder struct {
+	mu sync.Mutex
+
+	BuildManagerFn func(managerName string, prov *service.ManagerProvisionResult, spec v1beta1.ManagerSpec) map[string]string
+
+	Calls struct {
+		BuildManager []string
+	}
+}
+
+func NewMockManagerEnvBuilder() *MockManagerEnvBuilder {
+	return &MockManagerEnvBuilder{}
+}
+
+func (m *MockManagerEnvBuilder) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.clearCallsLocked()
+	m.BuildManagerFn = nil
+}
+
+func (m *MockManagerEnvBuilder) ClearCalls() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.clearCallsLocked()
+}
+
+func (m *MockManagerEnvBuilder) clearCallsLocked() {
+	m.Calls = struct {
+		BuildManager []string
+	}{}
+}
+
+func (m *MockManagerEnvBuilder) BuildManager(managerName string, prov *service.ManagerProvisionResult, spec v1beta1.ManagerSpec) map[string]string {
+	m.mu.Lock()
+	m.Calls.BuildManager = append(m.Calls.BuildManager, managerName)
+	m.mu.Unlock()
+	if m.BuildManagerFn != nil {
+		return m.BuildManagerFn(managerName, prov, spec)
+	}
+	return map[string]string{
+		"HICLAW_MANAGER_NAME": managerName,
+		"MOCK_ENV":            "true",
+	}
+}
+
+var _ service.ManagerEnvBuilderI = (*MockManagerEnvBuilder)(nil)

--- a/hiclaw-controller/test/testutil/mocks/manager_env_builder.go
+++ b/hiclaw-controller/test/testutil/mocks/manager_env_builder.go
@@ -44,9 +44,10 @@ func (m *MockManagerEnvBuilder) clearCallsLocked() {
 func (m *MockManagerEnvBuilder) BuildManager(managerName string, prov *service.ManagerProvisionResult, spec v1beta1.ManagerSpec) map[string]string {
 	m.mu.Lock()
 	m.Calls.BuildManager = append(m.Calls.BuildManager, managerName)
+	fn := m.BuildManagerFn
 	m.mu.Unlock()
-	if m.BuildManagerFn != nil {
-		return m.BuildManagerFn(managerName, prov, spec)
+	if fn != nil {
+		return fn(managerName, prov, spec)
 	}
 	return map[string]string{
 		"HICLAW_MANAGER_NAME": managerName,

--- a/hiclaw-controller/test/testutil/mocks/manager_provisioner.go
+++ b/hiclaw-controller/test/testutil/mocks/manager_provisioner.go
@@ -1,0 +1,221 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hiclaw/hiclaw-controller/internal/service"
+)
+
+// MockManagerProvisioner implements service.ManagerProvisioner for testing.
+type MockManagerProvisioner struct {
+	mu sync.Mutex
+
+	ProvisionManagerFn           func(ctx context.Context, req service.ManagerProvisionRequest) (*service.ManagerProvisionResult, error)
+	DeprovisionManagerFn         func(ctx context.Context, name string, mcpServers []string) error
+	RefreshCredentialsFn         func(ctx context.Context, name string) (*service.RefreshResult, error)
+	RefreshManagerCredentialsFn  func(ctx context.Context, managerName string) (*service.RefreshResult, error)
+	EnsureManagerGatewayAuthFn   func(ctx context.Context, managerName, gatewayKey string) error
+	ReconcileMCPAuthFn           func(ctx context.Context, consumerName string, mcpServers []string) ([]string, error)
+	EnsureManagerServiceAccountFn func(ctx context.Context, managerName string) error
+	DeleteManagerServiceAccountFn func(ctx context.Context, managerName string) error
+	DeleteCredentialsFn          func(ctx context.Context, name string) error
+	RequestManagerSATokenFn      func(ctx context.Context, managerName string) (string, error)
+	DeactivateMatrixUserFn       func(ctx context.Context, name string) error
+
+	Calls struct {
+		ProvisionManager           []service.ManagerProvisionRequest
+		DeprovisionManager         []string
+		RefreshCredentials         []string
+		RefreshManagerCredentials  []string
+		EnsureManagerGatewayAuth   []string
+		ReconcileMCPAuth           []string
+		EnsureManagerServiceAccount []string
+		DeleteManagerServiceAccount []string
+		DeleteCredentials          []string
+		RequestManagerSAToken      []string
+		DeactivateMatrixUser       []string
+	}
+}
+
+func NewMockManagerProvisioner() *MockManagerProvisioner {
+	return &MockManagerProvisioner{}
+}
+
+func (m *MockManagerProvisioner) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.clearCallsLocked()
+	m.ProvisionManagerFn = nil
+	m.DeprovisionManagerFn = nil
+	m.RefreshCredentialsFn = nil
+	m.RefreshManagerCredentialsFn = nil
+	m.EnsureManagerGatewayAuthFn = nil
+	m.ReconcileMCPAuthFn = nil
+	m.EnsureManagerServiceAccountFn = nil
+	m.DeleteManagerServiceAccountFn = nil
+	m.DeleteCredentialsFn = nil
+	m.RequestManagerSATokenFn = nil
+	m.DeactivateMatrixUserFn = nil
+}
+
+func (m *MockManagerProvisioner) ClearCalls() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.clearCallsLocked()
+}
+
+func (m *MockManagerProvisioner) clearCallsLocked() {
+	m.Calls = struct {
+		ProvisionManager           []service.ManagerProvisionRequest
+		DeprovisionManager         []string
+		RefreshCredentials         []string
+		RefreshManagerCredentials  []string
+		EnsureManagerGatewayAuth   []string
+		ReconcileMCPAuth           []string
+		EnsureManagerServiceAccount []string
+		DeleteManagerServiceAccount []string
+		DeleteCredentials          []string
+		RequestManagerSAToken      []string
+		DeactivateMatrixUser       []string
+	}{}
+}
+
+func (m *MockManagerProvisioner) ProvisionManager(ctx context.Context, req service.ManagerProvisionRequest) (*service.ManagerProvisionResult, error) {
+	m.mu.Lock()
+	m.Calls.ProvisionManager = append(m.Calls.ProvisionManager, req)
+	m.mu.Unlock()
+	if m.ProvisionManagerFn != nil {
+		return m.ProvisionManagerFn(ctx, req)
+	}
+	return &service.ManagerProvisionResult{
+		MatrixUserID:   "@manager:localhost",
+		MatrixToken:    "mock-token-manager",
+		RoomID:         "!room-manager:localhost",
+		GatewayKey:     "mock-gw-key-manager",
+		MinIOPassword:  "mock-minio-pw",
+		MatrixPassword: "mock-matrix-pw",
+	}, nil
+}
+
+func (m *MockManagerProvisioner) DeprovisionManager(ctx context.Context, name string, mcpServers []string) error {
+	m.mu.Lock()
+	m.Calls.DeprovisionManager = append(m.Calls.DeprovisionManager, name)
+	m.mu.Unlock()
+	if m.DeprovisionManagerFn != nil {
+		return m.DeprovisionManagerFn(ctx, name, mcpServers)
+	}
+	return nil
+}
+
+func (m *MockManagerProvisioner) RefreshCredentials(ctx context.Context, name string) (*service.RefreshResult, error) {
+	m.mu.Lock()
+	m.Calls.RefreshCredentials = append(m.Calls.RefreshCredentials, name)
+	m.mu.Unlock()
+	if m.RefreshCredentialsFn != nil {
+		return m.RefreshCredentialsFn(ctx, name)
+	}
+	return &service.RefreshResult{
+		MatrixToken:    "mock-token-manager",
+		GatewayKey:     "mock-gw-key-manager",
+		MinIOPassword:  "mock-minio-pw",
+		MatrixPassword: "mock-matrix-pw",
+	}, nil
+}
+
+func (m *MockManagerProvisioner) RefreshManagerCredentials(ctx context.Context, managerName string) (*service.RefreshResult, error) {
+	m.mu.Lock()
+	m.Calls.RefreshManagerCredentials = append(m.Calls.RefreshManagerCredentials, managerName)
+	m.mu.Unlock()
+	if m.RefreshManagerCredentialsFn != nil {
+		return m.RefreshManagerCredentialsFn(ctx, managerName)
+	}
+	return &service.RefreshResult{
+		MatrixToken:    "mock-token-manager",
+		GatewayKey:     "mock-gw-key-manager",
+		MinIOPassword:  "mock-minio-pw",
+		MatrixPassword: "mock-matrix-pw",
+	}, nil
+}
+
+func (m *MockManagerProvisioner) EnsureManagerGatewayAuth(ctx context.Context, managerName, gatewayKey string) error {
+	m.mu.Lock()
+	m.Calls.EnsureManagerGatewayAuth = append(m.Calls.EnsureManagerGatewayAuth, managerName)
+	m.mu.Unlock()
+	if m.EnsureManagerGatewayAuthFn != nil {
+		return m.EnsureManagerGatewayAuthFn(ctx, managerName, gatewayKey)
+	}
+	return nil
+}
+
+func (m *MockManagerProvisioner) ReconcileMCPAuth(ctx context.Context, consumerName string, mcpServers []string) ([]string, error) {
+	m.mu.Lock()
+	m.Calls.ReconcileMCPAuth = append(m.Calls.ReconcileMCPAuth, consumerName)
+	m.mu.Unlock()
+	if m.ReconcileMCPAuthFn != nil {
+		return m.ReconcileMCPAuthFn(ctx, consumerName, mcpServers)
+	}
+	return mcpServers, nil
+}
+
+func (m *MockManagerProvisioner) EnsureManagerServiceAccount(ctx context.Context, managerName string) error {
+	m.mu.Lock()
+	m.Calls.EnsureManagerServiceAccount = append(m.Calls.EnsureManagerServiceAccount, managerName)
+	m.mu.Unlock()
+	if m.EnsureManagerServiceAccountFn != nil {
+		return m.EnsureManagerServiceAccountFn(ctx, managerName)
+	}
+	return nil
+}
+
+func (m *MockManagerProvisioner) DeleteManagerServiceAccount(ctx context.Context, managerName string) error {
+	m.mu.Lock()
+	m.Calls.DeleteManagerServiceAccount = append(m.Calls.DeleteManagerServiceAccount, managerName)
+	m.mu.Unlock()
+	if m.DeleteManagerServiceAccountFn != nil {
+		return m.DeleteManagerServiceAccountFn(ctx, managerName)
+	}
+	return nil
+}
+
+func (m *MockManagerProvisioner) DeleteCredentials(ctx context.Context, name string) error {
+	m.mu.Lock()
+	m.Calls.DeleteCredentials = append(m.Calls.DeleteCredentials, name)
+	m.mu.Unlock()
+	if m.DeleteCredentialsFn != nil {
+		return m.DeleteCredentialsFn(ctx, name)
+	}
+	return nil
+}
+
+func (m *MockManagerProvisioner) RequestManagerSAToken(ctx context.Context, managerName string) (string, error) {
+	m.mu.Lock()
+	m.Calls.RequestManagerSAToken = append(m.Calls.RequestManagerSAToken, managerName)
+	m.mu.Unlock()
+	if m.RequestManagerSATokenFn != nil {
+		return m.RequestManagerSATokenFn(ctx, managerName)
+	}
+	return "mock-sa-token-manager", nil
+}
+
+func (m *MockManagerProvisioner) DeactivateMatrixUser(ctx context.Context, name string) error {
+	m.mu.Lock()
+	m.Calls.DeactivateMatrixUser = append(m.Calls.DeactivateMatrixUser, name)
+	m.mu.Unlock()
+	if m.DeactivateMatrixUserFn != nil {
+		return m.DeactivateMatrixUserFn(ctx, name)
+	}
+	return nil
+}
+
+// CallCounts returns a snapshot of call counts safe for concurrent use.
+func (m *MockManagerProvisioner) CallCounts() (provision, deprovision, refreshManager, deactivate int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.Calls.ProvisionManager),
+		len(m.Calls.DeprovisionManager),
+		len(m.Calls.RefreshManagerCredentials),
+		len(m.Calls.DeactivateMatrixUser)
+}
+
+var _ service.ManagerProvisioner = (*MockManagerProvisioner)(nil)

--- a/hiclaw-controller/test/testutil/mocks/manager_provisioner.go
+++ b/hiclaw-controller/test/testutil/mocks/manager_provisioner.go
@@ -218,4 +218,25 @@ func (m *MockManagerProvisioner) CallCounts() (provision, deprovision, refreshMa
 		len(m.Calls.DeactivateMatrixUser)
 }
 
+// ServiceAccountCallCounts returns EnsureManagerServiceAccount and DeleteManagerServiceAccount counts.
+func (m *MockManagerProvisioner) ServiceAccountCallCounts() (ensure, delete int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.Calls.EnsureManagerServiceAccount), len(m.Calls.DeleteManagerServiceAccount)
+}
+
+// MCPAuthCallCount returns the number of ReconcileMCPAuth calls.
+func (m *MockManagerProvisioner) MCPAuthCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.Calls.ReconcileMCPAuth)
+}
+
+// CredentialCallCounts returns DeleteCredentials and RequestManagerSAToken counts.
+func (m *MockManagerProvisioner) CredentialCallCounts() (deleteCredentials, requestSAToken int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.Calls.DeleteCredentials), len(m.Calls.RequestManagerSAToken)
+}
+
 var _ service.ManagerProvisioner = (*MockManagerProvisioner)(nil)

--- a/hiclaw-controller/test/testutil/mocks/manager_provisioner.go
+++ b/hiclaw-controller/test/testutil/mocks/manager_provisioner.go
@@ -84,9 +84,10 @@ func (m *MockManagerProvisioner) clearCallsLocked() {
 func (m *MockManagerProvisioner) ProvisionManager(ctx context.Context, req service.ManagerProvisionRequest) (*service.ManagerProvisionResult, error) {
 	m.mu.Lock()
 	m.Calls.ProvisionManager = append(m.Calls.ProvisionManager, req)
+	fn := m.ProvisionManagerFn
 	m.mu.Unlock()
-	if m.ProvisionManagerFn != nil {
-		return m.ProvisionManagerFn(ctx, req)
+	if fn != nil {
+		return fn(ctx, req)
 	}
 	return &service.ManagerProvisionResult{
 		MatrixUserID:   "@manager:localhost",
@@ -101,9 +102,10 @@ func (m *MockManagerProvisioner) ProvisionManager(ctx context.Context, req servi
 func (m *MockManagerProvisioner) DeprovisionManager(ctx context.Context, name string, mcpServers []string) error {
 	m.mu.Lock()
 	m.Calls.DeprovisionManager = append(m.Calls.DeprovisionManager, name)
+	fn := m.DeprovisionManagerFn
 	m.mu.Unlock()
-	if m.DeprovisionManagerFn != nil {
-		return m.DeprovisionManagerFn(ctx, name, mcpServers)
+	if fn != nil {
+		return fn(ctx, name, mcpServers)
 	}
 	return nil
 }
@@ -111,9 +113,10 @@ func (m *MockManagerProvisioner) DeprovisionManager(ctx context.Context, name st
 func (m *MockManagerProvisioner) RefreshCredentials(ctx context.Context, name string) (*service.RefreshResult, error) {
 	m.mu.Lock()
 	m.Calls.RefreshCredentials = append(m.Calls.RefreshCredentials, name)
+	fn := m.RefreshCredentialsFn
 	m.mu.Unlock()
-	if m.RefreshCredentialsFn != nil {
-		return m.RefreshCredentialsFn(ctx, name)
+	if fn != nil {
+		return fn(ctx, name)
 	}
 	return &service.RefreshResult{
 		MatrixToken:    "mock-token-manager",
@@ -126,9 +129,10 @@ func (m *MockManagerProvisioner) RefreshCredentials(ctx context.Context, name st
 func (m *MockManagerProvisioner) RefreshManagerCredentials(ctx context.Context, managerName string) (*service.RefreshResult, error) {
 	m.mu.Lock()
 	m.Calls.RefreshManagerCredentials = append(m.Calls.RefreshManagerCredentials, managerName)
+	fn := m.RefreshManagerCredentialsFn
 	m.mu.Unlock()
-	if m.RefreshManagerCredentialsFn != nil {
-		return m.RefreshManagerCredentialsFn(ctx, managerName)
+	if fn != nil {
+		return fn(ctx, managerName)
 	}
 	return &service.RefreshResult{
 		MatrixToken:    "mock-token-manager",
@@ -141,9 +145,10 @@ func (m *MockManagerProvisioner) RefreshManagerCredentials(ctx context.Context, 
 func (m *MockManagerProvisioner) EnsureManagerGatewayAuth(ctx context.Context, managerName, gatewayKey string) error {
 	m.mu.Lock()
 	m.Calls.EnsureManagerGatewayAuth = append(m.Calls.EnsureManagerGatewayAuth, managerName)
+	fn := m.EnsureManagerGatewayAuthFn
 	m.mu.Unlock()
-	if m.EnsureManagerGatewayAuthFn != nil {
-		return m.EnsureManagerGatewayAuthFn(ctx, managerName, gatewayKey)
+	if fn != nil {
+		return fn(ctx, managerName, gatewayKey)
 	}
 	return nil
 }
@@ -151,9 +156,10 @@ func (m *MockManagerProvisioner) EnsureManagerGatewayAuth(ctx context.Context, m
 func (m *MockManagerProvisioner) ReconcileMCPAuth(ctx context.Context, consumerName string, mcpServers []string) ([]string, error) {
 	m.mu.Lock()
 	m.Calls.ReconcileMCPAuth = append(m.Calls.ReconcileMCPAuth, consumerName)
+	fn := m.ReconcileMCPAuthFn
 	m.mu.Unlock()
-	if m.ReconcileMCPAuthFn != nil {
-		return m.ReconcileMCPAuthFn(ctx, consumerName, mcpServers)
+	if fn != nil {
+		return fn(ctx, consumerName, mcpServers)
 	}
 	return mcpServers, nil
 }
@@ -161,9 +167,10 @@ func (m *MockManagerProvisioner) ReconcileMCPAuth(ctx context.Context, consumerN
 func (m *MockManagerProvisioner) EnsureManagerServiceAccount(ctx context.Context, managerName string) error {
 	m.mu.Lock()
 	m.Calls.EnsureManagerServiceAccount = append(m.Calls.EnsureManagerServiceAccount, managerName)
+	fn := m.EnsureManagerServiceAccountFn
 	m.mu.Unlock()
-	if m.EnsureManagerServiceAccountFn != nil {
-		return m.EnsureManagerServiceAccountFn(ctx, managerName)
+	if fn != nil {
+		return fn(ctx, managerName)
 	}
 	return nil
 }
@@ -171,9 +178,10 @@ func (m *MockManagerProvisioner) EnsureManagerServiceAccount(ctx context.Context
 func (m *MockManagerProvisioner) DeleteManagerServiceAccount(ctx context.Context, managerName string) error {
 	m.mu.Lock()
 	m.Calls.DeleteManagerServiceAccount = append(m.Calls.DeleteManagerServiceAccount, managerName)
+	fn := m.DeleteManagerServiceAccountFn
 	m.mu.Unlock()
-	if m.DeleteManagerServiceAccountFn != nil {
-		return m.DeleteManagerServiceAccountFn(ctx, managerName)
+	if fn != nil {
+		return fn(ctx, managerName)
 	}
 	return nil
 }
@@ -181,9 +189,10 @@ func (m *MockManagerProvisioner) DeleteManagerServiceAccount(ctx context.Context
 func (m *MockManagerProvisioner) DeleteCredentials(ctx context.Context, name string) error {
 	m.mu.Lock()
 	m.Calls.DeleteCredentials = append(m.Calls.DeleteCredentials, name)
+	fn := m.DeleteCredentialsFn
 	m.mu.Unlock()
-	if m.DeleteCredentialsFn != nil {
-		return m.DeleteCredentialsFn(ctx, name)
+	if fn != nil {
+		return fn(ctx, name)
 	}
 	return nil
 }
@@ -191,9 +200,10 @@ func (m *MockManagerProvisioner) DeleteCredentials(ctx context.Context, name str
 func (m *MockManagerProvisioner) RequestManagerSAToken(ctx context.Context, managerName string) (string, error) {
 	m.mu.Lock()
 	m.Calls.RequestManagerSAToken = append(m.Calls.RequestManagerSAToken, managerName)
+	fn := m.RequestManagerSATokenFn
 	m.mu.Unlock()
-	if m.RequestManagerSATokenFn != nil {
-		return m.RequestManagerSATokenFn(ctx, managerName)
+	if fn != nil {
+		return fn(ctx, managerName)
 	}
 	return "mock-sa-token-manager", nil
 }
@@ -201,9 +211,10 @@ func (m *MockManagerProvisioner) RequestManagerSAToken(ctx context.Context, mana
 func (m *MockManagerProvisioner) DeactivateMatrixUser(ctx context.Context, name string) error {
 	m.mu.Lock()
 	m.Calls.DeactivateMatrixUser = append(m.Calls.DeactivateMatrixUser, name)
+	fn := m.DeactivateMatrixUserFn
 	m.mu.Unlock()
-	if m.DeactivateMatrixUserFn != nil {
-		return m.DeactivateMatrixUserFn(ctx, name)
+	if fn != nil {
+		return fn(ctx, name)
 	}
 	return nil
 }

--- a/hiclaw-controller/test/testutil/mocks/provisioner.go
+++ b/hiclaw-controller/test/testutil/mocks/provisioner.go
@@ -85,9 +85,10 @@ func (m *MockProvisioner) clearCallsLocked() {
 func (m *MockProvisioner) ProvisionWorker(ctx context.Context, req service.WorkerProvisionRequest) (*service.WorkerProvisionResult, error) {
 	m.mu.Lock()
 	m.Calls.ProvisionWorker = append(m.Calls.ProvisionWorker, req)
+	fn := m.ProvisionWorkerFn
 	m.mu.Unlock()
-	if m.ProvisionWorkerFn != nil {
-		return m.ProvisionWorkerFn(ctx, req)
+	if fn != nil {
+		return fn(ctx, req)
 	}
 	return &service.WorkerProvisionResult{
 		MatrixUserID:   "@" + req.Name + ":localhost",
@@ -102,9 +103,10 @@ func (m *MockProvisioner) ProvisionWorker(ctx context.Context, req service.Worke
 func (m *MockProvisioner) DeprovisionWorker(ctx context.Context, req service.WorkerDeprovisionRequest) error {
 	m.mu.Lock()
 	m.Calls.DeprovisionWorker = append(m.Calls.DeprovisionWorker, req)
+	fn := m.DeprovisionWorkerFn
 	m.mu.Unlock()
-	if m.DeprovisionWorkerFn != nil {
-		return m.DeprovisionWorkerFn(ctx, req)
+	if fn != nil {
+		return fn(ctx, req)
 	}
 	return nil
 }
@@ -112,9 +114,10 @@ func (m *MockProvisioner) DeprovisionWorker(ctx context.Context, req service.Wor
 func (m *MockProvisioner) RefreshCredentials(ctx context.Context, workerName string) (*service.RefreshResult, error) {
 	m.mu.Lock()
 	m.Calls.RefreshCredentials = append(m.Calls.RefreshCredentials, workerName)
+	fn := m.RefreshCredentialsFn
 	m.mu.Unlock()
-	if m.RefreshCredentialsFn != nil {
-		return m.RefreshCredentialsFn(ctx, workerName)
+	if fn != nil {
+		return fn(ctx, workerName)
 	}
 	return &service.RefreshResult{
 		MatrixToken:    "mock-token-" + workerName,
@@ -127,9 +130,10 @@ func (m *MockProvisioner) RefreshCredentials(ctx context.Context, workerName str
 func (m *MockProvisioner) ReconcileMCPAuth(ctx context.Context, consumerName string, mcpServers []string) ([]string, error) {
 	m.mu.Lock()
 	m.Calls.ReconcileMCPAuth = append(m.Calls.ReconcileMCPAuth, consumerName)
+	fn := m.ReconcileMCPAuthFn
 	m.mu.Unlock()
-	if m.ReconcileMCPAuthFn != nil {
-		return m.ReconcileMCPAuthFn(ctx, consumerName, mcpServers)
+	if fn != nil {
+		return fn(ctx, consumerName, mcpServers)
 	}
 	return mcpServers, nil
 }
@@ -137,9 +141,10 @@ func (m *MockProvisioner) ReconcileMCPAuth(ctx context.Context, consumerName str
 func (m *MockProvisioner) ReconcileExpose(ctx context.Context, workerName string, desired []v1beta1.ExposePort, current []v1beta1.ExposedPortStatus) ([]v1beta1.ExposedPortStatus, error) {
 	m.mu.Lock()
 	m.Calls.ReconcileExpose = append(m.Calls.ReconcileExpose, workerName)
+	fn := m.ReconcileExposeFn
 	m.mu.Unlock()
-	if m.ReconcileExposeFn != nil {
-		return m.ReconcileExposeFn(ctx, workerName, desired, current)
+	if fn != nil {
+		return fn(ctx, workerName, desired, current)
 	}
 	return nil, nil
 }
@@ -147,9 +152,10 @@ func (m *MockProvisioner) ReconcileExpose(ctx context.Context, workerName string
 func (m *MockProvisioner) EnsureServiceAccount(ctx context.Context, workerName string) error {
 	m.mu.Lock()
 	m.Calls.EnsureServiceAccount = append(m.Calls.EnsureServiceAccount, workerName)
+	fn := m.EnsureServiceAccountFn
 	m.mu.Unlock()
-	if m.EnsureServiceAccountFn != nil {
-		return m.EnsureServiceAccountFn(ctx, workerName)
+	if fn != nil {
+		return fn(ctx, workerName)
 	}
 	return nil
 }
@@ -157,9 +163,10 @@ func (m *MockProvisioner) EnsureServiceAccount(ctx context.Context, workerName s
 func (m *MockProvisioner) DeleteServiceAccount(ctx context.Context, workerName string) error {
 	m.mu.Lock()
 	m.Calls.DeleteServiceAccount = append(m.Calls.DeleteServiceAccount, workerName)
+	fn := m.DeleteServiceAccountFn
 	m.mu.Unlock()
-	if m.DeleteServiceAccountFn != nil {
-		return m.DeleteServiceAccountFn(ctx, workerName)
+	if fn != nil {
+		return fn(ctx, workerName)
 	}
 	return nil
 }
@@ -167,9 +174,10 @@ func (m *MockProvisioner) DeleteServiceAccount(ctx context.Context, workerName s
 func (m *MockProvisioner) DeleteCredentials(ctx context.Context, workerName string) error {
 	m.mu.Lock()
 	m.Calls.DeleteCredentials = append(m.Calls.DeleteCredentials, workerName)
+	fn := m.DeleteCredentialsFn
 	m.mu.Unlock()
-	if m.DeleteCredentialsFn != nil {
-		return m.DeleteCredentialsFn(ctx, workerName)
+	if fn != nil {
+		return fn(ctx, workerName)
 	}
 	return nil
 }
@@ -177,9 +185,10 @@ func (m *MockProvisioner) DeleteCredentials(ctx context.Context, workerName stri
 func (m *MockProvisioner) RequestSAToken(ctx context.Context, workerName string) (string, error) {
 	m.mu.Lock()
 	m.Calls.RequestSAToken = append(m.Calls.RequestSAToken, workerName)
+	fn := m.RequestSATokenFn
 	m.mu.Unlock()
-	if m.RequestSATokenFn != nil {
-		return m.RequestSATokenFn(ctx, workerName)
+	if fn != nil {
+		return fn(ctx, workerName)
 	}
 	return "mock-sa-token-" + workerName, nil
 }
@@ -187,9 +196,10 @@ func (m *MockProvisioner) RequestSAToken(ctx context.Context, workerName string)
 func (m *MockProvisioner) DeactivateMatrixUser(ctx context.Context, workerName string) error {
 	m.mu.Lock()
 	m.Calls.DeactivateMatrixUser = append(m.Calls.DeactivateMatrixUser, workerName)
+	fn := m.DeactivateMatrixUserFn
 	m.mu.Unlock()
-	if m.DeactivateMatrixUserFn != nil {
-		return m.DeactivateMatrixUserFn(ctx, workerName)
+	if fn != nil {
+		return fn(ctx, workerName)
 	}
 	return nil
 }
@@ -209,6 +219,13 @@ func (m *MockProvisioner) CallCounts() (provision, deprovision, refresh, deactiv
 		len(m.Calls.DeprovisionWorker),
 		len(m.Calls.RefreshCredentials),
 		len(m.Calls.DeactivateMatrixUser)
+}
+
+// ServiceAccountCallCounts returns EnsureServiceAccount and DeleteServiceAccount counts.
+func (m *MockProvisioner) ServiceAccountCallCounts() (ensure, delete int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.Calls.EnsureServiceAccount), len(m.Calls.DeleteServiceAccount)
 }
 
 var _ service.WorkerProvisioner = (*MockProvisioner)(nil)


### PR DESCRIPTION
## Summary

### 问题

Manager controller 的 reconcile 逻辑存在以下问题：

1. **K8s backend 缺少 `WithPrefix` 支持**：Manager 容器使用完整名称（如 `hiclaw-manager`）而非 worker 的前缀命名（`hiclaw-worker-X`），但 K8s backend 只有 Docker backend 实现了 `WithPrefix("")`，导致 K8s 环境下 Manager 的 Status/Delete/Stop 操作找不到正确的 Pod。

2. **Reconcile 逻辑耦合严重**：所有逻辑（创建、更新、删除、状态切换）堆在一个大函数里，`handleCreate`/`handleUpdate`/`handleDelete` 之间有大量重复代码，且 create 和 update 走完全不同的路径，容易出现行为不一致。

3. **ServiceAccount 创建失败不可恢复**：SA 创建被放在 infra provisioning 阶段内部，一旦失败，后续 reconcile 走 refresh 路径会跳过 SA 创建，导致 SA 永远缺失。

4. **Phase 状态管理不准确**：首次创建失败时 phase 可能停留在空字符串而非 `Pending`，且 infra 已 provision 成功但 config deploy 失败时会错误地标记为 `Failed`。

5. **Mock 并发安全问题**：所有 mock 在读取 `Fn` 字段时未持有锁，存在 data race。

### 方案

1. **K8s `WithPrefix` 支持**（commit 1）：为 `K8sBackend` 添加 `WithPrefix` 方法，与 Docker backend 对齐。`managerBackend()` 统一对 Docker 和 K8s 都调用 `WithPrefix("")`。添加了单元测试验证 prefix 切换、Status、Delete、Stop 行为。

2. **提取接口用于测试**（commit 2）：从 `ManagerReconciler` 的依赖中提取 `ManagerProvisioner`、`ManagerDeployer`、`ManagerEnvBuilderI` 三个接口，使 controller 字段从具体类型改为接口类型，支持 mock 注入。

3. **模块化重构 reconcile 逻辑**（commit 3）：将 500+ 行的单体 reconciler 拆分为：
   - `manager_scope.go`：reconcile 上下文 + phase 计算
   - `manager_reconcile_infra.go`：基础设施 provisioning（Matrix/Gateway/MinIO/Credentials）
   - `manager_reconcile_config.go`：配置部署（Package/Config/Skills）
   - `manager_reconcile_container.go`：容器生命周期管理（Running/Sleeping/Stopped）
   - `manager_reconcile_delete.go`：删除清理

   核心改动：统一 create/update 为同一条 reconcile 路径（infra → config → container），通过 `MatrixUserID` 是否存在判断是首次 provision 还是 refresh，消除了 `handleCreate`/`handleUpdate` 的代码重复。使用 `defer` + `client.MergeFrom` patch 统一状态回写。

4. **集成测试**（commit 4-5）：添加完整的 Manager controller 集成测试，覆盖：创建成功/失败、更新（spec 变更触发容器重建）、删除、状态切换（Running↔Sleeping↔Stopped）、Pod 被外部删除后自动重建、各阶段失败的错误处理和恢复。

5. **ServiceAccount 修复 + Phase 修正**（commit 6）：
   - 将 `EnsureServiceAccount` 从 infra 阶段提升到 reconcile 主流程，每次 reconcile 都会确保 SA 存在，失败可自动重试
   - 修正 `computePhase`：首次创建出错时返回 `Pending` 而非空字符串
   - 修复所有 mock 的并发安全问题（先拷贝 Fn 再释放锁）
   - Mock backend 的 `Create` 同时追踪 `ContainerName` 别名，使 Manager 的 pod deletion 模拟不再需要 `StatusFn` hack

## Test plan

- [x] K8s backend `WithPrefix` 单元测试通过
- [x] Manager controller 集成测试全部通过（`go test -tags integration ./test/integration/controller/...`）
- [x] Worker controller 现有集成测试无回归
- [x] SA 重试测试验证失败后自动恢复

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Summary

### Question

The reconcile logic of the Manager controller has the following problems:

1. **K8s backend lacks `WithPrefix` support**: The Manager container uses the full name (such as `hiclaw-manager`) instead of the worker prefix (`hiclaw-worker-X`), but only the Docker backend of K8s backend implements `WithPrefix("")`, causing the Manager's Status/Delete/Stop operations in the K8s environment to not find the correct Pod.

2. **Reconcile logic coupling is serious**: All logic (create, update, delete, state switching) is piled in one large function, there is a lot of duplicate code between `handleCreate`/`handleUpdate`/`handleDelete`, and create and update follow completely different paths, which is prone to inconsistent behavior.

3. **ServiceAccount creation fails and is not recoverable**: SA creation is placed inside the infra provisioning stage. Once it fails, subsequent reconciliation will skip SA creation by taking the refresh path, causing SA to be permanently missing.

4. **Inaccurate Phase status management**: When the first creation fails, phase may stay at an empty string instead of `Pending`, and infra will be incorrectly marked as `Failed` when provisioned successfully but config deploy fails.

5. **Mock concurrency security issue**: All mocks do not hold locks when reading the `Fn` field, and there is a data race.

### Plan

1. **K8s `WithPrefix` support** (commit 1): Add `WithPrefix` method to `K8sBackend` to align with Docker backend. `managerBackend()` uniformly calls `WithPrefix("")` for both Docker and K8s. Added unit tests to verify prefix toggle, Status, Delete, Stop behavior.

2. **Extract interfaces for testing** (commit 2): Extract three interfaces `ManagerProvisioner`, `ManagerDeployer`, and `ManagerEnvBuilderI` from the dependencies of `ManagerReconciler`, so that the controller field is changed from a specific type to an interface type, supporting mock injection.

3. **Modular reconstruction of reconcile logic** (commit 3): Split the single reconciler with 500+ lines into:
   - `manager_scope.go`: reconcile context + phase calculation
   - `manager_reconcile_infra.go`: Infrastructure provisioning (Matrix/Gateway/MinIO/Credentials)
   - `manager_reconcile_config.go`: Configure deployment (Package/Config/Skills)
   - `manager_reconcile_container.go`: Container life cycle management (Running/Sleeping/Stopped)
   - `manager_reconcile_delete.go`: delete cleanup

   Core changes: unify create/update to the same reconcile path (infra → config → container), determine whether it is the first provision or refresh by whether `MatrixUserID` exists, and eliminate the code duplication of `handleCreate`/`handleUpdate`. Use `defer` + `client.MergeFrom` patch to unify status writeback.

4. **Integration Test** (commit 4-5): Add a complete Manager controller integration test, covering: creation success/failure, update (spec change triggers container reconstruction), deletion, state switching (Running↔Sleeping↔Stopped), automatic reconstruction after Pod is deleted externally, error handling and recovery of failures at each stage.

5. **ServiceAccount fix + Phase fix** (commit 6):
   - Promote `EnsureServiceAccount` from the infra stage to the reconcile main process. Each reconcile will ensure that the SA exists. Failure can be automatically retried.
   - Fixed `computePhase`: returning `Pending` instead of empty string when first creation error
   - Fix the concurrency safety issues of all mocks (copy Fn first and then release the lock)
   - Mock backend's `Create` also tracks the `ContainerName` alias, so that the Manager's pod deletion simulation no longer requires the `StatusFn` hack

## Test plan

- [x] K8s backend `WithPrefix` unit test passed
- [x] Manager controller integration tests all passed (`go test -tags integration ./test/integration/controller/...`)
- [x] Worker controller’s existing integration test has no regression
- [x] SA retry automatically recovers after failed test verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)
