### PR TITLE
docs: update root AGENTS.md for current layout and runtimes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,40 +4,112 @@ This file helps AI Agents (and human developers) quickly understand the project 
 
 ## What is HiClaw
 
-HiClaw is an open-source Agent Teams system that uses IM (Matrix protocol) for multi-Agent collaboration with human-in-the-loop oversight. It consists of a Manager Agent (coordinator) and Worker Agents (task executors), connected via an AI Gateway (Higress), Matrix Homeserver (Tuwunel), and HTTP File System (MinIO).
+HiClaw is an open-source Agent Teams system that uses IM (Matrix protocol) for multi-Agent collaboration with human-in-the-loop oversight. It consists of a Manager Agent (coordinator) and Worker Agents (task executors), connected via an AI Gateway (Higress), Matrix Homeserver (Tuwunel), and HTTP file storage (MinIO or cloud OSS). Production-style deployments use the Kubernetes operator and Helm chart; local installs use Docker Compose scripts under `install/`.
 
 ## Project Structure
 
 ```
 hiclaw/
-├── manager/          # Manager Agent container (all-in-one: Higress + Tuwunel + MinIO + Element Web + OpenClaw)
-├── worker/           # Worker Agent container (lightweight: OpenClaw + mc + mcporter)
-├── install/          # One-click installation scripts
-├── scripts/          # Utility scripts (replay-task.sh for sending tasks to Manager via Matrix)
-├── hack/             # Maintenance scripts (mirror-images.sh for syncing base images to registry)
-├── tests/            # Automated integration test suite (10 test cases)
-├── .github/workflows/# CI/CD: build images, run tests, release
-├── docs/             # User-facing documentation
-├── design/           # Internal design documents and API specs
-└── logs/             # Replay conversation logs (gitignored)
+├── hiclaw-controller/   # Kubernetes operator (Go): reconciles Worker, Manager, Team, Human CRDs
+├── helm/                # Helm chart (K8s): Higress, Tuwunel, MinIO, controller, Manager CR, defaults
+├── manager/             # Manager images: OpenClaw-based (Dockerfile) and CoPaw-based (Dockerfile.copaw)
+├── worker/              # OpenClaw Worker image (shared base pattern; runtime also selected at deploy time)
+├── copaw/               # CoPaw Python package source (published as e.g. copaw-worker on PyPI)
+├── hermes/              # Hermes Python package source (Hermes Matrix worker runtime)
+├── openclaw-base/       # Base image: Ubuntu + Node.js + bundled agent assets + mcporter
+├── shared/lib/          # Shared shell libs copied into images (hiclaw-env.sh, render-skills.sh, …)
+├── install/             # Local install scripts (Docker Compose / embedded “all-in-one” stack)
+├── scripts/             # Project-level utilities (e.g. replay-task.sh)
+├── tests/               # Automated integration tests
+├── docs/                # User-facing documentation
+├── design/              # Internal design notes and API specs
+├── changelog/           # Release notes fragments (current.md rolled into releases)
+├── hack/                # Maintenance helpers (e.g. image mirror scripts)
+├── migrate/             # Optional migration helpers
+├── blog/                # Announcement / blog source
+└── .github/workflows/   # CI: build images, tests, release automation
 ```
