### PR TITLE
fix(install): extract Matrix credentials during upgrade when manager is stopped

### DIFF
--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -848,6 +848,122 @@ function Wait-MatrixReady {
     Write-Error (Get-Msg "install.wait_matrix.timeout" -f $Timeout, $Container)
 }
 
+# Read KEY=value from /data/hiclaw-secrets.env on a Docker volume (manager container not required).
+# Requires $script:EMBEDDED_IMAGE (set by Resolve-EmbeddedImage before Install-Manager uses this).
+function Read-HiclawSecretFromDataVolume {
+    param(
+        [string]$VolumeName,
+        [string]$Key
+    )
+    if ([string]::IsNullOrEmpty($VolumeName) -or [string]::IsNullOrEmpty($Key) -or [string]::IsNullOrEmpty($script:EMBEDDED_IMAGE)) {
+        return ""
+    }
+    $grepKey = [regex]::Escape($Key)
+    $shCmd = "grep ""^${grepKey}="" /data/hiclaw-secrets.env 2>/dev/null | cut -d= -f2- | head -1 | tr -d '\r'"
+    $out = docker run --rm --entrypoint sh -v "${VolumeName}:/data:ro" $script:EMBEDDED_IMAGE -c $shCmd 2>$null
+    if ($null -eq $out) { return "" }
+    return ($out | Out-String).Trim()
+}
+
+# Read KEY=value from /data/worker-creds/<worker>.env on a Docker volume.
+function Read-HiclawWorkerCredsFromVolume {
+    param(
+        [string]$VolumeName,
+        [string]$WorkerName,
+        [string]$Key
+    )
+    if ([string]::IsNullOrEmpty($VolumeName) -or [string]::IsNullOrEmpty($WorkerName) -or [string]::IsNullOrEmpty($Key) -or [string]::IsNullOrEmpty($script:EMBEDDED_IMAGE)) {
+        return ""
+    }
+    $grepKey = [regex]::Escape($Key)
+    $path = "/data/worker-creds/${WorkerName}.env"
+    $shCmd = "grep ""^${grepKey}="" ""${path}"" 2>/dev/null | cut -d= -f2- | head -1 | tr -d '\r'"
+    $out = docker run --rm --entrypoint sh -v "${VolumeName}:/data:ro" $script:EMBEDDED_IMAGE -c $shCmd 2>$null
+    if ($null -eq $out) { return "" }
+    return ($out | Out-String).Trim()
+}
+
+# Read admin_dm_room_id from host workspace state.json (fallback when Matrix API is unavailable).
+function Read-HiclawAdminDmRoomFromWorkspace {
+    param([string]$WorkspaceDir)
+    if ([string]::IsNullOrEmpty($WorkspaceDir)) { return "" }
+    $statePath = Join-Path $WorkspaceDir "state.json"
+    if (-not (Test-Path $statePath)) { return "" }
+    try {
+        $j = Get-Content $statePath -Raw -ErrorAction Stop | ConvertFrom-Json
+        $rid = $j.admin_dm_room_id
+        if ($null -eq $rid) { return "" }
+        $s = [string]$rid
+        if ($s -eq "" -or $s -eq "null") { return "" }
+        return $s.Trim()
+    } catch {
+        return ""
+    }
+}
+
+function Get-HiclawRandomHex {
+    param([int]$ByteCount)
+    $bytes = New-Object byte[] $ByteCount
+    $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+    $rng.GetBytes($bytes)
+    return ([BitConverter]::ToString($bytes)).Replace("-", "").ToLower()
+}
+
+# Resolve admin DM room with @manager (small room) via Matrix Client API inside hiclaw-manager.
+function Get-HiclawAdminDmRoomViaMatrix {
+    param(
+        [string]$AdminUser,
+        [string]$AdminPassword
+    )
+    $running = docker ps --format "{{.Names}}" 2>$null | Select-String "^hiclaw-manager$"
+    if (-not $running) { return "" }
+    if ([string]::IsNullOrEmpty($AdminPassword)) { return "" }
+
+    $loginObj = @{
+        type         = "m.login.password"
+        identifier   = @{ type = "m.id.user"; user = $AdminUser }
+        password     = $AdminPassword
+    }
+    $loginJson = $loginObj | ConvertTo-Json -Compress -Depth 5
+    try {
+        $loginRaw = $loginJson | docker exec -i hiclaw-manager sh -c "curl -sf -X POST http://127.0.0.1:6167/_matrix/client/v3/login -H 'Content-Type: application/json' -d @-" 2>$null
+        if (-not $loginRaw) { return "" }
+        $loginResp = $loginRaw | ConvertFrom-Json
+        $token = [string]$loginResp.access_token
+        if ([string]::IsNullOrEmpty($token)) { return "" }
+
+        $roomsRaw = docker exec hiclaw-manager curl -sf -X GET -H "Authorization: Bearer $token" `
+            "http://127.0.0.1:6167/_matrix/client/v3/joined_rooms" 2>$null
+        if (-not $roomsRaw) { return "" }
+        $roomsObj = $roomsRaw | ConvertFrom-Json
+        $roomList = @($roomsObj.joined_rooms)
+        foreach ($roomId in $roomList) {
+            if ([string]::IsNullOrEmpty($roomId)) { continue }
+            $enc = $roomId.Replace("!", "%21")
+            $memRaw = docker exec hiclaw-manager curl -sf -X GET -H "Authorization: Bearer $token" `
+                "http://127.0.0.1:6167/_matrix/client/v3/rooms/${enc}/members" 2>$null
+            if (-not $memRaw) { continue }
+            $memObj = $memRaw | ConvertFrom-Json
+            $chunk = @($memObj.chunk)
+            $memberIds = @($chunk | ForEach-Object { $_.state_key })
+            $match = $false
+            foreach ($m in $memberIds) {
+                $beforeColon = ($m -split ":")[0]
+                if ($m -like "*manager*" -and $beforeColon -notlike "*admin*") {
+                    $match = $true
+                    break
+                }
+            }
+            if ($match -and $memberIds.Count -le 3) {
+                return $roomId
+            }
+        }
+    } catch {
+        return ""
+    }
+    return ""
+}
+
 function New-EnvFile {
     param([hashtable]$Config, [string]$Path)
 
@@ -2455,6 +2571,146 @@ function Install-Manager {
         }
     }
 
+    # --- Pre-upgrade: extract Matrix passwords from old containers (old-arch -> embedded) ---
+    $credsTmp = $null
+    if ($script:HICLAW_UPGRADE -and $script:HICLAW_USE_EMBEDDED -eq "1") {
+        $controllerNameHit = docker ps -a --format "{{.Names}}" 2>$null | Select-String "^hiclaw-controller$"
+        $isOldArch = $false
+        if (-not $controllerNameHit) {
+            $isOldArch = $true
+        } else {
+            $ctrlImgLine = docker ps -a --format "{{.Names}} {{.Image}}" 2>$null | Where-Object { $_ -match '^hiclaw-controller ' } | Select-Object -First 1
+            if ($ctrlImgLine -and ($ctrlImgLine -notmatch 'embedded')) {
+                $isOldArch = $true
+            }
+        }
+
+        if ($isOldArch) {
+            $credsTmp = Join-Path ([System.IO.Path]::GetTempPath()) ("hiclaw-upgrade-creds-" + [Guid]::NewGuid().ToString("n"))
+            New-Item -ItemType Directory -Path $credsTmp -Force | Out-Null
+            $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+
+            $mgrCredsTempStart = $false
+            $mgrExists = docker ps -a --format "{{.Names}}" 2>$null | Select-String "^hiclaw-manager$"
+            $mgrRunning = docker ps --format "{{.Names}}" 2>$null | Select-String "^hiclaw-manager$"
+            if ($mgrExists -and -not $mgrRunning) {
+                Write-Log "hiclaw-manager is stopped; starting it temporarily to extract Matrix credentials for upgrade..."
+                docker start hiclaw-manager 2>$null | Out-Null
+                Wait-MatrixReady -Container "hiclaw-manager"
+                $mgrCredsTempStart = $true
+            }
+
+            $inspectLines = docker inspect hiclaw-manager --format "{{range .Config.Env}}{{println .}}{{end}}" 2>$null
+            $mgrPw = ""
+            if ($inspectLines) {
+                $envLine = $inspectLines -split "`n" | Where-Object { $_ -match '^HICLAW_MANAGER_PASSWORD=' } | Select-Object -First 1
+                if ($envLine) {
+                    $mgrPw = ($envLine -replace '^HICLAW_MANAGER_PASSWORD=', "").Trim()
+                }
+            }
+            $mgrRunningNow = docker ps --format "{{.Names}}" 2>$null | Select-String "^hiclaw-manager$"
+            if ([string]::IsNullOrEmpty($mgrPw) -and $mgrRunningNow) {
+                $mgrPw = docker exec hiclaw-manager bash -c 'source /data/hiclaw-secrets.env 2>/dev/null && echo "${HICLAW_MANAGER_PASSWORD}"' 2>$null
+                if ($mgrPw) { $mgrPw = $mgrPw.Trim() }
+            }
+            $dataVolPresent = docker volume ls -q 2>$null | Where-Object { $_ -eq $config.DATA_DIR }
+            if ([string]::IsNullOrEmpty($mgrPw) -and $dataVolPresent) {
+                $mgrPw = Read-HiclawSecretFromDataVolume -VolumeName $config.DATA_DIR -Key "HICLAW_MANAGER_PASSWORD"
+            }
+
+            $envFilePath = $script:HICLAW_ENV_FILE
+            $mgrRoom = ""
+            if (-not [string]::IsNullOrEmpty($mgrPw)) {
+                $adminPw = ""
+                $adminUser = "admin"
+                if (Test-Path $envFilePath) {
+                    $adminLine = Get-Content $envFilePath | Where-Object { $_ -match '^HICLAW_ADMIN_PASSWORD=' } | Select-Object -First 1
+                    if ($adminLine) { $adminPw = ($adminLine -replace '^HICLAW_ADMIN_PASSWORD=', "").Trim() }
+                    $userLine = Get-Content $envFilePath | Where-Object { $_ -match '^HICLAW_ADMIN_USER=' } | Select-Object -First 1
+                    if ($userLine) {
+                        $adminUser = ($userLine -replace '^HICLAW_ADMIN_USER=', "").Trim()
+                        if ([string]::IsNullOrEmpty($adminUser)) { $adminUser = "admin" }
+                    }
+                }
+
+                if (-not [string]::IsNullOrEmpty($adminPw) -and $mgrRunningNow) {
+                    $mgrRoom = Get-HiclawAdminDmRoomViaMatrix -AdminUser $adminUser -AdminPassword $adminPw
+                }
+                if ([string]::IsNullOrEmpty($mgrRoom)) {
+                    $mgrRoom = Read-HiclawAdminDmRoomFromWorkspace -WorkspaceDir $config.WORKSPACE_DIR
+                }
+
+                $gwKeyLine = if (Test-Path $envFilePath) {
+                    Get-Content $envFilePath | Where-Object { $_ -match '^HICLAW_MANAGER_GATEWAY_KEY=' } | Select-Object -First 1
+                } else { $null }
+                $gwKeyForDefault = if ($gwKeyLine) { ($gwKeyLine -replace '^HICLAW_MANAGER_GATEWAY_KEY=', "").Trim() } else { $config.MANAGER_GATEWAY_KEY }
+
+                $defaultEnvPath = Join-Path $credsTmp "default.env"
+                [System.IO.File]::WriteAllLines($defaultEnvPath, @(
+                    "WORKER_PASSWORD=$mgrPw"
+                    "WORKER_MINIO_PASSWORD=$(Get-HiclawRandomHex 24)"
+                    "WORKER_GATEWAY_KEY=$gwKeyForDefault"
+                    "WORKER_ROOM_ID=$mgrRoom"
+                ), $utf8NoBom)
+                if ($mgrRoom) {
+                    Write-Log "Extracted Manager Matrix password and room ID"
+                } else {
+                    Write-Log "Extracted Manager Matrix password"
+                }
+            }
+
+            $registryPath = Join-Path $config.WORKSPACE_DIR "workers-registry.json"
+            if (Test-Path $registryPath) {
+                try {
+                    $wreg = Get-Content $registryPath -Raw | ConvertFrom-Json
+                    $workerNames = @()
+                    if ($null -ne $wreg.workers) {
+                        $wreg.workers.PSObject.Properties | ForEach-Object { $workerNames += $_.Name }
+                    }
+                    foreach ($wname in $workerNames) {
+                        $wpw = ""
+                        if ($mgrRunningNow) {
+                            $wpw = docker exec hiclaw-manager cat "/root/hiclaw-fs/agents/${wname}/credentials/matrix/password" 2>$null
+                            if ($wpw) { $wpw = $wpw.Trim() }
+                        }
+                        if ([string]::IsNullOrEmpty($wpw) -and $dataVolPresent) {
+                            $wpw = Read-HiclawWorkerCredsFromVolume -VolumeName $config.DATA_DIR -WorkerName $wname -Key "WORKER_PASSWORD"
+                        }
+                        $wroom = ""
+                        $wEntry = $wreg.workers.$wname
+                        if ($wEntry -and $wEntry.room_id) {
+                            $wroom = [string]$wEntry.room_id
+                        }
+                        if ([string]::IsNullOrEmpty($wroom) -and $dataVolPresent) {
+                            $wroom = Read-HiclawWorkerCredsFromVolume -VolumeName $config.DATA_DIR -WorkerName $wname -Key "WORKER_ROOM_ID"
+                        }
+                        if (-not [string]::IsNullOrEmpty($wpw)) {
+                            $wEnvPath = Join-Path $credsTmp "${wname}.env"
+                            [System.IO.File]::WriteAllLines($wEnvPath, @(
+                                "WORKER_PASSWORD=$wpw"
+                                "WORKER_MINIO_PASSWORD=$(Get-HiclawRandomHex 24)"
+                                "WORKER_GATEWAY_KEY=$(Get-HiclawRandomHex 32)"
+                                "WORKER_ROOM_ID=$wroom"
+                            ), $utf8NoBom)
+                            if ($wroom) {
+                                Write-Log "Extracted ${wname} Matrix password and room ID"
+                            } else {
+                                Write-Log "Extracted ${wname} Matrix password"
+                            }
+                        }
+                    }
+                } catch {
+                    Write-Log "Warning: could not read workers-registry.json for credential extraction"
+                }
+            }
+
+            if ($mgrCredsTempStart) {
+                Write-Log "Stopping hiclaw-manager after credential extraction (upgrade will recreate containers)..."
+                docker stop hiclaw-manager 2>$null | Out-Null
+            }
+        }
+    }
+
     # Stop and remove existing containers (deferred until after all
     # configuration is collected and images are pulled successfully)
     $existingProxy = docker ps -a --format "{{.Names}}" 2>$null | Select-String "^hiclaw-controller$"
