### PR TITLE
feat(hiclaw-controller):support nacos auth type for sts hiclaw

### DIFF
--- a/hiclaw-controller/api/v1beta1/types.go
+++ b/hiclaw-controller/api/v1beta1/types.go
@@ -20,7 +20,7 @@ const (
 const LabelController = "hiclaw.io/controller"
 
 // AccessEntry declares one cloud-permission grant under a logical
-// service. v1 supported services: "object-storage", "ai-gateway".
+// service. v1 supported services: "object-storage", "ai-gateway", "ai-registry".
 //
 // Scope is a schema-less JSON blob in the CR layer: it may reference
 // logical names (bucketRef: workspace, gatewayRef: default) and

--- a/hiclaw-controller/internal/accessresolver/resolver.go
+++ b/hiclaw-controller/internal/accessresolver/resolver.go
@@ -208,6 +208,12 @@ func (r *Resolver) resolveEntries(in []v1beta1.AccessEntry, tmpl templateCtx) ([
 				return nil, fmt.Errorf("entry[%d]: %w", i, err)
 			}
 			out = append(out, entry)
+		case credprovider.ServiceAIRegistry:
+			entry, err := r.resolveAIRegistry(e, tmpl)
+			if err != nil {
+				return nil, fmt.Errorf("entry[%d]: %w", i, err)
+			}
+			out = append(out, entry)
 		case "":
 			return nil, fmt.Errorf("entry[%d]: missing service", i)
 		default:
@@ -302,6 +308,40 @@ func (r *Resolver) resolveAIGateway(e v1beta1.AccessEntry, tmpl templateCtx) (cr
 		Scope: credprovider.AccessScope{
 			GatewayID: gatewayID,
 			Resources: resources,
+		},
+	}, nil
+}
+
+type aiRegistryScope struct {
+	NamespaceID string   `json:"namespaceId,omitempty"`
+	Resources   []string `json:"resources,omitempty"`
+}
+
+func (r *Resolver) resolveAIRegistry(e v1beta1.AccessEntry, tmpl templateCtx) (credprovider.AccessEntry, error) {
+	var s aiRegistryScope
+	if err := unmarshalScope(e.Scope, &s); err != nil {
+		return credprovider.AccessEntry{}, fmt.Errorf("ai-registry: %w", err)
+	}
+
+	namespaceID := strings.TrimSpace(tmpl.expand(s.NamespaceID))
+	if namespaceID == "" {
+		return credprovider.AccessEntry{}, errors.New("ai-registry: namespaceId is required")
+	}
+
+	resources := make([]string, 0, len(s.Resources))
+	for _, res := range s.Resources {
+		resources = append(resources, tmpl.expand(res))
+	}
+	if len(resources) == 0 {
+		resources = []string{"agentSpec/*", "skill/*"}
+	}
+
+	return credprovider.AccessEntry{
+		Service:     credprovider.ServiceAIRegistry,
+		Permissions: copyPermissions(e.Permissions),
+		Scope: credprovider.AccessScope{
+			NamespaceID: namespaceID,
+			Resources:   resources,
 		},
 	}, nil
 }

--- a/hiclaw-controller/internal/accessresolver/resolver_test.go
+++ b/hiclaw-controller/internal/accessresolver/resolver_test.go
@@ -241,6 +241,72 @@ func TestResolve_AIGatewayHappyPath(t *testing.T) {
 	}
 }
 
