### PR TITLE
fix(ci): use falsy check for inputs.worker_runtime to fix non-dispatch triggers

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -159,7 +159,7 @@ jobs:
   integration-tests:
     needs: build-images
     if: >-
-      inputs.worker_runtime == '' || inputs.worker_runtime == 'both'
+      !inputs.worker_runtime || inputs.worker_runtime == 'both'
       || inputs.worker_runtime == matrix.runtime
     runs-on: ubuntu-latest
     timeout-minutes: 90


### PR DESCRIPTION
## Summary
- `inputs.worker_runtime` is `null` (not empty string `''`) for `pull_request_target` and `push` events
- This caused the `integration-tests` job `if` condition to evaluate to `false`, skipping all test jobs
- Fix: change `inputs.worker_runtime == ''` to `!inputs.worker_runtime` (falsy check covers both `null` and `''`)

## Test plan
- [x] Verify new PRs trigger integration tests again
- [x] Verify `workflow_dispatch` with specific runtime still filters correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)