@@ -2487,6 +2743,28 @@ function Install-Manager {
         Write-Log "Removing legacy container: $($legacy.Line)"
         docker stop $legacy.Line *>$null
         docker rm -f $legacy.Line *>$null
+    }
+
+    # --- Upgrade: inject extracted credentials into data volume (old-arch -> embedded) ---
+    if ($credsTmp -and (Test-Path $credsTmp)) {
+        $credsFiles = Get-ChildItem -Path $credsTmp -Filter "*.env" -ErrorAction SilentlyContinue
+        if ($credsFiles -and $credsFiles.Count -gt 0) {
+            $cleanupCtr = "hiclaw-upgrade-cleanup"
+            docker rm -f $cleanupCtr 2>$null | Out-Null
+            $credsDockerPath = ConvertTo-DockerPath -Path $credsTmp
+            $injectShell = "rm -rf /data/worker-creds && mkdir -p /data/worker-creds && cp /creds/*.env /data/worker-creds/ 2>/dev/null || true && chmod 600 /data/worker-creds/*.env 2>/dev/null || true"
+            docker run --rm --name $cleanupCtr --entrypoint sh `
+                -v "$($config.DATA_DIR):/data" `
+                -v "${credsDockerPath}:/creds:ro" `
+                $script:EMBEDDED_IMAGE `
+                -c $injectShell 2>$null | Out-Null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Log "Injected credentials for upgrade"
+            } else {
+                Write-Log "Warning: credential injection failed, continuing"
+            }
+        }
+        Remove-Item -Path $credsTmp -Recurse -Force -ErrorAction SilentlyContinue
     }
 
     if ($script:HICLAW_USE_EMBEDDED -eq "1") {

--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -14,7 +14,7 @@
 # Environment variables (for automation):
 #   HICLAW_NON_INTERACTIVE    Skip all prompts, use defaults  (default: 0)
 #   HICLAW_LLM_PROVIDER       LLM provider       (default: qwen)
-#   HICLAW_DEFAULT_MODEL      Default model      (default: qwen3.5-plus)
+#   HICLAW_DEFAULT_MODEL      Default model      (default: qwen3.6-plus for alibaba-cloud; qwen3.5-plus for qwen)
 #   HICLAW_LLM_API_KEY        LLM API key        (required)
 #   HICLAW_ADMIN_USER         Admin username     (default: admin)
 #   HICLAW_ADMIN_PASSWORD     Admin password     (auto-generated if not set, min 8 chars)
@@ -220,10 +220,10 @@ $script:Messages = @{
     # --- Onboarding mode ---
     "install.mode.title" = @{ zh = "--- Onboarding 模式 ---"; en = "--- Onboarding Mode ---" }
     "install.mode.choose" = @{ zh = "选择安装模式:"; en = "Choose your installation mode:" }
-    "install.mode.quickstart" = @{ zh = "  1) 快速开始  - 使用阿里云百炼快速安装（推荐）"; en = "  1) Quick Start  - Fast installation with Alibaba Cloud CodingPlan (recommended)" }
+    "install.mode.quickstart" = @{ zh = "  1) 快速开始  - 使用阿里云通义 Token 套餐快速安装（推荐）"; en = "  1) Quick Start  - Fast installation with Qwen Cloud (recommended)" }
     "install.mode.manual" = @{ zh = "  2) 手动配置  - 选择 LLM 提供商并自定义选项"; en = "  2) Manual       - Choose LLM provider and customize options" }
     "install.mode.prompt" = @{ zh = "请选择 [1/2]"; en = "Enter choice [1/2]" }
-    "install.mode.quickstart_selected" = @{ zh = "已选择快速开始模式 - 使用阿里云百炼"; en = "Quick Start mode selected - using Alibaba Cloud CodingPlan" }
+    "install.mode.quickstart_selected" = @{ zh = "已选择快速开始模式 - 使用阿里云通义 Token 套餐"; en = "Quick Start mode selected - using Qwen Cloud" }
     "install.mode.manual_selected" = @{ zh = "已选择手动配置模式 - 您将选择 LLM 提供商并自定义选项"; en = "Manual mode selected - you will choose LLM provider and customize options" }
     "install.mode.invalid" = @{ zh = "无效选择，默认使用快速开始模式"; en = "Invalid choice, defaulting to Quick Start mode" }
 
@@ -290,24 +290,28 @@ $script:Messages = @{
     "llm.provider.qwen" = @{ zh = "  提供商: qwen（阿里云百炼）"; en = "  Provider: qwen (Alibaba Cloud Bailian)" }
     "llm.provider.qwen_default" = @{ zh = "  提供商: {0}（默认）"; en = "  Provider: {0} (default)" }
     "llm.model.default" = @{ zh = "  模型: {0}（默认）"; en = "  Model: {0} (default)" }
-    "llm.apikey_hint" = @{ zh = "  提示: 获取阿里云百炼 API Key:"; en = "  Hint: Get your Alibaba Cloud CodingPlan API Key from:" }
-    "llm.apikey_url" = @{ zh = "     https://www.aliyun.com/product/bailian"; en = "     https://www.alibabacloud.com/en/campaign/ai-scene-coding" }
+    "llm.apikey_hint_bailian" = @{ zh = "  提示: 获取阿里云百炼（DashScope）API Key:"; en = "  Hint: Get your Alibaba Cloud Bailian (DashScope) API Key:" }
+    "llm.apikey_url_bailian" = @{ zh = "     https://www.aliyun.com/product/bailian"; en = "     https://www.aliyun.com/product/bailian" }
+    "llm.apikey_hint_qwencloud" = @{ zh = "  提示: 从 Qwen Cloud（国际站）获取 DASHSCOPE_API_KEY:"; en = "  Hint: Get your DASHSCOPE_API_KEY for Qwen Cloud (international) from:" }
+    "llm.apikey_url_qwencloud" = @{ zh = "     https://home.qwencloud.com/api-keys  （文档: https://docs.qwencloud.com/）"; en = "     https://home.qwencloud.com/api-keys  |  Docs: https://docs.qwencloud.com/" }
+    "llm.apikey_hint_tokenplan" = @{ zh = "  提示: 获取 DashScope API Key 或开通通义 Token 套餐，请参考:"; en = "  Hint: Get your DashScope or Token Plan API key (Alibaba Model Studio):" }
+    "llm.apikey_url_tokenplan" = @{ zh = "     https://help.aliyun.com/zh/model-studio/token-plan-quickstart"; en = "     https://common-buy.aliyun.com/token-plan/  |  https://help.aliyun.com/zh/model-studio/token-plan-quickstart" }
     "llm.apikey_prompt" = @{ zh = "LLM API Key"; en = "LLM API Key" }
     "llm.providers_title" = @{ zh = "可用 LLM 提供商:"; en = "Available LLM Providers:" }
-    "llm.provider.alibaba" = @{ zh = "  1) 阿里云百炼  - 推荐中国用户使用"; en = "  1) Alibaba Cloud CodingPlan  - Optimized for coding tasks (recommended)" }
+    "llm.provider.alibaba" = @{ zh = "  1) 阿里云通义 Token 套餐  - 推荐中国用户使用"; en = "  1) Qwen Cloud  - International (OpenAI-compatible API, recommended)" }
     "llm.provider.openai_compat" = @{ zh = "  2) OpenAI 兼容 API  - 自定义 Base URL（OpenAI、DeepSeek 等）"; en = "  2) OpenAI-compatible API  - Custom Base URL (OpenAI, DeepSeek, etc.)" }
     "llm.provider.select" = @{ zh = "选择提供商 [1/2]"; en = "Select provider [1/2]" }
     "llm.alibaba.models_title" = @{ zh = "选择百炼模型系列:"; en = "Select Bailian model series:" }
-    "llm.alibaba.model.codingplan" = @{ zh = "  1) CodingPlan  - 专为编程任务优化（推荐）"; en = "  1) CodingPlan  - Optimized for coding tasks (recommended)" }
+    "llm.alibaba.model.codingplan" = @{ zh = "  1) Token 套餐  - 多模型调用，替代已下线的 Coding 套餐（推荐）"; en = "  1) Alibaba Cloud Token Plan  - Multi-model access (replaces deprecated Coding plan)" }
     "llm.alibaba.model.qwen" = @{ zh = "  2) 百炼通用接口"; en = "  2) qwen general  - General purpose LLM" }
     "llm.alibaba.model.select" = @{ zh = "选择模型系列 [1/2]"; en = "Select model series [1/2]" }
-    "llm.codingplan.models_title" = @{ zh = "选择 CodingPlan 默认模型:"; en = "Select CodingPlan default model:" }
-    "llm.codingplan.model.qwen35plus" = @{ zh = "  1) qwen3.5-plus  - 千问 3.5（速度最快）"; en = "  1) qwen3.5-plus  - Qwen 3.5 (fastest)" }
+    "llm.codingplan.models_title" = @{ zh = "选择通义 Token 套餐默认模型:"; en = "Select Qwen Cloud default model:" }
+    "llm.codingplan.model.qwen36plus" = @{ zh = "  1) qwen3.6-plus  - 千问 3.6（推荐）"; en = "  1) qwen3.6-plus  - Qwen 3.6 (recommended)" }
     "llm.codingplan.model.glm5" = @{ zh = "  2) glm-5  - 智谱 GLM-5（编程推荐）"; en = "  2) glm-5  - Zhipu GLM-5 (recommended for coding)" }
     "llm.codingplan.model.kimi" = @{ zh = "  3) kimi-k2.5  - Moonshot Kimi K2.5"; en = "  3) kimi-k2.5  - Moonshot Kimi K2.5" }
     "llm.codingplan.model.minimax" = @{ zh = "  4) MiniMax-M2.5  - MiniMax M2.5"; en = "  4) MiniMax-M2.5  - MiniMax M2.5" }
     "llm.codingplan.model.select" = @{ zh = "选择模型 [1/2/3/4]"; en = "Select model [1/2/3/4]" }
-    "llm.provider.selected_codingplan" = @{ zh = "  提供商: 阿里云百炼 CodingPlan"; en = "  Provider: Alibaba Cloud CodingPlan" }
+    "llm.provider.selected_codingplan" = @{ zh = "  提供商: 阿里云通义 Token 套餐（alibaba-cloud）"; en = "  Provider: Qwen Cloud (international) (alibaba-cloud)" }
     "llm.provider.selected_qwen" = @{ zh = "  提供商: 阿里云百炼"; en = "  Provider: Alibaba Cloud Bailian" }
     "llm.provider.selected_openai" = @{ zh = "  提供商: {0}（OpenAI 兼容）"; en = "  Provider: {0} (OpenAI-compatible)" }
     "llm.provider.invalid" = @{ zh = "无效选择: {0}（请输入 1 或 2）"; en = "Invalid choice: {0} (please enter 1 or 2)" }
@@ -473,7 +477,7 @@ $script:Messages = @{
     "llm.openai.test.testing" = @{ zh = "正在测试 API 联通性..."; en = "Testing API connectivity..." }
     "llm.openai.test.ok" = @{ zh = "API 联通性测试通过"; en = "API connectivity test passed" }
     "llm.openai.test.fail" = @{ zh = "API 联通性测试失败（HTTP {0}）。响应内容:`n{1}`n请根据以上错误信息联系您的模型服务商解决。"; en = "API connectivity test failed (HTTP {0}). Response body:`n{1}`nPlease contact your model provider to resolve the issue." }
-    "llm.openai.test.fail.codingplan" = @{ zh = "提示: 请确认您的 API Key 已开通阿里云百炼 CodingPlan 服务。开通地址: https://www.aliyun.com/benefit/scene/codingplan"; en = "Hint: Please verify that your API Key has CodingPlan service enabled. Enable at: https://www.alibabacloud.com/en/campaign/ai-scene-coding" }
+    "llm.openai.test.fail.codingplan" = @{ zh = "提示: 请确认 API Key 有效且已开通通义 Token 套餐。文档: https://help.aliyun.com/zh/model-studio/token-plan-quickstart"; en = "Hint: Verify your DASHSCOPE_API_KEY for Qwen Cloud. API keys: https://home.qwencloud.com/api-keys  Docs: https://docs.qwencloud.com/" }
     "llm.openai.test.confirm" = @{ zh = "是否仍要继续安装？[y/N/b]"; en = "Continue with installation anyway? [y/N/b]" }
     "llm.openai.test.aborted" = @{ zh = "安装已中止。"; en = "Installation aborted." }
     "llm.embedding.title" = @{ zh = "📦 记忆搜索配置"; en = "📦 Memory Search Configuration" }
@@ -655,7 +659,7 @@ function Get-LanIP {
 $script:KnownModels = @(
     "gpt-5.4", "gpt-5.3-codex", "gpt-5-mini", "gpt-5-nano",
     "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5",
-    "qwen3.5-plus", "deepseek-chat", "deepseek-reasoner",
+    "qwen3.6-plus", "qwen3.5-plus", "deepseek-chat", "deepseek-reasoner",
     "kimi-k2.5", "glm-5", "MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5"
 )
 
@@ -1672,11 +1676,11 @@ function Step-Llm {
         "^(1|alibaba-cloud)$" {
             if ($script:HICLAW_LANGUAGE -eq "en") {
                 $script:config.LLM_PROVIDER = "openai-compat"
-                $script:config.OPENAI_BASE_URL = "https://coding-intl.dashscope.aliyuncs.com/v1"
-                $modelChoice = "codingplan"
+                $script:config.OPENAI_BASE_URL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+                $modelChoice = "tokenplan"
                 Write-Host ""
                 Write-Host (Get-Msg "llm.codingplan.models_title")
-                Write-Host (Get-Msg "llm.codingplan.model.qwen35plus")
+                Write-Host (Get-Msg "llm.codingplan.model.qwen36plus")
                 Write-Host (Get-Msg "llm.codingplan.model.glm5")
                 Write-Host (Get-Msg "llm.codingplan.model.kimi")
                 Write-Host (Get-Msg "llm.codingplan.model.minimax")
@@ -1689,11 +1693,11 @@ function Step-Llm {
                 $codingPlanModelChoice = if ($codingPlanModelChoice) { $codingPlanModelChoice } else { "1" }
                 if ($codingPlanModelChoice -eq "b") { $script:StepResult = "back"; return }
                 switch -Regex ($codingPlanModelChoice) {
-                    "^(1|qwen3\.5-plus)$"  { $script:config.DEFAULT_MODEL = "qwen3.5-plus" }
+                    "^(1|qwen3\.6-plus)$"  { $script:config.DEFAULT_MODEL = "qwen3.6-plus" }
                     "^(2|glm-5)$"          { $script:config.DEFAULT_MODEL = "glm-5" }
                     "^(3|kimi-k2\.5)$"     { $script:config.DEFAULT_MODEL = "kimi-k2.5" }
                     "^(4|MiniMax-M2\.5)$"  { $script:config.DEFAULT_MODEL = "MiniMax-M2.5" }
-                    default                { $script:config.DEFAULT_MODEL = "qwen3.5-plus" }
+                    default                { $script:config.DEFAULT_MODEL = "qwen3.6-plus" }
                 }
                 Write-Log (Get-Msg "llm.provider.selected_codingplan")
             } else {
@@ -1722,10 +1726,10 @@ function Step-Llm {
                     if ($script:StepResult -eq "back") { return }
                 } else {
                     $script:config.LLM_PROVIDER = "openai-compat"
-                    $script:config.OPENAI_BASE_URL = "https://coding.dashscope.aliyuncs.com/v1"
+                    $script:config.OPENAI_BASE_URL = "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
                     Write-Host ""
                     Write-Host (Get-Msg "llm.codingplan.models_title")
-                    Write-Host (Get-Msg "llm.codingplan.model.qwen35plus")
+                    Write-Host (Get-Msg "llm.codingplan.model.qwen36plus")
                     Write-Host (Get-Msg "llm.codingplan.model.glm5")
                     Write-Host (Get-Msg "llm.codingplan.model.kimi")
                     Write-Host (Get-Msg "llm.codingplan.model.minimax")
@@ -1738,11 +1742,11 @@ function Step-Llm {
                     $codingPlanModelChoice = if ($codingPlanModelChoice) { $codingPlanModelChoice } else { "1" }
                     if ($codingPlanModelChoice -eq "b") { $script:StepResult = "back"; return }
                     switch -Regex ($codingPlanModelChoice) {
-                        "^(1|qwen3\.5-plus)$"  { $script:config.DEFAULT_MODEL = "qwen3.5-plus" }
+                        "^(1|qwen3\.6-plus)$"  { $script:config.DEFAULT_MODEL = "qwen3.6-plus" }
                         "^(2|glm-5)$"          { $script:config.DEFAULT_MODEL = "glm-5" }
                         "^(3|kimi-k2\.5)$"     { $script:config.DEFAULT_MODEL = "kimi-k2.5" }
                         "^(4|MiniMax-M2\.5)$"  { $script:config.DEFAULT_MODEL = "MiniMax-M2.5" }
-                        default                { $script:config.DEFAULT_MODEL = "qwen3.5-plus" }
+                        default                { $script:config.DEFAULT_MODEL = "qwen3.6-plus" }
                     }
                     Write-Log (Get-Msg "llm.provider.selected_codingplan")
                 }
@@ -1750,8 +1754,16 @@ function Step-Llm {
 
             Write-Log (Get-Msg "llm.model.label" -f $script:config.DEFAULT_MODEL)
             Write-Log ""
-            Write-Log (Get-Msg "llm.apikey_hint")
-            Write-Log (Get-Msg "llm.apikey_url")
+            if ($modelChoice -match "^(2|qwen)$") {
+                Write-Log (Get-Msg "llm.apikey_hint_bailian")
+                Write-Log (Get-Msg "llm.apikey_url_bailian")
+            } elseif ($script:HICLAW_LANGUAGE -eq "en") {
+                Write-Log (Get-Msg "llm.apikey_hint_qwencloud")
+                Write-Log (Get-Msg "llm.apikey_url_qwencloud")
+            } else {
+                Write-Log (Get-Msg "llm.apikey_hint_tokenplan")
+                Write-Log (Get-Msg "llm.apikey_url_tokenplan")
+            }
             Write-Log ""
             $script:config.LLM_API_KEY = Read-Prompt -VarName "HICLAW_LLM_API_KEY" -PromptText (Get-Msg "llm.apikey_prompt") -Secret
             if ($script:StepResult -eq "back") { return }

--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -13,8 +13,9 @@
 #
 # Environment variables (for automation):
 #   HICLAW_NON_INTERACTIVE    Skip all prompts, use defaults  (default: 0)
-#   HICLAW_LLM_PROVIDER       LLM provider       (default: qwen)
-#   HICLAW_DEFAULT_MODEL      Default model      (default: qwen3.6-plus for alibaba-cloud; qwen3.5-plus for qwen)
+#   HICLAW_LLM_PROVIDER       LLM provider       (default: openai-compat for zh non-interactive Token Plan; qwen for en)
+#   HICLAW_DEFAULT_MODEL      Default model      (default: qwen3.6-plus for zh Token Plan; qwen3.5-plus for qwen)
+#   HICLAW_OPENAI_BASE_URL    OpenAI-compatible base URL (default for zh non-interactive: Alibaba Token Plan endpoint)
 #   HICLAW_LLM_API_KEY        LLM API key        (required)
 #   HICLAW_ADMIN_USER         Admin username     (default: admin)
 #   HICLAW_ADMIN_PASSWORD     Admin password     (auto-generated if not set, min 8 chars)
@@ -296,22 +297,28 @@ $script:Messages = @{
     "llm.apikey_url_qwencloud" = @{ zh = "     https://home.qwencloud.com/api-keys  （文档: https://docs.qwencloud.com/）"; en = "     https://home.qwencloud.com/api-keys  |  Docs: https://docs.qwencloud.com/" }
     "llm.apikey_hint_tokenplan" = @{ zh = "  提示: 获取 DashScope API Key 或开通通义 Token 套餐，请参考:"; en = "  Hint: Get your DashScope or Token Plan API key (Alibaba Model Studio):" }
     "llm.apikey_url_tokenplan" = @{ zh = "     https://help.aliyun.com/zh/model-studio/token-plan-quickstart"; en = "     https://common-buy.aliyun.com/token-plan/  |  https://help.aliyun.com/zh/model-studio/token-plan-quickstart" }
+    "llm.apikey_hint_codingplan" = @{ zh = "  提示: 获取 DashScope API Key（Coding 套餐 / coding.dashscope 接口）:"; en = "  Hint: Get your DashScope API key for Coding Plan (coding.dashscope endpoint):" }
+    "llm.apikey_url_codingplan" = @{ zh = "     https://help.aliyun.com/zh/model-studio/get-api-key"; en = "     https://help.aliyun.com/zh/model-studio/get-api-key" }
     "llm.apikey_prompt" = @{ zh = "LLM API Key"; en = "LLM API Key" }
     "llm.providers_title" = @{ zh = "可用 LLM 提供商:"; en = "Available LLM Providers:" }
     "llm.provider.alibaba" = @{ zh = "  1) 阿里云通义 Token 套餐  - 推荐中国用户使用"; en = "  1) Qwen Cloud  - International (OpenAI-compatible API, recommended)" }
     "llm.provider.openai_compat" = @{ zh = "  2) OpenAI 兼容 API  - 自定义 Base URL（OpenAI、DeepSeek 等）"; en = "  2) OpenAI-compatible API  - Custom Base URL (OpenAI, DeepSeek, etc.)" }
     "llm.provider.select" = @{ zh = "选择提供商 [1/2]"; en = "Select provider [1/2]" }
-    "llm.alibaba.models_title" = @{ zh = "选择百炼模型系列:"; en = "Select Bailian model series:" }
-    "llm.alibaba.model.codingplan" = @{ zh = "  1) Token 套餐  - 多模型调用，替代已下线的 Coding 套餐（推荐）"; en = "  1) Alibaba Cloud Token Plan  - Multi-model access (replaces deprecated Coding plan)" }
-    "llm.alibaba.model.qwen" = @{ zh = "  2) 百炼通用接口"; en = "  2) qwen general  - General purpose LLM" }
-    "llm.alibaba.model.select" = @{ zh = "选择模型系列 [1/2]"; en = "Select model series [1/2]" }
+    "llm.alibaba.models_title" = @{ zh = "选择阿里云模型接入方式:"; en = "Select Alibaba Cloud model access:" }
+    "llm.alibaba.model.tokenplan" = @{ zh = "  1) 阿里云通义 Token 套餐  - 兼容模式（推荐）"; en = "  1) Alibaba Cloud Token Plan  - compatible-mode (recommended)" }
+    "llm.alibaba.model.bailian" = @{ zh = "  2) 阿里云百炼  - DashScope 通用兼容接口"; en = "  2) Alibaba Cloud Bailian  - DashScope compatible mode" }
+    "llm.alibaba.model.codingplan_legacy" = @{ zh = "  3) 阿里云 Coding 套餐  - 旧版端点（兼容保留）"; en = "  3) Alibaba Cloud Coding Plan  - legacy endpoint (backward compatible)" }
+    "llm.alibaba.model.select" = @{ zh = "选择接入方式 [1/2/3]"; en = "Select access option [1/2/3]" }
+    "llm.alibaba.model.invalid" = @{ zh = "无效选择: {0}（请输入 1、2 或 3）"; en = "Invalid choice: {0} (please enter 1, 2, or 3)" }
     "llm.codingplan.models_title" = @{ zh = "选择通义 Token 套餐默认模型:"; en = "Select Qwen Cloud default model:" }
     "llm.codingplan.model.qwen36plus" = @{ zh = "  1) qwen3.6-plus  - 千问 3.6（推荐）"; en = "  1) qwen3.6-plus  - Qwen 3.6 (recommended)" }
     "llm.codingplan.model.glm5" = @{ zh = "  2) glm-5  - 智谱 GLM-5（编程推荐）"; en = "  2) glm-5  - Zhipu GLM-5 (recommended for coding)" }
     "llm.codingplan.model.kimi" = @{ zh = "  3) kimi-k2.5  - Moonshot Kimi K2.5"; en = "  3) kimi-k2.5  - Moonshot Kimi K2.5" }
     "llm.codingplan.model.minimax" = @{ zh = "  4) MiniMax-M2.5  - MiniMax M2.5"; en = "  4) MiniMax-M2.5  - MiniMax M2.5" }
     "llm.codingplan.model.select" = @{ zh = "选择模型 [1/2/3/4]"; en = "Select model [1/2/3/4]" }
+    "llm.provider.selected_tokenplan" = @{ zh = "  提供商: 阿里云通义 Token 套餐（兼容模式）"; en = "  Provider: Alibaba Cloud Token Plan (compatible mode)" }
     "llm.provider.selected_codingplan" = @{ zh = "  提供商: 阿里云通义 Token 套餐（alibaba-cloud）"; en = "  Provider: Qwen Cloud (international) (alibaba-cloud)" }
+    "llm.provider.selected_codingplan_legacy" = @{ zh = "  提供商: 阿里云 Coding 套餐（coding.dashscope）"; en = "  Provider: Alibaba Cloud Coding Plan (coding.dashscope)" }
     "llm.provider.selected_qwen" = @{ zh = "  提供商: 阿里云百炼"; en = "  Provider: Alibaba Cloud Bailian" }
     "llm.provider.selected_openai" = @{ zh = "  提供商: {0}（OpenAI 兼容）"; en = "  Provider: {0} (OpenAI-compatible)" }
     "llm.provider.invalid" = @{ zh = "无效选择: {0}（请输入 1 或 2）"; en = "Invalid choice: {0} (please enter 1 or 2)" }
@@ -477,7 +484,9 @@ $script:Messages = @{
     "llm.openai.test.testing" = @{ zh = "正在测试 API 联通性..."; en = "Testing API connectivity..." }
     "llm.openai.test.ok" = @{ zh = "API 联通性测试通过"; en = "API connectivity test passed" }
     "llm.openai.test.fail" = @{ zh = "API 联通性测试失败（HTTP {0}）。响应内容:`n{1}`n请根据以上错误信息联系您的模型服务商解决。"; en = "API connectivity test failed (HTTP {0}). Response body:`n{1}`nPlease contact your model provider to resolve the issue." }
+    "llm.openai.test.fail.tokenplan" = @{ zh = "提示: 请确认 API Key 有效且已开通通义 Token 套餐。文档: https://help.aliyun.com/zh/model-studio/token-plan-quickstart"; en = "Hint: Verify your Token Plan API key and compatible-mode access. Docs: https://help.aliyun.com/zh/model-studio/token-plan-quickstart" }
     "llm.openai.test.fail.codingplan" = @{ zh = "提示: 请确认 API Key 有效且已开通通义 Token 套餐。文档: https://help.aliyun.com/zh/model-studio/token-plan-quickstart"; en = "Hint: Verify your DASHSCOPE_API_KEY for Qwen Cloud. API keys: https://home.qwencloud.com/api-keys  Docs: https://docs.qwencloud.com/" }
+    "llm.openai.test.fail.codingplan_legacy" = @{ zh = "提示: 请确认 API Key 有效且 Coding 套餐接口可用。文档: https://help.aliyun.com/zh/model-studio/get-api-key"; en = "Hint: Verify your DashScope API key and Coding Plan access. Docs: https://help.aliyun.com/zh/model-studio/get-api-key" }
     "llm.openai.test.confirm" = @{ zh = "是否仍要继续安装？[y/N/b]"; en = "Continue with installation anyway? [y/N/b]" }
     "llm.openai.test.aborted" = @{ zh = "安装已中止。"; en = "Installation aborted." }
     "llm.embedding.title" = @{ zh = "📦 记忆搜索配置"; en = "📦 Memory Search Configuration" }
@@ -1647,10 +1656,18 @@ function Step-Llm {
     Write-Log (Get-Msg "llm.title")
 
     if ($script:HICLAW_NON_INTERACTIVE) {
-        $script:config.LLM_PROVIDER = if ($env:HICLAW_LLM_PROVIDER) { $env:HICLAW_LLM_PROVIDER } else { "qwen" }
-        $script:config.DEFAULT_MODEL = if ($env:HICLAW_DEFAULT_MODEL) { $env:HICLAW_DEFAULT_MODEL } else { "qwen3.5-plus" }
-        $script:config.OPENAI_BASE_URL = if ($env:HICLAW_OPENAI_BASE_URL) { $env:HICLAW_OPENAI_BASE_URL } else { "" }
-        Write-Log (Get-Msg "llm.provider.label" -f $script:config.LLM_PROVIDER)
+        if ($script:HICLAW_LANGUAGE -eq "zh") {
+            $script:config.LLM_PROVIDER = if ($env:HICLAW_LLM_PROVIDER) { $env:HICLAW_LLM_PROVIDER } else { "openai-compat" }
+            $script:config.DEFAULT_MODEL = if ($env:HICLAW_DEFAULT_MODEL) { $env:HICLAW_DEFAULT_MODEL } else { "qwen3.6-plus" }
+            $script:config.OPENAI_BASE_URL = if ($env:HICLAW_OPENAI_BASE_URL) { $env:HICLAW_OPENAI_BASE_URL } else { "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1" }
+            Write-Log (Get-Msg "llm.provider.label" -f $script:config.LLM_PROVIDER)
+            Write-Log (Get-Msg "llm.openai.base_url_label" -f $script:config.OPENAI_BASE_URL)
+        } else {
+            $script:config.LLM_PROVIDER = if ($env:HICLAW_LLM_PROVIDER) { $env:HICLAW_LLM_PROVIDER } else { "qwen" }
+            $script:config.DEFAULT_MODEL = if ($env:HICLAW_DEFAULT_MODEL) { $env:HICLAW_DEFAULT_MODEL } else { "qwen3.5-plus" }
+            $script:config.OPENAI_BASE_URL = if ($env:HICLAW_OPENAI_BASE_URL) { $env:HICLAW_OPENAI_BASE_URL } else { "" }
+            Write-Log (Get-Msg "llm.provider.qwen_default" -f $script:config.LLM_PROVIDER)
+        }
         Write-Log (Get-Msg "llm.model.label" -f $script:config.DEFAULT_MODEL)
         Write-Log ""
         $script:config.LLM_API_KEY = Read-Prompt -VarName "HICLAW_LLM_API_KEY" -PromptText (Get-Msg "llm.apikey_prompt") -Secret
@@ -1674,10 +1691,11 @@ function Step-Llm {
 
     switch -Regex ($providerChoice) {
         "^(1|alibaba-cloud)$" {
+            $alibabaAccess = $null
             if ($script:HICLAW_LANGUAGE -eq "en") {
                 $script:config.LLM_PROVIDER = "openai-compat"
                 $script:config.OPENAI_BASE_URL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
-                $modelChoice = "tokenplan"
+                $alibabaAccess = "tokenplan"
                 Write-Host ""
                 Write-Host (Get-Msg "llm.codingplan.models_title")
                 Write-Host (Get-Msg "llm.codingplan.model.qwen36plus")
@@ -1703,28 +1721,20 @@ function Step-Llm {
             } else {
                 Write-Host ""
                 Write-Host (Get-Msg "llm.alibaba.models_title")
-                Write-Host (Get-Msg "llm.alibaba.model.codingplan")
-                Write-Host (Get-Msg "llm.alibaba.model.qwen")
+                Write-Host (Get-Msg "llm.alibaba.model.tokenplan")
+                Write-Host (Get-Msg "llm.alibaba.model.bailian")
+                Write-Host (Get-Msg "llm.alibaba.model.codingplan_legacy")
                 Write-Host ""
-                if ($script:HICLAW_QUICKSTART) {
-                    $modelChoice = Read-Host "$(Get-Msg 'llm.alibaba.model.select') [1]"
+                $modelChoice = if ($script:HICLAW_QUICKSTART) {
+                    Read-Host "$(Get-Msg 'llm.alibaba.model.select') [1]"
                 } else {
-                    $modelChoice = Read-Host (Get-Msg "llm.alibaba.model.select")
+                    Read-Host (Get-Msg "llm.alibaba.model.select")
                 }
                 $modelChoice = if ($modelChoice) { $modelChoice } else { "1" }
                 if ($modelChoice -eq "b") { $script:StepResult = "back"; return }
 
-                if ($modelChoice -match "^(2|qwen)$") {
-                    $script:config.LLM_PROVIDER = "qwen"
-                    Write-Host ""
-                    $qwenModelInput = Read-Host (Get-Msg "llm.qwen.model_prompt")
-                    if ($qwenModelInput -eq "b") { $script:StepResult = "back"; return }
-                    $script:config.DEFAULT_MODEL = if ($qwenModelInput) { $qwenModelInput } elseif ($env:HICLAW_DEFAULT_MODEL) { $env:HICLAW_DEFAULT_MODEL } else { "qwen3.5-plus" }
-                    $script:config.OPENAI_BASE_URL = ""
-                    Write-Log (Get-Msg "llm.provider.selected_qwen")
-                    Request-CustomModelParams $script:config.DEFAULT_MODEL
-                    if ($script:StepResult -eq "back") { return }
-                } else {
+                if ($modelChoice -match "^(1|token-plan|tokenplan)$") {
+                    $alibabaAccess = "tokenplan"
                     $script:config.LLM_PROVIDER = "openai-compat"
                     $script:config.OPENAI_BASE_URL = "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
                     Write-Host ""
@@ -1748,18 +1758,45 @@ function Step-Llm {
                         "^(4|MiniMax-M2\.5)$"  { $script:config.DEFAULT_MODEL = "MiniMax-M2.5" }
                         default                { $script:config.DEFAULT_MODEL = "qwen3.6-plus" }
                     }
-                    Write-Log (Get-Msg "llm.provider.selected_codingplan")
+                    Write-Log (Get-Msg "llm.provider.selected_tokenplan")
+                } elseif ($modelChoice -match "^(2|qwen|bailian)$") {
+                    $alibabaAccess = "bailian"
+                    $script:config.LLM_PROVIDER = "qwen"
+                    $script:config.OPENAI_BASE_URL = ""
+                    Write-Host ""
+                    $qwenModelInput = Read-Host (Get-Msg "llm.qwen.model_prompt")
+                    if ($qwenModelInput -eq "b") { $script:StepResult = "back"; return }
+                    $script:config.DEFAULT_MODEL = if ($qwenModelInput) { $qwenModelInput } elseif ($env:HICLAW_DEFAULT_MODEL) { $env:HICLAW_DEFAULT_MODEL } else { "qwen3.5-plus" }
+                    Write-Log (Get-Msg "llm.provider.selected_qwen")
+                    Request-CustomModelParams $script:config.DEFAULT_MODEL
+                    if ($script:StepResult -eq "back") { return }
+                } elseif ($modelChoice -match "^(3|coding-plan|codingplan)$") {
+                    $alibabaAccess = "codingplan_legacy"
+                    $script:config.LLM_PROVIDER = "openai-compat"
+                    $script:config.OPENAI_BASE_URL = "https://coding.dashscope.aliyuncs.com/v1"
+                    Write-Host ""
+                    $codingModelInput = Read-Host (Get-Msg "llm.qwen.model_prompt")
+                    if ($codingModelInput -eq "b") { $script:StepResult = "back"; return }
+                    $script:config.DEFAULT_MODEL = if ($codingModelInput) { $codingModelInput } elseif ($env:HICLAW_DEFAULT_MODEL) { $env:HICLAW_DEFAULT_MODEL } else { "qwen3.5-plus" }
+                    Write-Log (Get-Msg "llm.provider.selected_codingplan_legacy")
+                    Request-CustomModelParams $script:config.DEFAULT_MODEL
+                    if ($script:StepResult -eq "back") { return }
+                } else {
+                    Write-Error (Get-Msg "llm.alibaba.model.invalid" -f $modelChoice)
                 }
             }
 
             Write-Log (Get-Msg "llm.model.label" -f $script:config.DEFAULT_MODEL)
             Write-Log ""
-            if ($modelChoice -match "^(2|qwen)$") {
+            if ($alibabaAccess -eq "bailian") {
                 Write-Log (Get-Msg "llm.apikey_hint_bailian")
                 Write-Log (Get-Msg "llm.apikey_url_bailian")
             } elseif ($script:HICLAW_LANGUAGE -eq "en") {
                 Write-Log (Get-Msg "llm.apikey_hint_qwencloud")
                 Write-Log (Get-Msg "llm.apikey_url_qwencloud")
+            } elseif ($alibabaAccess -eq "codingplan_legacy") {
+                Write-Log (Get-Msg "llm.apikey_hint_codingplan")
+                Write-Log (Get-Msg "llm.apikey_url_codingplan")
             } else {
                 Write-Log (Get-Msg "llm.apikey_hint_tokenplan")
                 Write-Log (Get-Msg "llm.apikey_url_tokenplan")
@@ -1767,10 +1804,14 @@ function Step-Llm {
             Write-Log ""
             $script:config.LLM_API_KEY = Read-Prompt -VarName "HICLAW_LLM_API_KEY" -PromptText (Get-Msg "llm.apikey_prompt") -Secret
             if ($script:StepResult -eq "back") { return }
-            if ($modelChoice -match "^(2|qwen)$") {
+            if ($alibabaAccess -eq "bailian") {
                 Test-LlmConnectivity -BaseUrl "https://dashscope.aliyuncs.com/compatible-mode/v1" -ApiKey $script:config.LLM_API_KEY -Model $script:config.DEFAULT_MODEL
-            } else {
+            } elseif ($alibabaAccess -eq "codingplan_legacy") {
+                Test-LlmConnectivity -BaseUrl "https://coding.dashscope.aliyuncs.com/v1" -ApiKey $script:config.LLM_API_KEY -Model $script:config.DEFAULT_MODEL -Hint (Get-Msg "llm.openai.test.fail.codingplan_legacy")
+            } elseif ($script:HICLAW_LANGUAGE -eq "en") {
                 Test-LlmConnectivity -BaseUrl $script:config.OPENAI_BASE_URL -ApiKey $script:config.LLM_API_KEY -Model $script:config.DEFAULT_MODEL -Hint (Get-Msg "llm.openai.test.fail.codingplan")
+            } else {
+                Test-LlmConnectivity -BaseUrl $script:config.OPENAI_BASE_URL -ApiKey $script:config.LLM_API_KEY -Model $script:config.DEFAULT_MODEL -Hint (Get-Msg "llm.openai.test.fail.tokenplan")
             }
             if ($script:StepResult -eq "back") { return }
         }

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -14,7 +14,7 @@
 # Environment variables (for automation):
 #   HICLAW_NON_INTERACTIVE    Skip all prompts, use defaults  (default: 0)
 #   HICLAW_LLM_PROVIDER      LLM provider       (default: alibaba-cloud)
-#   HICLAW_DEFAULT_MODEL      Default model       (default: qwen3.5-plus)
+#   HICLAW_DEFAULT_MODEL      Default model       (default: qwen3.6-plus for alibaba-cloud; qwen3.5-plus for qwen)
 #   HICLAW_LLM_API_KEY        LLM API key         (required)
 #   HICLAW_ADMIN_USER         Admin username       (default: admin)
 #   HICLAW_ADMIN_PASSWORD     Admin password       (auto-generated if not set, min 8 chars)
@@ -209,14 +209,14 @@ msg() {
         "install.mode.title.en") text="--- Onboarding Mode ---" ;;
         "install.mode.choose.zh") text="选择安装模式:" ;;
         "install.mode.choose.en") text="Choose your installation mode:" ;;
-        "install.mode.quickstart.zh") text="  1) 快速开始  - 使用阿里云百炼快速安装（推荐）" ;;
-        "install.mode.quickstart.en") text="  1) Quick Start  - Fast installation with Alibaba Cloud CodingPlan (recommended)" ;;
+        "install.mode.quickstart.zh") text="  1) 快速开始  - 使用阿里云通义 Token 套餐快速安装（推荐）" ;;
+        "install.mode.quickstart.en") text="  1) Quick Start  - Fast installation with Qwen Cloud (recommended)" ;;
         "install.mode.manual.zh") text="  2) 手动配置  - 选择 LLM 提供商并自定义选项" ;;
         "install.mode.manual.en") text="  2) Manual       - Choose LLM provider and customize options" ;;
         "install.mode.prompt.zh") text="请选择 [1/2]" ;;
         "install.mode.prompt.en") text="Enter choice [1/2]" ;;
-        "install.mode.quickstart_selected.zh") text="已选择快速开始模式 - 使用阿里云百炼" ;;
-        "install.mode.quickstart_selected.en") text="Quick Start mode selected - using Alibaba Cloud CodingPlan" ;;
+        "install.mode.quickstart_selected.zh") text="已选择快速开始模式 - 使用阿里云通义 Token 套餐" ;;
+        "install.mode.quickstart_selected.en") text="Quick Start mode selected - using Qwen Cloud" ;;
         "install.mode.manual_selected.zh") text="已选择手动配置模式 - 您将选择 LLM 提供商并自定义选项" ;;
         "install.mode.manual_selected.en") text="Manual mode selected - you will choose LLM provider and customize options" ;;
         "install.mode.invalid.zh") text="无效选择，默认使用快速开始模式" ;;
@@ -361,32 +361,40 @@ msg() {
         "llm.provider.qwen_default.en") text="  Provider: %s (default)" ;;
         "llm.model.default.zh") text="  模型: %s（默认）" ;;
         "llm.model.default.en") text="  Model: %s (default)" ;;
-        "llm.apikey_hint.zh") text="  💡 获取阿里云百炼 API Key:" ;;
-        "llm.apikey_hint.en") text="  💡 Get your Alibaba Cloud CodingPlan API Key from:" ;;
-        "llm.apikey_url.zh") text="     https://www.aliyun.com/product/bailian" ;;
-        "llm.apikey_url.en") text="     https://www.alibabacloud.com/en/campaign/ai-scene-coding" ;;
+        "llm.apikey_hint_bailian.zh") text="  💡 获取阿里云百炼（DashScope）API Key:" ;;
+        "llm.apikey_hint_bailian.en") text="  💡 Get your Alibaba Cloud Bailian (DashScope) API Key:" ;;
+        "llm.apikey_url_bailian.zh") text="     https://www.aliyun.com/product/bailian" ;;
+        "llm.apikey_url_bailian.en") text="     https://www.aliyun.com/product/bailian" ;;
+        "llm.apikey_hint_qwencloud.zh") text="  💡 从 Qwen Cloud（国际站）获取 DASHSCOPE_API_KEY:" ;;
+        "llm.apikey_hint_qwencloud.en") text="  💡 Get your DASHSCOPE_API_KEY for Qwen Cloud (international) from:" ;;
+        "llm.apikey_url_qwencloud.zh") text="     https://home.qwencloud.com/api-keys  （文档: https://docs.qwencloud.com/）" ;;
+        "llm.apikey_url_qwencloud.en") text="     https://home.qwencloud.com/api-keys  |  Docs: https://docs.qwencloud.com/" ;;
+        "llm.apikey_hint_tokenplan.zh") text="  💡 获取 DashScope API Key 或开通通义 Token 套餐，请参考:" ;;
+        "llm.apikey_hint_tokenplan.en") text="  💡 Get your DashScope or Token Plan API key (Alibaba Model Studio):" ;;
+        "llm.apikey_url_tokenplan.zh") text="     https://help.aliyun.com/zh/model-studio/token-plan-quickstart" ;;
+        "llm.apikey_url_tokenplan.en") text="     https://common-buy.aliyun.com/token-plan/  |  https://help.aliyun.com/zh/model-studio/token-plan-quickstart" ;;
         "llm.apikey_prompt.zh") text="LLM API Key" ;;
         "llm.apikey_prompt.en") text="LLM API Key" ;;
         "llm.providers_title.zh") text="可用 LLM 提供商:" ;;
         "llm.providers_title.en") text="Available LLM Providers:" ;;
