### PR TITLE
fix(controller): respect HICLAW_OPENAI_BASE_URL for non-qwen providers

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -167,6 +167,27 @@ helm install hiclaw higress.io/hiclaw \
 | `credentials.llmProvider` | 任意 | LLM プロバイダー名、デフォルトは `openai-compat` |
 | `credentials.defaultModel` | 任意 | デフォルトモデル、デフォルトは `gpt-5.4` |
 | `credentials.llmBaseUrl` | 任意 | OpenAI 互換のベース URL（例: `https://api.deepseek.com/v1`）。公式 OpenAI API を使用する場合は空のまま |
+| `manager.runtime` | 任意 | Manager エージェントランタイム: `openclaw`（デフォルト）、`copaw`、または `hermes` |
+| `worker.defaultRuntime` | 任意 | Worker デフォルトランタイム: `openclaw`（デフォルト）、`copaw`、または `hermes` |
+
+<details>
+<summary>代替ランタイムの使用（CoPaw Manager + Hermes Workers）</summary>
+
+```bash
+helm install hiclaw higress.io/hiclaw \
+  -n hiclaw-system --create-namespace --devel \
+  --set manager.runtime=copaw \
+  --set worker.defaultRuntime=hermes \
+  --set credentials.llmApiKey=<your-api-key> \
+  --set credentials.llmBaseUrl=https://your-provider.example.com/v1 \
+  --set credentials.defaultModel=your-model-name \
+  --set credentials.adminPassword=<your-admin-password> \
+  --set gateway.publicURL=http://localhost:18080
+```
+
+各コンポーネントのイメージはランタイムに基づいて自動的に選択されます（Manager: `hiclaw-manager` / `hiclaw-manager-copaw`、Worker: `hiclaw-worker` / `hiclaw-copaw-worker` / `hiclaw-hermes-worker`）。
+
+</details>
 
 **マルチリージョンイメージレジストリ**
 

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -164,7 +164,7 @@ helm install hiclaw higress.io/hiclaw \
 | `credentials.llmApiKey` | 必須 | LLM プロバイダーの API キー |
 | `gateway.publicURL` | 必須 | ユーザーが Element Web にアクセスする公開 URL（port-forward 環境では `http://localhost:18080`、本番では `https://hiclaw.example.com` 等） |
 | `credentials.adminPassword` | 推奨 | Matrix 管理者パスワード。空のままだと自動生成（後で Secret から読み出す必要あり） |
