### PR TITLE
fix(helm): add ClusterRole for CRD access and auto-derive imageTag from Chart.AppVersion

### DIFF
--- a/helm/hiclaw/templates/_helpers.tpl
+++ b/helm/hiclaw/templates/_helpers.tpl
@@ -47,11 +47,30 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 
 {{/*
+Global image tag: uses explicit global.imageTag if set, otherwise derives from Chart.AppVersion.
+Usage: include "hiclaw.globalImageTag" .
+*/}}
+{{- define "hiclaw.globalImageTag" -}}
+{{- if .Values.global.imageTag }}
+{{-   .Values.global.imageTag }}
+{{- else }}
+{{-   printf "v%s" .Chart.AppVersion }}
+{{- end }}
+{{- end }}
+
+{{/*
 Image tag: defaults to global.imageTag.
-Usage: include "hiclaw.imageTag" (dict "tag" .Values.foo.image.tag "global" .Values.global)
+Usage: include "hiclaw.imageTag" (dict "tag" .Values.foo.image.tag "global" .Values.global "root" $)
 */}}
 {{- define "hiclaw.imageTag" -}}
-{{- default .global.imageTag .tag }}
+{{- $tag := .tag }}
+{{- if not $tag }}
+{{-   $tag = .global.imageTag }}
+{{- end }}
+{{- if not $tag }}
+{{-   $tag = printf "v%s" .root.Chart.AppVersion }}
+{{- end }}
+{{- $tag }}
 {{- end }}
 
 {{/*
@@ -148,23 +167,23 @@ app.kubernetes.io/component: {{ .component }}
 {{/* ── Manager image helper (used by controller to create Manager CR) ──── */}}
 
 {{- define "hiclaw.manager.image" -}}
-{{- $tag := default .Values.global.imageTag .Values.manager.image.tag }}
+{{- $tag := default (include "hiclaw.globalImageTag" .) .Values.manager.image.tag }}
 {{- printf "%s:%s" .Values.manager.image.repository $tag }}
 {{- end }}
 
 {{/* ── Worker image helpers ────────────────────────────────────────────── */}}
 
 {{- define "hiclaw.worker.openclawImage" -}}
-{{- $tag := default .Values.global.imageTag .Values.worker.defaultImage.openclaw.tag }}
+{{- $tag := default (include "hiclaw.globalImageTag" .) .Values.worker.defaultImage.openclaw.tag }}
 {{- printf "%s:%s" .Values.worker.defaultImage.openclaw.repository $tag }}
 {{- end }}
 
 {{- define "hiclaw.worker.copawImage" -}}
-{{- $tag := default .Values.global.imageTag .Values.worker.defaultImage.copaw.tag }}
+{{- $tag := default (include "hiclaw.globalImageTag" .) .Values.worker.defaultImage.copaw.tag }}
 {{- printf "%s:%s" .Values.worker.defaultImage.copaw.repository $tag }}
 {{- end }}
 
 {{- define "hiclaw.worker.hermesImage" -}}
-{{- $tag := default .Values.global.imageTag .Values.worker.defaultImage.hermes.tag }}
+{{- $tag := default (include "hiclaw.globalImageTag" .) .Values.worker.defaultImage.hermes.tag }}
 {{- printf "%s:%s" .Values.worker.defaultImage.hermes.repository $tag }}
 {{- end }}

