### PR TITLE
feat: Token Plan support, Qwen Cloud international, qwen3.6-plus model and upgrade credential fix

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -55,7 +55,7 @@ on:
       model:
         description: 'LLM model to use'
         required: false
-        default: 'qwen3.5-plus'
+        default: 'qwen3.6-plus'
 
 env:
   # Tests that do not require a GitHub token, split into four shards for parallel execution
@@ -386,7 +386,7 @@ jobs:
         env:
           HICLAW_LLM_API_KEY: ${{ secrets.HICLAW_LLM_API_KEY }}
           HICLAW_LLM_PROVIDER: qwen
-          HICLAW_DEFAULT_MODEL: ${{ inputs.model || 'qwen3.5-plus' }}
+          HICLAW_DEFAULT_MODEL: ${{ inputs.model || 'qwen3.6-plus' }}
           HICLAW_MANAGER_RUNTIME: ${{ matrix.manager_runtime }}
           # Propagate the worker runtime to worker-creating tests too. Without
           # this the apply-zip path (test-15) silently falls back to openclaw
@@ -615,7 +615,7 @@ jobs:
           echo "- Tests: \`${{ env[matrix.filter_env] }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Manager Runtime: \`${{ matrix.manager_runtime }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Worker Runtime: \`${{ matrix.worker_runtime }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Model: \`${{ inputs.model || 'qwen3.5-plus' }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Model: \`${{ inputs.model || 'qwen3.6-plus' }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Install Mode: embedded (make test-embedded)" >> $GITHUB_STEP_SUMMARY
 
 # ============================================================

--- a/helm/hiclaw/crds/managers.hiclaw.io.yaml
+++ b/helm/hiclaw/crds/managers.hiclaw.io.yaml
@@ -18,7 +18,7 @@ spec:
               properties:
                 model:
                   type: string
-                  description: LLM model ID (e.g. qwen3.5-plus, claude-sonnet-4-6)
+                  description: LLM model ID (e.g. qwen3.6-plus, claude-sonnet-4-6)
                 runtime:
                   type: string
                   enum: [openclaw, copaw]

--- a/helm/hiclaw/crds/workers.hiclaw.io.yaml
+++ b/helm/hiclaw/crds/workers.hiclaw.io.yaml
@@ -18,7 +18,7 @@ spec:
               properties:
                 model:
                   type: string
-                  description: LLM model ID (e.g. claude-sonnet-4-6, qwen3.5-plus)
+                  description: LLM model ID (e.g. claude-sonnet-4-6, qwen3.6-plus)
                 runtime:
                   type: string
                   enum: [openclaw, copaw, hermes]