-| `credentials.llmProvider` | 任意 | LLM プロバイダー名、デフォルトは `openai` |
+| `credentials.llmProvider` | 任意 | LLM プロバイダー名、デフォルトは `openai-compat` |
 | `credentials.defaultModel` | 任意 | デフォルトモデル、デフォルトは `gpt-5.4` |
 | `credentials.llmBaseUrl` | 任意 | OpenAI 互換のベース URL（例: `https://api.deepseek.com/v1`）。公式 OpenAI API を使用する場合は空のまま |
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ helm install hiclaw higress.io/hiclaw \
 | `credentials.llmApiKey` | yes | API key for your LLM provider |
 | `gateway.publicURL` | yes | Public URL where users will reach Element Web (e.g. `http://localhost:18080` for port-forward, or `https://hiclaw.example.com` for an Ingress) |
 | `credentials.adminPassword` | recommended | Matrix admin password; auto-generated if left empty (you'll have to read it back from the Secret) |
-| `credentials.llmProvider` | no | LLM provider name, defaults to `openai` |
+| `credentials.llmProvider` | no | LLM provider name, defaults to `openai-compat` |
 | `credentials.defaultModel` | no | Default model, defaults to `gpt-5.4` |
 | `credentials.llmBaseUrl` | no | OpenAI-compatible base URL (e.g. `https://api.deepseek.com/v1`). Leave empty for official OpenAI API |
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,27 @@ helm install hiclaw higress.io/hiclaw \
 | `credentials.llmProvider` | no | LLM provider name, defaults to `openai-compat` |
 | `credentials.defaultModel` | no | Default model, defaults to `gpt-5.4` |
 | `credentials.llmBaseUrl` | no | OpenAI-compatible base URL (e.g. `https://api.deepseek.com/v1`). Leave empty for official OpenAI API |
+| `manager.runtime` | no | Manager agent runtime: `openclaw` (default), `copaw`, or `hermes` |
+| `worker.defaultRuntime` | no | Default Worker runtime: `openclaw` (default), `copaw`, or `hermes` |
+
+<details>
+<summary>Using alternative runtimes (CoPaw Manager + Hermes Workers)</summary>
+
+```bash
+helm install hiclaw higress.io/hiclaw \
+  -n hiclaw-system --create-namespace --devel \
+  --set manager.runtime=copaw \
+  --set worker.defaultRuntime=hermes \
+  --set credentials.llmApiKey=<your-api-key> \
+  --set credentials.llmBaseUrl=https://your-provider.example.com/v1 \
+  --set credentials.defaultModel=your-model-name \
+  --set credentials.adminPassword=<your-admin-password> \
+  --set gateway.publicURL=http://localhost:18080
+```
+
+The image for each component is automatically selected based on the runtime (`hiclaw-manager` / `hiclaw-manager-copaw` for Manager; `hiclaw-worker` / `hiclaw-copaw-worker` / `hiclaw-hermes-worker` for Workers).
+
+</details>
 
 **Multi-Region Image Registry**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -190,7 +190,7 @@ helm install hiclaw higress.io/hiclaw \
 | `credentials.llmApiKey` | 必填 | LLM 服务商 API Key |
 | `gateway.publicURL` | 必填 | 用户访问 Element Web 的对外地址（端口转发场景填 `http://localhost:18080`，正式环境填 `https://hiclaw.example.com` 等） |
 | `credentials.adminPassword` | 推荐 | Matrix 管理员密码；留空时会自动生成（之后需要从 Secret 中读取） |
-| `credentials.llmProvider` | 可选 | LLM 服务商名，默认 `openai` |
+| `credentials.llmProvider` | 可选 | LLM 服务商名，默认 `openai-compat` |
 | `credentials.defaultModel` | 可选 | 默认模型，默认 `gpt-5.4` |
 | `credentials.llmBaseUrl` | 可选 | OpenAI 兼容的 Base URL（例如 `https://api.deepseek.com/v1`）。使用官方 OpenAI API 时留空 |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -193,6 +193,27 @@ helm install hiclaw higress.io/hiclaw \
 | `credentials.llmProvider` | 可选 | LLM 服务商名，默认 `openai-compat` |
 | `credentials.defaultModel` | 可选 | 默认模型，默认 `gpt-5.4` |
 | `credentials.llmBaseUrl` | 可选 | OpenAI 兼容的 Base URL（例如 `https://api.deepseek.com/v1`）。使用官方 OpenAI API 时留空 |
+| `manager.runtime` | 可选 | Manager Agent 运行时：`openclaw`（默认）、`copaw` 或 `hermes` |
+| `worker.defaultRuntime` | 可选 | Worker 默认运行时：`openclaw`（默认）、`copaw` 或 `hermes` |
+
+<details>
+<summary>使用其他运行时（CoPaw Manager + Hermes Workers）</summary>
+
+```bash
+helm install hiclaw higress.io/hiclaw \
+  -n hiclaw-system --create-namespace --devel \
+  --set manager.runtime=copaw \
+  --set worker.defaultRuntime=hermes \
+  --set credentials.llmApiKey=<your-api-key> \
+  --set credentials.llmBaseUrl=https://your-provider.example.com/v1 \
+  --set credentials.defaultModel=your-model-name \
+  --set credentials.adminPassword=<your-admin-password> \
+  --set gateway.publicURL=http://localhost:18080
+```
+
+各组件镜像会根据运行时自动选择（Manager: `hiclaw-manager` / `hiclaw-manager-copaw`；Worker: `hiclaw-worker` / `hiclaw-copaw-worker` / `hiclaw-hermes-worker`）。
+
+</details>
 
 **多地域镜像仓库**
 

--- a/helm/hiclaw/values.yaml
+++ b/helm/hiclaw/values.yaml
@@ -18,7 +18,7 @@ credentials:
   adminUser: "admin"
   adminPassword: ""           # Matrix admin password (auto-generated if empty)
   llmApiKey: ""               # LLM API key (required)
-  llmProvider: "openai"
+  llmProvider: "openai-compat"
   defaultModel: "gpt-5.4"
   llmBaseUrl: ""              # OpenAI-compatible base URL (e.g. https://api.openai.com/v1)
 

--- a/hiclaw-controller/internal/initializer/initializer.go
+++ b/hiclaw-controller/internal/initializer/initializer.go
@@ -318,15 +318,48 @@ func (i *Initializer) initGatewayRoutes(ctx context.Context) error {
 			}
 
 		default:
-			raw := map[string]interface{}{"hiclawMode": true}
-			if err := i.Gateway.EnsureAIProvider(ctx, gateway.AIProviderRequest{
-				Name:     provider,
-				Type:     "openai",
-				Tokens:   []string{cfg.LLMAPIKey},
-				Protocol: "openai/v1",
-				Raw:      raw,
-			}); err != nil {
-				logger.Error(err, "failed to create LLM provider (non-fatal)")
+			if cfg.OpenAIBaseURL != "" {
+				// Provider name is unrecognized but a custom base URL is provided —
+				// set up an openai-compatible provider with the custom endpoint.
+				host, port, err := parseHostPort(cfg.OpenAIBaseURL)
+				if err != nil {
+					logger.Error(err, "failed to parse HICLAW_OPENAI_BASE_URL (non-fatal)")
+				} else {
+					proto := "https"
+					if strings.HasPrefix(cfg.OpenAIBaseURL, "http://") {
+						proto = "http"
+					}
+					if err := i.Gateway.EnsureServiceSource(ctx, provider, host, port, proto); err != nil {
+						logger.Error(err, "failed to register service source for provider (non-fatal)")
+					}
+					time.Sleep(2 * time.Second)
+					raw := map[string]interface{}{
+						"hiclawMode":              true,
+						"openaiCustomUrl":         cfg.OpenAIBaseURL,
+						"openaiCustomServiceName": provider + ".dns",
+						"openaiCustomServicePort": port,
+					}
+					if err := i.Gateway.EnsureAIProvider(ctx, gateway.AIProviderRequest{
+						Name:     provider,
+						Type:     "openai",
+						Tokens:   []string{cfg.LLMAPIKey},
+						Protocol: "openai/v1",
+						Raw:      raw,
+					}); err != nil {
+						logger.Error(err, "failed to create LLM provider (non-fatal)")
+					}
+				}
+			} else {
+				raw := map[string]interface{}{"hiclawMode": true}
+				if err := i.Gateway.EnsureAIProvider(ctx, gateway.AIProviderRequest{
+					Name:     provider,
+					Type:     "openai",
+					Tokens:   []string{cfg.LLMAPIKey},
+					Protocol: "openai/v1",
+					Raw:      raw,
+				}); err != nil {
+					logger.Error(err, "failed to create LLM provider (non-fatal)")
+				}
 			}
 		}
 

--- a/hiclaw-controller/internal/initializer/initializer.go
+++ b/hiclaw-controller/internal/initializer/initializer.go
@@ -283,7 +283,18 @@ func (i *Initializer) initGatewayRoutes(ctx context.Context) error {
 
 		case "openai-compat":
 			if cfg.OpenAIBaseURL == "" {
-				logger.Info("HICLAW_OPENAI_BASE_URL not set, skipping openai-compat provider setup")
+				// No custom base URL — fall back to official OpenAI endpoint
+				logger.Info("HICLAW_OPENAI_BASE_URL not set, using official OpenAI endpoint")
+				raw := map[string]interface{}{"hiclawMode": true}
+				if err := i.Gateway.EnsureAIProvider(ctx, gateway.AIProviderRequest{
+					Name:     "openai-compat",
+					Type:     "openai",
+					Tokens:   []string{cfg.LLMAPIKey},
+					Protocol: "openai/v1",
+					Raw:      raw,
+				}); err != nil {
+					logger.Error(err, "failed to create LLM provider (non-fatal)")
+				}
 			} else {
 				// Parse URL to create DNS service source
 				host, port, err := parseHostPort(cfg.OpenAIBaseURL)


### PR DESCRIPTION
## Problem

When configuring the Helm chart with:

```yaml
credentials:
  llmProvider: openai
  llmBaseUrl: https://open.bigmodel.cn/api/coding/paas/v4
```

The controller ignores `llmBaseUrl` and registers a plain OpenAI provider pointing at `api.openai.com`. This is because the initializer's switch statement only handles `openaiCustomUrl` in the `"openai-compat"` case, while `"openai"` falls through to the `default` branch which does not read `HICLAW_OPENAI_BASE_URL` at all.

You can verify the misconfiguration:

```bash
# Shows llm-openai.internal.dns → api.openai.com
kubectl get mcpbridge -n hiclaw-system default -o yaml

# Shows provider with type:openai but no openaiCustomUrl
kubectl get wasmplugin -n hiclaw-system ai-proxy.internal -o yaml
```

## Fix

The `default` branch in `initializer.go` now checks `cfg.OpenAIBaseURL`. When set, it creates an OpenAI-compatible provider with the custom endpoint (registering a DNS service source and setting `openaiCustomUrl`), identical to what the `"openai-compat"` case already does.

When `OpenAIBaseURL` is empty, the original behavior (plain openai provider) is preserved.

## Testing

- `go build ./...` passes
- Logic matches the existing `"openai-compat"` case which already works correctly