### PR TITLE
fix(manager): worker post-creation DM + send-worker-greeting helper (#652)

### DIFF
--- a/manager/agent/skills/worker-management/references/create-worker.md
+++ b/manager/agent/skills/worker-management/references/create-worker.md
@@ -161,34 +161,43 @@ This command returns ALL workers with their current status. Look for your Worker
 
 ## Post-creation
 
-1. **Verify Worker is Running**: Use `hiclaw get workers -o json` to confirm `phase` is `"Running"`.
+`hiclaw create worker` alone does **not** notify the admin. You must complete all three steps below, in this exact order. Do not skip Step 2 — it is the reply the admin DM has been waiting on since they asked you to create the Worker.
 
-2. **Reply to admin in DM** (do NOT wait for Worker to greet first):
-   ```
-   <NAME> is ready. Remember to @mention them when giving tasks.
+### Step 1. Verify Worker is Running
 
-   Note: By default, Workers only accept @mentions from Manager and admin — not from each other. Peer mentions can be enabled explicitly per-project.
-   ```
+```bash
+hiclaw get workers -o json
+```
 
-4. **Send greeting in Worker's Room**:
+Confirm the target Worker's `phase` is `"Running"`. If `"Pending"`, check again shortly. If `"Failed"`, report the `message` field to admin and stop.
 
-   **For CoPaw Manager**:
-   ```bash
-   copaw channels send \
-     --agent-id default \
-     --channel matrix \
-     --target-session "<ROOM_ID>" \
-     --message "@<NAME>:${HICLAW_MATRIX_DOMAIN} You're all set! Please introduce yourself to everyone in this room."
-   ```
+### Step 2. Reply to admin in the DM — THIS IS YOUR FINAL TEXT RESPONSE
 
-   **For OpenClaw Manager**:
-   ```bash
-   openclaw gateway send \
-     --room "<ROOM_ID>" \
-     --message "@<NAME>:${HICLAW_MATRIX_DOMAIN} You're all set! Please introduce yourself to everyone in this room."
-   ```
+This step has no shell command on purpose. The admin is currently in a DM session with you; the reply the test (and the admin) is waiting on is **the text you return at the end of this turn**, not another tool call. Do not use `copaw channels send`, `curl`, or any other messaging CLI for this — those are for group rooms, not admin DMs.
 
-   Use the appropriate command based on your runtime (check `$HICLAW_MANAGER_RUNTIME` environment variable).
+Make sure your final response for this turn contains at least:
+
+```
+<NAME> is ready. Remember to @mention them when giving tasks.
+
+Note: By default, Workers only accept @mentions from Manager and admin — not from each other. Peer mentions can be enabled explicitly per-project.
+```
+
+Failing to emit this reply is the number-one cause of "Manager replied to create … (value is empty or null)" test failures.
+
+### Step 3. Greet the Worker in the Worker's Room
+
+After Step 2's reply is prepared, greet the Worker via the helper script. It auto-detects your runtime and handles all shell escaping, flag naming, and the `@<name>:${HICLAW_MATRIX_DOMAIN}` mention format, so you do not have to build the command by hand:
+
+```bash
+bash /opt/hiclaw/agent/skills/worker-management/scripts/send-worker-greeting.sh \
+  --worker <NAME> \
+  --room "<ROOM_ID>"
+```
+
+`<ROOM_ID>` is the `room_id` field from the `hiclaw create worker -o json` response. Pass `--text "<custom message>"` to personalize the greeting.
+
+If the helper exits with code 2 instead of sending (this happens on non-CoPaw runtimes), it prints the target room, mention, and message text — deliver that greeting via your native message channel to the printed room.
 
 ## Imported Worker Pull-Up
 

--- a/manager/agent/skills/worker-management/scripts/send-worker-greeting.sh
+++ b/manager/agent/skills/worker-management/scripts/send-worker-greeting.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# send-worker-greeting.sh - Send the post-creation greeting in a Worker's Matrix Room
+#
+# Hides all shell-escape / flag-name / mention-format details behind a single
+# command so the Manager never burns a turn fighting bash quoting.
+#
+# Usage:
+#   send-worker-greeting.sh --worker <NAME> --room <ROOM_ID> [--text <CUSTOM_TEXT>]
+#
+# Runtime behavior (auto-detected from $HICLAW_MANAGER_RUNTIME):
+#   - copaw:    delegates to `copaw channels send` with the correct flags
+#               (--text, --target-user, --target-session) and the proper
+#               "@<name>:${HICLAW_MATRIX_DOMAIN}" mention format.
+#   - openclaw: prints the greeting text + target room and exits 2, so the
+#               Manager can deliver it via its native message channel.
+#
+# Output (success, CoPaw): passthrough from `copaw channels send`.
+# Output (OpenClaw): instructional text on stdout, non-zero exit to make the
+#                    branch decision obvious to the caller.
+
+set -euo pipefail
+
+WORKER=""
+ROOM=""
+CUSTOM_TEXT=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --worker) WORKER="$2"; shift 2 ;;
+        --room)   ROOM="$2"; shift 2 ;;
+        --text)   CUSTOM_TEXT="$2"; shift 2 ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            echo "Usage: send-worker-greeting.sh --worker <NAME> --room <ROOM_ID> [--text <CUSTOM_TEXT>]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "${WORKER}" ] || [ -z "${ROOM}" ]; then
+    echo "Usage: send-worker-greeting.sh --worker <NAME> --room <ROOM_ID> [--text <CUSTOM_TEXT>]" >&2
+    exit 1
+fi
+
+DOMAIN="${HICLAW_MATRIX_DOMAIN:-matrix-local.hiclaw.io:18080}"
+RUNTIME="${HICLAW_MANAGER_RUNTIME:-openclaw}"
+
+MENTION="@${WORKER}:${DOMAIN}"
+if [ -n "${CUSTOM_TEXT}" ]; then
+    TEXT="${CUSTOM_TEXT}"
+else
+    TEXT="${MENTION} You're all set! Please introduce yourself to everyone in this room."
+fi
+
+case "${RUNTIME}" in
+    copaw)
+        exec copaw channels send \
+            --agent-id default \
+            --channel matrix \
+            --target-user "${MENTION}" \
+            --target-session "${ROOM}" \
+            --text "${TEXT}"
+        ;;
+    openclaw|*)
+        cat <<EOF
+OpenClaw Manager runtime detected (HICLAW_MANAGER_RUNTIME="${RUNTIME}").
+This helper only runs the shell flow for CoPaw. For OpenClaw, send the
+greeting via your native message channel:
+
+  Target room:  ${ROOM}
+  Target user:  ${MENTION}
+  Message text: ${TEXT}
+
+Exit code 2 is expected in this branch.
+EOF
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
Fixes #652