-        "llm.provider.alibaba.zh") text="  1) 阿里云百炼  - 推荐中国用户使用" ;;
-        "llm.provider.alibaba.en") text="  1) Alibaba Cloud CodingPlan  - Optimized for coding tasks (recommended)" ;;
+        "llm.provider.alibaba.zh") text="  1) 阿里云通义 Token 套餐  - 推荐中国用户使用" ;;
+        "llm.provider.alibaba.en") text="  1) Qwen Cloud  - International (OpenAI-compatible API, recommended)" ;;
         "llm.provider.openai_compat.zh") text="  2) OpenAI 兼容 API  - 自定义 Base URL（OpenAI、DeepSeek 等）" ;;
         "llm.provider.openai_compat.en") text="  2) OpenAI-compatible API  - Custom Base URL (OpenAI, DeepSeek, etc.)" ;;
         "llm.provider.select.zh") text="选择提供商 [1/2]" ;;
         "llm.provider.select.en") text="Select provider [1/2]" ;;
         "llm.alibaba.models_title.zh") text="选择百炼模型系列:" ;;
         "llm.alibaba.models_title.en") text="Select Bailian model series:" ;;
-        "llm.alibaba.model.codingplan.zh") text="  1) CodingPlan  - 专为编程任务优化（推荐）" ;;
-        "llm.alibaba.model.codingplan.en") text="  1) CodingPlan  - Optimized for coding tasks (recommended)" ;;
+        "llm.alibaba.model.codingplan.zh") text="  1) Token 套餐  - 多模型调用，替代已下线的 Coding 套餐（推荐）" ;;
+        "llm.alibaba.model.codingplan.en") text="  1) Alibaba Cloud Token Plan  - Multi-model access (replaces deprecated Coding plan)" ;;
         "llm.alibaba.model.qwen.zh") text="  2) 百炼通用接口" ;;
         "llm.alibaba.model.qwen.en") text="  2) qwen general  - General purpose LLM" ;;
         "llm.alibaba.model.select.zh") text="选择模型系列 [1/2]" ;;
         "llm.alibaba.model.select.en") text="Select model series [1/2]" ;;
