### PR TITLE
fix(helm): sync CRDs, add OpenAI-compatible defaults, document multi-region registries

### DIFF
--- a/.github/workflows/check-crd-sync.yml
+++ b/.github/workflows/check-crd-sync.yml
@@ -1,0 +1,26 @@
+name: Check CRD Sync
+
+on:
+  pull_request:
+    paths:
+      - 'hiclaw-controller/config/crd/**'
+      - 'helm/hiclaw/crds/**'
+  workflow_dispatch: ~
+
+jobs:
+  check-crd-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify CRDs are in sync
+        run: |
+          if ! diff -r hiclaw-controller/config/crd/ helm/hiclaw/crds/; then
+            echo ""
+            echo "ERROR: CRD files are out of sync between hiclaw-controller/config/crd/ and helm/hiclaw/crds/"
+            echo "The source of truth is hiclaw-controller/config/crd/."
+            echo "Run 'make sync-crds' to copy them to helm/hiclaw/crds/."
+            exit 1
+          fi
+          echo "CRDs are in sync."

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ LINES          ?= 50
         test test-quick test-installed test-embedded \
         install install-embedded uninstall uninstall-embedded replay replay-log \
         verify wait-ready wait-ready-embedded \
+        sync-crds check-crd-sync \
         status logs \
         mirror-images clean help
 
@@ -726,6 +727,21 @@ local-k8s-up: ## Create kind cluster and deploy HiClaw via Helm
 
 local-k8s-down: ## Tear down the local HiClaw kind cluster
 	@bash hack/local-k8s-down.sh