## Summary

CoPaw integration shard `test-06-multi-worker` was flaking because `create-worker.md` Post-creation listed steps as **1, 2, 4** (missing 3) and ended with a long `copaw channels send` block using wrong flags (`--message` vs `--text`, missing `--target-user`). The Manager tended to chase the greeting shell and **never emitted the admin DM** (`bob is ready …`), so `matrix_wait_for_message_containing` timed out.

See [issue #652](https://github.com/agentscope-ai/HiClaw/issues/652) for the full analysis.

## Changes

- **Post-creation**: Rewritten into three explicit steps; Step 2 is titled **"Reply to admin in the DM — THIS IS YOUR FINAL TEXT RESPONSE"** (no shell block) so the Manager cannot treat it as optional reference text. Clarifies not to use `copaw channels send` inside admin DM for this ack.
- **New script** `manager/agent/skills/worker-management/scripts/send-worker-greeting.sh`: one command for Worker-room greeting; on `copaw` runs `copaw channels send` with correct flags; on `openclaw` prints room/mention/text and exits 2 for native channel delivery (avoids inventing `openclaw gateway send`).

## Test plan

- [ ] Local / CI: `integration-tests` shard with CoPaw Manager — `test-06-multi-worker` should get non-empty Manager reply containing worker name after create.