-        "llm.codingplan.models_title.zh") text="选择 CodingPlan 默认模型:" ;;
-        "llm.codingplan.models_title.en") text="Select CodingPlan default model:" ;;
-        "llm.codingplan.model.qwen35plus.zh") text="  1) qwen3.5-plus  - 千问 3.5（速度最快）" ;;
-        "llm.codingplan.model.qwen35plus.en") text="  1) qwen3.5-plus  - Qwen 3.5 (fastest)" ;;
+        "llm.codingplan.models_title.zh") text="选择通义 Token 套餐默认模型:" ;;
+        "llm.codingplan.models_title.en") text="Select Qwen Cloud default model:" ;;
+        "llm.codingplan.model.qwen36plus.zh") text="  1) qwen3.6-plus  - 千问 3.6（推荐）" ;;
+        "llm.codingplan.model.qwen36plus.en") text="  1) qwen3.6-plus  - Qwen 3.6 (recommended)" ;;
         "llm.codingplan.model.glm5.zh") text="  2) glm-5  - 智谱 GLM-5（编程推荐）" ;;
         "llm.codingplan.model.glm5.en") text="  2) glm-5  - Zhipu GLM-5 (recommended for coding)" ;;
         "llm.codingplan.model.kimi.zh") text="  3) kimi-k2.5  - Moonshot Kimi K2.5" ;;
