### PR TITLE
feat(copaw,controller): add heartbeat config to Team CRD and wire into CoPaw runtime

### DIFF
--- a/copaw/src/copaw_worker/bridge.py
+++ b/copaw/src/copaw_worker/bridge.py
@@ -446,6 +446,12 @@ def _apply_policy(
             _set_path(existing, path, _deep_merge_local_wins(remote_value, local_value))
         return
 
+    if policy == "seed":
+        local_value = _get_path(existing, path)
+        if local_value is _MISSING:
+            _set_path(existing, path, remote_value)
+        return
+
     raise ValueError(f"unknown merge policy: {policy}")
 
 
@@ -499,10 +505,10 @@ _CONTROLLER_FIELDS: list[tuple[tuple[str, ...], str, _PolicyDeriver]] = [
      lambda c, ic: _resolve_embedding_config(c, ic) if _resolve_embedding_config(c, ic) is not None else _MISSING),
 
     # ── heartbeat ────────────────────────────────────────────────────────
-    # Controller-sourced on Manager (via openclaw.agents.defaults.heartbeat);
-    # Workers' openclaw.json never declares heartbeat so deriver returns
-    # _MISSING and the key is untouched.
-    (("heartbeat",), "remote-wins", _derive_heartbeat),
+    # Seed-only: controller provides the initial heartbeat config on first
+    # boot; after that the user/agent owns it (can adjust every, disable,
+    # etc.) and restarts will not overwrite their changes.
+    (("heartbeat",), "seed", _derive_heartbeat),
 ]
 
 

--- a/copaw/src/copaw_worker/sync.py
+++ b/copaw/src/copaw_worker/sync.py
@@ -528,7 +528,7 @@ def push_local(sync: FileSync, since: float = 0) -> list[str]:
     # runtime.  These are "inner" copies derived from the "outer" files at
     # the sync root.  If the Agent modifies them, propagate changes back to
     # the outer layer so the normal push cycle uploads them to MinIO.
-    _INNER_OUTER_FILES = ("AGENTS.md", "SOUL.md")
+    _INNER_OUTER_FILES = ("AGENTS.md", "SOUL.md", "HEARTBEAT.md")
     copaw_ws_dir = local_dir / ".copaw" / "workspaces" / "default"
     for name in _INNER_OUTER_FILES:
         inner = copaw_ws_dir / name

--- a/copaw/src/copaw_worker/worker.py
+++ b/copaw/src/copaw_worker/worker.py
@@ -113,11 +113,13 @@ class Worker:
         self._copaw_working_dir = self.config.install_dir / self.worker_name / ".copaw"
         self._copaw_working_dir.mkdir(parents=True, exist_ok=True)
 
-        # Write SOUL.md / AGENTS.md into CoPaw workspace dir (workspaces/default/)
-        # CoPaw reads system_prompt_files from workspace dir, not .copaw root.
+        # Write SOUL.md / AGENTS.md / HEARTBEAT.md into CoPaw workspace dir
+        # (workspaces/default/). CoPaw reads system_prompt_files from workspace
+        # dir, not .copaw root. HEARTBEAT.md is read by the Agent via shell tool
+        # during heartbeat turns — must be co-located with SOUL.md/AGENTS.md.
         workspace_dir = self._copaw_working_dir / "workspaces" / "default"
         workspace_dir.mkdir(parents=True, exist_ok=True)
-        for name in ("SOUL.md", "AGENTS.md"):
+        for name in ("SOUL.md", "AGENTS.md", "HEARTBEAT.md"):
             src = self.sync.local_dir / name
             if src.exists():
                 (workspace_dir / name).write_text(src.read_text())

--- a/copaw/src/copaw_worker/worker.py
+++ b/copaw/src/copaw_worker/worker.py
@@ -117,12 +117,21 @@ class Worker:
         # (workspaces/default/). CoPaw reads system_prompt_files from workspace
         # dir, not .copaw root. HEARTBEAT.md is read by the Agent via shell tool
         # during heartbeat turns — must be co-located with SOUL.md/AGENTS.md.