+
+sync-crds: ## Sync CRDs from hiclaw-controller/config/crd/ to helm/hiclaw/crds/
+	@echo "==> Syncing CRDs to Helm chart..."
+	@cp hiclaw-controller/config/crd/*.yaml helm/hiclaw/crds/
+	@echo "==> CRDs synced"
+
+check-crd-sync: ## Verify CRDs are in sync between controller and Helm chart
+	@if ! diff -r hiclaw-controller/config/crd/ helm/hiclaw/crds/ >/dev/null 2>&1; then \
+		echo "ERROR: CRD files are out of sync."; \
+		echo "Source of truth: hiclaw-controller/config/crd/"; \
+		echo "Run 'make sync-crds' to fix."; \
+		diff -r hiclaw-controller/config/crd/ helm/hiclaw/crds/; \
+		exit 1; \
+	fi
+	@echo "==> CRDs are in sync"
 
 helm-lint: ## Lint Helm chart
 	@helm dependency build helm/hiclaw/

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -165,7 +165,7 @@ helm install hiclaw higress.io/hiclaw \
 | `gateway.publicURL` | 必須 | ユーザーが Element Web にアクセスする公開 URL（port-forward 環境では `http://localhost:18080`、本番では `https://hiclaw.example.com` 等） |
 | `credentials.adminPassword` | 推奨 | Matrix 管理者パスワード。空のままだと自動生成（後で Secret から読み出す必要あり） |
 | `credentials.llmProvider` | 任意 | LLM プロバイダー名、デフォルトは `openai` |
-| `credentials.defaultModel` | 任意 | デフォルトモデル、デフォルトは `gpt-4o` |
+| `credentials.defaultModel` | 任意 | デフォルトモデル、デフォルトは `gpt-5.4` |
 | `credentials.llmBaseUrl` | 任意 | OpenAI 互換のベース URL（例: `https://api.deepseek.com/v1`）。公式 OpenAI API を使用する場合は空のまま |
 
 **マルチリージョンイメージレジストリ**

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -116,7 +116,7 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; $wc=New-Object Net.WebClient; 
 - Helm 3.7+
 - デフォルトの StorageClass（Tuwunel と MinIO の PVC 用）
 
-**インストール**
+**インストール（OpenAI / OpenAI 互換モード）**
 
 ```bash
 helm repo add higress.io https://higress.io/helm-charts
@@ -125,18 +125,69 @@ helm repo update
 helm install hiclaw higress.io/hiclaw \
   -n hiclaw-system --create-namespace \
   --render-subchart-notes \
-  --set credentials.llmApiKey=<your-llm-api-key> \
+  --set credentials.llmApiKey=<your-api-key> \
   --set credentials.adminPassword=<your-admin-password> \
   --set gateway.publicURL=http://localhost:18080
 ```
+
+OpenAI 互換 API を提供する他のプロバイダーを使用する場合は、`llmBaseUrl` も設定してください：
+
+```bash
+helm install hiclaw higress.io/hiclaw \
+  -n hiclaw-system --create-namespace \
+  --render-subchart-notes \
+  --set credentials.llmApiKey=<your-api-key> \
+  --set credentials.llmBaseUrl=https://your-provider.example.com/v1 \
+  --set credentials.defaultModel=your-model-name \
+  --set credentials.adminPassword=<your-admin-password> \
+  --set gateway.publicURL=http://localhost:18080
+```
+
+<details>
+<summary>Qwen（通義千問）を使用する場合</summary>
+
+```bash
+helm install hiclaw higress.io/hiclaw \
+  -n hiclaw-system --create-namespace \
+  --render-subchart-notes \
+  --set credentials.llmApiKey=<your-qwen-api-key> \
+  --set credentials.llmProvider=qwen \
+  --set credentials.defaultModel=qwen3.5-plus \
+  --set credentials.adminPassword=<your-admin-password> \
+  --set gateway.publicURL=http://localhost:18080
+```
+
+</details>
 
 | 値 | 必須 | 説明 |
 |---|---|---|
 | `credentials.llmApiKey` | 必須 | LLM プロバイダーの API キー |
 | `gateway.publicURL` | 必須 | ユーザーが Element Web にアクセスする公開 URL（port-forward 環境では `http://localhost:18080`、本番では `https://hiclaw.example.com` 等） |
 | `credentials.adminPassword` | 推奨 | Matrix 管理者パスワード。空のままだと自動生成（後で Secret から読み出す必要あり） |
-| `credentials.llmProvider` | 任意 | LLM プロバイダー名、デフォルトは `qwen` |
-| `credentials.defaultModel` | 任意 | デフォルトモデル、例: `qwen3.5-plus` |
+| `credentials.llmProvider` | 任意 | LLM プロバイダー名、デフォルトは `openai` |
+| `credentials.defaultModel` | 任意 | デフォルトモデル、デフォルトは `gpt-4o` |
+| `credentials.llmBaseUrl` | 任意 | OpenAI 互換のベース URL（例: `https://api.deepseek.com/v1`）。公式 OpenAI API を使用する場合は空のまま |
+
+**マルチリージョンイメージレジストリ**
+
+デフォルトの `global.imageRegistry` は中国リージョン（`higress-registry.cn-hangzhou.cr.aliyuncs.com/higress`）を指しています。中国大陸以外にデプロイする場合は、近いリージョンに切り替えてイメージプルを高速化できます：
+
+| リージョン | レジストリ |
+|---|---|
+| 中国（デフォルト） | `higress-registry.cn-hangzhou.cr.aliyuncs.com/higress` |
+| 北米 | `higress-registry.us-west-1.cr.aliyuncs.com/higress` |
+| 東南アジア | `higress-registry.ap-southeast-7.cr.aliyuncs.com/higress` |
+
+```bash
+# 例: 北米リージョンのレジストリを使用してデプロイ
+helm install hiclaw higress.io/hiclaw \
+  -n hiclaw-system --create-namespace \
+  --render-subchart-notes \
+  --set global.imageRegistry=higress-registry.us-west-1.cr.aliyuncs.com/higress \
+  --set credentials.llmApiKey=<your-api-key> \
+  --set credentials.adminPassword=<your-admin-password> \
+  --set gateway.publicURL=http://localhost:18080
+```
 
 設定可能な全パラメータ（ゲートウェイ／ストレージの provider、イメージタグ、リソース、永続化など）は [`helm/hiclaw/values.yaml`](helm/hiclaw/values.yaml) を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ helm install hiclaw higress.io/hiclaw \
 | `gateway.publicURL` | yes | Public URL where users will reach Element Web (e.g. `http://localhost:18080` for port-forward, or `https://hiclaw.example.com` for an Ingress) |
 | `credentials.adminPassword` | recommended | Matrix admin password; auto-generated if left empty (you'll have to read it back from the Secret) |
 | `credentials.llmProvider` | no | LLM provider name, defaults to `openai` |
-| `credentials.defaultModel` | no | Default model, defaults to `gpt-4o` |
+| `credentials.defaultModel` | no | Default model, defaults to `gpt-5.4` |
 | `credentials.llmBaseUrl` | no | OpenAI-compatible base URL (e.g. `https://api.deepseek.com/v1`). Leave empty for official OpenAI API |
 
 **Multi-Region Image Registry**

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ For shared / production deployments you can install HiClaw on any Kubernetes clu
 - Helm 3.7+
 - A default StorageClass (for the Tuwunel + MinIO PVCs)
 
-**Install**
+**Install (OpenAI / OpenAI-compatible)**
 
 ```bash
 helm repo add higress.io https://higress.io/helm-charts
@@ -125,18 +125,69 @@ helm repo update
 helm install hiclaw higress.io/hiclaw \
   -n hiclaw-system --create-namespace \
   --render-subchart-notes \
-  --set credentials.llmApiKey=<your-llm-api-key> \
+  --set credentials.llmApiKey=<your-api-key> \
   --set credentials.adminPassword=<your-admin-password> \
   --set gateway.publicURL=http://localhost:18080
 ```
+
+For non-OpenAI providers that expose an OpenAI-compatible API, also set `llmBaseUrl`:
+
+```bash
+helm install hiclaw higress.io/hiclaw \
+  -n hiclaw-system --create-namespace \
+  --render-subchart-notes \
+  --set credentials.llmApiKey=<your-api-key> \
+  --set credentials.llmBaseUrl=https://your-provider.example.com/v1 \
+  --set credentials.defaultModel=your-model-name \
+  --set credentials.adminPassword=<your-admin-password> \
+  --set gateway.publicURL=http://localhost:18080
+```
+
+<details>
+<summary>Using Qwen (通义千问) instead</summary>
+
+```bash
+helm install hiclaw higress.io/hiclaw \
+  -n hiclaw-system --create-namespace \
+  --render-subchart-notes \
+  --set credentials.llmApiKey=<your-qwen-api-key> \
+  --set credentials.llmProvider=qwen \
+  --set credentials.defaultModel=qwen3.5-plus \
+  --set credentials.adminPassword=<your-admin-password> \
+  --set gateway.publicURL=http://localhost:18080
+```
+
+</details>
 
 | Value | Required | Description |
 |---|---|---|
 | `credentials.llmApiKey` | yes | API key for your LLM provider |
 | `gateway.publicURL` | yes | Public URL where users will reach Element Web (e.g. `http://localhost:18080` for port-forward, or `https://hiclaw.example.com` for an Ingress) |
 | `credentials.adminPassword` | recommended | Matrix admin password; auto-generated if left empty (you'll have to read it back from the Secret) |
-| `credentials.llmProvider` | no | LLM provider name, defaults to `qwen` |
-| `credentials.defaultModel` | no | Default model, e.g. `qwen3.5-plus` |
+| `credentials.llmProvider` | no | LLM provider name, defaults to `openai` |
+| `credentials.defaultModel` | no | Default model, defaults to `gpt-4o` |
+| `credentials.llmBaseUrl` | no | OpenAI-compatible base URL (e.g. `https://api.deepseek.com/v1`). Leave empty for official OpenAI API |
+
+**Multi-Region Image Registry**
+
+The default `global.imageRegistry` points to the China region (`higress-registry.cn-hangzhou.cr.aliyuncs.com/higress`). If you are deploying outside China, override it for faster image pulls:
+
+| Region | Registry |
+|---|---|
+| China (default) | `higress-registry.cn-hangzhou.cr.aliyuncs.com/higress` |
+| North America | `higress-registry.us-west-1.cr.aliyuncs.com/higress` |
+| Southeast Asia | `higress-registry.ap-southeast-7.cr.aliyuncs.com/higress` |
+
+```bash
+# Example: deploy from the North America registry
+helm install hiclaw higress.io/hiclaw \
+  -n hiclaw-system --create-namespace \
+  --render-subchart-notes \
+  --set global.imageRegistry=higress-registry.us-west-1.cr.aliyuncs.com/higress \
+  --set credentials.llmApiKey=<your-api-key> \
+  --set credentials.adminPassword=<your-admin-password> \
+  --set gateway.publicURL=http://localhost:18080
+```
 
 For all configurable values (gateway/storage providers, image tags, resources, persistence, etc.) see [`helm/hiclaw/values.yaml`](helm/hiclaw/values.yaml).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -191,7 +191,7 @@ helm install hiclaw higress.io/hiclaw \
 | `gateway.publicURL` | 必填 | 用户访问 Element Web 的对外地址（端口转发场景填 `http://localhost:18080`，正式环境填 `https://hiclaw.example.com` 等） |
 | `credentials.adminPassword` | 推荐 | Matrix 管理员密码；留空时会自动生成（之后需要从 Secret 中读取） |
 | `credentials.llmProvider` | 可选 | LLM 服务商名，默认 `openai` |
-| `credentials.defaultModel` | 可选 | 默认模型，默认 `gpt-4o` |
+| `credentials.defaultModel` | 可选 | 默认模型，默认 `gpt-5.4` |
 | `credentials.llmBaseUrl` | 可选 | OpenAI 兼容的 Base URL（例如 `https://api.deepseek.com/v1`）。使用官方 OpenAI API 时留空 |
 
 **多地域镜像仓库**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -142,7 +142,7 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; $wc=New-Object Net.WebClient; 
 - Helm 3.7+
 - 默认 StorageClass（用于 Tuwunel 与 MinIO 的 PVC）
 
-**安装**
+**安装（OpenAI / OpenAI 兼容模式）**
 
 ```bash
 helm repo add higress.io https://higress.io/helm-charts
@@ -151,18 +151,69 @@ helm repo update
 helm install hiclaw higress.io/hiclaw \
   -n hiclaw-system --create-namespace \
   --render-subchart-notes \
-  --set credentials.llmApiKey=<你的-LLM-API-Key> \
+  --set credentials.llmApiKey=<你的-API-Key> \
   --set credentials.adminPassword=<你的-管理员密码> \
   --set gateway.publicURL=http://localhost:18080
 ```
+
+如果使用非 OpenAI 但兼容 OpenAI API 的服务商，还需设置 `llmBaseUrl`：
+
+```bash
+helm install hiclaw higress.io/hiclaw \
+  -n hiclaw-system --create-namespace \
+  --render-subchart-notes \
+  --set credentials.llmApiKey=<你的-API-Key> \
+  --set credentials.llmBaseUrl=https://your-provider.example.com/v1 \
+  --set credentials.defaultModel=your-model-name \
+  --set credentials.adminPassword=<你的-管理员密码> \
+  --set gateway.publicURL=http://localhost:18080
+```
+
+<details>
+<summary>使用通义千问（Qwen）</summary>
+
+```bash
+helm install hiclaw higress.io/hiclaw \
+  -n hiclaw-system --create-namespace \
+  --render-subchart-notes \
+  --set credentials.llmApiKey=<你的-通义千问-API-Key> \
+  --set credentials.llmProvider=qwen \
+  --set credentials.defaultModel=qwen3.5-plus \
+  --set credentials.adminPassword=<你的-管理员密码> \
+  --set gateway.publicURL=http://localhost:18080
+```
+
+</details>
 
 | 参数 | 是否必填 | 说明 |
 |---|---|---|
 | `credentials.llmApiKey` | 必填 | LLM 服务商 API Key |
 | `gateway.publicURL` | 必填 | 用户访问 Element Web 的对外地址（端口转发场景填 `http://localhost:18080`，正式环境填 `https://hiclaw.example.com` 等） |
 | `credentials.adminPassword` | 推荐 | Matrix 管理员密码；留空时会自动生成（之后需要从 Secret 中读取） |
-| `credentials.llmProvider` | 可选 | LLM 服务商名，默认 `qwen` |
-| `credentials.defaultModel` | 可选 | 默认模型，例如 `qwen3.5-plus` |
+| `credentials.llmProvider` | 可选 | LLM 服务商名，默认 `openai` |
+| `credentials.defaultModel` | 可选 | 默认模型，默认 `gpt-4o` |
+| `credentials.llmBaseUrl` | 可选 | OpenAI 兼容的 Base URL（例如 `https://api.deepseek.com/v1`）。使用官方 OpenAI API 时留空 |
+
+**多地域镜像仓库**
+
+默认 `global.imageRegistry` 指向中国区域（`higress-registry.cn-hangzhou.cr.aliyuncs.com/higress`）。如果在中国大陆以外部署，可切换至就近区域以加速镜像拉取：
+
+| 区域 | Registry |
+|---|---|
+| 中国（默认） | `higress-registry.cn-hangzhou.cr.aliyuncs.com/higress` |
+| 北美 | `higress-registry.us-west-1.cr.aliyuncs.com/higress` |
+| 东南亚 | `higress-registry.ap-southeast-7.cr.aliyuncs.com/higress` |
+
+```bash
+# 示例：使用北美镜像仓库部署
+helm install hiclaw higress.io/hiclaw \
+  -n hiclaw-system --create-namespace \
+  --render-subchart-notes \
+  --set global.imageRegistry=higress-registry.us-west-1.cr.aliyuncs.com/higress \
+  --set credentials.llmApiKey=<你的-API-Key> \
+  --set credentials.adminPassword=<你的-管理员密码> \
+  --set gateway.publicURL=http://localhost:18080
+```
 
 完整可配置项（网关/存储 provider、镜像 tag、资源、持久化等）请参考 [`helm/hiclaw/values.yaml`](helm/hiclaw/values.yaml)。
 

--- a/helm/hiclaw/crds/managers.hiclaw.io.yaml
+++ b/helm/hiclaw/crds/managers.hiclaw.io.yaml
@@ -28,13 +28,13 @@ spec:
                     to "openclaw" if neither is set.
                 image:
                   type: string
-                  description: Custom Docker image for the Manager agent
+                  description: Custom Docker image for the Manager Agent
                 soul:
                   type: string
-                  description: Custom SOUL.md content (overrides image default)
+                  description: Custom SOUL.md content
                 agents:
                   type: string
-                  description: Custom AGENTS.md content (overrides image default)
+                  description: Custom AGENTS.md content
                 skills:
                   type: array
                   items:
@@ -44,10 +44,14 @@ spec:
                   type: array
                   items:
                     type: string
-                  description: MCP Servers to authorize via Gateway
+                  description: MCP servers to authorize via Gateway
                 package:
                   type: string
-                  description: "Package URI: file://, http(s)://, nacos://, or packages/{name}.zip"
+                  description: "Package URI: file://, http(s)://, or nacos://"
+                state:
+                  type: string
+                  enum: [Running, Sleeping, Stopped]
+                  description: "Desired lifecycle state (default: Running). The controller reconciles actual state toward this."
                 config:
                   type: object
                   properties:
@@ -59,7 +63,7 @@ spec:
                       description: "Worker idle timeout before auto-sleep (default: 720m)"
                     notifyChannel:
                       type: string
-                      description: "Admin notification channel (default: admin-dm)"
+                      description: "Notification channel (default: admin-dm)"
                 accessEntries:
                   type: array
                   description: >
@@ -98,15 +102,13 @@ spec:
                 observedGeneration:
                   type: integer
                   format: int64
-                  description: Last spec generation reconciled by the controller
                 phase:
                   type: string
-                  enum: [Pending, Running, Updating, Failed]
+                  enum: [Pending, Running, Sleeping, Updating, Stopped, Failed]
                 matrixUserID:
                   type: string
                 roomID:
                   type: string
-                  description: Admin DM room ID
                 containerState:
                   type: string
                 version:

--- a/helm/hiclaw/crds/workers.hiclaw.io.yaml
+++ b/helm/hiclaw/crds/workers.hiclaw.io.yaml
@@ -131,7 +131,6 @@ spec:
                 observedGeneration:
                   type: integer
                   format: int64
-                  description: Last spec generation reconciled by the controller
                 phase:
                   type: string
                   enum: [Pending, Running, Sleeping, Updating, Stopped, Failed]

--- a/helm/hiclaw/templates/secrets/runtime-env.yaml
+++ b/helm/hiclaw/templates/secrets/runtime-env.yaml
@@ -30,3 +30,6 @@ stringData:
   HICLAW_LLM_API_KEY: {{ required "credentials.llmApiKey is required" .Values.credentials.llmApiKey | quote }}
   HICLAW_LLM_PROVIDER: {{ .Values.credentials.llmProvider | quote }}
   HICLAW_DEFAULT_MODEL: {{ .Values.credentials.defaultModel | quote }}
+  {{- if .Values.credentials.llmBaseUrl }}
+  HICLAW_OPENAI_BASE_URL: {{ .Values.credentials.llmBaseUrl | quote }}
+  {{- end }}

--- a/helm/hiclaw/values.yaml
+++ b/helm/hiclaw/values.yaml
@@ -18,8 +18,9 @@ credentials:
   adminUser: "admin"
   adminPassword: ""           # Matrix admin password (auto-generated if empty)
   llmApiKey: ""               # LLM API key (required)
-  llmProvider: "qwen"
-  defaultModel: "qwen3.5-plus"
+  llmProvider: "openai"
+  defaultModel: "gpt-4o"
+  llmBaseUrl: ""              # OpenAI-compatible base URL (e.g. https://api.openai.com/v1)
 
 # ── Matrix ────────────────────────────────────────────────────────────────
 matrix:

--- a/helm/hiclaw/values.yaml
+++ b/helm/hiclaw/values.yaml
@@ -19,7 +19,7 @@ credentials:
   adminPassword: ""           # Matrix admin password (auto-generated if empty)
   llmApiKey: ""               # LLM API key (required)
   llmProvider: "openai"
-  defaultModel: "gpt-4o"
+  defaultModel: "gpt-5.4"
   llmBaseUrl: ""              # OpenAI-compatible base URL (e.g. https://api.openai.com/v1)
 
 # ── Matrix ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **CRD sync**: Copy CRDs from `hiclaw-controller/config/crd/` (source of truth) to `helm/hiclaw/crds/` to fix field drift (managers CRD missing `state` enum, updated descriptions; workers CRD stale `observedGeneration` description). Add a CI workflow (`.github/workflows/check-crd-sync.yml`) that fails PRs when the two directories diverge, and `make sync-crds` / `make check-crd-sync` Makefile targets for local use.
- **OpenAI-compatible defaults**: Change `values.yaml` defaults from `qwen`/`qwen3.5-plus` to `openai`/`gpt-4o` for better out-of-box experience with the most common LLM provider. Add `credentials.llmBaseUrl` field and wire `HICLAW_OPENAI_BASE_URL` into the `runtime-env` Secret template so any OpenAI-compatible provider (DeepSeek, Azure OpenAI, local vLLM, etc.) can be configured purely through Helm values.
- **Multi-region registry docs**: Document the three available image registries (China, North America, Southeast Asia) in the Helm install section of all three READMEs (EN/ZH/JA), with `--set global.imageRegistry=...` examples. Add Qwen as a collapsible alternative install example.

## Test plan

- [ ] `make check-crd-sync` passes (CRDs identical)
- [ ] `make helm-template` renders successfully with the new `llmBaseUrl` field
- [ ] `make helm-lint` passes
- [ ] CI `check-crd-sync` workflow triggers on PR and passes
- [ ] Verify README rendering on GitHub (collapsible sections, tables, code blocks)


Made with [Cursor](https://cursor.com)