@@ -395,8 +403,8 @@ msg() {
         "llm.codingplan.model.minimax.en") text="  4) MiniMax-M2.5  - MiniMax M2.5" ;;
         "llm.codingplan.model.select.zh") text="选择模型 [1/2/3/4]" ;;
         "llm.codingplan.model.select.en") text="Select model [1/2/3/4]" ;;
-        "llm.provider.selected_codingplan.zh") text="  提供商: 阿里云百炼 CodingPlan" ;;
-        "llm.provider.selected_codingplan.en") text="  Provider: Alibaba Cloud CodingPlan" ;;
+        "llm.provider.selected_codingplan.zh") text="  提供商: 阿里云通义 Token 套餐（alibaba-cloud）" ;;
+        "llm.provider.selected_codingplan.en") text="  Provider: Qwen Cloud (international) (alibaba-cloud)" ;;
         "llm.provider.selected_qwen.zh") text="  提供商: 阿里云百炼" ;;
         "llm.provider.selected_qwen.en") text="  Provider: Alibaba Cloud Bailian" ;;
         "llm.provider.selected_openai.zh") text="  提供商: %s（OpenAI 兼容）" ;;
@@ -656,8 +664,8 @@ msg() {
         "llm.openai.test.ok.en") text="✅ API connectivity test passed" ;;
         "llm.openai.test.fail.zh") text="⚠️  API 联通性测试失败（HTTP %s）。响应内容:\n%s\n请根据以上错误信息联系您的模型服务商解决。" ;;
         "llm.openai.test.fail.en") text="⚠️  API connectivity test failed (HTTP %s). Response body:\n%s\nPlease contact your model provider to resolve the issue." ;;