+        # HEARTBEAT.md is seed-only: written on first boot, then fully owned by
+        # the agent. SOUL.md and AGENTS.md are always overwritten from L1.
         workspace_dir = self._copaw_working_dir / "workspaces" / "default"
         workspace_dir.mkdir(parents=True, exist_ok=True)
-        for name in ("SOUL.md", "AGENTS.md", "HEARTBEAT.md"):
+        for name in ("SOUL.md", "AGENTS.md"):
             src = self.sync.local_dir / name
             if src.exists():
                 (workspace_dir / name).write_text(src.read_text())
+        for name in ("HEARTBEAT.md",):
+            dst = workspace_dir / name
+            if dst.exists():
+                continue
+            src = self.sync.local_dir / name
+            if src.exists():
+                dst.write_text(src.read_text())
 
         # 5. Bridge openclaw.json -> CoPaw workspaces/default/agent.json + providers.json
         #    Infer gateway port from FS endpoint so bridge's _port_remap uses

--- a/hiclaw-controller/internal/agentconfig/generator.go
+++ b/hiclaw-controller/internal/agentconfig/generator.go
@@ -161,6 +161,17 @@ func (g *Generator) GenerateOpenClawConfig(req WorkerConfigRequest) ([]byte, err
 		},
 	}
 