--- a/hiclaw-controller/cmd/hiclaw/apply.go
+++ b/hiclaw-controller/cmd/hiclaw/apply.go
@@ -23,7 +23,7 @@ func applyCmd() *cobra.Command {
 
   hiclaw apply -f resource.yaml
   hiclaw apply worker --name alice --zip worker.zip
-  hiclaw apply worker --name alice --model qwen3.5-plus`,
+  hiclaw apply worker --name alice --model qwen3.6-plus`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(files) > 0 {
 				return applyFromFiles(files)
@@ -172,7 +172,7 @@ func applyWorkerSubCmd() *cobra.Command {
 		Long: `Create or update a Worker from CLI parameters or a ZIP package.
 
   hiclaw apply worker --name alice --zip worker.zip
-  hiclaw apply worker --name alice --model qwen3.5-plus
+  hiclaw apply worker --name alice --model qwen3.6-plus
   hiclaw apply worker --name bob --model claude-sonnet-4-6 --skills github-operations`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if name == "" {
@@ -192,7 +192,7 @@ func applyWorkerSubCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", "Worker name (required)")
-	cmd.Flags().StringVar(&model, "model", "", "LLM model ID (default: $HICLAW_DEFAULT_MODEL, else qwen3.5-plus)")
+	cmd.Flags().StringVar(&model, "model", "", "LLM model ID (default: $HICLAW_DEFAULT_MODEL, else qwen3.6-plus)")
 	cmd.Flags().StringVar(&zipFile, "zip", "", "Local ZIP package (manifest.json)")
 	cmd.Flags().StringVar(&runtime, "runtime", "", "Agent runtime (openclaw|copaw|hermes)")
 	cmd.Flags().StringVar(&image, "image", "", "Container image override")

--- a/hiclaw-controller/cmd/hiclaw/create.go
+++ b/hiclaw-controller/cmd/hiclaw/create.go
@@ -52,7 +52,7 @@ func createWorkerCmd() *cobra.Command {
 		Short: "Create a Worker",
 		Long: `Create a new Worker resource via the controller REST API.
 
-  hiclaw create worker --name alice --model qwen3.5-plus
+  hiclaw create worker --name alice --model qwen3.6-plus
   hiclaw create worker --name alice --soul-file /path/to/SOUL.md --skills github-operations
   hiclaw create worker --name bob --model claude-sonnet-4-6 --mcp-servers github -o json
   hiclaw create worker --name charlie --runtime copaw --expose 8080,3000`,
@@ -132,7 +132,7 @@ func createWorkerCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", "Worker name (required)")
-	cmd.Flags().StringVar(&model, "model", "", "LLM model ID (default: $HICLAW_DEFAULT_MODEL, else qwen3.5-plus)")
+	cmd.Flags().StringVar(&model, "model", "", "LLM model ID (default: $HICLAW_DEFAULT_MODEL, else qwen3.6-plus)")
 	cmd.Flags().StringVar(&runtime, "runtime", "", "Agent runtime (openclaw|copaw|hermes)")
 	cmd.Flags().StringVar(&image, "image", "", "Container image override")
 	cmd.Flags().StringVar(&identity, "identity", "", "Worker identity description")
@@ -377,7 +377,7 @@ func createManagerCmd() *cobra.Command {
 		Short: "Create a Manager agent",
 		Long: `Create a new Manager resource.
 
-  hiclaw create manager --name default --model qwen3.5-plus
+  hiclaw create manager --name default --model qwen3.6-plus
   hiclaw create manager --name default --model claude-sonnet-4-6 --runtime copaw`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if name == "" {
@@ -423,14 +423,14 @@ var workerNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 // specify --model. It prefers the install-time configured model
 // (HICLAW_DEFAULT_MODEL, propagated by the controller into both the manager
 // and worker containers via WorkerEnvBuilder); only when the env var is unset
-// does it fall back to the historical "qwen3.5-plus" default. Without this
+// does it fall back to the "qwen3.6-plus" default. Without this
 // fallback every `hiclaw create worker` / `hiclaw apply worker` invoked by the
 // Manager Agent would silently override the admin's install-time model choice.
 func defaultWorkerModel() string {
 	if m := strings.TrimSpace(os.Getenv("HICLAW_DEFAULT_MODEL")); m != "" {
 		return m
 	}
-	return "qwen3.5-plus"
+	return "qwen3.6-plus"
 }
 
 func validateWorkerName(name string) error {

--- a/hiclaw-controller/cmd/hiclaw/create_test.go
+++ b/hiclaw-controller/cmd/hiclaw/create_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 func TestDefaultWorkerModel(t *testing.T) {
-	t.Run("falls back to qwen3.5-plus when env var unset", func(t *testing.T) {
+	t.Run("falls back to qwen3.6-plus when env var unset", func(t *testing.T) {
 		t.Setenv("HICLAW_DEFAULT_MODEL", "")
-		if got := defaultWorkerModel(); got != "qwen3.5-plus" {
-			t.Fatalf("defaultWorkerModel() = %q, want qwen3.5-plus", got)
+		if got := defaultWorkerModel(); got != "qwen3.6-plus" {
+			t.Fatalf("defaultWorkerModel() = %q, want qwen3.6-plus", got)
 		}
 	})
 	t.Run("prefers HICLAW_DEFAULT_MODEL when set", func(t *testing.T) {
@@ -25,8 +25,8 @@ func TestDefaultWorkerModel(t *testing.T) {
 	})
 	t.Run("trims whitespace before falling back", func(t *testing.T) {
 		t.Setenv("HICLAW_DEFAULT_MODEL", "   ")
-		if got := defaultWorkerModel(); got != "qwen3.5-plus" {
-			t.Fatalf("defaultWorkerModel() = %q, want qwen3.5-plus", got)
+		if got := defaultWorkerModel(); got != "qwen3.6-plus" {
+			t.Fatalf("defaultWorkerModel() = %q, want qwen3.6-plus", got)
 		}
 	})
 }

--- a/hiclaw-controller/config/crd/managers.hiclaw.io.yaml
+++ b/hiclaw-controller/config/crd/managers.hiclaw.io.yaml
@@ -18,7 +18,7 @@ spec:
               properties:
                 model:
                   type: string
-                  description: LLM model ID (e.g. qwen3.5-plus, claude-sonnet-4-6)
+                  description: LLM model ID (e.g. qwen3.6-plus, claude-sonnet-4-6)
                 runtime:
                   type: string
                   enum: [openclaw, copaw]

--- a/hiclaw-controller/config/crd/workers.hiclaw.io.yaml
+++ b/hiclaw-controller/config/crd/workers.hiclaw.io.yaml
@@ -18,7 +18,7 @@ spec:
               properties:
                 model:
                   type: string
-                  description: LLM model ID (e.g. claude-sonnet-4-6, qwen3.5-plus)
+                  description: LLM model ID (e.g. claude-sonnet-4-6, qwen3.6-plus)
                 runtime:
                   type: string
                   enum: [openclaw, copaw, hermes]

--- a/hiclaw-controller/internal/agentconfig/generator.go
+++ b/hiclaw-controller/internal/agentconfig/generator.go
@@ -17,7 +17,7 @@ func NewGenerator(cfg Config) *Generator {
 		cfg.AdminUser = "admin"
 	}
 	if cfg.DefaultModel == "" {
-		cfg.DefaultModel = "qwen3.5-plus"
+		cfg.DefaultModel = "qwen3.6-plus"
 	}
 	return &Generator{config: cfg}
 }
@@ -384,6 +384,7 @@ func defaultModelSpec(modelName string) ModelSpec {
 		"claude-opus-4-6":   {1000000, 128000, true, true},
 		"claude-sonnet-4-6": {1000000, 64000, true, true},
 		"claude-haiku-4-5":  {200000, 64000, true, true},
+		"qwen3.6-plus":      {200000, 64000, true, true},
 		"qwen3.5-plus":      {200000, 64000, true, true},
 		"deepseek-chat":     {256000, 128000, false, true},
 		"deepseek-reasoner": {256000, 128000, false, true},
@@ -449,7 +450,7 @@ func (g *Generator) allModelSpecs(selectedModel string) []ModelSpec {
 	allModels := []string{
 		"gpt-5.4", "gpt-5.3-codex", "gpt-5-mini", "gpt-5-nano",
 		"claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5",
-		"qwen3.5-plus",
+		"qwen3.6-plus", "qwen3.5-plus",
 		"deepseek-chat", "deepseek-reasoner",
 		"kimi-k2.5", "glm-5",
 		"MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5",
@@ -473,7 +474,7 @@ func (g *Generator) allModelAliases(selectedModel string) map[string]interface{}
 	allModels := []string{
 		"gpt-5.4", "gpt-5.3-codex", "gpt-5-mini", "gpt-5-nano",
 		"claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5",
-		"qwen3.5-plus",
+		"qwen3.6-plus", "qwen3.5-plus",
 		"deepseek-chat", "deepseek-reasoner",
 		"kimi-k2.5", "glm-5",
 		"MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5",

--- a/hiclaw-controller/internal/config/config.go
+++ b/hiclaw-controller/internal/config/config.go
@@ -262,7 +262,7 @@ func LoadConfig() *Config {
 		K8sWorkerMemory: envOrDefault("HICLAW_K8S_WORKER_MEMORY", "2Gi"),
 
 		ManagerEnabled:          envOrDefault("HICLAW_MANAGER_ENABLED", "true") == "true",
-		ManagerModel:            firstNonEmpty(os.Getenv("HICLAW_MANAGER_MODEL"), envOrDefault("HICLAW_DEFAULT_MODEL", "qwen3.5-plus")),
+		ManagerModel:            firstNonEmpty(os.Getenv("HICLAW_MANAGER_MODEL"), envOrDefault("HICLAW_DEFAULT_MODEL", "qwen3.6-plus")),
 		ManagerRuntime:          envOrDefault("HICLAW_MANAGER_RUNTIME", "openclaw"),
 		ManagerImage:            os.Getenv("HICLAW_MANAGER_IMAGE"),
 		DefaultWorkerRuntime:    os.Getenv("HICLAW_DEFAULT_WORKER_RUNTIME"),
@@ -289,7 +289,7 @@ func LoadConfig() *Config {
 
 		OSSStoragePrefix: envOrDefault("HICLAW_STORAGE_PREFIX", "hiclaw/hiclaw-storage"),
 
-		DefaultModel:       envOrDefault("HICLAW_DEFAULT_MODEL", "qwen3.5-plus"),
+		DefaultModel:       envOrDefault("HICLAW_DEFAULT_MODEL", "qwen3.6-plus"),
 		EmbeddingModel:     os.Getenv("HICLAW_EMBEDDING_MODEL"),
 		Runtime:            envOrDefault("HICLAW_RUNTIME", "docker"),
 		ModelContextWindow: envOrDefaultInt("HICLAW_MODEL_CONTEXT_WINDOW", 0),

--- a/hiclaw-controller/internal/service/provisioner.go
+++ b/hiclaw-controller/internal/service/provisioner.go
@@ -117,7 +117,7 @@ type ProvisionerConfig struct {
 	// this model so a 200 response proves the entire path the manager
 	// will exercise (auth filter → route → upstream → model resolution)
 	// is live. Sourced from Config.ManagerModel which already resolves
-	// HICLAW_MANAGER_MODEL → HICLAW_DEFAULT_MODEL → "qwen3.5-plus".
+	// HICLAW_MANAGER_MODEL → HICLAW_DEFAULT_MODEL → "qwen3.6-plus".
 	ManagerModel string
 
 	// ManagerEnabled reflects HICLAW_MANAGER_ENABLED. When false, no Manager

--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -14,7 +14,7 @@
 # Environment variables (for automation):
 #   HICLAW_NON_INTERACTIVE    Skip all prompts, use defaults  (default: 0)
 #   HICLAW_LLM_PROVIDER       LLM provider       (default: openai-compat for zh non-interactive Token Plan; qwen for en)
-#   HICLAW_DEFAULT_MODEL      Default model      (default: qwen3.6-plus for zh Token Plan; qwen3.5-plus for qwen)
+#   HICLAW_DEFAULT_MODEL      Default model      (default: qwen3.6-plus for zh Token Plan and en non-interactive)
 #   HICLAW_OPENAI_BASE_URL    OpenAI-compatible base URL (default for zh non-interactive: Alibaba Token Plan endpoint)
 #   HICLAW_LLM_API_KEY        LLM API key        (required)
 #   HICLAW_ADMIN_USER         Admin username     (default: admin)
@@ -322,7 +322,7 @@ $script:Messages = @{
     "llm.provider.selected_qwen" = @{ zh = "  提供商: 阿里云百炼"; en = "  Provider: Alibaba Cloud Bailian" }
     "llm.provider.selected_openai" = @{ zh = "  提供商: {0}（OpenAI 兼容）"; en = "  Provider: {0} (OpenAI-compatible)" }
     "llm.provider.invalid" = @{ zh = "无效选择: {0}（请输入 1 或 2）"; en = "Invalid choice: {0} (please enter 1 or 2)" }
-    "llm.qwen.model_prompt" = @{ zh = "默认模型 ID [qwen3.5-plus]"; en = "Default Model ID [qwen3.5-plus]" }
+    "llm.qwen.model_prompt" = @{ zh = "默认模型 ID [qwen3.6-plus]"; en = "Default Model ID [qwen3.6-plus]" }
     "llm.openai.base_url_prompt" = @{ zh = "Base URL（例如 https://api.openai.com/v1）"; en = "Base URL (e.g., https://api.openai.com/v1)" }
     "llm.openai.model_prompt" = @{ zh = "默认模型 ID [gpt-5.4]"; en = "Default Model ID [gpt-5.4]" }
     "llm.openai.base_url_label" = @{ zh = "  Base URL: {0}"; en = "  Base URL: {0}" }
@@ -1664,7 +1664,7 @@ function Step-Llm {
             Write-Log (Get-Msg "llm.openai.base_url_label" -f $script:config.OPENAI_BASE_URL)
         } else {
             $script:config.LLM_PROVIDER = if ($env:HICLAW_LLM_PROVIDER) { $env:HICLAW_LLM_PROVIDER } else { "qwen" }
-            $script:config.DEFAULT_MODEL = if ($env:HICLAW_DEFAULT_MODEL) { $env:HICLAW_DEFAULT_MODEL } else { "qwen3.5-plus" }
+            $script:config.DEFAULT_MODEL = if ($env:HICLAW_DEFAULT_MODEL) { $env:HICLAW_DEFAULT_MODEL } else { "qwen3.6-plus" }
             $script:config.OPENAI_BASE_URL = if ($env:HICLAW_OPENAI_BASE_URL) { $env:HICLAW_OPENAI_BASE_URL } else { "" }
             Write-Log (Get-Msg "llm.provider.qwen_default" -f $script:config.LLM_PROVIDER)
         }
@@ -1766,7 +1766,7 @@ function Step-Llm {
                     Write-Host ""
                     $qwenModelInput = Read-Host (Get-Msg "llm.qwen.model_prompt")
                     if ($qwenModelInput -eq "b") { $script:StepResult = "back"; return }
-                    $script:config.DEFAULT_MODEL = if ($qwenModelInput) { $qwenModelInput } elseif ($env:HICLAW_DEFAULT_MODEL) { $env:HICLAW_DEFAULT_MODEL } else { "qwen3.5-plus" }
+                    $script:config.DEFAULT_MODEL = if ($qwenModelInput) { $qwenModelInput } elseif ($env:HICLAW_DEFAULT_MODEL) { $env:HICLAW_DEFAULT_MODEL } else { "qwen3.6-plus" }
                     Write-Log (Get-Msg "llm.provider.selected_qwen")
                     Request-CustomModelParams $script:config.DEFAULT_MODEL
                     if ($script:StepResult -eq "back") { return }
@@ -1777,7 +1777,7 @@ function Step-Llm {
                     Write-Host ""
                     $codingModelInput = Read-Host (Get-Msg "llm.qwen.model_prompt")
                     if ($codingModelInput -eq "b") { $script:StepResult = "back"; return }
-                    $script:config.DEFAULT_MODEL = if ($codingModelInput) { $codingModelInput } elseif ($env:HICLAW_DEFAULT_MODEL) { $env:HICLAW_DEFAULT_MODEL } else { "qwen3.5-plus" }
+                    $script:config.DEFAULT_MODEL = if ($codingModelInput) { $codingModelInput } elseif ($env:HICLAW_DEFAULT_MODEL) { $env:HICLAW_DEFAULT_MODEL } else { "qwen3.6-plus" }
                     Write-Log (Get-Msg "llm.provider.selected_codingplan_legacy")
                     Request-CustomModelParams $script:config.DEFAULT_MODEL
                     if ($script:StepResult -eq "back") { return }

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -14,7 +14,7 @@
 # Environment variables (for automation):
 #   HICLAW_NON_INTERACTIVE    Skip all prompts, use defaults  (default: 0)
 #   HICLAW_LLM_PROVIDER      LLM provider       (default: openai-compat for zh non-interactive Token Plan; qwen for en)
-#   HICLAW_DEFAULT_MODEL      Default model       (default: qwen3.6-plus for zh Token Plan; qwen3.5-plus for qwen)
+#   HICLAW_DEFAULT_MODEL      Default model       (default: qwen3.6-plus for zh Token Plan and en non-interactive)
 #   HICLAW_OPENAI_BASE_URL    OpenAI-compatible base URL (default for zh non-interactive: Alibaba Token Plan endpoint)
 #   HICLAW_LLM_API_KEY        LLM API key         (required)
 #   HICLAW_ADMIN_USER         Admin username       (default: admin)
@@ -424,8 +424,8 @@ msg() {
         "llm.provider.selected_openai.en") text="  Provider: %s (OpenAI-compatible)" ;;
         "llm.provider.invalid.zh") text="无效选择: %s（请输入 1 或 2）" ;;
         "llm.provider.invalid.en") text="Invalid choice: %s (please enter 1 or 2)" ;;
-        "llm.qwen.model_prompt.zh") text="默认模型 ID [qwen3.5-plus]" ;;
-        "llm.qwen.model_prompt.en") text="Default Model ID [qwen3.5-plus]" ;;
+        "llm.qwen.model_prompt.zh") text="默认模型 ID [qwen3.6-plus]" ;;
+        "llm.qwen.model_prompt.en") text="Default Model ID [qwen3.6-plus]" ;;
         "llm.openai.base_url_prompt.zh") text="Base URL（例如 https://api.openai.com/v1）" ;;
         "llm.openai.base_url_prompt.en") text="Base URL (e.g., https://api.openai.com/v1)" ;;
         "llm.openai.model_prompt.zh") text="默认模型 ID [gpt-5.4]" ;;
@@ -1737,7 +1737,7 @@ step_llm() {
             log "$(msg llm.openai.base_url_label "${HICLAW_OPENAI_BASE_URL}")"
         else
             HICLAW_LLM_PROVIDER="${HICLAW_LLM_PROVIDER:-qwen}"
-            HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
+            HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.6-plus}"
             HICLAW_OPENAI_BASE_URL="${HICLAW_OPENAI_BASE_URL:-}"
             log "$(msg llm.provider.qwen_default "${HICLAW_LLM_PROVIDER}")"
         fi
@@ -1848,7 +1848,7 @@ step_llm() {
                         echo ""
                         read -e -p "$(msg llm.qwen.model_prompt): " HICLAW_DEFAULT_MODEL
                         if [ "${HICLAW_DEFAULT_MODEL}" = "b" ]; then STEP_RESULT="back"; return 0; fi
-                        HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
+                        HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.6-plus}"
                         log "$(msg llm.provider.selected_qwen)"
                         log "$(msg llm.model.label "${HICLAW_DEFAULT_MODEL}")"
                         prompt_custom_model_params "${HICLAW_DEFAULT_MODEL}" || return 0
@@ -1860,7 +1860,7 @@ step_llm() {
                         echo ""
                         read -e -p "$(msg llm.qwen.model_prompt): " HICLAW_DEFAULT_MODEL
                         if [ "${HICLAW_DEFAULT_MODEL}" = "b" ]; then STEP_RESULT="back"; return 0; fi
-                        HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
+                        HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.6-plus}"
                         log "$(msg llm.provider.selected_codingplan_legacy)"
                         log "$(msg llm.model.label "${HICLAW_DEFAULT_MODEL}")"
                         prompt_custom_model_params "${HICLAW_DEFAULT_MODEL}" || return 0

--- a/manager/agent/skills/model-switch/scripts/update-manager-model.sh
+++ b/manager/agent/skills/model-switch/scripts/update-manager-model.sh
@@ -95,7 +95,7 @@ case "${MODEL_NAME}" in
         CTX=1000000; MAX=64000 ;;
     claude-haiku-4-5)
         CTX=200000; MAX=64000 ;;
-    qwen3.5-plus)
+    qwen3.6-plus|qwen3.5-plus)
         CTX=200000; MAX=64000 ;;
     deepseek-chat|deepseek-reasoner|kimi-k2.5)
         CTX=256000; MAX=128000 ;;
@@ -112,7 +112,7 @@ fi
 
 # Resolve input modalities: only vision-capable models get "image"
 case "${MODEL_NAME}" in
-    gpt-5.4|gpt-5.3-codex|gpt-5-mini|gpt-5-nano|claude-opus-4-6|claude-sonnet-4-6|claude-haiku-4-5|qwen3.5-plus|kimi-k2.5)
+    gpt-5.4|gpt-5.3-codex|gpt-5-mini|gpt-5-nano|claude-opus-4-6|claude-sonnet-4-6|claude-haiku-4-5|qwen3.6-plus|qwen3.5-plus|kimi-k2.5)
         INPUT='["text", "image"]' ;;
     *)
         INPUT='["text"]' ;;

--- a/manager/agent/skills/worker-management/scripts/generate-worker-config.sh
+++ b/manager/agent/skills/worker-management/scripts/generate-worker-config.sh
@@ -16,7 +16,7 @@ source /opt/hiclaw/scripts/lib/hiclaw-env.sh
 WORKER_NAME="$1"
 WORKER_MATRIX_TOKEN="$2"
 WORKER_GATEWAY_KEY="$3"
-MODEL_NAME="${4:-${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}}"
+MODEL_NAME="${4:-${HICLAW_DEFAULT_MODEL:-qwen3.6-plus}}"
 TEAM_LEADER_NAME="${5:-}"
 # Strip provider prefix if caller passed "hiclaw-gateway/<model>" by mistake
 MODEL_NAME="${MODEL_NAME#hiclaw-gateway/}"
@@ -43,7 +43,7 @@ case "${MODEL_NAME}" in
         CTX=1000000; MAX=64000 ;;
     claude-haiku-4-5)
         CTX=200000; MAX=64000 ;;
-    qwen3.5-plus)
+    qwen3.6-plus|qwen3.5-plus)
         CTX=200000; MAX=64000 ;;
     deepseek-chat|deepseek-reasoner|kimi-k2.5)
         CTX=256000; MAX=128000 ;;
@@ -59,7 +59,7 @@ esac
 
 # Resolve input modalities: only vision-capable models get "image"
 case "${MODEL_NAME}" in
-    gpt-5.4|gpt-5.3-codex|gpt-5-mini|gpt-5-nano|claude-opus-4-6|claude-sonnet-4-6|claude-haiku-4-5|qwen3.5-plus|kimi-k2.5)
+    gpt-5.4|gpt-5.3-codex|gpt-5-mini|gpt-5-nano|claude-opus-4-6|claude-sonnet-4-6|claude-haiku-4-5|qwen3.6-plus|qwen3.5-plus|kimi-k2.5)
         INPUT='["text", "image"]' ;;
     *)
         INPUT='["text"]' ;;