-        "llm.openai.test.fail.codingplan.zh") text="⚠️  提示: 请确认您的 API Key 已开通阿里云百炼 CodingPlan 服务。开通地址: https://www.aliyun.com/benefit/scene/codingplan" ;;
-        "llm.openai.test.fail.codingplan.en") text="⚠️  Hint: Please verify that your API Key has CodingPlan service enabled. Enable at: https://www.alibabacloud.com/en/campaign/ai-scene-coding" ;;
+        "llm.openai.test.fail.codingplan.zh") text="⚠️  提示: 请确认 API Key 有效且已开通通义 Token 套餐。文档: https://help.aliyun.com/zh/model-studio/token-plan-quickstart" ;;
+        "llm.openai.test.fail.codingplan.en") text="⚠️  Hint: Verify your DASHSCOPE_API_KEY for Qwen Cloud. API keys: https://home.qwencloud.com/api-keys  Docs: https://docs.qwencloud.com/" ;;
         "llm.openai.test.no_curl.zh") text="⚠️  未找到 curl，跳过 API 联通性测试" ;;
         "llm.openai.test.no_curl.en") text="⚠️  curl not found, skipping API connectivity test" ;;
         "llm.openai.test.confirm.zh") text="是否仍要继续安装？[y/N/b] " ;;
@@ -1008,7 +1016,7 @@ resolve_embedded_image() {
 # ============================================================
 # Known models list — used to detect custom models during install
 # ============================================================
-KNOWN_MODELS="gpt-5.4 gpt-5.3-codex gpt-5-mini gpt-5-nano claude-opus-4-6 claude-sonnet-4-6 claude-haiku-4-5 qwen3.5-plus deepseek-chat deepseek-reasoner kimi-k2.5 glm-5 MiniMax-M2.7 MiniMax-M2.7-highspeed MiniMax-M2.5"
+KNOWN_MODELS="gpt-5.4 gpt-5.3-codex gpt-5-mini gpt-5-nano claude-opus-4-6 claude-sonnet-4-6 claude-haiku-4-5 qwen3.6-plus qwen3.5-plus deepseek-chat deepseek-reasoner kimi-k2.5 glm-5 MiniMax-M2.7 MiniMax-M2.7-highspeed MiniMax-M2.5"
 
 is_known_model() {
     local model="$1"
@@ -1731,11 +1739,11 @@ step_llm() {
         1|alibaba-cloud)
             if [ "${HICLAW_LANGUAGE}" = "en" ]; then
                 HICLAW_LLM_PROVIDER="openai-compat"
-                HICLAW_OPENAI_BASE_URL="https://coding-intl.dashscope.aliyuncs.com/v1"
-                ALIBABA_MODEL_CHOICE="codingplan"
+                HICLAW_OPENAI_BASE_URL="https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+                ALIBABA_MODEL_CHOICE="tokenplan"
                 echo ""
                 echo "$(msg llm.codingplan.models_title)"
-                echo "$(msg llm.codingplan.model.qwen35plus)"
+                echo "$(msg llm.codingplan.model.qwen36plus)"
                 echo "$(msg llm.codingplan.model.glm5)"
                 echo "$(msg llm.codingplan.model.kimi)"
                 echo "$(msg llm.codingplan.model.minimax)"
@@ -1750,11 +1758,11 @@ step_llm() {
                 fi
                 if [ "${CODINGPLAN_MODEL_CHOICE}" = "b" ]; then STEP_RESULT="back"; return 0; fi
                 case "${CODINGPLAN_MODEL_CHOICE}" in
-                    1|qwen3.5-plus) HICLAW_DEFAULT_MODEL="qwen3.5-plus" ;;
+                    1|qwen3.6-plus) HICLAW_DEFAULT_MODEL="qwen3.6-plus" ;;
                     2|glm-5)        HICLAW_DEFAULT_MODEL="glm-5" ;;
                     3|kimi-k2.5)    HICLAW_DEFAULT_MODEL="kimi-k2.5" ;;
                     4|MiniMax-M2.5) HICLAW_DEFAULT_MODEL="MiniMax-M2.5" ;;
-                    *)              HICLAW_DEFAULT_MODEL="qwen3.5-plus" ;;
+                    *)              HICLAW_DEFAULT_MODEL="qwen3.6-plus" ;;
                 esac
                 log "$(msg llm.provider.selected_codingplan)"
                 log "$(msg llm.model.label "${HICLAW_DEFAULT_MODEL}")"
@@ -1786,10 +1794,10 @@ step_llm() {
                         ;;
                     *)
                         HICLAW_LLM_PROVIDER="openai-compat"
-                        HICLAW_OPENAI_BASE_URL="https://coding.dashscope.aliyuncs.com/v1"
+                        HICLAW_OPENAI_BASE_URL="https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
                         echo ""
                         echo "$(msg llm.codingplan.models_title)"
-                        echo "$(msg llm.codingplan.model.qwen35plus)"
+                        echo "$(msg llm.codingplan.model.qwen36plus)"
                         echo "$(msg llm.codingplan.model.glm5)"
                         echo "$(msg llm.codingplan.model.kimi)"
                         echo "$(msg llm.codingplan.model.minimax)"
@@ -1804,20 +1812,27 @@ step_llm() {
                         fi
                         if [ "${CODINGPLAN_MODEL_CHOICE}" = "b" ]; then STEP_RESULT="back"; return 0; fi
                         case "${CODINGPLAN_MODEL_CHOICE}" in
-                            1|qwen3.5-plus) HICLAW_DEFAULT_MODEL="qwen3.5-plus" ;;
+                            1|qwen3.6-plus) HICLAW_DEFAULT_MODEL="qwen3.6-plus" ;;
                             2|glm-5)        HICLAW_DEFAULT_MODEL="glm-5" ;;
                             3|kimi-k2.5)    HICLAW_DEFAULT_MODEL="kimi-k2.5" ;;
                             4|MiniMax-M2.5) HICLAW_DEFAULT_MODEL="MiniMax-M2.5" ;;
-                            *)              HICLAW_DEFAULT_MODEL="qwen3.5-plus" ;;
+                            *)              HICLAW_DEFAULT_MODEL="qwen3.6-plus" ;;
                         esac
                         log "$(msg llm.provider.selected_codingplan)"
                         log "$(msg llm.model.label "${HICLAW_DEFAULT_MODEL}")"
                         ;;
                 esac
             fi
-            log ""
-            log "$(msg llm.apikey_hint)"
-            log "$(msg llm.apikey_url)"
+            if [ "${ALIBABA_MODEL_CHOICE}" = "2" ] || [ "${ALIBABA_MODEL_CHOICE}" = "qwen" ]; then
+                log "$(msg llm.apikey_hint_bailian)"
+                log "$(msg llm.apikey_url_bailian)"
+            elif [ "${HICLAW_LANGUAGE}" = "en" ]; then
+                log "$(msg llm.apikey_hint_qwencloud)"
+                log "$(msg llm.apikey_url_qwencloud)"
+            else
+                log "$(msg llm.apikey_hint_tokenplan)"
+                log "$(msg llm.apikey_url_tokenplan)"
+            fi
             log ""
             prompt HICLAW_LLM_API_KEY "$(msg llm.apikey_prompt)" "" "true" || return 0
             if [ "${ALIBABA_MODEL_CHOICE}" = "2" ] || [ "${ALIBABA_MODEL_CHOICE}" = "qwen" ]; then

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -1113,6 +1113,42 @@ wait_matrix_ready() {
     error "$(msg install.wait_matrix.timeout "${timeout}" "${container}")"
 }
 
