### PR TITLE
fix: restore manager-workspace from MinIO on k8s mode pod restart

### DIFF
--- a/hiclaw-controller/internal/oss/client_test.go
+++ b/hiclaw-controller/internal/oss/client_test.go
@@ -31,7 +31,7 @@ func TestMinIOClient_FullPathNoLeadingSlash(t *testing.T) {
 func TestMinIOAdminClient_BuildWorkerPolicy(t *testing.T) {
 	c := NewMinIOAdminClient(Config{Bucket: "hiclaw-storage"})
 
-	policy := c.buildWorkerPolicy("worker-1", "hiclaw-storage", "team-dev")
+	policy := c.buildWorkerPolicy("worker-1", "hiclaw-storage", "team-dev", false)
 
 	if policy.Version != "2012-10-17" {
 		t.Errorf("Version = %q", policy.Version)
@@ -72,13 +72,54 @@ func TestMinIOAdminClient_BuildWorkerPolicy(t *testing.T) {
 func TestMinIOAdminClient_BuildWorkerPolicyNoTeam(t *testing.T) {
 	c := NewMinIOAdminClient(Config{Bucket: "hiclaw-storage"})
 
-	policy := c.buildWorkerPolicy("worker-solo", "hiclaw-storage", "")
+	policy := c.buildWorkerPolicy("worker-solo", "hiclaw-storage", "", false)
 
 	rwStmt := policy.Statement[1]
 	for _, r := range rwStmt.Resource {
 		if r == "arn:aws:s3:::hiclaw-storage/teams/*" {
 			t.Error("solo worker should not have team resource")
 		}
+		if r == "arn:aws:s3:::hiclaw-storage/manager/*" {
+			t.Error("non-manager worker should not have manager resource")
+		}
+	}
+}
+
+func TestMinIOAdminClient_BuildManagerPolicy(t *testing.T) {
+	c := NewMinIOAdminClient(Config{Bucket: "hiclaw-storage"})
+
+	policy := c.buildWorkerPolicy("default", "hiclaw-storage", "", true)
+
+	if len(policy.Statement) != 2 {
+		t.Fatalf("expected 2 statements, got %d", len(policy.Statement))
+	}
+
+	// Verify manager prefix in list conditions
+	listStmt := policy.Statement[0]
+	condition := listStmt.Condition["StringLike"].(map[string]interface{})
+	prefixes := condition["s3:prefix"].([]string)
+	hasManager := false
+	for _, p := range prefixes {
+		if p == "manager" || p == "manager/*" {
+			hasManager = true
+			break
+		}
+	}
+	if !hasManager {
+		t.Errorf("expected manager prefix in list conditions: %v", prefixes)
+	}
+
+	// Verify manager resource in RW statement
+	rwStmt := policy.Statement[1]
+	hasManagerResource := false
+	for _, r := range rwStmt.Resource {
+		if r == "arn:aws:s3:::hiclaw-storage/manager/*" {
+			hasManagerResource = true
+			break
+		}
+	}
+	if !hasManagerResource {
+		t.Errorf("expected manager resource in RW statement: %v", rwStmt.Resource)
 	}
 }
 

--- a/hiclaw-controller/internal/oss/minio_admin.go
+++ b/hiclaw-controller/internal/oss/minio_admin.go
@@ -64,7 +64,7 @@ func (c *MinIOAdminClient) EnsurePolicy(ctx context.Context, req PolicyRequest) 
 		bucket = c.config.Bucket
 	}
 
-	policy := c.buildWorkerPolicy(req.WorkerName, bucket, req.TeamName)
+	policy := c.buildWorkerPolicy(req.WorkerName, bucket, req.TeamName, req.IsManager)
 	policyJSON, err := json.MarshalIndent(policy, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal policy: %w", err)
@@ -121,7 +121,7 @@ type s3PolicyStatement struct {
 	Condition map[string]interface{} `json:"Condition,omitempty"`
 }
 
-func (c *MinIOAdminClient) buildWorkerPolicy(workerName, bucket, teamName string) s3Policy {
+func (c *MinIOAdminClient) buildWorkerPolicy(workerName, bucket, teamName string, isManager bool) s3Policy {
 	listPrefixes := []string{
 		fmt.Sprintf("agents/%s", workerName),
 		fmt.Sprintf("agents/%s/*", workerName),
@@ -131,6 +131,16 @@ func (c *MinIOAdminClient) buildWorkerPolicy(workerName, bucket, teamName string
 	rwResources := []string{
 		fmt.Sprintf("arn:aws:s3:::%s/agents/%s/*", bucket, workerName),
 		fmt.Sprintf("arn:aws:s3:::%s/shared/*", bucket),
+	}
+
+	if isManager {
+		listPrefixes = append(listPrefixes,
+			"manager",
+			"manager/*",
+		)
+		rwResources = append(rwResources,
+			fmt.Sprintf("arn:aws:s3:::%s/manager/*", bucket),
+		)
 	}
 
 	if teamName != "" {

--- a/hiclaw-controller/internal/oss/types.go
+++ b/hiclaw-controller/internal/oss/types.go
@@ -22,4 +22,5 @@ type PolicyRequest struct {
 	WorkerName string // worker name (used as MinIO username and in path scoping)
 	Bucket     string // bucket name, e.g. "hiclaw-storage"
 	TeamName   string // optional: grants additional access to teams/<teamName>/ prefix
+	IsManager  bool   // when true, grants additional access to manager/ prefix for workspace sync
 }

--- a/hiclaw-controller/internal/service/provisioner.go
+++ b/hiclaw-controller/internal/service/provisioner.go
@@ -511,6 +511,7 @@ func (p *Provisioner) ProvisionManager(ctx context.Context, req ManagerProvision
 		}
 		if err := p.ossAdmin.EnsurePolicy(ctx, oss.PolicyRequest{
 			WorkerName: managerName,
+			IsManager:  true,
 		}); err != nil {
 			return nil, fmt.Errorf("MinIO policy creation failed: %w", err)
 		}

--- a/manager/scripts/init/start-manager-agent.sh
+++ b/manager/scripts/init/start-manager-agent.sh
@@ -161,6 +161,7 @@ if [ "${HICLAW_RUNTIME}" = "k8s" ]; then
     log "Configuring mc alias for cluster MinIO..."
     mc alias set hiclaw "${HICLAW_FS_ENDPOINT}" "${HICLAW_FS_ACCESS_KEY}" "${HICLAW_FS_SECRET_KEY}"
     log "Syncing workspace from MinIO..."
+    mc mirror "${HICLAW_STORAGE_PREFIX}/manager/" /root/manager-workspace/ --overwrite 2>/dev/null || true
     mc mirror "${HICLAW_STORAGE_PREFIX}/" "${HICLAW_FS}/" --overwrite 2>/dev/null || true
     ln -sfn "${HICLAW_FS}" /root/manager-workspace/hiclaw-fs
     touch "${HICLAW_FS}/.initialized"


### PR DESCRIPTION
## Summary

- Fixed manager MinIO policy missing `manager/` prefix read/write access, which caused all workspace sync operations to silently fail in incluster mode
- Added `mc mirror` restore step for manager-workspace on k8s mode pod startup, matching the existing aliyun mode behavior

## Test plan

- [x] Unit tests pass (`TestMinIOAdminClient_BuildManagerPolicy`)
- [x] Verified on local kind cluster: wrote test file → synced to MinIO → deleted pod → new pod restored file from MinIO

🤖 Generated with [Claude Code](https://claude.com/claude-code)