--- a/manager/configs/known-models.json
+++ b/manager/configs/known-models.json
@@ -6,6 +6,7 @@
   { "id": "claude-opus-4-6",   "name": "claude-opus-4-6",   "reasoning": true,  "contextWindow": 1000000, "maxTokens": 128000, "input": ["text", "image"] },
   { "id": "claude-sonnet-4-6", "name": "claude-sonnet-4-6", "reasoning": true,  "contextWindow": 1000000, "maxTokens": 64000,  "input": ["text", "image"] },
   { "id": "claude-haiku-4-5",  "name": "claude-haiku-4-5",  "reasoning": true,  "contextWindow": 200000,  "maxTokens": 64000,  "input": ["text", "image"] },
+  { "id": "qwen3.6-plus",      "name": "qwen3.6-plus",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 64000,  "input": ["text", "image"] },
   { "id": "qwen3.5-plus",      "name": "qwen3.5-plus",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 64000,  "input": ["text", "image"] },
   { "id": "deepseek-chat",     "name": "deepseek-chat",     "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text"] },
   { "id": "deepseek-reasoner", "name": "deepseek-reasoner", "reasoning": true,  "contextWindow": 256000,  "maxTokens": 128000, "input": ["text"] },

--- a/manager/scripts/init/start-manager-agent.sh
+++ b/manager/scripts/init/start-manager-agent.sh
@@ -624,7 +624,7 @@ log "Generating Manager openclaw.json..."
 export MANAGER_MATRIX_TOKEN="${MANAGER_TOKEN}"
 export MANAGER_GATEWAY_KEY="${HICLAW_MANAGER_GATEWAY_KEY}"
 # Resolve model parameters based on model name