--- a/helm/hiclaw/templates/controller/deployment.yaml
+++ b/helm/hiclaw/templates/controller/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $comp := dict "root" . "component" "controller" }}
-{{- $tag := include "hiclaw.imageTag" (dict "tag" .Values.controller.image.tag "global" .Values.global) }}
+{{- $tag := include "hiclaw.imageTag" (dict "tag" .Values.controller.image.tag "global" .Values.global "root" $) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -191,7 +191,7 @@ spec:
             periodSeconds: 20
             failureThreshold: 3
         {{- if .Values.credentialProvider.enabled }}
-        {{- $cpTag := include "hiclaw.imageTag" (dict "tag" .Values.credentialProvider.image.tag "global" .Values.global) }}
+        {{- $cpTag := include "hiclaw.imageTag" (dict "tag" .Values.credentialProvider.image.tag "global" .Values.global "root" $) }}
         - name: credential-provider
           image: "{{ required "credentialProvider.image.repository is required" .Values.credentialProvider.image.repository }}:{{ $cpTag }}"
           imagePullPolicy: {{ .Values.credentialProvider.image.pullPolicy | default "IfNotPresent" }}

--- a/helm/hiclaw/templates/controller/rbac.yaml
+++ b/helm/hiclaw/templates/controller/rbac.yaml
@@ -28,12 +28,6 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
-  - apiGroups: ["hiclaw.io"]
-    resources: ["workers", "teams", "humans", "managers"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["hiclaw.io"]
-    resources: ["workers/status", "teams/status", "humans/status", "managers/status"]
-    verbs: ["get", "update", "patch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
@@ -66,6 +60,20 @@ rules:
     verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "hiclaw.controller.fullname" . }}-crd
+  labels:
+    {{- include "hiclaw.component.labels" (dict "root" . "component" "controller") | nindent 4 }}
+rules:
+  - apiGroups: ["hiclaw.io"]
+    resources: ["workers", "teams", "humans", "managers"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["hiclaw.io"]
+    resources: ["workers/status", "teams/status", "humans/status", "managers/status"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "hiclaw.controller.fullname" . }}-tokenreview
@@ -75,6 +83,21 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ include "hiclaw.controller.fullname" . }}-tokenreview
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "hiclaw.controller.serviceAccountName" . }}
+    namespace: {{ include "hiclaw.namespace" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "hiclaw.controller.fullname" . }}-crd
+  labels:
+    {{- include "hiclaw.component.labels" (dict "root" . "component" "controller") | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "hiclaw.controller.fullname" . }}-crd
 subjects:
   - kind: ServiceAccount
     name: {{ include "hiclaw.controller.serviceAccountName" . }}

--- a/helm/hiclaw/values.yaml
+++ b/helm/hiclaw/values.yaml
@@ -8,7 +8,7 @@
 global:
   namespace: ""  # defaults to .Release.Namespace
   imageRegistry: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress
-  imageTag: "v1.0.9"
+  imageTag: ""
 
 imagePullSecrets: []
 


### PR DESCRIPTION
## Summary

Two fixes for the Helm chart discovered during testing with `helm install` on a kind cluster:

### 1. ClusterRole for CRD access

The controller could not start because CRDs (`workers`, `teams`, `humans`, `managers` in `hiclaw.io` API group) are cluster-scoped, but the Helm chart only provided a namespace-scoped Role. This caused:

```
workers.hiclaw.io is forbidden: User "system:serviceaccount:hiclaw-system:hiclaw-controller"
cannot list resource "workers" in API group "hiclaw.io" at the cluster scope
```

**Fix:** Move `hiclaw.io` RBAC rules to a new `ClusterRole` + `ClusterRoleBinding` (suffixed `-crd`). The namespace-scoped Role is kept for core resources (pods, secrets, configmaps, etc.).

### 2. Auto-derive imageTag from Chart.AppVersion

`global.imageTag` was hardcoded to `v1.0.9`, which becomes stale when a new chart version is released with a different appVersion. The controller, manager, and worker images would pull the wrong tag unless manually overridden.

**Fix:** Default `global.imageTag` to empty string and add a `hiclaw.globalImageTag` helper that falls back to `Chart.AppVersion` (with `v` prefix). All image tag lookups now use this helper.

## Testing

- Created a kind cluster, installed via `helm install hiclaw higress.io/hiclaw --devel`
- Verified controller starts without RBAC errors after fix
- Verified Manager CR is created and manager pod starts
- Verified image tags resolve to `v{Chart.AppVersion}` when `global.imageTag` is empty