+
+Logs and local artifacts (for example replay logs) stay out of git via `.gitignore`.
+
+## Runtime model
+
+**Worker runtimes** (per Worker CR `spec.runtime`, registry, or install defaults):
+
+| Runtime   | Stack | Role |
+|-----------|--------|------|
+| `openclaw` | Node.js / OpenClaw (default) | Primary worker agent runtime |
+| `copaw`    | Python / AgentScope via CoPaw | Alternative worker runtime |
+| `hermes`   | Python / `hermes-worker` package | Alternative worker runtime (Matrix bridge + policies under `hermes/src/`) |
+
+**Manager runtimes** (container env `HICLAW_MANAGER_RUNTIME`, CoPaw Manager CR / Helm `manager.runtime` where applicable):
+
+| Runtime   | Behavior |
+|-----------|-----------|
+| `openclaw` (default) | OpenClaw gateway; primary Matrix channel uses the **message** tool pattern (see upstream OpenClaw / HiClaw manager config). |
+| `copaw` | Python CoPaw workspace; Matrix traffic uses the **`copaw channels send`** CLI (see `start-copaw-manager.sh`). |
+
+Hermes is a **Worker** runtime in the API and Helm worker defaults; the Manager entrypoint in `start-manager-agent.sh` today starts **openclaw** or **copaw** only.
+
+**Deployment runtime** (`HICLAW_RUNTIME`): local embedded stack vs `aliyun` vs `k8s` changes which bootstrap steps run inside the Manager container (for example Matrix registration and Higress setup are skipped or reduced in `k8s` because the controller owns them).
+
+## `manager/agent/` layout (built into Manager images)
+
+Agent-facing Markdown and skills under `manager/agent/` are copied to `/opt/hiclaw/agent/` in the image and synced into the Manager workspace by `upgrade-builtins.sh`. This tree is the single source of truth for builtin prompts and skills.
+
+```
+manager/agent/
+├── AGENTS.md                    # OpenClaw Manager — primary bootstrap instructions
+├── HEARTBEAT.md                 # OpenClaw Manager — periodic duties
+├── SOUL.md                      # OpenClaw Manager — personality (often filled by onboarding)
+├── TOOLS.md                     # Optional; referenced where applicable
+├── skills/                      # Manager skills (shared by OpenClaw and CoPaw Managers)
+│   └── <name>/                  # e.g. task-management, worker-management, … (each with SKILL.md)
+├── skills-alpha/                # Experimental / optional skill packages
+├── copaw-manager-agent/         # CoPaw Manager overrides
+│   ├── AGENTS.md                # Replaces workspace AGENTS.md for CoPaw Manager
+│   └── HEARTBEAT.md             # Replaces workspace HEARTBEAT.md for CoPaw Manager
+├── worker-agent/                # Builtin OpenClaw Worker workspace template
+├── copaw-worker-agent/          # Builtin CoPaw Worker workspace template
+├── hermes-worker-agent/         # Builtin Hermes Worker workspace template
+├── team-leader-agent/           # Team Leader agent template (Teams feature)
+└── worker-skills/               # Extra worker skill templates (e.g. GitHub) pushed on demand
+```
+
+**Which files apply at startup**
+
+- **OpenClaw Manager**: workspace copies of `AGENTS.md`, `HEARTBEAT.md`, `SOUL.md`, plus everything under `skills/` (from image builtins).
+- **CoPaw Manager**: `copaw-manager-agent/AGENTS.md` and `copaw-manager-agent/HEARTBEAT.md` are merged into the workspace copies during `upgrade-builtins.sh` when `MANAGER_RUNTIME=copaw`; **skills/** stay shared with OpenClaw Manager.
+- **Workers**: the controller (or local registry) records `runtime` per worker; init scripts materialize the matching `*-worker-agent/` tree into that worker’s storage.
+
+**Template rendering**: `shared/lib/render-skills.sh` runs from `start-manager-agent.sh` over workspace and image paths so known `${VAR}` placeholders become literal text before agents read them.
 
 ## Key Entry Points
 
 ### To understand the architecture
+
 - Read [docs/architecture.md](docs/architecture.md) for system overview and component diagram
 - Read [design/design.md](design/design.md) for full product design (Chinese)
 - Read [design/poc-design.md](design/poc-design.md) for detailed implementation specs
 
+### Kubernetes deployment
+
+- [helm/hiclaw/](helm/hiclaw/) — primary Helm chart (`Chart.yaml`, `values.yaml`): matrix, gateway, storage, controller, Manager CR, worker defaults, optional Element Web and CMS hooks
+
+### Controller (operator) development
+
+- [hiclaw-controller/](hiclaw-controller/) — Go operator: CRD definitions under `api/v1beta1/`, reconcilers, `hiclaw` CLI baked into Manager/Worker images
+
 ### To build and run
-- [Makefile](Makefile) -- unified build/test/push/install/replay interface (`make help` for all targets)
-- [docs/quickstart.md](docs/quickstart.md) -- end-to-end guide from zero to working team
-- [install/hiclaw-install.sh](install/hiclaw-install.sh) -- the installation script
-- [scripts/replay-task.sh](scripts/replay-task.sh) -- send tasks to Manager via Matrix CLI
+
+- [Makefile](Makefile) — unified build/test/push/install/replay interface (`make help` for all targets)
+- [docs/quickstart.md](docs/quickstart.md) — end-to-end guide from zero to working team
+- [install/hiclaw-install.sh](install/hiclaw-install.sh) — local installation script
+- [scripts/replay-task.sh](scripts/replay-task.sh) — send tasks to Manager via Matrix CLI
 
 ### Local full build (from source)
 
-The image dependency chain is: `openclaw-base` → `manager` / `worker`. CoPaw worker is independent.
+The image dependency chain is: `openclaw-base` → `manager` / `worker`. CoPaw and Hermes worker images and the controller image are additional build targets; see the `Makefile` for current image names.
 
 By default, `OPENCLAW_BASE_IMAGE` points to the remote registry (`higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/openclaw-base`). When building locally from a modified `openclaw-base`, you **must** override it to the local image name so that manager/worker actually use your local base:
 
@@ -54,6 +126,7 @@ make build-manager build-worker build-copaw-worker \
 **Common pitfall**: Running `make build-manager build-worker OPENCLAW_BASE_VERSION=latest` without `OPENCLAW_BASE_IMAGE=hiclaw/openclaw-base` will pull the remote registry's `:latest` tag instead of using the locally-built image. Always set both variables together for local builds.
 
 **Proxy support**: If behind an HTTP proxy, pass proxy build args. This covers APT, PIP, NPM and all other network access — no mirror args needed:
+
 ```bash
 PROXY_ARGS="--build-arg HTTP_PROXY=http://host.containers.internal:1087 \
     --build-arg HTTPS_PROXY=http://host.containers.internal:1087 \
@@ -62,9 +135,11 @@ PROXY_ARGS="--build-arg HTTP_PROXY=http://host.containers.internal:1087 \
 
 make build-embedded build-manager build-worker build-copaw-worker DOCKER_BUILD_ARGS="${PROXY_ARGS}"
 ```
+
 Note: use `host.containers.internal` for Podman on macOS, `host.docker.internal` for Docker Desktop.
 
 **China build acceleration (without proxy)**: All Dockerfiles default to official sources. For builds in China without proxy, pass mirror args:
+
 ```bash
 # APT mirror (for Ubuntu/Debian-based images: openclaw-base, copaw, manager-copaw, embedded)
 make build-embedded DOCKER_BUILD_ARGS="--build-arg APT_MIRROR=mirrors.aliyun.com"
@@ -77,59 +152,80 @@ make build-openclaw-base DOCKER_BUILD_ARGS="--build-arg APT_MIRROR=mirrors.aliyu
 ```
 
 ### To modify the Manager container
-- [manager/Dockerfile](manager/Dockerfile) -- multi-stage build definition
-- [manager/supervisord.conf](manager/supervisord.conf) -- process orchestration
-- [manager/scripts/init/](manager/scripts/init/) -- container startup scripts (supervisord)
-- [manager/scripts/lib/](manager/scripts/lib/) -- shared libraries (base.sh, container-api.sh)
-- [manager/configs/](manager/configs/) -- init-time configuration templates
+
+- [manager/Dockerfile](manager/Dockerfile) — OpenClaw-based Manager (from `openclaw-base`; bundles `hiclaw` CLI from controller image)
+- [manager/Dockerfile.copaw](manager/Dockerfile.copaw) — CoPaw-based Manager (Python venv + CoPaw from PyPI; same agent tree and scripts pattern)
+- [manager/supervisord.conf](manager/supervisord.conf) — process orchestration (local embedded stack)
+- [manager/scripts/init/](manager/scripts/init/) — startup: `start-manager-agent.sh` (runtime + `HICLAW_RUNTIME`), `upgrade-builtins.sh`, Higress/Matrix bootstrap where applicable
+- [manager/scripts/lib/](manager/scripts/lib/) — shared libraries (`base.sh`, `container-api.sh`, …)
+- [manager/configs/](manager/configs/) — init-time configuration templates (e.g. `manager-openclaw.json.tmpl`)
+
+The Manager **image** is an agent runtime plus scripts; Higress, Tuwunel, MinIO, and Element Web are brought up by **Helm** or **install/**, not inside the slim Manager Dockerfile unless you use the legacy all-in-one local compose layout.
 
 ### To modify the Worker container (OpenClaw)
-- [worker/Dockerfile](worker/Dockerfile) -- build definition (Node.js 22 from build stage)
-- [worker/scripts/worker-entrypoint.sh](worker/scripts/worker-entrypoint.sh) -- startup logic
+
+- [worker/Dockerfile](worker/Dockerfile) — build definition (Node.js from build stage / openclaw-base pattern)
+- [worker/scripts/worker-entrypoint.sh](worker/scripts/worker-entrypoint.sh) — startup logic
 
 ### To modify the Worker container (CoPaw)
-- [copaw/Dockerfile](copaw/Dockerfile) -- build definition (Python 3.11)
-- [copaw/scripts/copaw-worker-entrypoint.sh](copaw/scripts/copaw-worker-entrypoint.sh) -- startup logic
-- [copaw/src/copaw_worker/](copaw/src/copaw_worker/) -- CoPaw worker Python package
 
-### To manage Worker containers via socket
-- [manager/scripts/lib/container-api.sh](manager/scripts/lib/container-api.sh) -- Docker/Podman REST API helpers for direct Worker creation
+- [copaw/Dockerfile](copaw/Dockerfile) — CoPaw worker image build
+- [copaw/scripts/copaw-worker-entrypoint.sh](copaw/scripts/copaw-worker-entrypoint.sh) — startup logic
+- [copaw/src/copaw_worker/](copaw/src/copaw_worker/) — CoPaw worker Python package
+- [copaw/README.md](copaw/README.md) — PyPI package `copaw-worker` install and CLI overview
+
+### To modify the Hermes worker runtime
+
+- [hermes/](hermes/) — Python package layout under `hermes/src/` (`hermes_worker`, `hermes_matrix`, CLI)
+
+### To manage Worker containers via socket (local Docker)
+
+- [manager/scripts/lib/container-api.sh](manager/scripts/lib/container-api.sh) — Docker/Podman REST API helpers for direct Worker creation on the Manager host
+
+In `k8s` / `aliyun` modes, Workers are created via the controller API instead of a local socket.
 
 ### To modify Agent behavior
-- [manager/agent/SOUL.md](manager/agent/SOUL.md) -- Manager personality and rules
-- [manager/agent/HEARTBEAT.md](manager/agent/HEARTBEAT.md) -- periodic check routine
-- [manager/agent/skills/](manager/agent/skills/) -- Manager's skills (9 skill directories, each with SKILL.md and optional scripts/references/)
-- [manager/agent/worker-skills/](manager/agent/worker-skills/) -- Skill definitions pushed to Workers on creation
-- [manager/agent/worker-skills/github-operations/SKILL.md](manager/agent/worker-skills/github-operations/SKILL.md) -- Worker GitHub skill (on-demand, pushed by Manager)
+
+- [manager/agent/SOUL.md](manager/agent/SOUL.md) — OpenClaw Manager personality and rules
+- [manager/agent/HEARTBEAT.md](manager/agent/HEARTBEAT.md) — OpenClaw Manager periodic check routine
+- [manager/agent/skills/](manager/agent/skills/) — Manager skills (each skill directory contains `SKILL.md` and optional `scripts/` / `references/`)
+- [manager/agent/copaw-manager-agent/](manager/agent/copaw-manager-agent/) — CoPaw Manager prompt overrides
+- [manager/agent/worker-skills/](manager/agent/worker-skills/) — Skill definitions pushed to Workers on creation
+- [manager/agent/worker-skills/github-operations/SKILL.md](manager/agent/worker-skills/github-operations/SKILL.md) — Worker GitHub skill (on-demand)
 
 ### To modify CI/CD
-- [.github/workflows/](/.github/workflows/) -- GitHub Actions workflows
-- [tests/](tests/) -- integration test suite
+
+- [.github/workflows/](.github/workflows/) — GitHub Actions workflows
+- [tests/](tests/) — integration test suite
 
 ### To modify Higress routing and initialization
-- [manager/scripts/init/setup-higress.sh](manager/scripts/init/setup-higress.sh) -- route, consumer, MCP server setup
-- [design/higress-console-api.yaml](design/higress-console-api.yaml) -- Higress Console API spec (OpenAPI 3.0)
+
+- [manager/scripts/init/setup-higress.sh](manager/scripts/init/setup-higress.sh) — route, consumer, MCP server setup (local / full console mode)
+- [design/higress-console-api.yaml](design/higress-console-api.yaml) — Higress Console API spec (OpenAPI 3.0)
 
 ## Technology Stack
 
 | Component | Technology | Purpose |
 |-----------|-----------|---------|
-| AI Gateway | Higress (all-in-one) | LLM proxy, MCP Server hosting, consumer auth, route management |
-| Matrix Server | Tuwunel (conduwuit fork) | IM communication between Agents and Human |
-| Matrix Client | Element Web | Browser-based IM interface |
-| File System | MinIO + mc mirror | Centralized HTTP file storage with local sync |
-| Agent Framework | OpenClaw (fork) | Agent runtime with Matrix plugin, skills, heartbeat |
-| Agent Framework | CoPaw (Python) | Alternative Python-based agent runtime for Workers |
+| Kubernetes operator | hiclaw-controller (Go) | Reconciles Worker / Manager / Team / Human CRDs; REST API; worker lifecycle |
+| AI Gateway | Higress (chart or external) | LLM proxy, MCP Server hosting, consumer auth, route management |
+| Matrix Server | Tuwunel (conduwuit fork) | IM between Agents and Human |
+| Matrix Client | Element Web (optional) | Browser-based IM interface |
+| File System | MinIO or OSS | Centralized object storage for workspaces and agent state |
+| Agent Framework | OpenClaw (fork) | Default Manager/Worker runtime (Node.js gateway + Matrix plugin) |
+| Agent Framework | CoPaw (Python / AgentScope) | Alternative Manager and Worker runtime |
+| Agent Framework | Hermes (`hermes-worker`) | Alternative Python Worker runtime |
 | MCP CLI | mcporter | Worker calls MCP Server tools via CLI |
 
 ## Changelog Policy
 
-Any change that affects the content of a built image — i.e. modifications under `manager/`, `worker/`, `copaw/`, or `openclaw-base/` — **must** be recorded in [`changelog/current.md`](changelog/current.md) before committing.
+Any change that affects the content of a built image — i.e. modifications under `manager/`, `worker/`, `copaw/`, `hermes/`, `openclaw-base/`, or `hiclaw-controller/` — **must** be recorded in [`changelog/current.md`](changelog/current.md) before committing.
 
 Format: one bullet per logical change, with a linked commit hash, e.g.:
+
 ```
-- feat(manager): add task-management skill extracted from AGENTS.md ([a1b2c3d](https://github.com/higress-group/hiclaw/commit/a1b2c3d...))
-- fix(manager): fix upgrade-builtins idempotency (duplicate marker insertion) ([e4f5g6h](https://github.com/higress-group/hiclaw/commit/e4f5g6h...))
+- feat(manager): add task-management skill extracted from AGENTS.md ([a1b2c3d](https://github.com/agentscope-ai/HiClaw/commit/a1b2c3d...))
+- fix(manager): fix upgrade-builtins idempotency (duplicate marker insertion) ([e4f5g6h](https://github.com/agentscope-ai/HiClaw/commit/e4f5g6h...))
 ```
 
 On release, the workflow automatically renames `current.md` → `vX.Y.Z.md` and creates a fresh `current.md`.
@@ -137,7 +233,7 @@ On release, the workflow automatically renames `current.md` → `vX.Y.Z.md` and 
 ## Key Design Patterns
 
 1. **All communication in Matrix Rooms**: Human + Manager + Worker are all in the same Room. Human sees everything, can intervene anytime.
-2. **Centralized file system**: All Agent configs and state stored in MinIO. Workers are stateless -- destroy and recreate freely.
+2. **Centralized file system**: All Agent configs and state stored in MinIO (or cloud object storage). Workers are stateless — destroy and recreate freely.
 3. **Unified credential management**: Worker uses one Consumer key-auth token for both LLM and MCP Server access. Manager controls permissions.
 4. **Skills as documentation**: Each SKILL.md is a self-contained reference that tells the Agent how to use an API or tool.
 
@@ -153,9 +249,12 @@ Files under `manager/agent/` are **read by the Agent at runtime**, not by human 
 **Do NOT** use third-person descriptions like "Manager can call..." or "This skill provides..." in agent-facing files. The Agent is the reader — talk to it directly.
 
 This convention applies to all files that end up in the Agent's workspace or are loaded as skills/prompts at runtime:
+
 - `manager/agent/**` (Manager Agent config, skills, tools)
 - `manager/agent/worker-agent/**` (OpenClaw Worker Agent config, builtin skills)
 - `manager/agent/copaw-worker-agent/**` (CoPaw Worker Agent config, builtin skills)
+- `manager/agent/hermes-worker-agent/**` (Hermes Worker Agent config, builtin skills)
+- `manager/agent/team-leader-agent/**` (Team Leader Agent config and skills)
 - `manager/agent/worker-skills/**` (on-demand skill definitions pushed to Workers)
 
 ## Environment Variables


### PR DESCRIPTION
## Summary

This updates the repository root `AGENTS.md` so it matches how the project is organized today: Kubernetes operator and Helm chart, multiple worker/manager runtimes, slim Manager images, and the `manager/agent/` tree (including CoPaw Manager overrides and Hermes worker assets).

## What changed

- **Project structure**: Document `hiclaw-controller/`, `helm/`, `copaw/`, `hermes/`, `openclaw-base/`, `shared/lib/`, `changelog/`, and other top-level dirs; clarify that the Manager image is not an "all-in-one" infra box.
- **Runtime model**: Table for Worker runtimes (`openclaw`, `copaw`, `hermes`) and Manager runtimes (`openclaw` vs `copaw`), plus `HICLAW_RUNTIME` and note that Hermes is worker-only in the shipped Manager entrypoint.
- **`manager/agent/`**: New section describing subdirs (`skills/`, `copaw-manager-agent/`, `*-worker-agent/`, `team-leader-agent/`, `worker-skills/`), startup file selection, and `render-skills.sh`.
- **Key entry points**: Added Helm and controller; refreshed Manager/Worker modification bullets.
- **Technology stack**: Added hiclaw-controller row; Hermes row.
- **Changelog policy**: Extended image paths to `hermes/` and `hiclaw-controller/`; example commit links point to `agentscope-ai/HiClaw`.

## Preserved

Build/pitfall notes, proxy and China mirror examples, design patterns, agent-facing writing rules, env var pointer, and verified POC technical details.

Made with [Cursor](https://cursor.com)