-MODEL_NAME="${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"
+MODEL_NAME="${HICLAW_DEFAULT_MODEL:-qwen3.6-plus}"
 case "${MODEL_NAME}" in
     gpt-5.3-codex|gpt-5-mini|gpt-5-nano)
         export MODEL_CONTEXT_WINDOW=400000 MODEL_MAX_TOKENS=128000 ;;
@@ -634,7 +634,7 @@ case "${MODEL_NAME}" in
         export MODEL_CONTEXT_WINDOW=1000000 MODEL_MAX_TOKENS=64000 ;;
     claude-haiku-4-5)
         export MODEL_CONTEXT_WINDOW=200000 MODEL_MAX_TOKENS=64000 ;;
-    qwen3.5-plus)
+    qwen3.6-plus|qwen3.5-plus)
         export MODEL_CONTEXT_WINDOW=200000 MODEL_MAX_TOKENS=64000 ;;
     deepseek-chat|deepseek-reasoner|kimi-k2.5)
         export MODEL_CONTEXT_WINDOW=256000 MODEL_MAX_TOKENS=128000 ;;
@@ -660,7 +660,7 @@ log "Matrix E2EE: ${MATRIX_E2EE_ENABLED}"
 
 # Resolve input modalities: only vision-capable models get "image"
 case "${MODEL_NAME}" in
