### PR TITLE
ci: add push-embedded target and selective image building

### DIFF
--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -7,6 +7,11 @@ on:
         description: 'RC version tag (e.g. v1.0.5-rc.1)'
         required: true
         type: string
+      targets:
+        description: 'Space-separated list of push targets (default: all). Options: openclaw-base hiclaw-controller embedded manager manager-copaw worker copaw-worker hermes-worker'
+        required: false
+        type: string
+        default: 'all'
 
 env:
   REGISTRY: higress-registry.cn-hangzhou.cr.aliyuncs.com
@@ -96,6 +101,7 @@ jobs:
           HERMES_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-hermes-worker
           CONTROLLER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-controller
           EMBEDDED_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-embedded
+          EMBEDDED_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-embedded
         run: |
           STABLE_TAG="${{ steps.meta.outputs.base_stable_tag }}"
           echo "### RC Build Summary" >> $GITHUB_STEP_SUMMARY
@@ -107,6 +113,7 @@ jobs:
           echo "- CoPaw Worker: \`${COPAW_WORKER_IMAGE}:${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Hermes Worker: \`${HERMES_WORKER_IMAGE}:${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Controller: \`${CONTROLLER_IMAGE}:${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Embedded: \`${EMBEDDED_IMAGE}:${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Embedded: \`${EMBEDDED_IMAGE}:${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Base (RC): \`${BASE_IMAGE}:${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Base (stable): \`${BASE_IMAGE}:${STABLE_TAG}\`" >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ WORKER_IMAGE         ?= $(REGISTRY)/$(REPO)/hiclaw-worker
 COPAW_WORKER_IMAGE   ?= $(REGISTRY)/$(REPO)/hiclaw-copaw-worker
 HERMES_WORKER_IMAGE  ?= $(REGISTRY)/$(REPO)/hiclaw-hermes-worker
 OPENCLAW_BASE_IMAGE  ?= $(REGISTRY)/$(REPO)/openclaw-base
+CONTROLLER_IMAGE     ?= $(REGISTRY)/$(REPO)/hiclaw-controller
 EMBEDDED_IMAGE       ?= $(REGISTRY)/$(REPO)/hiclaw-embedded
 
 MANAGER_TAG        ?= $(MANAGER_IMAGE):$(VERSION)
@@ -39,7 +40,6 @@ COPAW_WORKER_TAG   ?= $(COPAW_WORKER_IMAGE):$(VERSION)
 HERMES_WORKER_TAG  ?= $(HERMES_WORKER_IMAGE):$(VERSION)
 OPENCLAW_BASE_TAG  ?= $(OPENCLAW_BASE_IMAGE):$(VERSION)
 CONTROLLER_TAG     ?= $(CONTROLLER_IMAGE):$(VERSION)
-EMBEDDED_IMAGE     ?= $(REGISTRY)/$(REPO)/hiclaw-embedded
 EMBEDDED_TAG       ?= $(EMBEDDED_IMAGE):$(VERSION)
 
 # Local image names (no registry prefix, used by tests and install script)

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ WORKER_IMAGE         ?= $(REGISTRY)/$(REPO)/hiclaw-worker
 COPAW_WORKER_IMAGE   ?= $(REGISTRY)/$(REPO)/hiclaw-copaw-worker
 HERMES_WORKER_IMAGE  ?= $(REGISTRY)/$(REPO)/hiclaw-hermes-worker
 OPENCLAW_BASE_IMAGE  ?= $(REGISTRY)/$(REPO)/openclaw-base
-CONTROLLER_IMAGE     ?= $(REGISTRY)/$(REPO)/hiclaw-controller
+EMBEDDED_IMAGE       ?= $(REGISTRY)/$(REPO)/hiclaw-embedded
 
 MANAGER_TAG        ?= $(MANAGER_IMAGE):$(VERSION)
 MANAGER_COPAW_TAG  ?= $(MANAGER_COPAW_IMAGE):$(VERSION)
@@ -223,7 +223,7 @@ else
 	fi
 endif
 
-push: push-manager push-manager-copaw push-worker push-copaw-worker push-hermes-worker push-hiclaw-controller ## Build + push multi-arch images (amd64 + arm64); base image built separately via build-base.yml
+push: push-manager push-manager-copaw push-worker push-copaw-worker push-hermes-worker push-hiclaw-controller push-embedded ## Build + push multi-arch images (amd64 + arm64); base image built separately via build-base.yml
 
 push-openclaw-base: buildx-setup ## Build + push multi-arch OpenClaw base image
 	@echo "==> Building + pushing multi-arch OpenClaw base: $(OPENCLAW_BASE_TAG) [$(MULTIARCH_PLATFORMS)]"
@@ -297,6 +297,29 @@ else
 		-t $(EMBEDDED_TAG) \
 		--push \
 		.
+endif
+
+push-embedded: push-hiclaw-controller buildx-setup ## Build + push multi-arch embedded all-in-one image
+	@echo "==> Building + pushing multi-arch hiclaw-embedded: $(EMBEDDED_TAG) [$(MULTIARCH_PLATFORMS)]"
+ifeq ($(IS_PODMAN),1)
+	-podman manifest rm $(EMBEDDED_TAG) 2>/dev/null
+	$(foreach plat,$(subst $(comma), ,$(MULTIARCH_PLATFORMS)), \
+		echo "  -> Building hiclaw-embedded for $(plat)..." && \
+		podman build --platform $(plat) \
+			--build-arg HICLAW_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
+			$(REGISTRY_ARG) $(DOCKER_BUILD_ARGS) \
+			--manifest $(EMBEDDED_TAG) \
+			-f hiclaw-controller/Dockerfile.embedded . && ) true
+	podman manifest push --all $(EMBEDDED_TAG) docker://$(EMBEDDED_TAG)
+else
+	docker buildx build \
+		--builder $(BUILDX_BUILDER) \
+		--platform $(MULTIARCH_PLATFORMS) \
+		--build-arg HICLAW_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
+		$(REGISTRY_ARG) $(DOCKER_BUILD_ARGS) \
+		-t $(EMBEDDED_TAG) \
+		--push \
+		-f hiclaw-controller/Dockerfile.embedded .
 endif
 
 push-manager: push-hiclaw-controller buildx-setup ## Build + push multi-arch Manager image (OpenClaw)


### PR DESCRIPTION
## Changes

### 1. Add `push-embedded` Makefile target
- New `push-embedded` target builds and pushes multi-arch `hiclaw-embedded` image
- Depends on `push-hiclaw-controller` (embedded image uses controller as build stage)
- `push` target now includes `push-embedded`

### 2. Add `targets` input to Build RC workflow
- New optional `targets` parameter for building specific images only
- Default `all` (same behavior as before)
- Options: `openclaw-base` `hiclaw-controller` `embedded` `manager` `copaw-worker` `hermes-worker`
- Example: set targets to `embedded` to only build+push the embedded image