### PR TITLE
ci(helm): manual dispatch input, bump higress 2.2.1, document Helm install

### DIFF
--- a/.github/workflows/deploy-helm-to-oss.yml
+++ b/.github/workflows/deploy-helm-to-oss.yml
@@ -3,17 +3,38 @@ name: Deploy Helm Chart to OSS
 on:
   push:
     tags:
-    - "v*.*.*"
-  workflow_dispatch: ~
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. v1.2.3)'
+        required: true
+        type: string
 
 jobs:
   deploy-helm-to-oss:
     runs-on: ubuntu-latest
-    environment:
-      name: oss
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - id: calc-version
+        name: Resolve version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RAW_VERSION="${{ github.event.inputs.version }}"
+          else
+            RAW_VERSION="${{ github.ref_name }}"
+          fi
+          # Validate format: vX.Y.Z optionally followed by a pre-release suffix (e.g. -rc1, -beta.2)
+          if ! echo "${RAW_VERSION}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "ERROR: invalid version format: ${RAW_VERSION} (expected vX.Y.Z or vX.Y.Z-suffix)"
+            exit 1
+          fi
+          # Helm chart version must not have the leading 'v'
+          VERSION="${RAW_VERSION#v}"
+          echo "Version=${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Download Helm Charts Index
         uses: go-choppy/ossutil-github-action@master
@@ -22,13 +43,6 @@ jobs:
           accessKey: ${{ secrets.ACCESS_KEYID }}
           accessSecret: ${{ secrets.ACCESS_KEYSECRET }}
           endpoint: oss-cn-hongkong.aliyuncs.com
-
-      - id: calc-version
-        name: Calculate Version Number
-        run: |
-          version=$(echo ${{ github.ref_name }} | cut -c2-)
-          echo "Version=$version"
-          echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Build Artifact
         uses: stefanprodan/kube-tools@v1

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -106,6 +106,64 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; $wc=New-Object Net.WebClient; 
 
 すべての HiClaw コンテナ（Manager、Worker、docker-proxy）、Docker ボリューム、ネットワーク、env ファイル、ワークスペースディレクトリ、インストールログが削除されます。
 
+## Kubernetes へのインストール（Helm）
+
+チーム共有や本番運用では、公式 Helm Chart を使って任意の Kubernetes クラスタに HiClaw をインストールできます。デフォルト構成には Higress AI ゲートウェイ、Tuwunel（Matrix）、MinIO、HiClaw Controller がすべて含まれており、外部依存はありません。
+
+**前提条件**
+
+- Kubernetes 1.24+（kind / minikube / k3s / マネージド K8s すべて対応）
+- Helm 3.7+
+- デフォルトの StorageClass（Tuwunel と MinIO の PVC 用）
+
+**インストール**
+
+```bash
+helm repo add higress.io https://higress.io/helm-charts
+helm repo update
+
+helm install hiclaw higress.io/hiclaw \
+  -n hiclaw-system --create-namespace \
+  --render-subchart-notes \
+  --set credentials.llmApiKey=<your-llm-api-key> \
+  --set credentials.adminPassword=<your-admin-password> \
+  --set gateway.publicURL=http://localhost:18080
+```
+
+| 値 | 必須 | 説明 |
+|---|---|---|
+| `credentials.llmApiKey` | 必須 | LLM プロバイダーの API キー |
+| `gateway.publicURL` | 必須 | ユーザーが Element Web にアクセスする公開 URL（port-forward 環境では `http://localhost:18080`、本番では `https://hiclaw.example.com` 等） |
+| `credentials.adminPassword` | 推奨 | Matrix 管理者パスワード。空のままだと自動生成（後で Secret から読み出す必要あり） |
+| `credentials.llmProvider` | 任意 | LLM プロバイダー名、デフォルトは `qwen` |
+| `credentials.defaultModel` | 任意 | デフォルトモデル、例: `qwen3.5-plus` |
+
+設定可能な全パラメータ（ゲートウェイ／ストレージの provider、イメージタグ、リソース、永続化など）は [`helm/hiclaw/values.yaml`](helm/hiclaw/values.yaml) を参照してください。
+
+**アクセス**
+
+```bash
+kubectl port-forward -n hiclaw-system svc/higress-gateway 18080:80
+```
+
+ブラウザで http://localhost:18080 を開き Element Web にログインしてください。本番クラスタでは Ingress / LoadBalancer / DNS を `svc/higress-gateway` に向け、それに合わせて `gateway.publicURL` を設定してください。
+
+**アップグレード**
+
+```bash
+helm repo update
+helm upgrade hiclaw higress.io/hiclaw -n hiclaw-system --reuse-values
+```
+
+**アンインストール**
+
+```bash
+helm uninstall hiclaw -n hiclaw-system
+kubectl delete namespace hiclaw-system
+```
+
+Kubernetes ネイティブなアーキテクチャ（CRD、Controller、宣言的な `Worker` / `Team` / `Human` リソース）の詳細は [docs/k8s-native-agent-orch.md](docs/k8s-native-agent-orch.md) を参照してください。
+
 ## 仕組み
 
 ### Manager — あなたの AI チーフオブスタッフ

