### PR TITLE
fix(test): de-flake TestLeaderElection_TwoInstances_OnlyOneReconciles

### DIFF
--- a/hiclaw-controller/test/integration/controller/leaderelection_test.go
+++ b/hiclaw-controller/test/integration/controller/leaderelection_test.go
@@ -210,15 +210,24 @@ func TestLeaderElection_TwoInstances_OnlyOneReconciles(t *testing.T) {
 
 	provCountA, _, _, _ := provA.CallCounts()
 	provCountB, _, _, _ := provB.CallCounts()
+	globalProvCount, _, _, _ := mockProv.CallCounts()
 
+	// The core leader-election guarantee under test: of the two LE-enabled
+	// managers competing for the same lease, both must NOT reconcile.
 	if provCountA > 0 && provCountB > 0 {
-		t.Errorf("both instances provisioned: A=%d, B=%d — only leader should reconcile", provCountA, provCountB)
-	}
-	if provCountA == 0 && provCountB == 0 {
-		t.Error("neither instance provisioned — leader should have reconciled")
+		t.Errorf("both LE instances provisioned: A=%d, B=%d — only leader should reconcile", provCountA, provCountB)
 	}
 
-	t.Logf("provision calls: A=%d, B=%d", provCountA, provCountB)
+	// Liveness check: someone must have reconciled the Worker to Running.
+	// We don't require A or B specifically, because the suite-wide non-LE
+	// manager (see suite_test.go) shares the same apiserver and cache and
+	// will frequently grab the work first; that race is not what this test
+	// is validating.
+	if provCountA == 0 && provCountB == 0 && globalProvCount == 0 {
+		t.Error("no reconciler provisioned the worker — something is broken")
+	}
+
+	t.Logf("provision calls: A=%d, B=%d, global=%d", provCountA, provCountB, globalProvCount)
 }
 
 // TestLeaderElection_InitializerRunsOnlyOnLeader verifies that a post-election


### PR DESCRIPTION
## Summary

`TestLeaderElection_TwoInstances_OnlyOneReconciles` is flaky in CI (e.g. [run 24598213467](https://github.com/agentscope-ai/HiClaw/actions/runs/24598213467) failed with `provision calls: A=0, B=0` and `"neither instance provisioned — leader should have reconciled"`).

Root cause: the suite-wide controller manager set up in `suite_test.go` runs **without** leader election and shares the same apiserver/cache as the test-local LE-enabled managers (`mgrA` / `mgrB`). The suite manager has no lease delay and a warm cache, so it routinely wins the race to reconcile the test Worker before either A or B acquires the lease — leaving both LE counters at 0 and tripping the “neither provisioned” assertion.

That assertion was never really testing leader election; it was testing "someone reconciled" (liveness). The real exclusivity guarantee — "of the two LE-enabled managers, NOT both reconcile" — is already captured by the existing `provCountA > 0 && provCountB > 0` check, and that part is preserved.

This PR makes the same accommodation that `TestLeaderElection_SingleInstance_BecomesLeader` already does (see the comment at `leaderelection_test.go:108-117`): include the suite-wide `mockProv` in the liveness check so it's satisfied whether the suite manager or one of the LE managers got there first. Exclusivity remains strictly enforced between A and B.

## Test plan

- [x] `make test-integration` locally — all 3 leader-election tests pass:
  - `TestLeaderElection_SingleInstance_BecomesLeader (2.28s)`
  - `TestLeaderElection_TwoInstances_OnlyOneReconciles (2.28s)`
  - `TestLeaderElection_InitializerRunsOnlyOnLeader (5.03s)`
- [x] `go vet -tags=integration ./test/integration/controller/...` clean
- [ ] CI green on the PR