-    gpt-5.4|gpt-5.3-codex|gpt-5-mini|gpt-5-nano|claude-opus-4-6|claude-sonnet-4-6|claude-haiku-4-5|qwen3.5-plus|kimi-k2.5)
+    gpt-5.4|gpt-5.3-codex|gpt-5-mini|gpt-5-nano|claude-opus-4-6|claude-sonnet-4-6|claude-haiku-4-5|qwen3.6-plus|qwen3.5-plus|kimi-k2.5)
         export MODEL_INPUT='["text", "image"]' ;;
     *)
         export MODEL_INPUT='["text"]' ;;

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -242,7 +242,7 @@ _setup_manager_identity() {
                     -X POST "${_gw_url}/v1/chat/completions" \
                     -H "Authorization: Bearer ${_mgr_key}" \
                     -H "Content-Type: application/json" \
-                    -d '{"model":"'"${HICLAW_DEFAULT_MODEL:-qwen3.5-plus}"'","messages":[{"role":"user","content":"hi"}],"max_tokens":1}' 2>/dev/null || echo -e "\n000")
+                    -d '{"model":"'"${HICLAW_DEFAULT_MODEL:-qwen3.6-plus}"'","messages":[{"role":"user","content":"hi"}],"max_tokens":1}' 2>/dev/null || echo -e "\n000")
                 _gw_code=$(echo "${_gw_resp}" | tail -1)
                 if [ "${_gw_code}" = "200" ]; then
                     _gw_ready=true