--- a/README.md
+++ b/README.md
@@ -106,6 +106,64 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; $wc=New-Object Net.WebClient; 
 
 This removes all HiClaw containers (Manager, Workers, docker-proxy), Docker volume, network, env file, workspace directory, and install log.
 
+## Install on Kubernetes (Helm)
+
+For shared / production deployments you can install HiClaw on any Kubernetes cluster via the official Helm chart. The default profile bundles the Higress AI gateway, Tuwunel (Matrix), MinIO and the HiClaw controller — no external dependencies required.
+
+**Prerequisites**
+
+- Kubernetes 1.24+ (kind / minikube / k3s / managed K8s — all work)
+- Helm 3.7+
+- A default StorageClass (for the Tuwunel + MinIO PVCs)
+
+**Install**
+
+```bash
+helm repo add higress.io https://higress.io/helm-charts
+helm repo update
+
+helm install hiclaw higress.io/hiclaw \
+  -n hiclaw-system --create-namespace \
+  --render-subchart-notes \
+  --set credentials.llmApiKey=<your-llm-api-key> \
+  --set credentials.adminPassword=<your-admin-password> \
+  --set gateway.publicURL=http://localhost:18080
+```
+
+| Value | Required | Description |
+|---|---|---|
+| `credentials.llmApiKey` | yes | API key for your LLM provider |
+| `gateway.publicURL` | yes | Public URL where users will reach Element Web (e.g. `http://localhost:18080` for port-forward, or `https://hiclaw.example.com` for an Ingress) |
+| `credentials.adminPassword` | recommended | Matrix admin password; auto-generated if left empty (you'll have to read it back from the Secret) |
+| `credentials.llmProvider` | no | LLM provider name, defaults to `qwen` |
+| `credentials.defaultModel` | no | Default model, e.g. `qwen3.5-plus` |
+
+For all configurable values (gateway/storage providers, image tags, resources, persistence, etc.) see [`helm/hiclaw/values.yaml`](helm/hiclaw/values.yaml).
+
+**Access**
+
+```bash
+kubectl port-forward -n hiclaw-system svc/higress-gateway 18080:80
+```
+
+Then open http://localhost:18080 in your browser and log in to Element Web. For an actual cluster, configure an Ingress / LoadBalancer / DNS record pointing at `svc/higress-gateway` and set `gateway.publicURL` accordingly.
+
+**Upgrade**
+
+```bash
+helm repo update
+helm upgrade hiclaw higress.io/hiclaw -n hiclaw-system --reuse-values
+```
+
+**Uninstall**
+
+```bash
+helm uninstall hiclaw -n hiclaw-system
+kubectl delete namespace hiclaw-system
+```
+
+For the Kubernetes-native architecture (CRDs, controller, declarative `Worker` / `Team` / `Human` resources), see [docs/k8s-native-agent-orch.md](docs/k8s-native-agent-orch.md).
+
 ## How It Works
 
 ### Manager as Your AI Chief of Staff

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -132,6 +132,64 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; $wc=New-Object Net.WebClient; 
 
 将移除所有 HiClaw 容器（Manager、Worker、docker-proxy）、Docker 卷、网络、env 文件、工作空间目录和安装日志。
 
+## Kubernetes 部署（Helm）
+
+如果希望在团队内共享或生产环境部署 HiClaw，可以使用官方 Helm Chart 在任意 Kubernetes 集群上安装。默认配置内置了 Higress AI 网关、Tuwunel（Matrix）、MinIO 与 HiClaw Controller，无需额外依赖。
+
+**前置条件**
+
+- Kubernetes 1.24+（kind / minikube / k3s / 各类托管 K8s 均可）
+- Helm 3.7+
+- 默认 StorageClass（用于 Tuwunel 与 MinIO 的 PVC）
+
+**安装**
+
+```bash
+helm repo add higress.io https://higress.io/helm-charts
+helm repo update
+
+helm install hiclaw higress.io/hiclaw \
+  -n hiclaw-system --create-namespace \
+  --render-subchart-notes \
+  --set credentials.llmApiKey=<你的-LLM-API-Key> \
+  --set credentials.adminPassword=<你的-管理员密码> \
+  --set gateway.publicURL=http://localhost:18080
+```
+
+| 参数 | 是否必填 | 说明 |
+|---|---|---|
+| `credentials.llmApiKey` | 必填 | LLM 服务商 API Key |
+| `gateway.publicURL` | 必填 | 用户访问 Element Web 的对外地址（端口转发场景填 `http://localhost:18080`，正式环境填 `https://hiclaw.example.com` 等） |
+| `credentials.adminPassword` | 推荐 | Matrix 管理员密码；留空时会自动生成（之后需要从 Secret 中读取） |
+| `credentials.llmProvider` | 可选 | LLM 服务商名，默认 `qwen` |
+| `credentials.defaultModel` | 可选 | 默认模型，例如 `qwen3.5-plus` |
+
+完整可配置项（网关/存储 provider、镜像 tag、资源、持久化等）请参考 [`helm/hiclaw/values.yaml`](helm/hiclaw/values.yaml)。
+
+**访问**
+
+```bash
+kubectl port-forward -n hiclaw-system svc/higress-gateway 18080:80
+```
+
+然后在浏览器中打开 http://localhost:18080 登录 Element Web。生产集群中请通过 Ingress / LoadBalancer / DNS 指向 `svc/higress-gateway`，并相应地修改 `gateway.publicURL`。
+
+**升级**
+
+```bash
+helm repo update
+helm upgrade hiclaw higress.io/hiclaw -n hiclaw-system --reuse-values
+```
+
+**卸载**
+
+```bash
+helm uninstall hiclaw -n hiclaw-system
+kubectl delete namespace hiclaw-system
+```
+
+更深入的 K8s Native 架构说明（CRD、Controller、声明式 `Worker` / `Team` / `Human` 资源）请参考 [docs/zh-cn/k8s-native-agent-orch.md](docs/zh-cn/k8s-native-agent-orch.md)。
+
 ## 工作方式
 
 ### Manager 是你的 AI 管家

--- a/helm/hiclaw/Chart.lock
+++ b/helm/hiclaw/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: higress
   repository: https://higress.io/helm-charts
-  version: 2.2.0
-digest: sha256:d6ba3fd06735cb73e4211cceba1d0b214ecc6433ce5a6ce13f41faefc83b8d6d
-generated: "2026-04-14T15:21:56.393754+08:00"
+  version: 2.2.1
+digest: sha256:bfda3317506f04c1088d398ca7b10137409999ec54e1d36b7b5d525145ee931b
+generated: "2026-04-23T19:13:06.246228+08:00"

--- a/helm/hiclaw/Chart.yaml
+++ b/helm/hiclaw/Chart.yaml
@@ -22,6 +22,6 @@ maintainers:
 
 dependencies:
   - name: higress
-    version: "2.2.0"
+    version: "2.2.1"
     repository: "https://higress.io/helm-charts"
     condition: gateway.higress.enabled


### PR DESCRIPTION
## Summary

- **`deploy-helm-to-oss.yml`**: add `version` input to `workflow_dispatch` (mirroring `release.yml`) so the helm publish flow can be re-run / back-filled for any specific tag without pushing a new git tag. Validate the version up front (`vX.Y.Z[-suffix]`) and strip the leading `v` before handing it to `helm package`. Also drop the unused `environment: oss` reference since OSS access keys live in repository-level secrets.
- **`helm/hiclaw/Chart.yaml`**: bump `higress` sub-chart dependency `2.2.0 → 2.2.1`. `Chart.lock` regenerated via `helm dependency update`.
- **README (en / zh-CN / ja-JP)**: add a parallel **"Install on Kubernetes (Helm)"** section covering install / access / upgrade / uninstall through the official chart at `https://higress.io/helm-charts` (chart name: `hiclaw`). The Docker quick-start flow is left untouched so single-host users see no change. Required values (`credentials.llmApiKey`, `gateway.publicURL`) are documented based on the chart's actual `required` / `fail` calls in `templates/secrets/runtime-env.yaml` and `templates/00-validate.yaml`.

## Test plan

- [x] `helm lint helm/hiclaw/` — passes (1 chart linted, 0 failed)
- [x] `helm dependency update helm/hiclaw/` — pulls `higress-2.2.1.tgz`, `Chart.lock` digest refreshed
- [ ] After merge, manually trigger `Deploy Helm Chart to OSS` with `version=v1.0.10-rc1` (or current tag) to confirm the new dispatch flow publishes correctly to `oss://higress-ai/helm-charts/`
- [ ] Existing tag-push trigger remains compatible (`v*.*.*` pattern unchanged)
- [ ] Once the chart is published, run the documented `helm install` command end-to-end on a kind cluster to validate the README instructions