+# Read KEY=value from /data/hiclaw-secrets.env on a Docker volume (manager container not required).
+# Requires EMBEDDED_IMAGE (resolved earlier in install_manager). Uses ${DOCKER_CMD}.
+hiclaw_read_secret_from_data_volume() {
+    local _vol="$1" _key="$2"
+    if [ -z "${_vol}" ] || [ -z "${_key}" ] || [ -z "${EMBEDDED_IMAGE:-}" ]; then
+        echo ""
+        return 0
+    fi
+    ${DOCKER_CMD} run --rm --entrypoint sh \
+        -v "${_vol}:/data:ro" \
+        "${EMBEDDED_IMAGE}" -c "grep \"^${_key}=\" /data/hiclaw-secrets.env 2>/dev/null | cut -d= -f2- | head -1 | tr -d '\r'" 2>/dev/null
+}
+
+# Read KEY=value from /data/worker-creds/<worker>.env on a Docker volume.
+hiclaw_read_worker_creds_value_from_volume() {
+    local _vol="$1" _worker="$2" _key="$3"
+    if [ -z "${_vol}" ] || [ -z "${_worker}" ] || [ -z "${_key}" ] || [ -z "${EMBEDDED_IMAGE:-}" ]; then
+        echo ""
+        return 0
+    fi
+    ${DOCKER_CMD} run --rm --entrypoint sh \
+        -v "${_vol}:/data:ro" \
+        "${EMBEDDED_IMAGE}" -c "grep \"^${_key}=\" \"/data/worker-creds/${_worker}.env\" 2>/dev/null | cut -d= -f2- | head -1 | tr -d \"\\r\"" 2>/dev/null
+}
+
+# Read admin_dm_room_id from host workspace state.json (fallback when Matrix API is unavailable).
+hiclaw_read_admin_dm_room_from_workspace() {
+    local _ws="$1"
+    local _f="${_ws}/state.json"
+    if [ ! -f "${_f}" ] || ! command -v jq >/dev/null 2>&1; then
+        echo ""
+        return 0
+    fi
+    jq -r '.admin_dm_room_id // empty | select(. != "null")' "${_f}" 2>/dev/null
+}
+
 # Read secret input with masked echo (shows * per keystroke, supports backspace)
 # Usage: read_secret "prompt text: "; value="${_RS_RESULT}"
 read_secret() {
@@ -2541,8 +2577,26 @@ EOF
         if [ "${_is_old_arch}" = "1" ]; then
         _creds_tmp=$(mktemp -d)
 
-        # Manager password (stored in container env as HICLAW_MANAGER_PASSWORD)
+        # docker exec for Matrix/minio paths only works while hiclaw-manager is running.
+        _mgr_creds_tempstart=0
+        if ${DOCKER_CMD} ps -a --format '{{.Names}}' 2>/dev/null | grep -q '^hiclaw-manager$'; then
+            if ! ${DOCKER_CMD} ps --format '{{.Names}}' 2>/dev/null | grep -q '^hiclaw-manager$'; then
+                log "hiclaw-manager is stopped; starting it temporarily to extract Matrix credentials for upgrade..."
+                ${DOCKER_CMD} start hiclaw-manager 2>/dev/null || true
+                wait_matrix_ready "hiclaw-manager"
+                _mgr_creds_tempstart=1
+            fi
+        fi
+
+        # Manager password (container Config.Env, then secrets file inside running manager, then data volume)
         _mgr_pw=$(${DOCKER_CMD} inspect hiclaw-manager --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null | grep '^HICLAW_MANAGER_PASSWORD=' | cut -d= -f2-)
+        if [ -z "${_mgr_pw}" ] && ${DOCKER_CMD} ps --format '{{.Names}}' 2>/dev/null | grep -q '^hiclaw-manager$'; then
+            _mgr_pw=$(${DOCKER_CMD} exec hiclaw-manager bash -c 'source /data/hiclaw-secrets.env 2>/dev/null && echo "${HICLAW_MANAGER_PASSWORD}"' 2>/dev/null)
+        fi
+        if [ -z "${_mgr_pw}" ] && ${DOCKER_CMD} volume ls -q 2>/dev/null | grep -q "^${HICLAW_DATA_DIR}$"; then
+            _mgr_pw=$(hiclaw_read_secret_from_data_volume "${HICLAW_DATA_DIR}" HICLAW_MANAGER_PASSWORD)
+        fi
+
         # Manager admin DM room ID: login as admin, find DM room with @manager
         _mgr_room=""
         if [ -n "${_mgr_pw}" ]; then
@@ -2550,7 +2604,7 @@ EOF
             _admin_user=$(grep HICLAW_ADMIN_USER "${HICLAW_ENV_FILE:-${HOME}/hiclaw-manager.env}" 2>/dev/null | cut -d= -f2-)
             _admin_user="${_admin_user:-admin}"
             _matrix_domain=$(grep HICLAW_MATRIX_DOMAIN "${HICLAW_ENV_FILE:-${HOME}/hiclaw-manager.env}" 2>/dev/null | cut -d= -f2-)
-            if [ -n "${_admin_pw}" ]; then
+            if [ -n "${_admin_pw}" ] && ${DOCKER_CMD} ps --format '{{.Names}}' 2>/dev/null | grep -q '^hiclaw-manager$'; then
                 _admin_token=$(${DOCKER_CMD} exec hiclaw-manager curl -sf -X POST http://127.0.0.1:6167/_matrix/client/v3/login \
                     -H "Content-Type: application/json" \
                     -d '{"type":"m.login.password","identifier":{"type":"m.id.user","user":"'"${_admin_user}"'"},"password":"'"${_admin_pw}"'"}' 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('access_token',''))" 2>/dev/null || true)
@@ -2575,6 +2629,9 @@ for room_id in rooms:
 " 2>/dev/null || true)
                 fi
             fi
+            if [ -z "${_mgr_room}" ]; then
+                _mgr_room=$(hiclaw_read_admin_dm_room_from_workspace "${HICLAW_WORKSPACE_DIR}")
+            fi
             cat > "${_creds_tmp}/default.env" <<CREDEOF
 WORKER_PASSWORD="${_mgr_pw}"
 WORKER_MINIO_PASSWORD="$(openssl rand -hex 24)"
@@ -2588,8 +2645,17 @@ CREDEOF
         if [ -f "${HICLAW_WORKSPACE_DIR}/workers-registry.json" ]; then
             _worker_names=$(python3 -c "import json; d=json.load(open('${HICLAW_WORKSPACE_DIR}/workers-registry.json')); print(' '.join(d.get('workers',{}).keys()))" 2>/dev/null || true)
             for _wname in ${_worker_names}; do
-                _wpw=$(${DOCKER_CMD} exec hiclaw-manager cat "/root/hiclaw-fs/agents/${_wname}/credentials/matrix/password" 2>/dev/null || true)
+                _wpw=""
+                if ${DOCKER_CMD} ps --format '{{.Names}}' 2>/dev/null | grep -q '^hiclaw-manager$'; then
+                    _wpw=$(${DOCKER_CMD} exec hiclaw-manager cat "/root/hiclaw-fs/agents/${_wname}/credentials/matrix/password" 2>/dev/null || true)
+                fi
+                if [ -z "${_wpw}" ] && ${DOCKER_CMD} volume ls -q 2>/dev/null | grep -q "^${HICLAW_DATA_DIR}$"; then
+                    _wpw=$(hiclaw_read_worker_creds_value_from_volume "${HICLAW_DATA_DIR}" "${_wname}" WORKER_PASSWORD)
+                fi
                 _wroom=$(python3 -c "import json; d=json.load(open('${HICLAW_WORKSPACE_DIR}/workers-registry.json')); print(d.get('workers',{}).get('${_wname}',{}).get('room_id',''))" 2>/dev/null || true)
+                if [ -z "${_wroom}" ] && ${DOCKER_CMD} volume ls -q 2>/dev/null | grep -q "^${HICLAW_DATA_DIR}$"; then
+                    _wroom=$(hiclaw_read_worker_creds_value_from_volume "${HICLAW_DATA_DIR}" "${_wname}" WORKER_ROOM_ID)
+                fi
                 if [ -n "${_wpw}" ]; then
                     cat > "${_creds_tmp}/${_wname}.env" <<CREDEOF
 WORKER_PASSWORD="${_wpw}"
@@ -2600,6 +2666,11 @@ CREDEOF
                     log "Extracted ${_wname} Matrix password${_wroom:+ and room ID}"
                 fi
             done
+        fi
+
+        if [ "${_mgr_creds_tempstart}" = "1" ]; then
+            log "Stopping hiclaw-manager after credential extraction (upgrade will recreate containers)..."
+            ${DOCKER_CMD} stop hiclaw-manager 2>/dev/null || true
         fi
         fi  # _is_old_arch
     fi

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -13,8 +13,9 @@
 #
 # Environment variables (for automation):
 #   HICLAW_NON_INTERACTIVE    Skip all prompts, use defaults  (default: 0)
-#   HICLAW_LLM_PROVIDER      LLM provider       (default: alibaba-cloud)
-#   HICLAW_DEFAULT_MODEL      Default model       (default: qwen3.6-plus for alibaba-cloud; qwen3.5-plus for qwen)
+#   HICLAW_LLM_PROVIDER      LLM provider       (default: openai-compat for zh non-interactive Token Plan; qwen for en)
+#   HICLAW_DEFAULT_MODEL      Default model       (default: qwen3.6-plus for zh Token Plan; qwen3.5-plus for qwen)
+#   HICLAW_OPENAI_BASE_URL    OpenAI-compatible base URL (default for zh non-interactive: Alibaba Token Plan endpoint)
 #   HICLAW_LLM_API_KEY        LLM API key         (required)
 #   HICLAW_ADMIN_USER         Admin username       (default: admin)
 #   HICLAW_ADMIN_PASSWORD     Admin password       (auto-generated if not set, min 8 chars)
@@ -373,6 +374,10 @@ msg() {
         "llm.apikey_hint_tokenplan.en") text="  💡 Get your DashScope or Token Plan API key (Alibaba Model Studio):" ;;
         "llm.apikey_url_tokenplan.zh") text="     https://help.aliyun.com/zh/model-studio/token-plan-quickstart" ;;
         "llm.apikey_url_tokenplan.en") text="     https://common-buy.aliyun.com/token-plan/  |  https://help.aliyun.com/zh/model-studio/token-plan-quickstart" ;;
+        "llm.apikey_hint_codingplan.zh") text="  💡 获取 DashScope API Key（Coding 套餐 / coding.dashscope 接口）:" ;;
+        "llm.apikey_hint_codingplan.en") text="  💡 Get your DashScope API key for Coding Plan (coding.dashscope endpoint):" ;;
+        "llm.apikey_url_codingplan.zh") text="     https://help.aliyun.com/zh/model-studio/get-api-key" ;;
+        "llm.apikey_url_codingplan.en") text="     https://help.aliyun.com/zh/model-studio/get-api-key" ;;
         "llm.apikey_prompt.zh") text="LLM API Key" ;;
         "llm.apikey_prompt.en") text="LLM API Key" ;;
         "llm.providers_title.zh") text="可用 LLM 提供商:" ;;
@@ -383,14 +388,18 @@ msg() {
         "llm.provider.openai_compat.en") text="  2) OpenAI-compatible API  - Custom Base URL (OpenAI, DeepSeek, etc.)" ;;
         "llm.provider.select.zh") text="选择提供商 [1/2]" ;;
         "llm.provider.select.en") text="Select provider [1/2]" ;;
-        "llm.alibaba.models_title.zh") text="选择百炼模型系列:" ;;
-        "llm.alibaba.models_title.en") text="Select Bailian model series:" ;;
-        "llm.alibaba.model.codingplan.zh") text="  1) Token 套餐  - 多模型调用，替代已下线的 Coding 套餐（推荐）" ;;
-        "llm.alibaba.model.codingplan.en") text="  1) Alibaba Cloud Token Plan  - Multi-model access (replaces deprecated Coding plan)" ;;
-        "llm.alibaba.model.qwen.zh") text="  2) 百炼通用接口" ;;
-        "llm.alibaba.model.qwen.en") text="  2) qwen general  - General purpose LLM" ;;
-        "llm.alibaba.model.select.zh") text="选择模型系列 [1/2]" ;;
-        "llm.alibaba.model.select.en") text="Select model series [1/2]" ;;
+        "llm.alibaba.models_title.zh") text="选择阿里云模型接入方式:" ;;
+        "llm.alibaba.models_title.en") text="Select Alibaba Cloud model access:" ;;
+        "llm.alibaba.model.tokenplan.zh") text="  1) 阿里云通义 Token 套餐  - 兼容模式（推荐）" ;;
+        "llm.alibaba.model.tokenplan.en") text="  1) Alibaba Cloud Token Plan  - compatible-mode (recommended)" ;;
+        "llm.alibaba.model.bailian.zh") text="  2) 阿里云百炼  - DashScope 通用兼容接口" ;;
+        "llm.alibaba.model.bailian.en") text="  2) Alibaba Cloud Bailian  - DashScope compatible mode" ;;
+        "llm.alibaba.model.codingplan_legacy.zh") text="  3) 阿里云 Coding 套餐  - 旧版端点（兼容保留）" ;;
+        "llm.alibaba.model.codingplan_legacy.en") text="  3) Alibaba Cloud Coding Plan  - legacy endpoint (backward compatible)" ;;
+        "llm.alibaba.model.select.zh") text="选择接入方式 [1/2/3]" ;;
+        "llm.alibaba.model.select.en") text="Select access option [1/2/3]" ;;
+        "llm.alibaba.model.invalid.zh") text="无效选择: %s（请输入 1、2 或 3）" ;;
+        "llm.alibaba.model.invalid.en") text="Invalid choice: %s (please enter 1, 2, or 3)" ;;
         "llm.codingplan.models_title.zh") text="选择通义 Token 套餐默认模型:" ;;
         "llm.codingplan.models_title.en") text="Select Qwen Cloud default model:" ;;
         "llm.codingplan.model.qwen36plus.zh") text="  1) qwen3.6-plus  - 千问 3.6（推荐）" ;;
@@ -403,8 +412,12 @@ msg() {
         "llm.codingplan.model.minimax.en") text="  4) MiniMax-M2.5  - MiniMax M2.5" ;;
         "llm.codingplan.model.select.zh") text="选择模型 [1/2/3/4]" ;;
         "llm.codingplan.model.select.en") text="Select model [1/2/3/4]" ;;
+        "llm.provider.selected_tokenplan.zh") text="  提供商: 阿里云通义 Token 套餐（兼容模式）" ;;
+        "llm.provider.selected_tokenplan.en") text="  Provider: Alibaba Cloud Token Plan (compatible mode)" ;;
         "llm.provider.selected_codingplan.zh") text="  提供商: 阿里云通义 Token 套餐（alibaba-cloud）" ;;
         "llm.provider.selected_codingplan.en") text="  Provider: Qwen Cloud (international) (alibaba-cloud)" ;;
+        "llm.provider.selected_codingplan_legacy.zh") text="  提供商: 阿里云 Coding 套餐（coding.dashscope）" ;;
+        "llm.provider.selected_codingplan_legacy.en") text="  Provider: Alibaba Cloud Coding Plan (coding.dashscope)" ;;
         "llm.provider.selected_qwen.zh") text="  提供商: 阿里云百炼" ;;
         "llm.provider.selected_qwen.en") text="  Provider: Alibaba Cloud Bailian" ;;
         "llm.provider.selected_openai.zh") text="  提供商: %s（OpenAI 兼容）" ;;