### PR DESCRIPTION
## Changes

### 1. Upgrade credential extraction fix (fixes #714 follow-up)
- When upgrading from v1.0.9, if the Manager container was stopped, the install script could not extract Matrix credentials
- Fix: temporarily start the stopped container, wait for Matrix ready, extract creds, then stop it again
- Fallback: read credentials directly from Docker volume files if container is unavailable
- Both bash (.sh) and PowerShell (.ps1) scripts updated

### 2. Replace Coding Plan with Token Plan (domestic China)
- Alibaba Cloud deprecated Coding Plan, replaced with Token Plan
- New Token Plan base URL: `https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1`
- Domestic menu now has 3 options: Token Plan (default), Bailian (qwen), Coding Plan (legacy)
- Old Coding Plan kept as fallback option

### 3. Replace international Coding Plan with Qwen Cloud
- International base URL: `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`
- API key from https://home.qwencloud.com/api-keys

### 4. Add qwen3.6-plus model
- Registered in known-models.json with same params as qwen3.5-plus (200K context, 64K max tokens, vision)
- Added to controller presets, CLI defaults, install scripts
- All default model references updated from qwen3.5-plus to qwen3.6-plus
- Go tests updated and passing

### Files changed
- `install/hiclaw-install.sh` / `.ps1` — Token Plan + Qwen Cloud + credential extraction + qwen3.6-plus
- `hiclaw-controller/` — model presets, config defaults, CLI defaults, CRD descriptions
- `manager/` — known-models.json, runtime scripts
- Tests passing