+	// Add heartbeat config for team leaders
+	if req.Heartbeat != nil && req.Heartbeat.Enabled {
+		agents := config["agents"].(map[string]interface{})
+		defaults := agents["defaults"].(map[string]interface{})
+		hb := map[string]interface{}{"enabled": true}
+		if req.Heartbeat.Every != "" {
+			hb["every"] = req.Heartbeat.Every
+		}
+		defaults["heartbeat"] = hb
+	}
+
 	// Add embedding model for memory search if configured
 	if g.config.EmbeddingModel != "" {
 		agents := config["agents"].(map[string]interface{})

--- a/hiclaw-controller/internal/agentconfig/types.go
+++ b/hiclaw-controller/internal/agentconfig/types.go
@@ -27,6 +27,12 @@ type Config struct {
 	CMSServiceName    string
 }
 
+// HeartbeatConfig describes the heartbeat settings to embed in openclaw.json.
+type HeartbeatConfig struct {
+	Enabled bool
+	Every   string // e.g. "30m", "1h"
+}
+
 // WorkerConfigRequest describes everything needed to generate a worker's config files.
 type WorkerConfigRequest struct {
 	WorkerName     string // e.g. "worker-alice"
@@ -35,6 +41,7 @@ type WorkerConfigRequest struct {
 	ModelName      string // optional: override default model
 	TeamLeaderName string // if non-empty, this is a team worker
 	ChannelPolicy  *ChannelPolicy // optional communication policy overrides
+	Heartbeat      *HeartbeatConfig // optional: team leader heartbeat settings
 }
 
 // ChannelPolicy describes additive/subtractive communication rules.

--- a/hiclaw-controller/internal/controller/member_reconcile.go
+++ b/hiclaw-controller/internal/controller/member_reconcile.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	"github.com/hiclaw/hiclaw-controller/internal/agentconfig"
 	authpkg "github.com/hiclaw/hiclaw-controller/internal/auth"
 	"github.com/hiclaw/hiclaw-controller/internal/backend"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
@@ -66,6 +67,9 @@ type MemberContext struct {
 	TeamName          string
 	TeamLeaderName    string
 	TeamAdminMatrixID string
+
+	// Heartbeat config from Team CR leader spec (nil for non-leader members)
+	Heartbeat *agentconfig.HeartbeatConfig
 
 	// ExistingMatrixUserID is non-empty when prior provisioning has recorded a
 	// Matrix user; the Infra phase then uses RefreshCredentials instead of
@@ -236,6 +240,7 @@ func ReconcileMemberConfig(ctx context.Context, d MemberDeps, m MemberContext, s
 		MatrixPassword:    state.ProvResult.MatrixPassword,
 		AuthorizedMCPs:    authorizedMCPs,
 		TeamAdminMatrixID: m.TeamAdminMatrixID,
+		Heartbeat:         m.Heartbeat,
 		IsUpdate:          m.IsUpdate,
 	}); err != nil {
 		return fmt.Errorf("deploy worker config: %w", err)

--- a/hiclaw-controller/internal/controller/team_controller.go
+++ b/hiclaw-controller/internal/controller/team_controller.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	"github.com/hiclaw/hiclaw-controller/internal/agentconfig"
 	"github.com/hiclaw/hiclaw-controller/internal/auth"
 	"github.com/hiclaw/hiclaw-controller/internal/backend"
 	"github.com/hiclaw/hiclaw-controller/internal/executor"
@@ -673,6 +674,17 @@ func buildDesiredMembers(t *v1beta1.Team, controllerName string) []MemberContext
 
 	leaderSpec := leaderWorkerSpec(t)
 	leaderObserved := isObserved(t.Spec.Leader.Name)
+	var leaderHeartbeat *agentconfig.HeartbeatConfig
+	if t.Spec.Leader.Heartbeat != nil && t.Spec.Leader.Heartbeat.Enabled {
+		every := t.Spec.Leader.Heartbeat.Every
+		if every == "" {
+			every = "30m"
+		}
+		leaderHeartbeat = &agentconfig.HeartbeatConfig{
+			Enabled: true,
+			Every:   every,
+		}
+	}
 	members = append(members, MemberContext{
 		Name:              t.Spec.Leader.Name,
 		Namespace:         t.Namespace,
@@ -686,6 +698,7 @@ func buildDesiredMembers(t *v1beta1.Team, controllerName string) []MemberContext
 		TeamAdminMatrixID: teamAdminMatrixID(t),
 		PodLabels:         memberLabels(RoleTeamLeader),
 		Owner:             t,
+		Heartbeat:         leaderHeartbeat,
 	})
 
 	for _, w := range t.Spec.Workers {

--- a/hiclaw-controller/internal/service/deployer.go
+++ b/hiclaw-controller/internal/service/deployer.go
@@ -32,6 +32,9 @@ type WorkerDeployRequest struct {
 
 	TeamAdminMatrixID string
 
+	// Heartbeat config from Team CR leader spec (nil for non-leader workers)
+	Heartbeat *agentconfig.HeartbeatConfig
+
 	IsUpdate bool
 }
 
@@ -169,6 +172,7 @@ func (d *Deployer) DeployWorkerConfig(ctx context.Context, req WorkerDeployReque
 		ModelName:      req.Spec.Model,
 		TeamLeaderName: req.TeamLeaderName,
 		ChannelPolicy:  channelPolicy,
+		Heartbeat:      req.Heartbeat,
 	})
 	if err != nil {
 		return fmt.Errorf("config generation failed: %w", err)
@@ -490,6 +494,11 @@ func (d *Deployer) pushBuiltinSkills(ctx context.Context, workerName, agentPrefi
 func (d *Deployer) pushBuiltinTopLevelFiles(ctx context.Context, workerName, agentPrefix, role, runtime string) error {
 	agentDir := d.builtinAgentDir(role, runtime)
 	for _, name := range []string{"HEARTBEAT.md"} {
+		ossKey := agentPrefix + "/" + name
+		if existing, _ := d.oss.GetObject(ctx, ossKey); existing != nil {
+			log.FromContext(ctx).Info("seed-only: skipping (already in MinIO)", "file", name, "worker", workerName)
+			continue
+		}
 		src := filepath.Join(agentDir, name)
 		content, err := os.ReadFile(src)
 		if err != nil {
@@ -498,7 +507,7 @@ func (d *Deployer) pushBuiltinTopLevelFiles(ctx context.Context, workerName, age
 			}
 			return err
 		}
-		if err := d.oss.PutObject(ctx, agentPrefix+"/"+name, content); err != nil {
+		if err := d.oss.PutObject(ctx, ossKey, content); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

- Add `TeamLeaderHeartbeatSpec` (`enabled`, `every`) to Team CRD, allowing declarative heartbeat configuration for team leaders
- Controller injects heartbeat block into `openclaw.json` → CoPaw bridge maps it to `agent.json` with **seed** policy (initial-only, user/agent owns it after first boot)
- Propagate `HEARTBEAT.md` to CoPaw workspace on startup (seed-only: written once, then fully owned by the agent)