### PR TITLE
fix: make OpenClaw repo URL configurable via build arg (#617)

### DIFF
--- a/openclaw-base/Dockerfile
+++ b/openclaw-base/Dockerfile
@@ -10,6 +10,7 @@
 # Build args:
 #   HIGRESS_REGISTRY  - base image registry (default: cn-hangzhou)
 #   APT_MIRROR        - APT mirror host (default: empty; set to mirrors.aliyun.com for China)
+#   OPENCLAW_REPO_URL - OpenClaw git repository URL (default: https://github.com/johnlanni/openclaw.git)
 # ============================================================
 
 ARG HIGRESS_REGISTRY=higress-registry.cn-hangzhou.cr.aliyuncs.com
@@ -24,6 +25,7 @@ ARG HTTPS_PROXY
 ARG http_proxy
 ARG https_proxy
 ARG NPM_REGISTRY=https://registry.npmjs.org/
+ARG OPENCLAW_REPO_URL=https://github.com/johnlanni/openclaw.git
 
 # Set proxy as environment variables to ensure all tools can use them
 ENV HTTP_PROXY=${HTTP_PROXY} \
@@ -52,7 +54,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
 # 2. Install dependencies and build
 # 3. Remove unnecessary files (tests, .git, etc.) - keep all node_modules for extensions
 RUN git clone --depth 1 --single-branch -b hiclaw-v1 \
-        https://github.com/johnlanni/openclaw.git /opt/openclaw && \
+        ${OPENCLAW_REPO_URL} /opt/openclaw && \
     cd /opt/openclaw && \
     git fetch --depth 1 origin 86dad1383c12629ad3aa48575f2dd350fc0775d4 && \
     git checkout 86dad1383c12629ad3aa48575f2dd350fc0775d4 && \


### PR DESCRIPTION
Hi there! 👋

This is my first contribution to HiClaw, and I'm excited to be here!

## What this PR does

This fix makes the OpenClaw repository URL configurable via a Docker build argument instead of being hardcoded in the Dockerfile. This improves flexibility for users who may need to use mirrors or custom forks.

### Changes
- Added  build argument with a sensible default
- Updated the  command to use the configurable URL

This should make it easier for folks to build the image in different environments without modifying the source code. 🚀

Fixes #617

Thanks for maintaining this awesome project! Let me know if there's anything you'd like me to adjust. 😊

---
*First-time contributor here – feedback is very welcome!*