### PR TITLE
fix(copaw): emit Element-style visible mentions in MatrixChannel

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,6 +4,8 @@ Record image-affecting changes to `manager/`, `worker/`, `openclaw-base/` here b
 
 ---
 
+- fix(copaw): `MatrixChannel._apply_mention` now emits Element-style visible mentions (`matrix.to` anchor in `formatted_body` + MXID in `body` + `m.mentions.user_ids`) so openclaw >= 2026.4.x workers actually wake up instead of dropping the event as `no-mention`; `send()` / `send_media()` also accept `meta["mention_user_ids"]` for explicit targets.
+
 - feat(manager): add Team Leader heartbeat and worker lifecycle builtins for team-scoped sleep/wake coordination (unreleased)
 
 - fix(manager): make find-skills use deterministic script paths in worker/copaw SKILL.md, render canonical install/search commands from `hiclaw-find-skill.sh`, and treat "import/install xxx skill from market" as a direct install trigger

--- a/copaw/src/matrix/channel.py
+++ b/copaw/src/matrix/channel.py
@@ -1941,22 +1941,74 @@ class MatrixChannel(BaseChannel):
         matches = self._MATRIX_USER_ID_RE.findall(text)
         return list(dict.fromkeys(matches))  # dedupe, preserve order
 
-    def _apply_mention(  # pylint: disable=unused-argument
+    def _apply_mention(
         self,
         content: dict[str, Any],
-        user_id: str,
         room_id: str,
+        *,
+        explicit_user_ids: Optional[List[str]] = None,
+        fallback_user_id: Optional[str] = None,
     ) -> None:
-        """Add Matrix mentions to an outgoing event content dict.
+        """Attach an Element-style visible mention to an outgoing event.
 
-        Scans the message body for @user:domain patterns and populates
-        ``m.mentions.user_ids`` (MSC3952). Only includes user IDs that
-        actually appear in the text. Does NOT modify the body text.
+        openclaw >= 2026.4.x requires BOTH ``m.mentions.user_ids`` AND a
+        *visible* mention (either a ``matrix.to`` link in ``formatted_body``
+        or a regex match on identity) before it will wake up on a
+        mention. A metadata-only mention is silently dropped with
+        ``reason: "no-mention"``. To stay compatible with OpenClaw
+        workers running a minimal SOUL (no custom identity regex), this
+        helper writes three layers in one shot:
+
+        1. ``body``           — ensure every mentioned MXID appears as plain
+                                text (prefix if missing).
+        2. ``formatted_body`` — rewrite each MXID occurrence as a
+                                ``<a href="https://matrix.to/#/...">...</a>``
+                                anchor, creating the field if absent.
+        3. ``m.mentions``     — list the mentioned MXIDs per MSC3952.
+
+        Mention target resolution (highest priority first):
+
+        * ``explicit_user_ids`` — caller-supplied list
+          (e.g. from ``meta["mention_user_ids"]``).
+        * ``fallback_user_id`` — e.g. the original sender when replying.
+        * Regex scan of ``body`` for ``@user:domain`` tokens.
         """
-        body = content.get("body", "")
-        mentioned_ids = self._extract_mentions_from_text(body)
-        if mentioned_ids:
-            content["m.mentions"] = {"user_ids": mentioned_ids}
+        body = content.get("body", "") or ""
+
+        targets: list[str]
+        if explicit_user_ids:
+            targets = list(dict.fromkeys(explicit_user_ids))
+        elif fallback_user_id:
+            targets = [fallback_user_id]
+        else:
+            targets = self._extract_mentions_from_text(body)
+
+        targets = [t for t in targets if t and t != self._user_id]
+        if not targets:
+            return
+
+        html_body = content.get("formatted_body", "") or ""
+        if not html_body:
+            html_body = html.escape(body).replace("\n", "<br>\n")
+
+        for mxid in targets:
+            if mxid not in body:
+                body = f"{mxid} {body}" if body else mxid
+            mxid_enc = urllib.parse.quote(mxid, safe="")
+            display = self._resolve_display_name(mxid, room_id) or mxid
+            anchor = (
+                f'<a href="https://matrix.to/#/{mxid_enc}">'
+                f"{html.escape(display)}</a>"
+            )
+            if mxid in html_body:
+                html_body = html_body.replace(mxid, anchor, 1)
+            else:
+                html_body = f"{anchor} {html_body}" if html_body else anchor
+
+        content["body"] = body
+        content["format"] = "org.matrix.custom.html"
+        content["formatted_body"] = html_body
+        content["m.mentions"] = {"user_ids": targets}
 
     def _resolve_display_name(self, user_id: str, room_id: str) -> str:
         """Best-effort display name for *user_id* in *room_id*."""
@@ -2018,11 +2070,16 @@ class MatrixChannel(BaseChannel):
             len(html_body),
         )
 
-        sender_id = (meta or {}).get("sender_id") or (meta or {}).get(
-            "user_id",
-        )
-        if sender_id:
-            self._apply_mention(content, sender_id, room_id)
+        meta_dict = meta or {}
+        explicit_ids = meta_dict.get("mention_user_ids") or None
+        sender_id = meta_dict.get("sender_id") or meta_dict.get("user_id")
+        if explicit_ids or sender_id:
+            self._apply_mention(
+                content,
+                room_id,
+                explicit_user_ids=explicit_ids,
+                fallback_user_id=sender_id if not explicit_ids else None,
+            )
 
         try:
             await self._client.room_send(
@@ -2109,11 +2166,18 @@ class MatrixChannel(BaseChannel):
                     "size": file_size,
                 },
             }
-            sender_id = (meta or {}).get("sender_id") or (meta or {}).get(
-                "user_id",
-            )
-            if sender_id:
-                self._apply_mention(event_content, sender_id, room_id)
+            meta_dict = meta or {}
+            explicit_ids = meta_dict.get("mention_user_ids") or None
+            sender_id = meta_dict.get("sender_id") or meta_dict.get("user_id")
+            if explicit_ids or sender_id:
+                self._apply_mention(
+                    event_content,
+                    room_id,
+                    explicit_user_ids=explicit_ids,
+                    fallback_user_id=(
+                        sender_id if not explicit_ids else None
+                    ),
+                )
 
             await self._client.room_send(
                 room_id,

--- a/copaw/tests/test_channel_mention.py
+++ b/copaw/tests/test_channel_mention.py
@@ -1,0 +1,201 @@
+"""Tests for MatrixChannel._apply_mention: outgoing visible mentions.
+
+openclaw >= 2026.4.x's mention monitor requires BOTH ``m.mentions.user_ids``
+metadata AND a *visible* mention (a ``matrix.to`` link in ``formatted_body``
+or a regex match on the agent's identity) — a metadata-only mention is
+silently dropped with ``reason: "no-mention"``. These tests pin down the
+three-layer invariant that ``_apply_mention`` must uphold so CoPaw-issued
+messages actually wake up receiving OpenClaw agents.
+"""
+
+from matrix.channel import MatrixChannel
+
+
+def _make_channel(user_id: str = "@bot:hs.local") -> MatrixChannel:
+    """Build a bare channel instance without going through __init__.
+
+    ``MatrixChannel.__init__`` wires up BaseChannel/AsyncClient state we do
+    not need here; ``_apply_mention`` only touches ``self._user_id`` and
+    ``self._client`` (via ``_resolve_display_name``). Setting
+    ``_client = None`` forces the display-name resolver down its localpart
+    fallback, which keeps these tests deterministic.
+    """
+    ch = MatrixChannel.__new__(MatrixChannel)
+    ch._user_id = user_id
+    ch._client = None
+    return ch
+
+
+def test_apply_mention_explicit_user_ids_prefixes_body_and_adds_anchor():
+    ch = _make_channel()
+    content = {
+        "msgtype": "m.text",
+        "body": "Please handle this.",
+        "format": "org.matrix.custom.html",
+        "formatted_body": "<p>Please handle this.</p>",
+    }
+
+    ch._apply_mention(
+        content,
+        "!room:hs.local",
+        explicit_user_ids=["@worker-a:hs.local"],
+    )
+
+    assert content["m.mentions"] == {"user_ids": ["@worker-a:hs.local"]}
+    assert content["body"].startswith("@worker-a:hs.local ")
+    assert (
+        'href="https://matrix.to/#/%40worker-a%3Ahs.local"'
+        in content["formatted_body"]
+    )
+    assert content["format"] == "org.matrix.custom.html"
+
+
+def test_apply_mention_fallback_sender_id_when_no_explicit_list():
+    ch = _make_channel()
+    content = {
+        "msgtype": "m.text",
+        "body": "Got it, thanks!",
+        "format": "org.matrix.custom.html",
+        "formatted_body": "<p>Got it, thanks!</p>",
+    }
+
+    ch._apply_mention(
+        content,
+        "!room:hs.local",
+        fallback_user_id="@alice:hs.local",
+    )
+
+    assert content["m.mentions"] == {"user_ids": ["@alice:hs.local"]}
+    assert "@alice:hs.local" in content["body"]
+    assert (
+        'href="https://matrix.to/#/%40alice%3Ahs.local"'
+        in content["formatted_body"]
+    )
+
+
+def test_apply_mention_body_scan_rewrites_existing_mxid_to_anchor():
+    ch = _make_channel()
+    content = {
+        "msgtype": "m.text",
+        "body": "@worker-b:hs.local hello there",
+        "format": "org.matrix.custom.html",
+        "formatted_body": "<p>@worker-b:hs.local hello there</p>",
+    }
+
+    ch._apply_mention(content, "!room:hs.local")
+
+    assert content["m.mentions"] == {"user_ids": ["@worker-b:hs.local"]}
+    # Body already had the MXID — no duplicate prefix.
+    assert content["body"].count("@worker-b:hs.local") == 1
+    # First occurrence in formatted_body is replaced with a matrix.to anchor.
+    assert (
+        'href="https://matrix.to/#/%40worker-b%3Ahs.local"'
+        in content["formatted_body"]
+    )
+
+
+def test_apply_mention_explicit_overrides_sender_fallback():
+    ch = _make_channel()
+    content = {
+        "msgtype": "m.text",
+        "body": "move to next",
+        "format": "org.matrix.custom.html",
+        "formatted_body": "<p>move to next</p>",
+    }
+
+    ch._apply_mention(
+        content,
+        "!room:hs.local",
+        explicit_user_ids=["@worker-c:hs.local"],
+        fallback_user_id="@alice:hs.local",
+    )
+
+    assert content["m.mentions"] == {"user_ids": ["@worker-c:hs.local"]}
+    assert "@alice:hs.local" not in content["body"]
+
+
+def test_apply_mention_skips_self_mention():
+    """The agent must never mention itself — that would loop on its own reply."""
+    ch = _make_channel(user_id="@bot:hs.local")
+    content = {
+        "msgtype": "m.text",
+        "body": "hello",
+        "format": "org.matrix.custom.html",
+        "formatted_body": "<p>hello</p>",
+    }
+
+    ch._apply_mention(
+        content,
+        "!room:hs.local",
+        explicit_user_ids=["@bot:hs.local"],
+    )
+
+    assert "m.mentions" not in content
+
+
+def test_apply_mention_no_targets_leaves_content_untouched():
+    ch = _make_channel()
+    content = {
+        "msgtype": "m.text",
+        "body": "plain chatter with no mention",
+        "format": "org.matrix.custom.html",
+        "formatted_body": "<p>plain chatter with no mention</p>",
+    }
+    snapshot = dict(content)
+
+    ch._apply_mention(content, "!room:hs.local")
+
+    assert content == snapshot
+
+
+def test_apply_mention_synthesizes_formatted_body_for_media_events():
+    """``send_media`` only sets ``body`` (filename); mention must still land."""
+    ch = _make_channel()
+    content = {
+        "msgtype": "m.image",
+        "body": "screenshot.png",
+        "url": "mxc://hs.local/abc",
+        "info": {"mimetype": "image/png", "size": 0},
+    }
+
+    ch._apply_mention(
+        content,
+        "!room:hs.local",
+        explicit_user_ids=["@worker-d:hs.local"],
+    )
+
+    assert content["format"] == "org.matrix.custom.html"
+    assert content["body"].startswith("@worker-d:hs.local ")
+    assert (
+        'href="https://matrix.to/#/%40worker-d%3Ahs.local"'
+        in content["formatted_body"]
+    )
+    assert content["m.mentions"] == {"user_ids": ["@worker-d:hs.local"]}
+
+
+def test_apply_mention_multiple_targets_all_get_visible_anchors():
+    ch = _make_channel()
+    content = {
+        "msgtype": "m.text",
+        "body": "team syncing",
+        "format": "org.matrix.custom.html",
+        "formatted_body": "<p>team syncing</p>",
+    }
+
+    ch._apply_mention(
+        content,
+        "!room:hs.local",
+        explicit_user_ids=["@worker-a:hs.local", "@worker-b:hs.local"],
+    )
+
+    assert content["m.mentions"] == {
+        "user_ids": ["@worker-a:hs.local", "@worker-b:hs.local"],
+    }
+    for uid_enc in (
+        "%40worker-a%3Ahs.local",
+        "%40worker-b%3Ahs.local",
+    ):
+        assert (
+            f'href="https://matrix.to/#/{uid_enc}"'
+            in content["formatted_body"]
+        )


### PR DESCRIPTION
## Summary

- `MatrixChannel._apply_mention` now emits all three layers of a mention in one shot: `body` (plain-text MXID fallback), `formatted_body` (with a `matrix.to` anchor), and `m.mentions.user_ids` per MSC3952. This satisfies openclaw >= 2026.4.x's mention monitor, which requires BOTH the metadata AND a visible mention — previously CoPaw-issued messages only wrote the metadata and were silently dropped with `reason: "no-mention"`, so the CoPaw ↔ OpenClaw cross-runtime path was effectively broken.
- `send()` / `send_media()` now accept `meta["mention_user_ids"]` so callers can target specific workers explicitly. Priority order: **explicit list > `meta["sender_id"]` / `meta["user_id"]` fallback > regex scan of `body`**. The agent's own MXID is filtered out of targets to prevent self-mention loops.
- New `copaw/tests/test_channel_mention.py` (8 cases) pins the three-layer invariant across explicit / sender-id / body-scan / multi-target / self-filter / media-event / no-target paths.

## Background

Follow-up to the problem surfaced by `test(test-15)` in #654: openclaw 2026.4.x tightened `extensions/matrix/src/matrix/monitor/mentions.ts:resolveMentions` to require a visible mention (a `matrix.to` link in `formatted_body`, or a regex match on identity) on top of `m.mentions.user_ids`. A Worker created from a minimal SOUL (no custom identity regex) never woke up on messages from a CoPaw agent under the old behaviour.

## Test plan

- [x] `copaw/tests/test_channel_mention.py` unit tests covering the three mention-source paths, multi-target anchors, self-mention filtering, and media-event formatted_body synthesis
- [x] Full local integration suite: 21/21 PASS (test-01 through test-21-team-project-dag, including test-15-import-worker-zip and test-06-multi-worker which exercise cross-worker mentions)
- [ ] CI green

## Notes

`copaw/src/matrix/` is vendored into **both** `copaw-worker` and `hiclaw-manager-copaw` (see `copaw/AGENTS.md` pitfall #1). Both images need to be rebuilt on release; otherwise Manager and Worker behaviour will drift.

Made with [Cursor](https://cursor.com)