+func TestResolve_AIRegistryDefaultResources(t *testing.T) {
+	worker := &v1beta1.Worker{}
+	worker.Name = "nacos-w"
+	worker.Namespace = testNS
+	worker.Spec.AccessEntries = []v1beta1.AccessEntry{
+		{
+			Service:     credprovider.ServiceAIRegistry,
+			Permissions: []string{"read", "write"},
+			Scope:       rawJSON(t, map[string]any{"namespaceId": "gw-abc123"}),
+		},
+	}
+	c := newFakeClient(t, worker)
+
+	r := New(c, testNS, "hiclaw-test", "", auth.DefaultResourcePrefix)
+	_, entries, err := r.ResolveForCaller(context.Background(), &auth.CallerIdentity{
+		Role: auth.RoleWorker, Username: "nacos-w", WorkerName: "nacos-w",
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries", len(entries))
+	}
+	got := entries[0]
+	if got.Service != credprovider.ServiceAIRegistry {
+		t.Fatalf("service = %q", got.Service)
+	}
+	if got.Scope.NamespaceID != "gw-abc123" {
+		t.Fatalf("namespaceId = %q", got.Scope.NamespaceID)
+	}
+	if len(got.Scope.Resources) != 2 || got.Scope.Resources[0] != "agentSpec/*" || got.Scope.Resources[1] != "skill/*" {
+		t.Fatalf("resources = %+v", got.Scope.Resources)
+	}
+}
+
+func TestResolve_AIRegistryCustomResources(t *testing.T) {
+	worker := &v1beta1.Worker{}
+	worker.Name = "nacos-w2"
+	worker.Namespace = testNS
+	worker.Spec.AccessEntries = []v1beta1.AccessEntry{
+		{
+			Service: credprovider.ServiceAIRegistry,
+			Scope: rawJSON(t, map[string]any{
+				"namespaceId": "ns1",
+				"resources":   []string{"agentspec/*", "mcp/*"},
+			}),
+		},
+	}
+	c := newFakeClient(t, worker)
+
+	r := New(c, testNS, "hiclaw-test", "", auth.DefaultResourcePrefix)
+	_, entries, err := r.ResolveForCaller(context.Background(), &auth.CallerIdentity{
+		Role: auth.RoleWorker, Username: "nacos-w2", WorkerName: "nacos-w2",
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	got := entries[0]
+	if got.Scope.NamespaceID != "ns1" {
+		t.Fatalf("namespaceId = %q", got.Scope.NamespaceID)
+	}
+	if len(got.Scope.Resources) != 2 || got.Scope.Resources[0] != "agentspec/*" {
+		t.Fatalf("resources = %+v", got.Scope.Resources)
+	}
+}
+
 func TestResolve_AIGatewayNoDefault(t *testing.T) {
 	worker := &v1beta1.Worker{}
 	worker.Name = "gw-bot2"

--- a/hiclaw-controller/internal/app/app.go
+++ b/hiclaw-controller/internal/app/app.go
@@ -195,6 +195,7 @@ func (a *App) initInfraClients(_ context.Context) error {
 	a.agentGen = agentconfig.NewGenerator(cfg.AgentConfig())
 	a.shell = executor.NewShell(cfg.SkillsDir)
 	a.packages = executor.NewPackageResolver("/tmp/import")
+	a.packages.NacosAuthType = cfg.NacosAuthType
 
 	// Credential provider sidecar — required for ai-gateway / external OSS /
 	// worker STS issuance, optional otherwise.
@@ -204,6 +205,9 @@ func (a *App) initInfraClients(_ context.Context) error {
 		// controller-runtime Manager (and its client.Client) is built, since
 		// the accessresolver needs to read Worker/Manager CRs.
 		logger.Info("credential-provider sidecar configured", "url", cfg.CredentialProviderURL)
+	}
+	if cfg.NacosAuthType == "sts-hiclaw" && a.credProvider != nil {
+		a.packages.CredClient = a.credProvider
 	}
 
 	// Gateway client — provider-driven.
@@ -416,14 +420,16 @@ func (a *App) initServiceLayer(_ context.Context) error {
 	}
 
 	a.deployer = service.NewDeployer(service.DeployerConfig{
-		AgentConfig:    a.agentGen,
-		OSS:            a.oss,
-		Executor:       a.shell,
-		Packages:       a.packages,
-		Legacy:         a.legacy,
-		AgentFSDir:     cfg.AgentFSDir(),
-		WorkerAgentDir: cfg.WorkerAgentDir(),
-		MatrixDomain:   cfg.MatrixDomain,
+		AgentConfig:     a.agentGen,
+		OSS:             a.oss,
+		Executor:        a.shell,
+		Packages:        a.packages,
+		Legacy:          a.legacy,
+		AgentFSDir:      cfg.AgentFSDir(),
+		WorkerAgentDir:  cfg.WorkerAgentDir(),
+		MatrixDomain:    cfg.MatrixDomain,
+		NacosAuthType:   cfg.NacosAuthType,
+		NacosCredClient: a.credProvider,
 	})
 
 	return nil

--- a/hiclaw-controller/internal/config/config.go
+++ b/hiclaw-controller/internal/config/config.go
@@ -72,6 +72,11 @@ type Config struct {
 	// sidecar is not deployed (e.g. self-hosted higress+minio stack).
 	CredentialProviderURL string
 
+	// NacosAuthType selects the authentication method for Nacos AI client
+	// connections: "nacos" (username/password), "sts-hiclaw" (STS via
+	// hiclaw-credential-provider), "none", or "" (auto-detect from URL).
+	NacosAuthType string
+
 	// Kubernetes Backend
 	K8sNamespace    string
 	K8sWorkerCPU    string
@@ -237,6 +242,7 @@ func LoadConfig() *Config {
 		StorageProvider: envOrDefault("HICLAW_STORAGE_PROVIDER", "minio"),
 
 		CredentialProviderURL: os.Getenv("HICLAW_CREDENTIAL_PROVIDER_URL"),
+		NacosAuthType:         os.Getenv("HICLAW_NACOS_AUTH_TYPE"),
 
 		HigressBaseURL:    envOrDefault("HICLAW_AI_GATEWAY_ADMIN_URL", "http://127.0.0.1:8001"),
 		HigressCookieFile: os.Getenv("HIGRESS_COOKIE_FILE"),

--- a/hiclaw-controller/internal/controller/manager_reconcile_config.go
+++ b/hiclaw-controller/internal/controller/manager_reconcile_config.go
@@ -49,7 +49,7 @@ func (r *ManagerReconciler) reconcileManagerConfig(ctx context.Context, s *manag
 	}
 
 	if err := r.Deployer.PushOnDemandSkills(ctx, m.Name, m.Spec.Skills); err != nil {
-		logger.Error(err, "skill push failed (non-fatal)")
+		logger.Info("skill push failed", "error", err)
 	}
 
 	return reconcile.Result{}, nil

--- a/hiclaw-controller/internal/controller/member_reconcile.go
+++ b/hiclaw-controller/internal/controller/member_reconcile.go
@@ -247,7 +247,7 @@ func ReconcileMemberConfig(ctx context.Context, d MemberDeps, m MemberContext, s
 	}
 
 	if err := d.Deployer.PushOnDemandSkills(ctx, m.Name, m.Spec.Skills); err != nil {
-		logger.Error(err, "skill push failed (non-fatal)")
+		logger.Info("skill push failed", "error", err)
 	}
 	return nil
 }

--- a/hiclaw-controller/internal/credprovider/types.go
+++ b/hiclaw-controller/internal/credprovider/types.go
@@ -48,8 +48,11 @@ type AccessScope struct {
 	Bucket   string   `json:"bucket,omitempty"`
 	Prefixes []string `json:"prefixes,omitempty"`
 	// ai-gateway
-	GatewayID string   `json:"gatewayId,omitempty"`
+	GatewayID string `json:"gatewayId,omitempty"`
+	// Resources: ai-gateway API paths; for ai-registry, agentSpec/skill patterns (e.g. agentSpec/*, skill/*).
 	Resources []string `json:"resources,omitempty"`
+	// ai-registry
+	NamespaceID string `json:"namespaceId,omitempty"`
 }
 
 // IssueResponse is the sidecar's reply to POST /issue.
@@ -71,4 +74,5 @@ type IssueResponse struct {
 const (
 	ServiceObjectStorage = "object-storage"
 	ServiceAIGateway     = "ai-gateway"
+	ServiceAIRegistry    = "ai-registry"
 )

--- a/hiclaw-controller/internal/executor/nacos_ai_service.go
+++ b/hiclaw-controller/internal/executor/nacos_ai_service.go
@@ -7,32 +7,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 )
-
-const (
-	nacosAuthTypeNone     = "none"
-	nacosAuthTypeNacos    = "nacos"
-	nacosPreflightTimeout = 5 * time.Second
-)
-
-type nacosAgentSpecClient struct {
-	serverAddr       string
-	namespace        string
-	authType         string
-	username         string
-	password         string
-	accessToken      string
-	tokenExpireAt    time.Time
-	authLoginVersion string
-	httpClient       *http.Client
-}
 
 type nacosV3Response struct {
 	Code    int             `json:"code"`
@@ -84,62 +65,68 @@ type nacosAgentSpecListResponse struct {
 	PageItems  []nacosAgentSpecSummary `json:"pageItems"`
 }
 
-func newNacosAgentSpecClient(ctx context.Context, rawAddr, namespace string) (*nacosAgentSpecClient, error) {
-	host, port, username, password, err := parseNacosAddr(rawAddr)
+// GetSkill fetches a Skill ZIP from Nacos and extracts it into outputDir/{name}/.
+// version may be empty (latest) or a specific version string.
+// label may be used instead of version; both may not be set simultaneously.
+func (c *NacosAIClient) GetSkill(ctx context.Context, name, outputDir, version, label string) error {
+	params := url.Values{}
+	params.Set("namespaceId", c.namespace)
+	params.Set("name", name)
+	if version != "" {
+		params.Set("version", version)
+	}
+	if label != "" {
+		params.Set("label", label)
+	}
+
+	apiURL := fmt.Sprintf("http://%s/nacos/v3/client/ai/skills?%s", c.serverAddr, params.Encode())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("invalid nacos address %q: %w", rawAddr, err)
+		return fmt.Errorf("failed to build request: %w", err)
+	}
+	if err := c.prepareRequest(ctx, req); err != nil {
+		return err
 	}
 
-	authType := nacosAuthTypeNone
-	if username != "" && password != "" {
-		authType = nacosAuthTypeNacos
-	} else if username != "" || password != "" {
-		return nil, fmt.Errorf("both username and password are required in nacos URL or env (use nacos://user:pass@host:port or set HICLAW_NACOS_USERNAME/HICLAW_NACOS_PASSWORD)")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to get skill: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return parseNacosHTTPError(resp.StatusCode, body, "get skill")
 	}
 
-	client := &nacosAgentSpecClient{
-		serverAddr: net.JoinHostPort(host, port),
-		namespace:  namespace,
-		authType:   authType,
-		username:   username,
-		password:   password,
-		httpClient: &http.Client{
-			Timeout: 60 * time.Second,
-		},
+	// Write the ZIP response to a temp file.
+	tmp, err := os.CreateTemp("", "nacos-skill-*.zip")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		tmp.Close()
+		return fmt.Errorf("failed to download skill ZIP: %w", err)
+	}
+	tmp.Close()
+
+	// Extract into outputDir/{name}/.
+	destDir := filepath.Join(outputDir, name)
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create skill directory: %w", err)
 	}
 
-	if client.namespace == "" {
-		client.namespace = "public"
+	cmd := exec.CommandContext(ctx, "unzip", "-q", "-o", tmpPath, "-d", destDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to extract skill ZIP for %s: %s: %w", name, string(out), err)
 	}
-
-	if err := client.preflightConnect(ctx); err != nil {
-		return nil, err
-	}
-
-	if client.authType == nacosAuthTypeNacos {
-		if err := client.login(ctx); err != nil {
-			return nil, fmt.Errorf("login failed: %w", err)
-		}
-	}
-
-	return client, nil
+	return nil
 }
 
-func (c *nacosAgentSpecClient) preflightConnect(ctx context.Context) error {
-	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, nacosPreflightTimeout)
-		defer cancel()
-	}
-
-	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", c.serverAddr)
-	if err != nil {
-		return fmt.Errorf("failed to connect to %s: %w", c.serverAddr, err)
-	}
-	return conn.Close()
-}
-
-func (c *nacosAgentSpecClient) GetAgentSpec(ctx context.Context, name, outputDir string, version, label string) error {
+func (c *NacosAIClient) GetAgentSpec(ctx context.Context, name, outputDir string, version, label string) error {
 	spec, err := c.fetchAgentSpec(ctx, name, version, label)
 	if err != nil {
 		return err
@@ -182,7 +169,7 @@ func (c *nacosAgentSpecClient) GetAgentSpec(ctx context.Context, name, outputDir
 	return writeAgentSpecManifest(specDir, spec.Content)
 }
 
-func (c *nacosAgentSpecClient) CheckAgentSpecExists(ctx context.Context, name, version, label string) error {
+func (c *NacosAIClient) CheckAgentSpecExists(ctx context.Context, name, version, label string) error {
 	summary, err := c.fetchAgentSpecSummary(ctx, name)
 	if err != nil {
 		return err
@@ -219,11 +206,7 @@ func isNacosHTTPStatus(err error, statusCode int) bool {
 	return strings.Contains(err.Error(), fmt.Sprintf("(HTTP %d)", statusCode))
 }
 
-func (c *nacosAgentSpecClient) fetchAgentSpecSummary(ctx context.Context, name string) (*nacosAgentSpecSummary, error) {
-	if err := c.ensureTokenValid(ctx); err != nil {
-		return nil, err
-	}
-
+func (c *NacosAIClient) fetchAgentSpecSummary(ctx context.Context, name string) (*nacosAgentSpecSummary, error) {
 	params := url.Values{}
 	params.Set("namespaceId", c.namespace)
 	params.Set("agentSpecName", name)
@@ -236,7 +219,9 @@ func (c *nacosAgentSpecClient) fetchAgentSpecSummary(ctx context.Context, name s
 	if err != nil {
 		return nil, fmt.Errorf("failed to build request: %w", err)
 	}
-	c.setAuthHeaders(req)
+	if err := c.prepareRequest(ctx, req); err != nil {
+		return nil, err
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -273,11 +258,7 @@ func (c *nacosAgentSpecClient) fetchAgentSpecSummary(ctx context.Context, name s
 	return nil, formatNacosHTTPError("check agentspec", http.StatusNotFound, "", fmt.Sprintf("agentspec %q not found", name))
 }
 
-func (c *nacosAgentSpecClient) fetchAgentSpec(ctx context.Context, name, version, label string) (*nacosAgentSpec, error) {
-	if err := c.ensureTokenValid(ctx); err != nil {
-		return nil, err
-	}
-
+func (c *NacosAIClient) fetchAgentSpec(ctx context.Context, name, version, label string) (*nacosAgentSpec, error) {
 	params := url.Values{}
 	params.Set("namespaceId", c.namespace)
 	params.Set("name", name)
@@ -293,7 +274,9 @@ func (c *nacosAgentSpecClient) fetchAgentSpec(ctx context.Context, name, version
 	if err != nil {
 		return nil, fmt.Errorf("failed to build request: %w", err)
 	}
-	c.setAuthHeaders(req)
+	if err := c.prepareRequest(ctx, req); err != nil {
+		return nil, err
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -323,109 +306,6 @@ func (c *nacosAgentSpecClient) fetchAgentSpec(ctx context.Context, name, version
 		return nil, fmt.Errorf("failed to parse agentspec: %w", err)
 	}
 	return &spec, nil
-}
-
-func (c *nacosAgentSpecClient) ensureTokenValid(ctx context.Context) error {
-	if c.authType != nacosAuthTypeNacos {
-		return nil
-	}
-	if c.accessToken == "" {
-		return c.login(ctx)
-	}
-	if !c.tokenExpireAt.IsZero() && time.Now().Add(5*time.Second).After(c.tokenExpireAt) {
-		return c.login(ctx)
-	}
-	return nil
-}
-
-func (c *nacosAgentSpecClient) login(ctx context.Context) error {
-	form := url.Values{}
-	form.Set("username", c.username)
-	form.Set("password", c.password)
-
-	tryV3 := c.authLoginVersion == "" || c.authLoginVersion == "v3"
-	if tryV3 {
-		ok, err := c.tryLogin(ctx, fmt.Sprintf("http://%s/nacos/v3/auth/user/login", c.serverAddr), form)
-		if err == nil && ok {
-			c.authLoginVersion = "v3"
-			return nil
-		}
-	}
-
-	ok, err := c.tryLogin(ctx, fmt.Sprintf("http://%s/nacos/v1/auth/login", c.serverAddr), form)
-	if err != nil {
-		return err
-	}
-	if ok {
-		c.authLoginVersion = "v1"
-		return nil
-	}
-
-	return fmt.Errorf("login failed with both v3 and v1 auth endpoints")
-}
-
-func (c *nacosAgentSpecClient) tryLogin(ctx context.Context, loginURL string, form url.Values) (bool, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, loginURL, strings.NewReader(form.Encode()))
-	if err != nil {
-		return false, err
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return false, err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return false, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return false, nil
-	}
-	return c.applyLoginResponse(body), nil
-}
-
-func (c *nacosAgentSpecClient) applyLoginResponse(body []byte) bool {
-	var result map[string]interface{}
-	if err := json.Unmarshal(body, &result); err != nil {
-		return false
-	}
-	if data, ok := result["data"].(map[string]interface{}); ok {
-		return c.applyLoginMap(data)
-	}
-	return c.applyLoginMap(result)
-}
-
-func (c *nacosAgentSpecClient) applyLoginMap(data map[string]interface{}) bool {
-	token, ok := data["accessToken"].(string)
-	if !ok || token == "" {
-		return false
-	}
-	c.accessToken = token
-
-	var ttlSeconds int64
-	switch value := data["tokenTtl"].(type) {
-	case float64:
-		ttlSeconds = int64(value)
-	case int64:
-		ttlSeconds = value
-	case int:
-		ttlSeconds = int64(value)
-	}
-	if ttlSeconds > 0 {
-		c.tokenExpireAt = time.Now().Add(time.Duration(ttlSeconds) * time.Second)
-	} else {
-		c.tokenExpireAt = time.Time{}
-	}
-	return true
-}
-
-func (c *nacosAgentSpecClient) setAuthHeaders(req *http.Request) {
-	if c.accessToken != "" {
-		req.Header.Set("Authorization", "Bearer "+c.accessToken)
-	}
 }
 
 func buildAgentSpecResourcePath(res *nacosAgentSpecResource) string {
@@ -496,35 +376,4 @@ func formatNacosHTTPError(operation string, statusCode int, serverMessage string
 		return fmt.Errorf("%s failed (HTTP %d): %s; hint: %s", operation, statusCode, serverMessage, hint)
 	}
 	return fmt.Errorf("%s failed (HTTP %d): %s", operation, statusCode, hint)
-}
-
-func parseNacosAddr(raw string) (host, port, username, password string, err error) {
-	if !strings.Contains(raw, "://") {
-		raw = "http://" + raw
-	}
-
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return "", "", "", "", err
-	}
-	if parsed.Hostname() == "" {
-		return "", "", "", "", fmt.Errorf("missing host")
-	}
-
-	port = parsed.Port()
-	if port == "" {
-		port = "8848"
-	}
-
-	if parsed.User != nil {
-		username = parsed.User.Username()
-		password, _ = parsed.User.Password()
-	}
-
-	if username == "" && password == "" {
-		username = os.Getenv("HICLAW_NACOS_USERNAME")
-		password = os.Getenv("HICLAW_NACOS_PASSWORD")
-	}
-
-	return parsed.Hostname(), port, username, password, nil
 }

--- a/hiclaw-controller/internal/executor/nacos_client.go
+++ b/hiclaw-controller/internal/executor/nacos_client.go
@@ -1,0 +1,161 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/hiclaw/hiclaw-controller/internal/credprovider"
+)
+
+const (
+	nacosPreflightTimeout = 5 * time.Second
+)
+
+// NacosAIClient is the unified entry point for Nacos AI capabilities.
+// Authentication is fully delegated to cred; the struct holds no auth state.
+type NacosAIClient struct {
+	serverAddr string
+	namespace  string
+	httpClient *http.Client
+	cred       nacosCredential
+}
+
+// NewNacosAIClient constructs and connects a NacosAIClient.
+//
+//   - rawAddr: host:port, optionally prefixed with user:pass@ or nacos://
+//   - namespace: Nacos namespace ID (empty → "public")
+//   - authType: "nacos" | "sts-hiclaw" | "none" | "" (auto-detect from addr)
+//   - credClient: required only for "sts-hiclaw"; pass nil otherwise
+func NewNacosAIClient(
+	ctx context.Context,
+	rawAddr string,
+	namespace string,
+	authType string,
+	credClient credprovider.Client,
+) (*NacosAIClient, error) {
+	host, port, username, password, err := parseNacosAddr(rawAddr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid nacos address %q: %w", rawAddr, err)
+	}
+
+	if namespace == "" {
+		namespace = "public"
+	}
+
+	serverAddr := net.JoinHostPort(host, port)
+	httpCl := &http.Client{Timeout: 60 * time.Second}
+
+	// Auto-detect auth type when not explicitly set.
+	if authType == "" {
+		if username != "" && password != "" {
+			authType = nacosAuthTypeNacos
+		} else if username != "" || password != "" {
+			return nil, fmt.Errorf("both username and password are required in nacos URL or env (use nacos://user:pass@host:port or set HICLAW_NACOS_USERNAME/HICLAW_NACOS_PASSWORD)")
+		} else {
+			authType = nacosAuthTypeNone
+		}
+	}
+
+	var cred nacosCredential
+	switch authType {
+	case nacosAuthTypeNacos:
+		if username == "" || password == "" {
+			return nil, fmt.Errorf("nacos auth requires username and password")
+		}
+		cred = &nacosUserPassCredential{
+			serverAddr: serverAddr,
+			username:   username,
+			password:   password,
+			httpClient: httpCl,
+		}
+	case nacosAuthTypeSTS:
+		if credClient == nil {
+			return nil, fmt.Errorf("sts-hiclaw auth requires a credprovider.Client")
+		}
+		cred = newNacosSTSCredential(namespace, credClient)
+	case nacosAuthTypeNone, "":
+		cred = nacosNoneCredential{}
+	default:
+		return nil, fmt.Errorf("unsupported nacos auth type %q", authType)
+	}
+
+	client := &NacosAIClient{
+		serverAddr: serverAddr,
+		namespace:  namespace,
+		httpClient: httpCl,
+		cred:       cred,
+	}
+
+	if err := client.preflightConnect(ctx); err != nil {
+		return nil, err
+	}
+
+	if err := cred.Refresh(ctx); err != nil {
+		return nil, fmt.Errorf("credential refresh failed: %w", err)
+	}
+
+	return client, nil
+}
+
+func (c *NacosAIClient) preflightConnect(ctx context.Context) error {
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, nacosPreflightTimeout)
+		defer cancel()
+	}
+
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", c.serverAddr)
+	if err != nil {
+		return fmt.Errorf("failed to connect to %s: %w", c.serverAddr, err)
+	}
+	return conn.Close()
+}
+
+// prepareRequest refreshes credentials if needed and applies auth headers.
+// Must be called before every outbound HTTP request.
+func (c *NacosAIClient) prepareRequest(ctx context.Context, req *http.Request) error {
+	if err := c.cred.Refresh(ctx); err != nil {
+		return fmt.Errorf("credential refresh: %w", err)
+	}
+	c.cred.Apply(req)
+	return nil
+}
+
+// ── parseNacosAddr ────────────────────────────────────────────────────────
+
+func parseNacosAddr(raw string) (host, port, username, password string, err error) {
+	if !strings.Contains(raw, "://") {
+		raw = "http://" + raw
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", "", "", "", err
+	}
+	if parsed.Hostname() == "" {
+		return "", "", "", "", fmt.Errorf("missing host")
+	}
+
+	port = parsed.Port()
+	if port == "" {
+		port = "8848"
+	}
+
+	if parsed.User != nil {
+		username = parsed.User.Username()
+		password, _ = parsed.User.Password()
+	}
+
+	if username == "" && password == "" {
+		username = os.Getenv("HICLAW_NACOS_USERNAME")
+		password = os.Getenv("HICLAW_NACOS_PASSWORD")
+	}
+
+	return parsed.Hostname(), port, username, password, nil
+}

--- a/hiclaw-controller/internal/executor/nacos_client_test.go
+++ b/hiclaw-controller/internal/executor/nacos_client_test.go
@@ -1,0 +1,133 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/hiclaw/hiclaw-controller/internal/credprovider"
+)
+
+func TestNewNacosAIClient_UnsupportedAuthType(t *testing.T) {
+	_, err := NewNacosAIClient(context.Background(), "127.0.0.1:8848", "public", "not-a-mode", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "unsupported nacos auth type") {
+		t.Fatalf("got: %v", err)
+	}
+}
+
+func TestNewNacosAIClient_ExplicitNacos_RequiresCredsInAddrOrEnv(t *testing.T) {
+	t.Setenv("HICLAW_NACOS_USERNAME", "")
+	t.Setenv("HICLAW_NACOS_PASSWORD", "")
+
+	_, err := NewNacosAIClient(context.Background(), "127.0.0.1:8848", "public", nacosAuthTypeNacos, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "nacos auth requires username and password") {
+		t.Fatalf("got: %v", err)
+	}
+}
+
+func TestNewNacosAIClient_PreflightFails_WhenUnreachable(t *testing.T) {
+	_, err := NewNacosAIClient(context.Background(), "127.0.0.1:19999", "public", nacosAuthTypeNone, nil)
+	if err == nil {
+		t.Fatal("expected connection error")
+	}
+	if !strings.Contains(err.Error(), "failed to connect") {
+		t.Fatalf("got: %v", err)
+	}
+}
+
+func TestNewNacosAIClient_ExplicitNone_Succeeds(t *testing.T) {
+	s := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(s.Close)
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = NewNacosAIClient(context.Background(), u.Host, "public", nacosAuthTypeNone, nil)
+	if err != nil {
+		t.Fatalf("NewNacosAIClient: %v", err)
+	}
+}
+
+func TestNewNacosAIClient_AutoDetect_None_WhenNoCredentials(t *testing.T) {
+	s := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(s.Close)
+
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	c, err := NewNacosAIClient(ctx, u.Host, "public", "", nil)
+	if err != nil {
+		t.Fatalf("expected auto none + preflight to succeed: %v", err)
+	}
+	_ = c
+}
+
+func TestNewNacosAIClient_STS_RequiresCredClient(t *testing.T) {
+	_, err := NewNacosAIClient(context.Background(), "127.0.0.1:8848", "public", nacosAuthTypeSTS, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "sts-hiclaw auth requires a credprovider.Client") {
+		t.Fatalf("got: %v", err)
+	}
+}
+
+// recordingIssueClient captures the last IssueRequest for assertions.
+type recordingIssueClient struct {
+	last credprovider.IssueRequest
+}
+
+func (r *recordingIssueClient) Issue(ctx context.Context, req credprovider.IssueRequest) (*credprovider.IssueResponse, error) {
+	r.last = req
+	return &credprovider.IssueResponse{
+		AccessKeyID:     "test-ak",
+		AccessKeySecret: "test-sk",
+		SecurityToken:   "test-sts",
+		ExpiresInSec:    3600,
+	}, nil
+}
+
+func TestNewNacosAIClient_STS_IssueUsesAIRegistryForNamespace(t *testing.T) {
+	s := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(s.Close)
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	rec := &recordingIssueClient{}
+	_, err = NewNacosAIClient(ctx, u.Host, "my-nacos-ns", nacosAuthTypeSTS, rec)
+	if err != nil {
+		t.Fatalf("NewNacosAIClient: %v", err)
+	}
+
+	if rec.last.SessionName != "hiclaw-nacos-my-nacos-ns" {
+		t.Errorf("SessionName = %q, want hiclaw-nacos-my-nacos-ns", rec.last.SessionName)
+	}
+	if len(rec.last.Entries) != 1 {
+		t.Fatalf("Entries: %+v", rec.last.Entries)
+	}
+	if rec.last.Entries[0].Service != credprovider.ServiceAIRegistry {
+		t.Errorf("Service = %q", rec.last.Entries[0].Service)
+	}
+	if rec.last.Entries[0].Scope.NamespaceID != "my-nacos-ns" {
+		t.Errorf("Scope.NamespaceID = %q", rec.last.Entries[0].Scope.NamespaceID)
+	}
+	if len(rec.last.Entries[0].Scope.Resources) != 2 ||
+		rec.last.Entries[0].Scope.Resources[0] != "agentSpec/*" ||
+		rec.last.Entries[0].Scope.Resources[1] != "skill/*" {
+		t.Errorf("Scope.Resources = %+v, want [agentSpec/* skill/*]", rec.last.Entries[0].Scope.Resources)
+	}
+}

--- a/hiclaw-controller/internal/executor/nacos_credential.go
+++ b/hiclaw-controller/internal/executor/nacos_credential.go
@@ -1,0 +1,220 @@
+package executor
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hiclaw/hiclaw-controller/internal/credprovider"
+)
+
+const (
+	nacosAuthTypeNone  = "none"
+	nacosAuthTypeNacos = "nacos"
+	nacosAuthTypeSTS   = "sts-hiclaw"
+)
+
+// nacosCredential abstracts all authentication logic for NacosAIClient.
+// NacosAIClient never touches credential state directly — it only calls
+// Refresh before sending a request and Apply to inject headers.
+type nacosCredential interface {
+	// Refresh ensures the credential is valid (re-login or STS refresh as needed).
+	Refresh(ctx context.Context) error
+	// Apply injects authentication headers into an outbound request.
+	Apply(req *http.Request)
+}
+
+// ── nacosNoneCredential ───────────────────────────────────────────────────
+
+type nacosNoneCredential struct{}
+
+func (nacosNoneCredential) Refresh(_ context.Context) error { return nil }
+func (nacosNoneCredential) Apply(_ *http.Request)           {}
+
+// ── nacosUserPassCredential ───────────────────────────────────────────────
+
+type nacosUserPassCredential struct {
+	serverAddr       string
+	username         string
+	password         string
+	httpClient       *http.Client
+	mu               sync.Mutex
+	accessToken      string
+	tokenExpireAt    time.Time
+	authLoginVersion string
+}
+
+func (c *nacosUserPassCredential) Refresh(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.accessToken != "" {
+		if c.tokenExpireAt.IsZero() || time.Now().Add(5*time.Second).Before(c.tokenExpireAt) {
+			return nil
+		}
+	}
+	return c.login(ctx)
+}
+
+func (c *nacosUserPassCredential) Apply(req *http.Request) {
+	c.mu.Lock()
+	tok := c.accessToken
+	c.mu.Unlock()
+	if tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+}
+
+func (c *nacosUserPassCredential) login(ctx context.Context) error {
+	form := url.Values{}
+	form.Set("username", c.username)
+	form.Set("password", c.password)
+
+	tryV3 := c.authLoginVersion == "" || c.authLoginVersion == "v3"
+	if tryV3 {
+		ok, err := c.tryLogin(ctx, fmt.Sprintf("http://%s/nacos/v3/auth/user/login", c.serverAddr), form)
+		if err == nil && ok {
+			c.authLoginVersion = "v3"
+			return nil
+		}
+	}
+
+	ok, err := c.tryLogin(ctx, fmt.Sprintf("http://%s/nacos/v1/auth/login", c.serverAddr), form)
+	if err != nil {
+		return err
+	}
+	if ok {
+		c.authLoginVersion = "v1"
+		return nil
+	}
+	return fmt.Errorf("login failed with both v3 and v1 auth endpoints")
+}
+
+func (c *nacosUserPassCredential) tryLogin(ctx context.Context, loginURL string, form url.Values) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, loginURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return false, nil
+	}
+	return c.applyLoginResponse(body), nil
+}
+
+func (c *nacosUserPassCredential) applyLoginResponse(body []byte) bool {
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return false
+	}
+	if data, ok := result["data"].(map[string]interface{}); ok {
+		return c.applyLoginMap(data)
+	}
+	return c.applyLoginMap(result)
+}
+
+func (c *nacosUserPassCredential) applyLoginMap(data map[string]interface{}) bool {
+	token, ok := data["accessToken"].(string)
+	if !ok || token == "" {
+		return false
+	}
+	c.accessToken = token
+
+	var ttlSeconds int64
+	switch value := data["tokenTtl"].(type) {
+	case float64:
+		ttlSeconds = int64(value)
+	case int64:
+		ttlSeconds = value
+	case int:
+		ttlSeconds = int64(value)
+	}
+	if ttlSeconds > 0 {
+		c.tokenExpireAt = time.Now().Add(time.Duration(ttlSeconds) * time.Second)
+	} else {
+		c.tokenExpireAt = time.Time{}
+	}
+	return true
+}
+
+// ── nacosSTSCredential ────────────────────────────────────────────────────
+
+type nacosSTSCredential struct {
+	namespace string
+	tm        *credprovider.TokenManager
+	mu        sync.RWMutex
+	cached    *credprovider.IssueResponse
+}
+
+func newNacosSTSCredential(namespace string, client credprovider.Client) *nacosSTSCredential {
+	tm := credprovider.NewTokenManager(client, credprovider.IssueRequest{
+		SessionName: "hiclaw-nacos-" + namespace,
+		Entries: []credprovider.AccessEntry{
+			{
+				Service: credprovider.ServiceAIRegistry,
+				Scope: credprovider.AccessScope{
+					NamespaceID: namespace,
+					Resources:   []string{"agentSpec/*", "skill/*"},
+				},
+			},
+		},
+	})
+	return &nacosSTSCredential{namespace: namespace, tm: tm}
+}
+
+func (c *nacosSTSCredential) Refresh(ctx context.Context) error {
+	tok, err := c.tm.Token(ctx)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.cached = tok
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *nacosSTSCredential) Apply(req *http.Request) {
+	c.mu.RLock()
+	tok := c.cached
+	c.mu.RUnlock()
+	if tok == nil {
+		return
+	}
+
+	timestamp := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	group := "DEFAULT_GROUP"
+
+	signData := c.namespace + "+" + group + "+" + timestamp
+	if c.namespace == "" {
+		signData = timestamp
+	}
+
+	mac := hmac.New(sha1.New, []byte(tok.AccessKeySecret))
+	mac.Write([]byte(signData))
+	signature := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	req.Header.Set("Spas-AccessKey", tok.AccessKeyID)
+	req.Header.Set("Spas-SecurityToken", tok.SecurityToken)
+	req.Header.Set("Timestamp", timestamp)
+	req.Header.Set("Spas-Signature", signature)
+}

--- a/hiclaw-controller/internal/executor/nacos_credential_test.go
+++ b/hiclaw-controller/internal/executor/nacos_credential_test.go
@@ -1,0 +1,134 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/hiclaw/hiclaw-controller/internal/credprovider"
+)
+
+func TestNacosSTSCredential_RefreshAndApply_SpasHeaders(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	stub := stubCredForCredentialTest()
+	c := newNacosSTSCredential("team-ns", stub)
+	if err := c.Refresh(ctx); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example/nacos", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Apply(req)
+	if g := req.Header.Get("Spas-AccessKey"); g != "test-ak" {
+		t.Errorf("Spas-AccessKey = %q", g)
+	}
+	if req.Header.Get("Spas-SecurityToken") == "" {
+		t.Error("expected non-empty Spas-SecurityToken")
+	}
+	if req.Header.Get("Spas-Signature") == "" {
+		t.Error("expected non-empty Spas-Signature")
+	}
+	if req.Header.Get("Timestamp") == "" {
+		t.Error("expected non-empty Timestamp")
+	}
+}
+
+// Empty namespace: signing uses timestamp-only path (see nacos_credential Apply).
+func TestNacosSTSCredential_Apply_EmptyNamespace_StillSetsHeaders(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	stub := stubCredForCredentialTest()
+	c := newNacosSTSCredential("", stub)
+	if err := c.Refresh(ctx); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	req, _ := http.NewRequest(http.MethodGet, "http://example", nil)
+	c.Apply(req)
+	if req.Header.Get("Spas-AccessKey") == "" {
+		t.Error("expected Spas-AccessKey")
+	}
+}
+
+func TestNacosSTSCredential_Apply_WithoutRefresh_DoesNotSetSpas(t *testing.T) {
+	t.Parallel()
+	stub := stubCredForCredentialTest()
+	c := newNacosSTSCredential("ns", stub)
+	req, _ := http.NewRequest(http.MethodGet, "http://example", nil)
+	c.Apply(req)
+	if req.Header.Get("Spas-AccessKey") != "" {
+		t.Error("expected no Spas headers when cached is nil")
+	}
+}
+
+type stubTokenIssuer struct {
+	out *credprovider.IssueResponse
+}
+
+func (s stubTokenIssuer) Issue(_ context.Context, _ credprovider.IssueRequest) (*credprovider.IssueResponse, error) {
+	return s.out, nil
+}
+
+func stubCredForCredentialTest() credprovider.Client {
+	return stubTokenIssuer{
+		out: &credprovider.IssueResponse{
+			AccessKeyID:     "test-ak",
+			AccessKeySecret: "test-sk",
+			SecurityToken:   "test-sts",
+			ExpiresInSec:    3600,
+		},
+	}
+}
+
+func TestNacosNoneCredential_RefreshAndApply_DoesNotInjectAuth(t *testing.T) {
+	t.Parallel()
+	var c nacosNoneCredential
+	if err := c.Refresh(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	req, _ := http.NewRequest(http.MethodGet, "http://nacos", nil)
+	c.Apply(req)
+	if h := req.Header.Get("Authorization"); h != "" {
+		t.Errorf("Authorization = %q, want empty", h)
+	}
+	if req.Header.Get("Spas-AccessKey") != "" {
+		t.Error("unexpected Spas-AccessKey")
+	}
+}
+
+func TestNacosUserPass_Apply_WithoutLogin_NoBearer(t *testing.T) {
+	t.Parallel()
+	c := &nacosUserPassCredential{serverAddr: "127.0.0.1:8848"}
+	req, _ := http.NewRequest(http.MethodGet, "http://nacos", nil)
+	c.Apply(req)
+	if req.Header.Get("Authorization") != "" {
+		t.Error("expected no Bearer before login")
+	}
+}
+
+func TestNacosUserPass_tryLogin_Non200ReturnsFalse(t *testing.T) {
+	// 404: tryLogin returns (false, nil) — not an HTTP transport error
+	s := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(s.Close)
+
+	c := nacosUserPassCredential{
+		serverAddr: s.Listener.Addr().String(),
+		username:   "u",
+		password:   "p",
+		httpClient: s.Client(),
+	}
+	form := url.Values{}
+	form.Set("username", "u")
+	form.Set("password", "p")
+	ok, err := c.tryLogin(context.Background(), s.URL+"/nacos/v3/auth/user/login", form)
+	if err != nil {
+		t.Fatalf("tryLogin: %v", err)
+	}
+	if ok {
+		t.Error("expected ok=false for non-200")
+	}
+}

--- a/hiclaw-controller/internal/executor/package.go
+++ b/hiclaw-controller/internal/executor/package.go
@@ -11,12 +11,20 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/hiclaw/hiclaw-controller/internal/credprovider"
 )
 
 // PackageResolver handles file://, http(s)://, and nacos:// package URIs.
 type PackageResolver struct {
 	ImportDir  string // e.g. /tmp/import
 	ExtractDir string // e.g. /tmp/import/extracted
+
+	// NacosAuthType selects the Nacos auth implementation:
+	// "nacos" (user/pass), "sts-hiclaw" (STS), "none" or "" (auto-detect).
+	NacosAuthType string
+	// CredClient is required when NacosAuthType == "sts-hiclaw".
+	CredClient credprovider.Client
 }
 
 func NewPackageResolver(importDir string) *PackageResolver {
@@ -519,7 +527,7 @@ func (p *PackageResolver) resolveNacos(ctx context.Context, u *url.URL) (string,
 		return "", fmt.Errorf("failed to clean previous nacos package %s: %w", destPath, err)
 	}
 
-	client, err := newNacosAgentSpecClient(ctx, nacosAddr, namespace)
+	client, err := NewNacosAIClient(ctx, nacosAddr, namespace, p.NacosAuthType, p.CredClient)
 	if err != nil {
 		return "", err
 	}
@@ -545,10 +553,26 @@ func (p *PackageResolver) resolveNacos(ctx context.Context, u *url.URL) (string,
 	return destPath, nil
 }
 
+// ValidateNacosURIOptions configures Nacos preflight so it matches runtime
+// PackageResolver behavior. Use the same values as the controller: AuthType
+// from HICLAW_NACOS_AUTH_TYPE and CredClient from the credential-provider
+// (when NacosAuthType is sts-hiclaw).
+type ValidateNacosURIOptions struct {
+	// AuthType is one of "nacos", "sts-hiclaw", "none", or "" (auto-detect from
+	// the URI, same as NewNacosAIClient). When empty, the value of
+	// HICLAW_NACOS_AUTH_TYPE is used so CLI preflight can align with the
+	// controller's environment.
+	AuthType string
+	// CredClient is required when the effective auth type is "sts-hiclaw"; it
+	// should be the same credprovider.Client wired into PackageResolver
+	// (HTTP client to hiclaw-credential-provider /issue).
+	CredClient credprovider.Client
+}
+
 // ValidateNacosURI checks that a nacos:// URI is well-formed, the server is
 // reachable, and any embedded credentials are accepted.  It is intended as a
 // preflight check before persisting a Worker resource.
-func ValidateNacosURI(ctx context.Context, raw string) error {
+func ValidateNacosURI(ctx context.Context, raw string, opts ValidateNacosURIOptions) error {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return fmt.Errorf("invalid nacos URI %q: %w", raw, err)
@@ -582,9 +606,14 @@ func ValidateNacosURI(ctx context.Context, raw string) error {
 		version = ""
 	}
 
-	// newNacosAgentSpecClient validates the address format, connects, and
-	// performs login when credentials are present.
-	client, err := newNacosAgentSpecClient(ctx, nacosAddr, namespace)
+	authType := opts.AuthType
+	if authType == "" {
+		authType = os.Getenv("HICLAW_NACOS_AUTH_TYPE")
+	}
+
+	// newNacosAIClient validates the address format, connects, and
+	// performs login (or STS) when credentials are present — same as resolveNacos.
+	client, err := NewNacosAIClient(ctx, nacosAddr, namespace, authType, opts.CredClient)
 	if err != nil {
 		return fmt.Errorf("nacos preflight check failed for %q: %w", raw, err)
 	}

--- a/hiclaw-controller/internal/executor/package_test.go
+++ b/hiclaw-controller/internal/executor/package_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/hiclaw/hiclaw-controller/internal/credprovider"
 )
 
 func TestWriteInlineConfigs_AllFields_OpenClaw(t *testing.T) {
@@ -264,7 +266,7 @@ func TestValidateNacosURI_FormatErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateNacosURI(context.Background(), tt.uri)
+			err := ValidateNacosURI(context.Background(), tt.uri, ValidateNacosURIOptions{})
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
@@ -300,7 +302,7 @@ func TestValidateNacosURI_ValidFormat_UnreachableServer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateNacosURI(context.Background(), tt.uri)
+			err := ValidateNacosURI(context.Background(), tt.uri, ValidateNacosURIOptions{})
 			if err == nil {
 				t.Fatal("expected connection error for unreachable server, got nil")
 			}
@@ -427,7 +429,7 @@ func TestValidateNacosURI_UsesEnvCredentialsWhenURIHasNoAuth(t *testing.T) {
 	t.Setenv("HICLAW_NACOS_USERNAME", "env-user")
 	t.Setenv("HICLAW_NACOS_PASSWORD", "env-pass")
 
-	err := ValidateNacosURI(context.Background(), "nacos://127.0.0.1:19999/ns/my-spec")
+	err := ValidateNacosURI(context.Background(), "nacos://127.0.0.1:19999/ns/my-spec", ValidateNacosURIOptions{})
 	if err == nil {
 		t.Fatal("expected connection error for unreachable server, got nil")
 	}
@@ -445,7 +447,7 @@ func TestValidateNacosURI_PartialEnvCredentialsFail(t *testing.T) {
 	t.Setenv("HICLAW_NACOS_USERNAME", "env-user")
 	t.Setenv("HICLAW_NACOS_PASSWORD", "")
 
-	err := ValidateNacosURI(context.Background(), "nacos://127.0.0.1:19999/ns/my-spec")
+	err := ValidateNacosURI(context.Background(), "nacos://127.0.0.1:19999/ns/my-spec", ValidateNacosURIOptions{})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -463,7 +465,7 @@ func TestValidateNacosURI_ChecksAgentSpecExists(t *testing.T) {
 	)
 	defer server.Close()
 
-	err := ValidateNacosURI(context.Background(), "nacos://"+server.Listener.Addr().String()+"/public/missing-spec")
+	err := ValidateNacosURI(context.Background(), "nacos://"+server.Listener.Addr().String()+"/public/missing-spec", ValidateNacosURIOptions{})
 	if err == nil {
 		t.Fatal("expected missing agentspec error, got nil")
 	}
@@ -484,7 +486,7 @@ func TestValidateNacosURI_SucceedsWhenAgentSpecExists(t *testing.T) {
 	)
 	defer server.Close()
 
-	err := ValidateNacosURI(context.Background(), "nacos://"+server.Listener.Addr().String()+"/public/existing-spec")
+	err := ValidateNacosURI(context.Background(), "nacos://"+server.Listener.Addr().String()+"/public/existing-spec", ValidateNacosURIOptions{})
 	if err != nil {
 		t.Fatalf("expected success, got: %v", err)
 	}
@@ -499,7 +501,7 @@ func TestValidateNacosURI_FailsWhenAgentSpecHasNoOnlineVersion(t *testing.T) {
 	)
 	defer server.Close()
 
-	err := ValidateNacosURI(context.Background(), "nacos://"+server.Listener.Addr().String()+"/public/offline-spec")
+	err := ValidateNacosURI(context.Background(), "nacos://"+server.Listener.Addr().String()+"/public/offline-spec", ValidateNacosURIOptions{})
 	if err == nil {
 		t.Fatal("expected offline agentspec error, got nil")
 	}
@@ -517,7 +519,7 @@ func TestValidateNacosURI_FailsWhenRequestedVersionIsNotOnline(t *testing.T) {
 	)
 	defer server.Close()
 
-	err := ValidateNacosURI(context.Background(), "nacos://"+server.Listener.Addr().String()+"/public/mixed-spec/v1")
+	err := ValidateNacosURI(context.Background(), "nacos://"+server.Listener.Addr().String()+"/public/mixed-spec/v1", ValidateNacosURIOptions{})
 	if err == nil {
 		t.Fatal("expected offline version error, got nil")
 	}
@@ -526,7 +528,49 @@ func TestValidateNacosURI_FailsWhenRequestedVersionIsNotOnline(t *testing.T) {
 	}
 }
 
+func TestValidateNacosURI_STSHiclaw_RequiresCredClient(t *testing.T) {
+	uri := "nacos://127.0.0.1:19999/public/my-spec"
+	err := ValidateNacosURI(context.Background(), uri, ValidateNacosURIOptions{AuthType: "sts-hiclaw"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "sts-hiclaw auth requires a credprovider.Client") {
+		t.Fatalf("expected credprovider requirement error, got: %v", err)
+	}
+}
+
+func TestValidateNacosURI_STSHiclaw_SucceedsWithCredClient(t *testing.T) {
+	server := newNacosAgentSpecCheckTestServer(t,
+		http.StatusOK,
+		`{"code":0,"message":"success","data":{"totalCount":1,"pageItems":[{"namespaceId":"public","name":"sts-spec","description":"demo","enable":true,"onlineCnt":1,"labels":{"latest":"v1"}}]}}`,
+		0,
+		"",
+	)
+	defer server.Close()
+
+	stub := stubCredClient{}
+	err := ValidateNacosURI(context.Background(), "nacos://"+server.Listener.Addr().String()+"/public/sts-spec", ValidateNacosURIOptions{
+		AuthType:   "sts-hiclaw",
+		CredClient: stub,
+	})
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+}
+
 // --- helpers ---
+
+// stubCredClient returns a static STS-like triple for Nacos Spas signing tests.
+type stubCredClient struct{}
+
+func (stubCredClient) Issue(ctx context.Context, req credprovider.IssueRequest) (*credprovider.IssueResponse, error) {
+	return &credprovider.IssueResponse{
+		AccessKeyID:     "test-access-key-id",
+		AccessKeySecret: "test-access-key-secret",
+		SecurityToken:   "test-security-token",
+		Expiration:      "2099-01-01T00:00:00Z",
+	}, nil
+}
 func newNacosAgentSpecCheckTestServer(t *testing.T, listStatus int, listBody string, getStatus int, getBody string) *httptest.Server {
 	t.Helper()
 

--- a/hiclaw-controller/internal/service/deployer.go
+++ b/hiclaw-controller/internal/service/deployer.go
@@ -3,12 +3,14 @@ package service
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
 	"github.com/hiclaw/hiclaw-controller/internal/agentconfig"
+	"github.com/hiclaw/hiclaw-controller/internal/credprovider"
 	"github.com/hiclaw/hiclaw-controller/internal/executor"
 	"github.com/hiclaw/hiclaw-controller/internal/oss"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -63,32 +65,41 @@ type DeployerConfig struct {
 	AgentFSDir     string // embedded: /root/hiclaw-fs/agents
 	WorkerAgentDir string // source for builtin agent files
 	MatrixDomain   string
+
+	// NacosAuthType and NacosCredClient mirror the same fields on PackageResolver
+	// but are used when PushOnDemandSkills encounters nacos:// skill URIs.
+	NacosAuthType   string
+	NacosCredClient credprovider.Client
 }
 
 // Deployer orchestrates configuration deployment for workers: package resolution,
 // inline config writes, openclaw.json generation, AGENTS.md merging, skill pushing,
 // and OSS synchronization.
 type Deployer struct {
-	agentConfig    *agentconfig.Generator
-	oss            oss.StorageClient
-	executor       *executor.Shell
-	packages       *executor.PackageResolver
-	legacy         *LegacyCompat
-	agentFSDir     string
-	workerAgentDir string
-	matrixDomain   string
+	agentConfig     *agentconfig.Generator
+	oss             oss.StorageClient
+	executor        *executor.Shell
+	packages        *executor.PackageResolver
+	legacy          *LegacyCompat
+	agentFSDir      string
+	workerAgentDir  string
+	matrixDomain    string
+	nacosAuthType   string
+	nacosCredClient credprovider.Client
 }
 
 func NewDeployer(cfg DeployerConfig) *Deployer {
 	return &Deployer{
-		agentConfig:    cfg.AgentConfig,
-		oss:            cfg.OSS,
-		executor:       cfg.Executor,
-		packages:       cfg.Packages,
-		legacy:         cfg.Legacy,
-		agentFSDir:     cfg.AgentFSDir,
-		workerAgentDir: cfg.WorkerAgentDir,
-		matrixDomain:   cfg.MatrixDomain,
+		agentConfig:     cfg.AgentConfig,
+		oss:             cfg.OSS,
+		executor:        cfg.Executor,
+		packages:        cfg.Packages,
+		legacy:          cfg.Legacy,
+		agentFSDir:      cfg.AgentFSDir,
+		workerAgentDir:  cfg.WorkerAgentDir,
+		matrixDomain:    cfg.MatrixDomain,
+		nacosAuthType:   cfg.NacosAuthType,
+		nacosCredClient: cfg.NacosCredClient,
 	}
 }
 
@@ -299,24 +310,109 @@ func (d *Deployer) renderAndPushSoulTemplate(ctx context.Context, agentPrefix st
 	return d.oss.PutObject(ctx, agentPrefix+"/SOUL.md", []byte(result))
 }
 
-// PushOnDemandSkills runs the push-worker-skills.sh script for on-demand skills.
-// No-op if no skills or executor is nil.
-// NOTE: In incluster mode, the script may not exist in the controller container.
-// On-demand skills are then expected to be pushed by the Manager agent via its
-// worker-management skill at runtime.
+// PushOnDemandSkills pushes on-demand skills to a worker.
+// Skills named with the "nacos://" scheme are fetched from Nacos and mirrored
+// to OSS. All other skills fall back to the legacy push-worker-skills.sh script.
+// No-op if no skills are provided.
 func (d *Deployer) PushOnDemandSkills(ctx context.Context, workerName string, skills []string) error {
 	logger := log.FromContext(ctx)
-	if len(skills) == 0 || d.executor == nil {
+	if len(skills) == 0 {
+		return nil
+	}
+
+	agentPrefix := fmt.Sprintf("agents/%s", workerName)
+	var builtinSkills []string
+
+	for _, skill := range skills {
+		if !strings.HasPrefix(skill, "nacos://") {
+			builtinSkills = append(builtinSkills, skill)
+			continue
+		}
+
+		// ── nacos:// skill ──────────────────────────────────────────────────
+		u, err := parseNacosSkillURI(skill)
+		if err != nil {
+			return fmt.Errorf("invalid nacos skill URI %q: %w", skill, err)
+		}
+
+		client, err := executor.NewNacosAIClient(ctx, u.nacosAddr, u.namespace, d.nacosAuthType, d.nacosCredClient)
+		if err != nil {
+			return fmt.Errorf("connect to nacos for skill %q: %w", skill, err)
+		}
+
+		// Download and extract ZIP into a temp directory.
+		tmpDir, err := os.MkdirTemp("", "nacos-skill-")
+		if err != nil {
+			return fmt.Errorf("create temp dir for skill %q: %w", skill, err)
+		}
+		defer os.RemoveAll(tmpDir)
+
+		if err := client.GetSkill(ctx, u.skillName, tmpDir, u.version, u.label); err != nil {
+			return fmt.Errorf("fetch skill %q from nacos: %w", skill, err)
+		}
+
+		// Mirror extracted skill directory to OSS.
+		src := filepath.Join(tmpDir, u.skillName) + "/"
+		dst := agentPrefix + "/skills/" + u.skillName + "/"
+		if err := d.oss.Mirror(ctx, src, dst, oss.MirrorOptions{Overwrite: true}); err != nil {
+			return fmt.Errorf("mirror skill %q to OSS: %w", skill, err)
+		}
+		logger.Info("nacos skill pushed", "worker", workerName, "skill", u.skillName, "version", u.version)
+	}
+
+	// ── legacy builtin skills via push-worker-skills.sh ──────────────────
+	if len(builtinSkills) == 0 || d.executor == nil {
 		return nil
 	}
 	scriptPath := "/opt/hiclaw/agent/skills/worker-management/scripts/push-worker-skills.sh"
 	if _, err := os.Stat(scriptPath); os.IsNotExist(err) {
 		logger.Info("push-worker-skills.sh not found (incluster mode), skipping on-demand skill push",
-			"worker", workerName, "skills", skills)
+			"worker", workerName, "skills", builtinSkills)
 		return nil
 	}
 	_, err := d.executor.RunSimple(ctx, scriptPath, "--worker", workerName, "--no-notify")
 	return err
+}
+
+type nacosSkillURIParts struct {
+	nacosAddr string
+	namespace string
+	skillName string
+	version   string
+	label     string
+}
+
+// parseNacosSkillURI parses nacos://[user:pass@]host:port/{namespace}/{skill-name}[/{version}]
+func parseNacosSkillURI(raw string) (*nacosSkillURIParts, error) {
+	// Replace the nacos:// scheme with http:// so url.Parse handles user-info correctly.
+	parsed, err := url.Parse("http://" + strings.TrimPrefix(raw, "nacos://"))
+	if err != nil {
+		return nil, err
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("expected nacos://[user:pass@]host:port/{namespace}/{skill-name}[/{version}]")
+	}
+
+	nacosAddr := parsed.Host
+	if parsed.User != nil {
+		nacosAddr = parsed.User.String() + "@" + parsed.Host
+	}
+
+	u := &nacosSkillURIParts{
+		nacosAddr: nacosAddr,
+		namespace: parts[0],
+		skillName: parts[1],
+	}
+	if len(parts) >= 3 {
+		v := parts[2]
+		if strings.HasPrefix(v, "label:") {
+			u.label = strings.TrimPrefix(v, "label:")
+		} else {
+			u.version = v
+		}
+	}
+	return u, nil
 }
 
 // CleanupOSSData removes all agent data from OSS for a deleted worker.


### PR DESCRIPTION
This pull request introduces support for the new `ai-registry` service in the access control and credential provider layers, and refactors the Nacos AI client to support multiple authentication methods and skill download workflows. It also adds configuration options for Nacos authentication and improves error handling and logging in the service layer.

**Access Control and Credential Provider Enhancements:**
- Added support for the `ai-registry` service in `AccessEntry`, including a new scope with `namespaceId` and `resources` fields. The resolver now handles `ai-registry` entries, supporting both default and custom resource patterns.
- Added comprehensive tests for `ai-registry` access entry resolution, covering default and custom resource scenarios.

**Nacos AI Client Refactoring and Authentication:**
- Refactored the Nacos AI client (renamed file and major code changes) to support multiple authentication methods, skill ZIP downloads, and extraction, with improved request preparation and token management.

**Configuration and Service Layer Updates:**
- Introduced the `NacosAuthType` configuration option, allowing selection of authentication methods for Nacos AI client connections, and propagated this config through the app and service layers.
**Logging Improvements:**
- Changed skill push failure logs from error to info level in both manager and member controllers, including the error in the log context for better observability. 

- Change-Id: I97cdd13d58be71141f4e0dbdb97a22e8679900d4