### PR TITLE
fix(install): always pull all worker runtime images and sync ps1 with sh

### DIFF
--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -181,7 +181,7 @@ function Get-Registry {
     }
 
     # Southeast Asia
-    if ($Timezone -match "^(Asia/Singapore|Asia/Bangkok|Asia/Jakarta|Asia/Kuala_Lumpur|Asia/Ho_Chi_Minh|Asia/Manila|Asia/Yangon)") {
+    if ($Timezone -match "^(Asia/Singapore|Asia/Bangkok|Asia/Jakarta|Asia/Makassar|Asia/Jayapura|Asia/Kuala_Lumpur|Asia/Ho_Chi_Minh|Asia/Manila|Asia/Yangon|Asia/Vientiane|Asia/Phnom_Penh|Asia/Pontianak|Asia/Ujung_Pandang)") {
         return "higress-registry.ap-southeast-7.cr.aliyuncs.com"
     }
 
@@ -254,6 +254,8 @@ $script:Messages = @{
     "install.reinstall.warn_workers" = @{ zh = "   - 所有 worker 容器"; en = "   - All worker containers" }
     "install.reinstall.warn_proxy" = @{ zh = "   - Docker API 代理容器: hiclaw-controller"; en = "   - Docker API proxy container: hiclaw-controller" }
     "install.reinstall.removing_proxy" = @{ zh = "正在移除 Docker API 代理容器: hiclaw-controller"; en = "Removing Docker API proxy container: hiclaw-controller" }
+    "install.reinstall.warn_network" = @{ zh = "   - Docker 网络: hiclaw-net"; en = "   - Docker network: hiclaw-net" }
+    "install.reinstall.removing_network" = @{ zh = "正在移除 Docker 网络: hiclaw-net"; en = "Removing Docker network: hiclaw-net" }
     "install.reinstall.confirm_type" = @{ zh = "请输入工作空间路径以确认删除（或按 Ctrl+C 取消）:"; en = "To confirm deletion, please type the workspace path:" }
     "install.reinstall.confirm_path" = @{ zh = "输入路径以确认（或按 Ctrl+C 取消）"; en = "Type the path to confirm (or press Ctrl+C to cancel)" }
     "install.reinstall.path_mismatch" = @{ zh = "路径不匹配。中止重装。输入: '{0}'，期望: '{1}'"; en = "Path mismatch. Aborting reinstall. Input: '{0}', Expected: '{1}'" }
@@ -707,18 +709,31 @@ function ConvertTo-DockerPath {
 function Wait-ManagerReady {
     param(
         [string]$Container = "hiclaw-manager",
-        [int]$Timeout = 300
+        [int]$Timeout = $(if ($env:HICLAW_READY_TIMEOUT) { [int]$env:HICLAW_READY_TIMEOUT } else { 300 })
     )
 
     $elapsed = 0
     Write-Log (Get-Msg "install.wait_ready" -f $Timeout)
 
+    $runtime = if ($script:config.MANAGER_RUNTIME) { $script:config.MANAGER_RUNTIME } else { "openclaw" }
+
     while ($elapsed -lt $Timeout) {
         try {
-            $result = docker exec $Container openclaw gateway health --json 2>$null
-            if ($result -match '"ok"') {
-                Write-Log (Get-Msg "install.wait_ready.ok")
-                return $true
+            switch ($runtime) {
+                "copaw" {
+                    $result = docker exec $Container curl -sf http://127.0.0.1:18799/api/agents 2>$null
+                    if ($result -match '"agents"') {
+                        Write-Log (Get-Msg "install.wait_ready.ok")
+                        return $true
+                    }
+                }
+                default {
+                    $result = docker exec $Container openclaw gateway health --json 2>$null
+                    if ($result -match '"ok"') {
+                        Write-Log (Get-Msg "install.wait_ready.ok")
+                        return $true
+                    }
+                }
             }
         } catch {
             # Ignore errors during polling
@@ -736,7 +751,7 @@ function Wait-ManagerReady {
 function Wait-MatrixReady {
     param(
         [string]$Container = "hiclaw-manager",
-        [int]$Timeout = 300
+        [int]$Timeout = $(if ($env:HICLAW_READY_TIMEOUT) { [int]$env:HICLAW_READY_TIMEOUT } else { 300 })
     )
 
     $elapsed = 0
@@ -817,13 +832,23 @@ HICLAW_REGISTRATION_TOKEN=$($Config.REGISTRATION_TOKEN)
 # GitHub (optional)
 HICLAW_GITHUB_TOKEN=$($Config.GITHUB_TOKEN)
 
-# Nacos defaults for Worker skill discovery / package import (optional)
+# Nacos package import defaults
+HICLAW_NACOS_REGISTRY_URI=$(if ($env:HICLAW_NACOS_REGISTRY_URI) { $env:HICLAW_NACOS_REGISTRY_URI } else { "nacos://market.hiclaw.io:80/public" })
 HICLAW_NACOS_USERNAME=$($env:HICLAW_NACOS_USERNAME)
 HICLAW_NACOS_PASSWORD=$($env:HICLAW_NACOS_PASSWORD)
 HICLAW_NACOS_TOKEN=$($env:HICLAW_NACOS_TOKEN)
 
 # Skills Registry (optional, default: nacos://market.hiclaw.io:80/public)
 HICLAW_SKILLS_API_URL=$(if ($Config.SKILLS_API_URL) { $Config.SKILLS_API_URL } else { "nacos://market.hiclaw.io:80/public" })
+
+# OpenClaw CMS plugin (optional)
+HICLAW_CMS_TRACES_ENABLED=$(if ($env:HICLAW_CMS_TRACES_ENABLED) { $env:HICLAW_CMS_TRACES_ENABLED } else { "false" })
+HICLAW_CMS_ENDPOINT=$($env:HICLAW_CMS_ENDPOINT)
+HICLAW_CMS_LICENSE_KEY=$($env:HICLAW_CMS_LICENSE_KEY)
+HICLAW_CMS_PROJECT=$($env:HICLAW_CMS_PROJECT)
+HICLAW_CMS_WORKSPACE=$($env:HICLAW_CMS_WORKSPACE)
+HICLAW_CMS_SERVICE_NAME=$(if ($env:HICLAW_CMS_SERVICE_NAME) { $env:HICLAW_CMS_SERVICE_NAME } else { "hiclaw-manager" })
+HICLAW_CMS_METRICS_ENABLED=$(if ($env:HICLAW_CMS_METRICS_ENABLED) { $env:HICLAW_CMS_METRICS_ENABLED } else { "false" })
 
 # Worker images (for direct container creation)
 HICLAW_WORKER_IMAGE=$($Config.WORKER_IMAGE)
@@ -847,6 +872,9 @@ HICLAW_PROXY_ALLOWED_REGISTRIES=$($Config.PROXY_ALLOWED_REGISTRIES)
 
 # Worker idle timeout in minutes (default: 720 = 12 hours)
 HICLAW_WORKER_IDLE_TIMEOUT=$($Config.WORKER_IDLE_TIMEOUT)
+
+# JVM Args for Higress Console
+JVM_ARGS=$($env:JVM_ARGS)
 
 # Higress WASM plugin image registry (auto-selected by timezone)
 HIGRESS_ADMIN_WASM_PLUGIN_IMAGE_REGISTRY=$($Config.REGISTRY)
@@ -1159,6 +1187,10 @@ function Test-ShouldSkipStep {
             if ($script:HICLAW_QUICKSTART -and -not $script:HICLAW_UPGRADE) { return $true }
             return $false
         }
+        "Step-ManagerRuntime" {
+            if ($script:HICLAW_NON_INTERACTIVE) { return $true }
+            return $false
+        }
         "Step-Hostshare" {
             if ($script:HICLAW_NON_INTERACTIVE) { return $true }
             if ($script:HICLAW_QUICKSTART) { return $true }
@@ -1350,6 +1382,7 @@ function Step-Existing {
             Write-Host "$($script:ESC)[31m$(Get-Msg 'install.reinstall.warn_workspace' -f $existingWorkspace)$($script:ESC)[0m"
             Write-Host "$($script:ESC)[31m$(Get-Msg 'install.reinstall.warn_workers')$($script:ESC)[0m"
             Write-Host "$($script:ESC)[31m$(Get-Msg 'install.reinstall.warn_proxy')$($script:ESC)[0m"
+            Write-Host "$($script:ESC)[31m$(Get-Msg 'install.reinstall.warn_network')$($script:ESC)[0m"
             Write-Host ""
             Write-Host "$($script:ESC)[31m$(Get-Msg 'install.reinstall.confirm_type')$($script:ESC)[0m"
             Write-Host "$($script:ESC)[31m  $existingWorkspace$($script:ESC)[0m"
@@ -1383,6 +1416,11 @@ function Step-Existing {
             if (Test-Path $script:HICLAW_ENV_FILE) {
                 Write-Log (Get-Msg "install.reinstall.removing_env" -f $script:HICLAW_ENV_FILE)
                 Remove-Item -Force $script:HICLAW_ENV_FILE
+            }
+            $existingNetwork = docker network ls --format "{{.Name}}" 2>$null | Select-String "^hiclaw-net$"
+            if ($existingNetwork) {
+                Write-Log (Get-Msg "install.reinstall.removing_network")
+                docker network rm hiclaw-net *>$null
             }
             Write-Log (Get-Msg "install.reinstall.cleanup_done")
         }
@@ -2199,9 +2237,11 @@ function Install-Manager {
                     --restart unless-stopped `
                     $proxyImage
                 $dockerArgs += @("-e", "HICLAW_CONTROLLER_URL=http://hiclaw-controller:8090")
+                $dockerArgs += @("-e", "HICLAW_CONTAINER_API=http://hiclaw-controller:8090")
                 Write-Log (Get-Msg "docker_proxy.selected_enabled")
             } else {
                 $dockerArgs += @("-v", "//var/run/docker.sock:/var/run/docker.sock")
+                $dockerArgs += @("--security-opt", "label=disable")
                 Write-Log (Get-Msg "install.socket_detected" -f "//var/run/docker.sock")
             }
         } else {

--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -252,6 +252,8 @@ $script:Messages = @{
     "install.reinstall.warn_env" = @{ zh = "   - Env 文件: {0}"; en = "   - Env file: {0}" }
     "install.reinstall.warn_workspace" = @{ zh = "   - Manager 工作空间: {0}"; en = "   - Manager workspace: {0}" }
     "install.reinstall.warn_workers" = @{ zh = "   - 所有 worker 容器"; en = "   - All worker containers" }
+    "install.reinstall.warn_proxy" = @{ zh = "   - Docker API 代理容器: hiclaw-controller"; en = "   - Docker API proxy container: hiclaw-controller" }
+    "install.reinstall.removing_proxy" = @{ zh = "正在移除 Docker API 代理容器: hiclaw-controller"; en = "Removing Docker API proxy container: hiclaw-controller" }
     "install.reinstall.confirm_type" = @{ zh = "请输入工作空间路径以确认删除（或按 Ctrl+C 取消）:"; en = "To confirm deletion, please type the workspace path:" }
     "install.reinstall.confirm_path" = @{ zh = "输入路径以确认（或按 Ctrl+C 取消）"; en = "Type the path to confirm (or press Ctrl+C to cancel)" }
     "install.reinstall.path_mismatch" = @{ zh = "路径不匹配。中止重装。输入: '{0}'，期望: '{1}'"; en = "Path mismatch. Aborting reinstall. Input: '{0}', Expected: '{1}'" }
@@ -831,7 +833,7 @@ HICLAW_HERMES_WORKER_IMAGE=$($Config.HERMES_WORKER_IMAGE)
 # Manager runtime (openclaw | copaw)
 HICLAW_MANAGER_RUNTIME=$($Config.MANAGER_RUNTIME)
 
-# Default Worker runtime (openclaw | copaw)
+# Default Worker runtime (openclaw | copaw | hermes)
 HICLAW_DEFAULT_WORKER_RUNTIME=$($Config.DEFAULT_WORKER_RUNTIME)
 
 # Matrix E2EE (0=disabled, 1=enabled; default: 0)
@@ -1347,6 +1349,7 @@ function Step-Existing {
             Write-Host "$($script:ESC)[31m$(Get-Msg 'install.reinstall.warn_env' -f $script:HICLAW_ENV_FILE)$($script:ESC)[0m"
             Write-Host "$($script:ESC)[31m$(Get-Msg 'install.reinstall.warn_workspace' -f $existingWorkspace)$($script:ESC)[0m"
             Write-Host "$($script:ESC)[31m$(Get-Msg 'install.reinstall.warn_workers')$($script:ESC)[0m"
+            Write-Host "$($script:ESC)[31m$(Get-Msg 'install.reinstall.warn_proxy')$($script:ESC)[0m"
             Write-Host ""
             Write-Host "$($script:ESC)[31m$(Get-Msg 'install.reinstall.confirm_type')$($script:ESC)[0m"
             Write-Host "$($script:ESC)[31m  $existingWorkspace$($script:ESC)[0m"
@@ -1362,6 +1365,12 @@ function Step-Existing {
                 docker stop $_ *>$null
                 docker rm $_ *>$null
                 Write-Log (Get-Msg "install.reinstall.removed_worker" -f $_)
+            }
+            $existingController = docker ps -a --format "{{.Names}}" 2>$null | Select-String "^hiclaw-controller$"
+            if ($existingController) {
+                Write-Log (Get-Msg "install.reinstall.removing_proxy")
+                docker stop hiclaw-controller *>$null
+                docker rm hiclaw-controller *>$null
             }
             if (docker volume ls -q 2>$null | Select-String "^hiclaw-data$") {
                 Write-Log (Get-Msg "install.reinstall.removing_volume")
@@ -1959,8 +1968,10 @@ function Install-Manager {
         "$($script:HICLAW_REGISTRY)/higress/hiclaw-manager-copaw:$($script:HICLAW_VERSION)"
     }
 
-    $script:CONTROLLER_IMAGE = if ($env:HICLAW_INSTALL_CONTROLLER_IMAGE) {
-        $env:HICLAW_INSTALL_CONTROLLER_IMAGE
+    # Backward compatibility: accept old env var name from previous versions
+    $controllerImageOverride = if ($env:HICLAW_INSTALL_CONTROLLER_IMAGE) { $env:HICLAW_INSTALL_CONTROLLER_IMAGE } elseif ($env:HICLAW_INSTALL_DOCKER_PROXY_IMAGE) { $env:HICLAW_INSTALL_DOCKER_PROXY_IMAGE } else { $null }
+    $script:CONTROLLER_IMAGE = if ($controllerImageOverride) {
+        $controllerImageOverride
     } else {
         "$($script:HICLAW_REGISTRY)/higress/hiclaw-controller:$($script:HICLAW_VERSION)"
     }
@@ -2128,6 +2139,7 @@ function Install-Manager {
     $config.REGISTRY = $script:HICLAW_REGISTRY
     $config.WORKER_IMAGE = $script:WORKER_IMAGE
     $config.COPAW_WORKER_IMAGE = $script:COPAW_WORKER_IMAGE
+    $config.HERMES_WORKER_IMAGE = $script:HERMES_WORKER_IMAGE
     $config.MANAGER_COPAW_IMAGE = $script:MANAGER_COPAW_IMAGE
 
     # Write env file
@@ -2235,6 +2247,11 @@ function Install-Manager {
         Write-Log (Get-Msg "install.yolo")
     }
 
+    # Matrix-plugin debug tracing
+    if ($env:HICLAW_MATRIX_DEBUG -eq "1") {
+        $dockerArgs += @("-e", "HICLAW_MATRIX_DEBUG=1")
+    }
+
     # Restart policy
     $dockerArgs += @("--restart", "unless-stopped")
 
@@ -2265,63 +2282,19 @@ function Install-Manager {
         & docker pull $managerImage
     }
 
-    # Pull the worker image matching the selected runtime
-    $selectedWorkerImage = switch ($config.DEFAULT_WORKER_RUNTIME) {
-        "copaw"  { $script:COPAW_WORKER_IMAGE }
-        "hermes" { $script:HERMES_WORKER_IMAGE }
-        default  { $script:WORKER_IMAGE }
-    }
-    if ($selectedWorkerImage.StartsWith($LocalImagePrefix)) {
-        $workerImageExists = docker image inspect $selectedWorkerImage 2>$null
-        if ($LASTEXITCODE -eq 0) {
-            Write-Log (Get-Msg "install.image.worker_exists" -f $selectedWorkerImage)
-        } else {
-            Write-Log (Get-Msg "install.image.pulling_worker" -f $selectedWorkerImage)
-            & docker pull $selectedWorkerImage
-        }
-    } else {
-        Write-Log (Get-Msg "install.image.pulling_worker" -f $selectedWorkerImage)
-        & docker pull $selectedWorkerImage
-    }
-
-    # Always pull copaw worker image — team workers require copaw runtime
-    if ($config.DEFAULT_WORKER_RUNTIME -ne "copaw") {
-        $copawExists = docker image inspect $script:COPAW_WORKER_IMAGE 2>$null
-        if ($LASTEXITCODE -eq 0) {
-            Write-Log (Get-Msg "install.image.worker_exists" -f $script:COPAW_WORKER_IMAGE)
-        } else {
-            try {
-                Write-Log (Get-Msg "install.image.pulling_worker" -f $script:COPAW_WORKER_IMAGE)
-                & docker pull $script:COPAW_WORKER_IMAGE
-            } catch {
-                Write-Log "Warning: copaw worker image not available, team features may not work"
-            }
-        }
-    }
-
-    # During upgrade, also pull other worker images if they exist locally
-    if ($script:HICLAW_UPGRADE) {
-        if ($config.DEFAULT_WORKER_RUNTIME -ne "openclaw") {
-            $otherExists = docker image inspect $script:WORKER_IMAGE 2>$null
+    # Pull all worker runtime images (workers may use any runtime regardless of the default)
+    foreach ($workerImg in @($script:WORKER_IMAGE, $script:COPAW_WORKER_IMAGE, $script:HERMES_WORKER_IMAGE)) {
+        if ($workerImg.StartsWith($LocalImagePrefix)) {
+            $imgExists = docker image inspect $workerImg 2>$null
             if ($LASTEXITCODE -eq 0) {
-                if ($script:WORKER_IMAGE.StartsWith($LocalImagePrefix)) {
-                    Write-Log (Get-Msg "install.image.worker_exists" -f $script:WORKER_IMAGE)
-                } else {
-                    Write-Log (Get-Msg "install.image.pulling_worker" -f $script:WORKER_IMAGE)
-                    & docker pull $script:WORKER_IMAGE
-                }
+                Write-Log (Get-Msg "install.image.worker_exists" -f $workerImg)
+            } else {
+                Write-Log (Get-Msg "install.image.pulling_worker" -f $workerImg)
+                & docker pull $workerImg
             }
-        }
-        if ($config.DEFAULT_WORKER_RUNTIME -ne "hermes") {
-            $hermesExists = docker image inspect $script:HERMES_WORKER_IMAGE 2>$null
-            if ($LASTEXITCODE -eq 0) {
-                if ($script:HERMES_WORKER_IMAGE.StartsWith($LocalImagePrefix)) {
-                    Write-Log (Get-Msg "install.image.worker_exists" -f $script:HERMES_WORKER_IMAGE)
-                } else {
-                    Write-Log (Get-Msg "install.image.pulling_worker" -f $script:HERMES_WORKER_IMAGE)
-                    & docker pull $script:HERMES_WORKER_IMAGE
-                }
-            }
+        } else {
+            Write-Log (Get-Msg "install.image.pulling_worker" -f $workerImg)
+            & docker pull $workerImg
         }
     }
 
@@ -2339,8 +2312,7 @@ function Install-Manager {
         docker rm hiclaw-manager *>$null
     }
 
-    # Stop and remove worker containers saved during upgrade detection
-    # (Manager IP changes on restart, so workers must be recreated)
+    # Stop and remove worker containers (controller will recreate via CR reconciliation)
     if ($script:UPGRADE_EXISTING_WORKERS) {
         Write-Log (Get-Msg "install.existing.stopping_workers")
         $script:UPGRADE_EXISTING_WORKERS | ForEach-Object {
@@ -2348,6 +2320,16 @@ function Install-Manager {
             docker rm $_ *>$null
             Write-Log (Get-Msg "install.existing.removed" -f $_)
         }
+    }
+
+    # Clean up legacy containers (e.g. hiclaw-docker-proxy from v1.0.x)
+    $legacyContainers = docker ps -a --format "{{.Names}}" 2>$null |
+        Select-String "^hiclaw-" |
+        Where-Object { $_.Line -notmatch "^(hiclaw-controller|hiclaw-manager|hiclaw-worker-)" }
+    foreach ($legacy in $legacyContainers) {
+        Write-Log "Removing legacy container: $($legacy.Line)"
+        docker stop $legacy.Line *>$null
+        docker rm -f $legacy.Line *>$null
     }
 
     # Run container

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -2392,7 +2392,7 @@ EOF
     # E2EE is already in the env file; but also pass explicitly in case env file is not the source
     # (HICLAW_MATRIX_E2EE is already written to ENV_FILE above via --env-file)
 
-    # Pull images (pull the selected runtime's worker image; on upgrade, also pull the other if present locally)
+    # Pull images (manager based on runtime config; all worker runtimes always pulled)
     LOCAL_IMAGE_PREFIX="hiclaw/"
 
     # Helper: pull or skip a single image
@@ -2419,42 +2419,10 @@ EOF
         _pull_image "${MANAGER_IMAGE}" "install.image.exists" "install.image.pulling_manager"
     fi
 
-    # Pull worker image for the selected runtime
-    case "${HICLAW_DEFAULT_WORKER_RUNTIME}" in
-        copaw)
-            _pull_image "${COPAW_WORKER_IMAGE}" "install.image.worker_exists" "install.image.pulling_worker"
-            ;;
-        hermes)
-            _pull_image "${HERMES_WORKER_IMAGE}" "install.image.worker_exists" "install.image.pulling_worker"
-            ;;
-        *)
-            _pull_image "${WORKER_IMAGE}" "install.image.worker_exists" "install.image.pulling_worker"
-            ;;
-    esac
-
-    # Always pull copaw worker image — team workers require copaw runtime
-    if [ "${HICLAW_DEFAULT_WORKER_RUNTIME}" != "copaw" ]; then
-        if ${DOCKER_CMD} image inspect "${COPAW_WORKER_IMAGE}" >/dev/null 2>&1; then
-            log "$(msg "install.image.worker_exists" "${COPAW_WORKER_IMAGE}")"
-        else
-            _pull_image "${COPAW_WORKER_IMAGE}" "install.image.worker_exists" "install.image.pulling_worker" || \
-                log "Warning: copaw worker image not available, team features may not work"
-        fi
-    fi
-
-    # During upgrade, also pull the other worker images if containers using them exist locally.
-    if [ "${HICLAW_UPGRADE:-0}" = "1" ]; then
-        if [ "${HICLAW_DEFAULT_WORKER_RUNTIME}" != "openclaw" ]; then
-            if ${DOCKER_CMD} image inspect "${WORKER_IMAGE}" >/dev/null 2>&1; then
-                _pull_image "${WORKER_IMAGE}" "install.image.worker_exists" "install.image.pulling_worker"
-            fi
-        fi
-        if [ "${HICLAW_DEFAULT_WORKER_RUNTIME}" != "hermes" ]; then
-            if ${DOCKER_CMD} image inspect "${HERMES_WORKER_IMAGE}" >/dev/null 2>&1; then
-                _pull_image "${HERMES_WORKER_IMAGE}" "install.image.worker_exists" "install.image.pulling_worker"
-            fi
-        fi
-    fi
+    # Pull all worker runtime images (workers may use any runtime regardless of the default)
+    _pull_image "${WORKER_IMAGE}" "install.image.worker_exists" "install.image.pulling_worker"
+    _pull_image "${COPAW_WORKER_IMAGE}" "install.image.worker_exists" "install.image.pulling_worker"
+    _pull_image "${HERMES_WORKER_IMAGE}" "install.image.worker_exists" "install.image.pulling_worker"
 
     # --- Pre-upgrade: extract Matrix passwords from running old containers ---
     # Only needed when upgrading FROM old architecture (v1.0.9) TO embedded.


### PR DESCRIPTION
## Summary

- **Always pull all worker images**: The install scripts no longer consider the user's configured default worker runtime when deciding which worker images to pull. All three runtimes (openclaw, copaw, hermes) are always pulled, since workers may use any runtime regardless of the default setting. Manager images still respect the configured runtime and only pull the matching image.
- **Sync ps1 with sh since v1.0.9**: Applied missing changes from `hiclaw-install.sh` to `hiclaw-install.ps1`:
  - Pull all worker runtime images unconditionally (same as sh)
  - Add `hermes` to env file runtime comment (`openclaw | copaw` → `openclaw | copaw | hermes`)
  - Add missing `config.HERMES_WORKER_IMAGE` assignment for env file template
  - Add `HICLAW_MATRIX_DEBUG` passthrough to manager container
  - Add backward compat for `HICLAW_INSTALL_DOCKER_PROXY_IMAGE` env var (renamed to controller)
  - Add reinstall warn/cleanup for `hiclaw-controller` container
  - Add legacy container cleanup (e.g. `hiclaw-docker-proxy` from v1.0.x)

## Test plan

- [ ] Run `hiclaw-install.sh` with `HICLAW_DEFAULT_WORKER_RUNTIME=openclaw` and verify all 3 worker images are pulled
- [ ] Run `hiclaw-install.sh` with `HICLAW_DEFAULT_WORKER_RUNTIME=copaw` and verify all 3 worker images are pulled
- [ ] Run `hiclaw-install.sh` with `HICLAW_MANAGER_RUNTIME=copaw` and verify only copaw manager image is pulled
- [ ] Run `hiclaw-install.ps1` on Windows and verify all 3 worker images are pulled
- [ ] Verify reinstall on ps1 properly cleans up `hiclaw-controller` container


Made with [Cursor](https://cursor.com)