### PR TITLE
fix: MinIO S3 endpoint must use port 9000, not Higress 8080

### DIFF
--- a/hiclaw-controller/internal/config/config.go
+++ b/hiclaw-controller/internal/config/config.go
@@ -342,6 +342,9 @@ func LoadConfig() *Config {
 			cfg.WorkerEnv.FSEndpoint = replaceHost(cfg.WorkerEnv.FSEndpoint, ctrlHost)
 		}
 	}
+	// S3/MinIO API is never on the Higress HTTP gateway port (8080). Misconfigured
+	// HICLAW_FS_DOMAIN:8080 URLs are rewritten to the MinIO object port.
+	cfg.WorkerEnv.FSEndpoint = normalizeMinIOS3Endpoint(cfg.WorkerEnv.FSEndpoint)
 
 	if specJSON := os.Getenv("HICLAW_MANAGER_SPEC"); specJSON != "" {
 		if err := applyManagerSpec(cfg, specJSON); err != nil {
@@ -540,6 +543,25 @@ func replaceHost(rawURL, newHost string) string {
 	return u.String()
 }
 
+// normalizeMinIOS3Endpoint rewrites a common misconfiguration: the S3/MinIO API
+// is served on the object store port (9000 in HiClaw), not the Higress HTTP
+// gateway (8080). A URL like http://fs-local.hiclaw.io:8080 breaks mc silently.
+func normalizeMinIOS3Endpoint(raw string) string {
+	if raw == "" {
+		return raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Port() != "8080" {
+		return raw
+	}
+	hostname := u.Hostname()
+	if hostname == "" {
+		return raw
+	}
+	u.Host = hostname + ":9000"
+	return u.String()
+}
+
 func (c *Config) MatrixConfig() matrix.Config {
 	return matrix.Config{
 		ServerURL:         c.MatrixServerURL,
@@ -563,10 +585,11 @@ func (c *Config) GatewayConfig() gateway.Config {
 func (c *Config) OSSConfig() oss.Config {
 	accessKey := firstNonEmpty(os.Getenv("HICLAW_FS_ACCESS_KEY"), os.Getenv("HICLAW_MINIO_USER"))
 	secretKey := firstNonEmpty(os.Getenv("HICLAW_FS_SECRET_KEY"), os.Getenv("HICLAW_MINIO_PASSWORD"))
+	endpoint := firstNonEmpty(os.Getenv("HICLAW_FS_ENDPOINT"), c.WorkerEnv.FSEndpoint)
 	return oss.Config{
 		StoragePrefix: c.OSSStoragePrefix,
 		Bucket:        c.OSSBucket,
-		Endpoint:      firstNonEmpty(os.Getenv("HICLAW_FS_ENDPOINT"), c.WorkerEnv.FSEndpoint),
+		Endpoint:      normalizeMinIOS3Endpoint(endpoint),
 		AccessKey:     accessKey,
 		SecretKey:     secretKey,
 	}

--- a/hiclaw-controller/internal/config/config_test.go
+++ b/hiclaw-controller/internal/config/config_test.go
@@ -1,6 +1,25 @@
 package config
 
-import "testing"
+import (
+	"testing"
+)
+
+func TestNormalizeMinIOS3Endpoint(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"http://fs-local.hiclaw.io:9000", "http://fs-local.hiclaw.io:9000"},
+		{"http://fs-local.hiclaw.io:8080", "http://fs-local.hiclaw.io:9000"},
+		{"http://hiclaw-controller:8080", "http://hiclaw-controller:9000"},
+		{"http://example:18080", "http://example:18080"},
+	}
+	for _, tc := range tests {
+		if got := normalizeMinIOS3Endpoint(tc.in); got != tc.want {
+			t.Errorf("normalizeMinIOS3Endpoint(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
 
 func TestLoadConfigAppliesManagerSpec(t *testing.T) {
 	t.Setenv("HICLAW_MANAGER_SPEC", `{

--- a/manager/agent/skills/worker-management/scripts/get-worker-install-cmd.sh
+++ b/manager/agent/skills/worker-management/scripts/get-worker-install-cmd.sh
@@ -55,7 +55,7 @@ source "${CREDS_FILE}"
 FS_DOMAIN="${HICLAW_FS_DOMAIN:-fs-local.hiclaw.io}"
 FS_EXTERNAL_PORT="${HICLAW_PORT_GATEWAY:-18080}"
 FS_EXTERNAL_ENDPOINT="http://${FS_DOMAIN}:${FS_EXTERNAL_PORT}"
-FS_INTERNAL_ENDPOINT="http://${FS_DOMAIN}:8080"
+FS_INTERNAL_ENDPOINT="http://${FS_DOMAIN%%:*}:9000"
 
 if [ "${RUNTIME}" = "copaw" ]; then
     INSTALL_CMD="pip install -i https://mirrors.aliyun.com/pypi/simple/ copaw-worker && copaw-worker --name ${WORKER_NAME} --fs ${FS_EXTERNAL_ENDPOINT} --fs-key ${WORKER_NAME} --fs-secret ${WORKER_MINIO_PASSWORD} --console-port 8088"

--- a/manager/agent/skills/worker-management/scripts/lifecycle-worker.sh
+++ b/manager/agent/skills/worker-management/scripts/lifecycle-worker.sh
@@ -409,7 +409,7 @@ action_start() {
             --arg controller_url "${HICLAW_CONTROLLER_URL:-}" \
             '{
                 "HICLAW_WORKER_NAME": $name,
-                "HICLAW_FS_ENDPOINT": (if $fs_endpoint != "" then $fs_endpoint else ("http://" + ($fs_domain | split(":")[0]) + ":8080") end),
+                "HICLAW_FS_ENDPOINT": (if $fs_endpoint != "" then $fs_endpoint else ("http://" + ($fs_domain | split(":")[0]) + ":9000") end),
                 "HICLAW_FS_ACCESS_KEY": $fak,
                 "HICLAW_FS_SECRET_KEY": $fsk
             }

--- a/manager/scripts/init/start-manager-agent.sh
+++ b/manager/scripts/init/start-manager-agent.sh
@@ -1024,7 +1024,7 @@ if container_api_available; then
                         --arg controller_url "${HICLAW_CONTROLLER_URL:-}" \
                         '{
                             "HICLAW_WORKER_NAME": $name,
-                            "HICLAW_FS_ENDPOINT": ("http://" + ($fs_domain | split(":")[0]) + ":8080"),
+                            "HICLAW_FS_ENDPOINT": ("http://" + ($fs_domain | split(":")[0]) + ":9000"),
                             "HICLAW_FS_ACCESS_KEY": $fak,
                             "HICLAW_FS_SECRET_KEY": $fsk
                         }

--- a/manager/scripts/init/start-mc-mirror.sh
+++ b/manager/scripts/init/start-mc-mirror.sh
@@ -25,13 +25,32 @@
 # ────────────────────────────────────────────────────────────────────────────
 
 source /opt/hiclaw/scripts/lib/hiclaw-env.sh
-waitForService "MinIO" "127.0.0.1" 9000
 
-# Configure mc alias (local access, not through Higress)
-mc alias set hiclaw http://127.0.0.1:9000 "${HICLAW_MINIO_USER:-${HICLAW_ADMIN_USER:-admin}}" "${HICLAW_MINIO_PASSWORD:-${HICLAW_ADMIN_PASSWORD:-admin}}"
+# MinIO S3: use explicit URL, or cluster FS endpoint, or in-process minio (embedded controller)
+# (Port 8080 is Higress, not the S3 API; never use it for mc.)
+MINIO_S3_URL="${HICLAW_MINIO_S3_URL:-${HICLAW_FS_ENDPOINT:-${HICLAW_MINIO_ENDPOINT:-http://127.0.0.1:9000}}}"
+MINIO_S3_URL="${MINIO_S3_URL//:8080/:9000}"
+_HP="${MINIO_S3_URL#*://}"
+_HP="${_HP%%/*}"
+_MINIO_HOST="${_HP%%:*}"
+_MINIO_PORT="${_HP##*:}"
+if [ "${_MINIO_PORT}" = "${_HP}" ] || [ -z "${_MINIO_PORT}" ]; then
+    _MINIO_PORT=9000
+fi
+waitForService "MinIO" "${_MINIO_HOST}" "${_MINIO_PORT}"
+
+# Configure mc alias (direct S3, not Higress HTTP)
+mc alias set hiclaw "${MINIO_S3_URL}" \
+    "${HICLAW_MINIO_USER:-${HICLAW_ADMIN_USER:-admin}}" \
+    "${HICLAW_MINIO_PASSWORD:-${HICLAW_ADMIN_PASSWORD:-admin}}"
 
 # Create default bucket
 mc mb "${HICLAW_STORAGE_PREFIX}" --ignore-existing
+
+if ! mc ls "${HICLAW_STORAGE_PREFIX}/" > /dev/null 2>&1; then
+    log "ERROR: MinIO S3 is not usable at ${MINIO_S3_URL} (HICLAW_MINIO_S3_URL / HICLAW_FS_ENDPOINT must be the S3 port, e.g. :9000, not the Higress gateway 8080)."
+    exit 1
+fi
 
 # Initialize placeholder directories for shared data and worker artifacts
 for dir in shared/knowledge shared/tasks workers; do


### PR DESCRIPTION
## Problem

`mc alias hiclaw` and worker `HICLAW_FS_ENDPOINT` were sometimes built with **:8080** (Higress HTTP gateway) instead of the **MinIO S3 API** on **:9000**, causing `mc` operations to fail or behave as no-ops (see #717, e.g. `http://fs-local.hiclaw.io:8080` vs `http://hiclaw-controller:9000`).

## Changes

- **hiclaw-controller** (`config`): normalize any `HICLAW_FS_ENDPOINT` with port `:8080` to `:9000` and apply the same in `OSSConfig` (covers `mc alias set` from the Go MinIO client).
- **start-mc-mirror.sh**: resolve the S3 URL from `HICLAW_MINIO_S3_URL` (optional override), `HICLAW_FS_ENDPOINT`, or `HICLAW_MINIO_ENDPOINT`, defaulting to `http://127.0.0.1:9000`; also rewrite `:8080` to `:9000`; wait on the resolved host:port; verify with `mc ls` after `mb`.
- **Manager scripts** (`start-manager-agent.sh`, `lifecycle-worker.sh`, `get-worker-install-cmd.sh`): default internal FS URL uses **:9000** instead of **:8080**.

## Config and health check

- Optional override: `HICLAW_MINIO_S3_URL` (full S3 base URL for non-default layouts).
- Startup check: `start-mc-mirror.sh` exits with an error if the bucket is not listable after configuration.

Closes #717