@@ -664,8 +677,12 @@ msg() {
         "llm.openai.test.ok.en") text="✅ API connectivity test passed" ;;
         "llm.openai.test.fail.zh") text="⚠️  API 联通性测试失败（HTTP %s）。响应内容:\n%s\n请根据以上错误信息联系您的模型服务商解决。" ;;
         "llm.openai.test.fail.en") text="⚠️  API connectivity test failed (HTTP %s). Response body:\n%s\nPlease contact your model provider to resolve the issue." ;;
+        "llm.openai.test.fail.tokenplan.zh") text="⚠️  提示: 请确认 API Key 有效且已开通通义 Token 套餐。文档: https://help.aliyun.com/zh/model-studio/token-plan-quickstart" ;;
+        "llm.openai.test.fail.tokenplan.en") text="⚠️  Hint: Verify your Token Plan API key and compatible-mode access. Docs: https://help.aliyun.com/zh/model-studio/token-plan-quickstart" ;;
         "llm.openai.test.fail.codingplan.zh") text="⚠️  提示: 请确认 API Key 有效且已开通通义 Token 套餐。文档: https://help.aliyun.com/zh/model-studio/token-plan-quickstart" ;;
         "llm.openai.test.fail.codingplan.en") text="⚠️  Hint: Verify your DASHSCOPE_API_KEY for Qwen Cloud. API keys: https://home.qwencloud.com/api-keys  Docs: https://docs.qwencloud.com/" ;;
+        "llm.openai.test.fail.codingplan_legacy.zh") text="⚠️  提示: 请确认 API Key 有效且 Coding 套餐接口可用。文档: https://help.aliyun.com/zh/model-studio/get-api-key" ;;
+        "llm.openai.test.fail.codingplan_legacy.en") text="⚠️  Hint: Verify your DashScope API key and Coding Plan access. Docs: https://help.aliyun.com/zh/model-studio/get-api-key" ;;
         "llm.openai.test.no_curl.zh") text="⚠️  未找到 curl，跳过 API 联通性测试" ;;
         "llm.openai.test.no_curl.en") text="⚠️  curl not found, skipping API connectivity test" ;;
         "llm.openai.test.confirm.zh") text="是否仍要继续安装？[y/N/b] " ;;
@@ -1712,12 +1729,23 @@ step_existing() {
 step_llm() {
     log "$(msg llm.title)"
     if [ "${HICLAW_NON_INTERACTIVE}" = "1" ]; then
-        HICLAW_LLM_PROVIDER="${HICLAW_LLM_PROVIDER:-qwen}"
-        HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
-        log "$(msg llm.provider.qwen_default "${HICLAW_LLM_PROVIDER}")"
+        if [ "${HICLAW_LANGUAGE}" = "zh" ]; then
+            HICLAW_LLM_PROVIDER="${HICLAW_LLM_PROVIDER:-openai-compat}"
+            HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.6-plus}"
+            HICLAW_OPENAI_BASE_URL="${HICLAW_OPENAI_BASE_URL:-https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1}"
+            log "$(msg llm.provider.label "${HICLAW_LLM_PROVIDER}")"
+            log "$(msg llm.openai.base_url_label "${HICLAW_OPENAI_BASE_URL}")"
+        else
+            HICLAW_LLM_PROVIDER="${HICLAW_LLM_PROVIDER:-qwen}"
+            HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
+            HICLAW_OPENAI_BASE_URL="${HICLAW_OPENAI_BASE_URL:-}"
+            log "$(msg llm.provider.qwen_default "${HICLAW_LLM_PROVIDER}")"
+        fi
         log "$(msg llm.model.default "${HICLAW_DEFAULT_MODEL}")"
         prompt HICLAW_LLM_API_KEY "$(msg llm.apikey_prompt)" "" "true"
         HICLAW_EMBEDDING_MODEL="${HICLAW_EMBEDDING_MODEL-text-embedding-v4}"
+        export HICLAW_LLM_PROVIDER HICLAW_DEFAULT_MODEL HICLAW_EMBEDDING_MODEL
+        [ -n "${HICLAW_OPENAI_BASE_URL+x}" ] && export HICLAW_OPENAI_BASE_URL
         return 0
     fi
     echo ""
@@ -1735,12 +1763,13 @@ step_llm() {
     fi
     if [ "${PROVIDER_CHOICE}" = "b" ]; then STEP_RESULT="back"; return 0; fi
     local ALIBABA_MODEL_CHOICE=""
+    local ALIBABA_ACCESS=""
     case "${PROVIDER_CHOICE}" in
         1|alibaba-cloud)
             if [ "${HICLAW_LANGUAGE}" = "en" ]; then
                 HICLAW_LLM_PROVIDER="openai-compat"
                 HICLAW_OPENAI_BASE_URL="https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
-                ALIBABA_MODEL_CHOICE="tokenplan"
+                ALIBABA_ACCESS="tokenplan"
                 echo ""
                 echo "$(msg llm.codingplan.models_title)"
                 echo "$(msg llm.codingplan.model.qwen36plus)"
@@ -1769,8 +1798,9 @@ step_llm() {
             else
                 echo ""
                 echo "$(msg llm.alibaba.models_title)"
-                echo "$(msg llm.alibaba.model.codingplan)"
-                echo "$(msg llm.alibaba.model.qwen)"
+                echo "$(msg llm.alibaba.model.tokenplan)"
+                echo "$(msg llm.alibaba.model.bailian)"
+                echo "$(msg llm.alibaba.model.codingplan_legacy)"
                 echo ""
                 if [ "${HICLAW_QUICKSTART}" = "1" ]; then
                     read -e -p "$(msg llm.alibaba.model.select) [1]: " ALIBABA_MODEL_CHOICE
@@ -1781,18 +1811,8 @@ step_llm() {
                 fi
                 if [ "${ALIBABA_MODEL_CHOICE}" = "b" ]; then STEP_RESULT="back"; return 0; fi
                 case "${ALIBABA_MODEL_CHOICE}" in
-                    2|qwen)
-                        HICLAW_LLM_PROVIDER="qwen"
-                        HICLAW_OPENAI_BASE_URL=""
-                        echo ""
-                        read -e -p "$(msg llm.qwen.model_prompt): " HICLAW_DEFAULT_MODEL
-                        if [ "${HICLAW_DEFAULT_MODEL}" = "b" ]; then STEP_RESULT="back"; return 0; fi
-                        HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
-                        log "$(msg llm.provider.selected_qwen)"
-                        log "$(msg llm.model.label "${HICLAW_DEFAULT_MODEL}")"
-                        prompt_custom_model_params "${HICLAW_DEFAULT_MODEL}" || return 0
-                        ;;
-                    *)
+                    1|token-plan|tokenplan)
+                        ALIBABA_ACCESS="tokenplan"
                         HICLAW_LLM_PROVIDER="openai-compat"
                         HICLAW_OPENAI_BASE_URL="https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
                         echo ""
@@ -1818,27 +1838,61 @@ step_llm() {
                             4|MiniMax-M2.5) HICLAW_DEFAULT_MODEL="MiniMax-M2.5" ;;
                             *)              HICLAW_DEFAULT_MODEL="qwen3.6-plus" ;;
                         esac
-                        log "$(msg llm.provider.selected_codingplan)"
+                        log "$(msg llm.provider.selected_tokenplan)"
                         log "$(msg llm.model.label "${HICLAW_DEFAULT_MODEL}")"
+                        ;;
+                    2|qwen|bailian)
+                        ALIBABA_ACCESS="bailian"
+                        HICLAW_LLM_PROVIDER="qwen"
+                        HICLAW_OPENAI_BASE_URL=""
+                        echo ""
+                        read -e -p "$(msg llm.qwen.model_prompt): " HICLAW_DEFAULT_MODEL
+                        if [ "${HICLAW_DEFAULT_MODEL}" = "b" ]; then STEP_RESULT="back"; return 0; fi
+                        HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
+                        log "$(msg llm.provider.selected_qwen)"
+                        log "$(msg llm.model.label "${HICLAW_DEFAULT_MODEL}")"
+                        prompt_custom_model_params "${HICLAW_DEFAULT_MODEL}" || return 0
+                        ;;
+                    3|coding-plan|codingplan)
+                        ALIBABA_ACCESS="codingplan_legacy"
+                        HICLAW_LLM_PROVIDER="openai-compat"
+                        HICLAW_OPENAI_BASE_URL="https://coding.dashscope.aliyuncs.com/v1"
+                        echo ""
+                        read -e -p "$(msg llm.qwen.model_prompt): " HICLAW_DEFAULT_MODEL
+                        if [ "${HICLAW_DEFAULT_MODEL}" = "b" ]; then STEP_RESULT="back"; return 0; fi
+                        HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
+                        log "$(msg llm.provider.selected_codingplan_legacy)"
+                        log "$(msg llm.model.label "${HICLAW_DEFAULT_MODEL}")"
+                        prompt_custom_model_params "${HICLAW_DEFAULT_MODEL}" || return 0
+                        ;;
+                    *)
+                        error "$(msg llm.alibaba.model.invalid "${ALIBABA_MODEL_CHOICE}")"
                         ;;
                 esac
             fi
-            if [ "${ALIBABA_MODEL_CHOICE}" = "2" ] || [ "${ALIBABA_MODEL_CHOICE}" = "qwen" ]; then
+            if [ "${ALIBABA_ACCESS}" = "bailian" ]; then
                 log "$(msg llm.apikey_hint_bailian)"
                 log "$(msg llm.apikey_url_bailian)"
             elif [ "${HICLAW_LANGUAGE}" = "en" ]; then
                 log "$(msg llm.apikey_hint_qwencloud)"
                 log "$(msg llm.apikey_url_qwencloud)"
+            elif [ "${ALIBABA_ACCESS}" = "codingplan_legacy" ]; then
+                log "$(msg llm.apikey_hint_codingplan)"
+                log "$(msg llm.apikey_url_codingplan)"
             else
                 log "$(msg llm.apikey_hint_tokenplan)"
                 log "$(msg llm.apikey_url_tokenplan)"
             fi
             log ""
             prompt HICLAW_LLM_API_KEY "$(msg llm.apikey_prompt)" "" "true" || return 0
-            if [ "${ALIBABA_MODEL_CHOICE}" = "2" ] || [ "${ALIBABA_MODEL_CHOICE}" = "qwen" ]; then
+            if [ "${ALIBABA_ACCESS}" = "bailian" ]; then
                 test_llm_connectivity "https://dashscope.aliyuncs.com/compatible-mode/v1" "${HICLAW_LLM_API_KEY}" "${HICLAW_DEFAULT_MODEL}" || return 0
-            else
+            elif [ "${ALIBABA_ACCESS}" = "codingplan_legacy" ]; then
+                test_llm_connectivity "https://coding.dashscope.aliyuncs.com/v1" "${HICLAW_LLM_API_KEY}" "${HICLAW_DEFAULT_MODEL}" "$(msg llm.openai.test.fail.codingplan_legacy)" || return 0
+            elif [ "${HICLAW_LANGUAGE}" = "en" ]; then
                 test_llm_connectivity "${HICLAW_OPENAI_BASE_URL}" "${HICLAW_LLM_API_KEY}" "${HICLAW_DEFAULT_MODEL}" "$(msg llm.openai.test.fail.codingplan)" || return 0
+            else
+                test_llm_connectivity "${HICLAW_OPENAI_BASE_URL}" "${HICLAW_LLM_API_KEY}" "${HICLAW_DEFAULT_MODEL}" "$(msg llm.openai.test.fail.tokenplan)" || return 0
             fi
             ;;
         2|openai-compat)


### PR DESCRIPTION
## Summary

During **old-architecture → embedded** upgrades, the installer extracts Matrix passwords and room IDs before tearing down `hiclaw-manager`. That path used `docker exec` against a **stopped** container, so login and file reads failed silently and new rooms could be created instead of reusing existing ones.

## Changes

- If `hiclaw-manager` exists but is not running, **start it temporarily**, run `wait_matrix_ready`, perform credential extraction, then **stop** it so the normal upgrade teardown/re-create flow continues unchanged.
- If the manager password is not in container `Config.Env`, try **`/data/hiclaw-secrets.env`** via a short-lived container on the data volume.
- If the manager container is **missing**, read the manager password from the data volume and the admin DM **room id** from `state.json` in the workspace when Matrix discovery is unavailable.
- For workers, fall back to **`/data/worker-creds/<name>.env`** on the volume when `docker exec` cannot be used.

## Testing

- `bash -n install/hiclaw-install.sh` (syntax check).


Made with [Cursor](https://cursor.com)