### PR TITLE
fix: ensure agent directory exists before mc mirror sync

### DIFF
--- a/hiclaw-controller/internal/service/deployer.go
+++ b/hiclaw-controller/internal/service/deployer.go
@@ -149,6 +149,10 @@ func (d *Deployer) DeployWorkerConfig(ctx context.Context, req WorkerDeployReque
 	// (not the local file), so a subsequent reconcile's mirror would push the
 	// stale local copy back over OSS, transiently exposing wrapped-empty or
 	// pre-merge content (the root cause of test-17 flakes).
+	// Ensure the local agent directory exists before mirroring
+	if err := os.MkdirAll(localAgentDir, 0755); err != nil {
+		return fmt.Errorf("create agent dir: %w", err)
+	}
 	logger.Info("syncing agent files to storage", "name", req.Name)
 	mirrorExcludes := []string{"SOUL.md", "AGENTS.md", "HEARTBEAT.md"}
 	if err := d.oss.Mirror(ctx, localAgentDir+"/", agentPrefix+"/", oss.MirrorOptions{Overwrite: true, Exclude: mirrorExcludes}); err != nil {


### PR DESCRIPTION
## Summary
Worker creation fails when `mc mirror` is called because the source directory `/root/hiclaw-fs/agents/<worker-name>/` does not exist.

## Root Cause
In `DeployWorkerConfig` (deployer.go:154), `mc mirror` is called without ensuring the source directory exists. When a worker is created with empty `package` and empty inline configs (identity/soul/agents), neither `DeployPackage` nor `WriteInlineConfigs` creates this directory.

## Fix
Add `os.MkdirAll(localAgentDir, 0755)` before calling `d.oss.Mirror()` to ensure the directory exists.

## Test
- Create worker with empty package and inline configs
- Verify directory `/root/hiclaw-fs/agents/<worker-name>/` is created  
- Verify mc mirror sync completes without error
