### PR TITLE
feat(controller): optional SOUL.md in Worker package resolve/extract

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,6 +4,7 @@ Record image-affecting changes to `manager/`, `worker/`, `openclaw-base/` here b
 
 ---
 
+- feat(controller): Worker package resolve/extract no longer requires `SOUL.md` in the archive or directory; missing personality is filled later by `DeployWorkerConfig` defaults or inline `spec.soul`
 - fix(controller): add `+kubebuilder:subresource:status` on CR types; patch Worker finalizers instead of full `Update`; exponential backoff on REST update conflict retries
 - fix(manager): document runtime-aware Worker dispatch (avoid @worker text in admin DM only); update task-management references, AGENTS.md, HEARTBEAT.md, channel-management skill
 - fix(manager): separate runtime-specific AGENTS/HEARTBEAT for OpenClaw vs CoPaw; remove cross-runtime references from manager agent docs

--- a/hiclaw-controller/internal/executor/package.go
+++ b/hiclaw-controller/internal/executor/package.go
@@ -79,11 +79,12 @@ func (p *PackageResolver) Resolve(ctx context.Context, uri string) (string, erro
 }
 
 // ResolveAndExtract downloads/locates a package, extracts it, and returns the
-// extracted directory path. The directory follows the standard package layout:
+// extracted directory path. Typical layout (SOUL.md is optional; DeployWorkerConfig
+// supplies a default SOUL when missing):
 //
 //	{extractDir}/{name}/
 //	├── config/
-//	│   ├── SOUL.md
+//	│   ├── SOUL.md (optional)
 //	│   └── AGENTS.md (optional)
 //	├── skills/ (optional)
 //	└── Dockerfile (optional)
@@ -99,9 +100,6 @@ func (p *PackageResolver) ResolveAndExtract(ctx context.Context, uri, name strin
 
 	// If Resolve already returned a directory (e.g. nacos://), use it directly.
 	if info, err := os.Stat(resolved); err == nil && info.IsDir() {
-		if err := validatePackageDir(resolved); err != nil {
-			return "", err
-		}
 		return resolved, nil
 	}
 
@@ -117,15 +115,12 @@ func (p *PackageResolver) ResolveAndExtract(ctx context.Context, uri, name strin
 		return "", fmt.Errorf("extract ZIP %s: %s: %w", resolved, string(out), err)
 	}
 
-	if err := validatePackageDir(destDir); err != nil {
-		return "", err
-	}
-
 	return destDir, nil
 }
 
 // DeployToMinIO copies extracted package contents to the worker's MinIO agent space.
-// This ensures SOUL.md, custom skills, etc. are in place before create-worker.sh runs.
+// Config files and skills from the package are applied when present; SOUL may come
+// from the package, inline spec, or DeployWorkerConfig defaults.
 //
 // To avoid a race with the background MinIO→local sync (which could overwrite local
 // files between the local write and the mc mirror push), we push to MinIO FIRST from
@@ -275,16 +270,6 @@ func mcPut(ctx context.Context, minioPath string, data []byte) error {
 		return fmt.Errorf("mc cp to %s: %s: %w", minioPath, string(out), err)
 	}
 	return nil
-}
-
-// validatePackageDir checks that a SOUL.md exists in the package directory.
-func validatePackageDir(dir string) error {
-	for _, rel := range []string{"SOUL.md", "config/SOUL.md"} {
-		if _, err := os.Stat(filepath.Join(dir, rel)); err == nil {
-			return nil
-		}
-	}
-	return fmt.Errorf("invalid package: SOUL.md not found in %s (checked root and config/)", dir)
 }
 
 // wrapWithBuiltinMarkers wraps user AGENTS.md content with hiclaw-builtin markers.

--- a/hiclaw-controller/internal/executor/package_test.go
+++ b/hiclaw-controller/internal/executor/package_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"archive/zip"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -523,6 +524,73 @@ func TestValidateNacosURI_FailsWhenRequestedVersionIsNotOnline(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `online version "v1" not found`) {
 		t.Fatalf("expected online-version-not-found error, got: %v", err)
+	}
+}
+
+func TestResolveAndExtract_FileDirectoryWithoutSoulmd_Succeeds(t *testing.T) {
+	ctx := context.Background()
+	importDir := t.TempDir()
+	pkgRoot := filepath.Join(importDir, "pkgroot")
+	if err := os.MkdirAll(pkgRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgRoot, "note.txt"), []byte("no soul"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	abs, err := filepath.Abs(pkgRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	u := url.URL{Scheme: "file", Path: filepath.ToSlash(abs)}
+	pr := NewPackageResolver(importDir)
+	out, err := pr.ResolveAndExtract(ctx, u.String(), "ignored")
+	if err != nil {
+		t.Fatalf("ResolveAndExtract: %v", err)
+	}
+	if filepath.Clean(out) != filepath.Clean(pkgRoot) {
+		t.Fatalf("got dir %q want %q", out, pkgRoot)
+	}
+}
+
+func TestResolveAndExtract_ZipWithoutSoulmd_Succeeds(t *testing.T) {
+	ctx := context.Background()
+	importDir := t.TempDir()
+	zipPath := filepath.Join(importDir, "minimal.zip")
+	f, err := os.Create(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zw := zip.NewWriter(f)
+	w, err := zw.Create("skills/x.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("skill")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	absZip, err := filepath.Abs(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	u := url.URL{Scheme: "file", Path: filepath.ToSlash(absZip)}
+	pr := NewPackageResolver(importDir)
+	out, err := pr.ResolveAndExtract(ctx, u.String(), "w1")
+	if err != nil {
+		t.Fatalf("ResolveAndExtract: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(out, "skills", "x.txt"))
+	if err != nil {
+		t.Fatalf("read extracted file: %v", err)
+	}
+	if string(data) != "skill" {
+		t.Fatalf("content = %q", string(data))
 	}
 }
 


### PR DESCRIPTION
## Background

Worker reconcile failed when `spec.package` pointed at a Nacos AgentSpec or ZIP that did not include `SOUL.md` (at repo root or `config/SOUL.md`). The controller returned:

`invalid package: SOUL.md not found ... (checked root and config/)`

That validation ran in `ResolveAndExtract` **before** `DeployWorkerConfig`, which already applies inline `spec.soul`, copies SOUL from the deployed package files when present, and **writes a default SOUL** for new non–team-leader workers when neither applies. Requiring SOUL inside the package was redundant and blocked valid minimal templates (skills-only packages, etc.).

## Solution

- Remove `validatePackageDir` and its calls after directory resolution and ZIP extraction.
- Update comments on `ResolveAndExtract` / `DeployToMinIO` to state that SOUL in the package is optional and may come from inline spec or deploy defaults.
- Add unit tests: `file://` directory and ZIP packages **without** SOUL both succeed.
- Changelog entry under `changelog/current.md`.

## Testing

`go test ./hiclaw-controller/internal/executor/...`

Made with [Cursor](https://cursor.com)