### PR TITLE
fix: Phantom removal of Humans from Team rooms after controller restarts

### DIFF
--- a/hiclaw-controller/internal/app/app.go
+++ b/hiclaw-controller/internal/app/app.go
@@ -391,6 +391,7 @@ func (a *App) initServiceLayer(_ context.Context) error {
 		OSSAdmin:          a.ossAdmin,
 		Creds:             credStore,
 		K8sClient:         a.k8sClient,
+		K8sCRClient:       a.mgr.GetClient(),
 		KubeMode:          cfg.KubeMode,
 		Namespace:         a.namespace,
 		AuthAudience:      cfg.AuthAudience,

--- a/hiclaw-controller/internal/controller/human_reconcile_rooms.go
+++ b/hiclaw-controller/internal/controller/human_reconcile_rooms.go
@@ -72,11 +72,11 @@ func (r *HumanReconciler) reconcileHumanRooms(ctx context.Context, s *humanScope
 	// Removals: in-place filter. A failed kick keeps the room so the
 	// next reconcile retries, matching pre-refactor behavior.
 	//
-	// Unlike additions which rely on status.TeamRoomID, removals are
-	// based on the spec: we only kick if the team was explicitly
-	// removed from accessibleTeams. This prevents phantom removals when
-	// a team hasn't finished provisioning yet (TeamRoomID is empty) or
-	// when status hasn't been updated.
+	// Unlike additions which rely on status.TeamRoomID/Worker.Status.RoomID,
+	// removals are based on the spec: we only kick if the team/worker was
+	// explicitly removed from accessibleTeams/AccessibleWorkers. This prevents
+	// phantom removals when a team/worker hasn't finished provisioning yet
+	// (TeamRoomID/RoomID is empty) or when status hasn't been updated.
 	kept := next[:0]
 	for _, rid := range next {
 		if _, ok := desired[rid]; ok {
@@ -84,24 +84,15 @@ func (r *HumanReconciler) reconcileHumanRooms(ctx context.Context, s *humanScope
 			continue
 		}
 
-		// Check if this room belongs to a team that is still in accessibleTeams.
+		// Check if this room belongs to a team still in accessibleTeams.
 		// If so, don't kick - the team just hasn't been provisioned yet.
-		if teamName := findTeamNameByRoomID(ctx, r.Client, h.Namespace, rid); teamName != "" {
-			found := false
-			for _, accessibleTeam := range h.Spec.AccessibleTeams {
-				if accessibleTeam == teamName {
-					// Team is still accessible, don't kick even though status.TeamRoomID might be empty
-					kept = append(kept, rid)
-					found = true
-					break
-				}
-			}
-			if found {
-				continue
-			}
+		// Uses isRoomFromAccessibleTeam to avoid the findTeamNameByRoomID paradox.
+		if isRoomFromAccessibleTeam(ctx, r.Client, h.Namespace, rid, h.Spec.AccessibleTeams) {
+			kept = append(kept, rid)
+			continue
 		}
 
-		// Not in desired, and not in accessibleTeams - safe to kick
+		// Not in desired, and not accessible via spec - safe to kick
 		if err := r.Provisioner.KickFromRoom(ctx, rid, matrixUserID, "access revoked"); err != nil {
 			logger.Error(err, "failed to kick human from room", "room", rid)
 			kept = append(kept, rid)

--- a/hiclaw-controller/internal/controller/human_reconcile_rooms.go
+++ b/hiclaw-controller/internal/controller/human_reconcile_rooms.go
@@ -85,9 +85,14 @@ func (r *HumanReconciler) reconcileHumanRooms(ctx context.Context, s *humanScope
 		}
 
 		// Check if this room belongs to a team still in accessibleTeams.
-		// If so, don't kick - the team just hasn't been provisioned yet.
-		// Uses isRoomFromAccessibleTeam to avoid the findTeamNameByRoomID paradox.
-		if isRoomFromAccessibleTeam(ctx, r.Client, h.Namespace, rid, h.Spec.AccessibleTeams) {
+		// If API error, skip kick for safety (transient error).
+		inTeam, err := isRoomFromAccessibleTeam(ctx, r.Client, h.Namespace, rid, h.Spec.AccessibleTeams)
+		if err != nil {
+			logger.Error(err, "transient error checking accessible teams; skipping kick for safety", "room", rid)
+			kept = append(kept, rid)
+			continue
+		}
+		if inTeam {
 			kept = append(kept, rid)
 			continue
 		}

--- a/hiclaw-controller/internal/controller/human_reconcile_rooms.go
+++ b/hiclaw-controller/internal/controller/human_reconcile_rooms.go
@@ -71,12 +71,33 @@ func (r *HumanReconciler) reconcileHumanRooms(ctx context.Context, s *humanScope
 
 	// Removals: in-place filter. A failed kick keeps the room so the
 	// next reconcile retries, matching pre-refactor behavior.
+	//
+	// Unlike additions which rely on status.TeamRoomID, removals are
+	// based on the spec: we only kick if the team was explicitly
+	// removed from accessibleTeams. This prevents phantom removals when
+	// a team hasn't finished provisioning yet (TeamRoomID is empty) or
+	// when status hasn't been updated.
 	kept := next[:0]
 	for _, rid := range next {
 		if _, ok := desired[rid]; ok {
 			kept = append(kept, rid)
 			continue
 		}
+
+		// Check if this room belongs to a team that is still in accessibleTeams.
+		// If so, don't kick - the team just hasn't been provisioned yet.
+		if teamName := findTeamNameByRoomID(ctx, r.Client, h.Namespace, rid); teamName != "" {
+			for _, accessibleTeam := range h.Spec.AccessibleTeams {
+				if accessibleTeam == teamName {
+					// Team is still accessible, don't kick even though status.TeamRoomID might be empty
+					kept = append(kept, rid)
+					break
+				}
+			}
+			continue
+		}
+
+		// Not in desired, and not in accessibleTeams - safe to kick
 		if err := r.Provisioner.KickFromRoom(ctx, rid, matrixUserID, "access revoked"); err != nil {
 			logger.Error(err, "failed to kick human from room", "room", rid)
 			kept = append(kept, rid)

--- a/hiclaw-controller/internal/controller/human_reconcile_rooms.go
+++ b/hiclaw-controller/internal/controller/human_reconcile_rooms.go
@@ -87,14 +87,18 @@ func (r *HumanReconciler) reconcileHumanRooms(ctx context.Context, s *humanScope
 		// Check if this room belongs to a team that is still in accessibleTeams.
 		// If so, don't kick - the team just hasn't been provisioned yet.
 		if teamName := findTeamNameByRoomID(ctx, r.Client, h.Namespace, rid); teamName != "" {
+			found := false
 			for _, accessibleTeam := range h.Spec.AccessibleTeams {
 				if accessibleTeam == teamName {
 					// Team is still accessible, don't kick even though status.TeamRoomID might be empty
 					kept = append(kept, rid)
+					found = true
 					break
 				}
 			}
-			continue
+			if found {
+				continue
+			}
 		}
 
 		// Not in desired, and not in accessibleTeams - safe to kick

--- a/hiclaw-controller/internal/controller/human_scope.go
+++ b/hiclaw-controller/internal/controller/human_scope.go
@@ -79,24 +79,19 @@ func buildDesiredHumanRooms(ctx context.Context, c client.Client, h *v1beta1.Hum
 }
 
 // isRoomFromAccessibleTeam checks if roomID belongs to a team still in accessibleTeams.
-// Returns true if team is in spec AND roomID matches, OR team hasn't provisioned yet
-// (TeamRoomID empty). Returns false only if roomID definitely doesn't match any
-// accessible team (safe to kick).
-//
-// This avoids the findTeamNameByRoomID paradox: that function used Status.TeamRoomID
-// to find the team, but protection is needed precisely when TeamRoomID is empty.
-func isRoomFromAccessibleTeam(ctx context.Context, c client.Client, ns, roomID string, accessibleTeams []string) bool {
+// Returns (true, nil) if team is in spec AND roomID matches.
+// Returns (false, err) if API fails - caller should skip kick for safety.
+// Returns (false, nil) if roomID definitely doesn't match any accessible team (safe to kick).
+func isRoomFromAccessibleTeam(ctx context.Context, c client.Client, ns, roomID string, accessibleTeams []string) (bool, error) {
 	for _, teamName := range accessibleTeams {
 		var team v1beta1.Team
 		if err := c.Get(ctx, client.ObjectKey{Name: teamName, Namespace: ns}, &team); err != nil {
-			// If error fetching team, we can't determine - don't kick to be safe
-			return true
+			return false, err
 		}
-		// If roomID matches this team's room, or if team hasn't provisioned yet (empty), don't kick
-		if team.Status.TeamRoomID == roomID || team.Status.TeamRoomID == "" {
-			return true
+		if team.Status.TeamRoomID == roomID {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 

--- a/hiclaw-controller/internal/controller/human_scope.go
+++ b/hiclaw-controller/internal/controller/human_scope.go
@@ -78,17 +78,25 @@ func buildDesiredHumanRooms(ctx context.Context, c client.Client, h *v1beta1.Hum
 	return desired
 }
 
-// findTeamNameByRoomID looks up a Team by its TeamRoomID and returns the team name.
-// Returns empty string if no matching team is found.
-func findTeamNameByRoomID(ctx context.Context, c client.Client, ns, roomID string) string {
-	var teamList v1beta1.TeamList
-	if err := c.List(ctx, &teamList, client.InNamespace(ns)); err != nil {
-		return ""
-	}
-	for _, t := range teamList.Items {
-		if t.Status.TeamRoomID == roomID {
-			return t.Name
+// isRoomFromAccessibleTeam checks if roomID belongs to a team still in accessibleTeams.
+// Returns true if team is in spec AND roomID matches, OR team hasn't provisioned yet
+// (TeamRoomID empty). Returns false only if roomID definitely doesn't match any
+// accessible team (safe to kick).
+//
+// This avoids the findTeamNameByRoomID paradox: that function used Status.TeamRoomID
+// to find the team, but protection is needed precisely when TeamRoomID is empty.
+func isRoomFromAccessibleTeam(ctx context.Context, c client.Client, ns, roomID string, accessibleTeams []string) bool {
+	for _, teamName := range accessibleTeams {
+		var team v1beta1.Team
+		if err := c.Get(ctx, client.ObjectKey{Name: teamName, Namespace: ns}, &team); err != nil {
+			// If error fetching team, we can't determine - don't kick to be safe
+			return true
+		}
+		// If roomID matches this team's room, or if team hasn't provisioned yet (empty), don't kick
+		if team.Status.TeamRoomID == roomID || team.Status.TeamRoomID == "" {
+			return true
 		}
 	}
-	return ""
+	return false
 }
+

--- a/hiclaw-controller/internal/controller/human_scope.go
+++ b/hiclaw-controller/internal/controller/human_scope.go
@@ -80,6 +80,7 @@ func buildDesiredHumanRooms(ctx context.Context, c client.Client, h *v1beta1.Hum
 
 // isRoomFromAccessibleTeam checks if roomID belongs to a team still in accessibleTeams.
 // Returns (true, nil) if team is in spec AND roomID matches.
+// Returns (true, nil) if team is in spec AND TeamRoomID is empty (team not provisioned yet).
 // Returns (false, err) if API fails - caller should skip kick for safety.
 // Returns (false, nil) if roomID definitely doesn't match any accessible team (safe to kick).
 func isRoomFromAccessibleTeam(ctx context.Context, c client.Client, ns, roomID string, accessibleTeams []string) (bool, error) {
@@ -88,7 +89,13 @@ func isRoomFromAccessibleTeam(ctx context.Context, c client.Client, ns, roomID s
 		if err := c.Get(ctx, client.ObjectKey{Name: teamName, Namespace: ns}, &team); err != nil {
 			return false, err
 		}
+		// If TeamRoomID matches, room is protected
 		if team.Status.TeamRoomID == roomID {
+			return true, nil
+		}
+		// If TeamRoomID is empty, team might not be provisioned yet
+		// Don't kick - we'll re-check on next reconcile
+		if team.Status.TeamRoomID == "" {
 			return true, nil
 		}
 	}

--- a/hiclaw-controller/internal/controller/human_scope.go
+++ b/hiclaw-controller/internal/controller/human_scope.go
@@ -77,3 +77,18 @@ func buildDesiredHumanRooms(ctx context.Context, c client.Client, h *v1beta1.Hum
 	}
 	return desired
 }
+
+// findTeamNameByRoomID looks up a Team by its TeamRoomID and returns the team name.
+// Returns empty string if no matching team is found.
+func findTeamNameByRoomID(ctx context.Context, c client.Client, ns, roomID string) string {
+	var teamList v1beta1.TeamList
+	if err := c.List(ctx, &teamList, client.InNamespace(ns)); err != nil {
+		return ""
+	}
+	for _, t := range teamList.Items {
+		if t.Status.TeamRoomID == roomID {
+			return t.Name
+		}
+	}
+	return ""
+}

--- a/hiclaw-controller/internal/service/provisioner.go
+++ b/hiclaw-controller/internal/service/provisioner.go
@@ -626,27 +626,11 @@ func (p *Provisioner) ProvisionTeamRooms(ctx context.Context, req TeamRoomReques
 	adminMatrixID := p.matrix.UserID(p.adminUser)
 	leaderMatrixID := p.matrix.UserID(req.LeaderName)
 
-	// Team Room: Leader + Admin + all Workers + Humans with this team in accessibleTeams
+	// Team Room: Leader + Admin + all Workers
 	teamInvites := []string{adminMatrixID, leaderMatrixID}
 	for _, wn := range req.WorkerNames {
 		teamInvites = append(teamInvites, p.matrix.UserID(wn))
 	}
-
-	// Add Humans that have this team in their accessibleTeams
-	var humanList v1beta1.HumanList
-	if err := p.k8sClient.CoreV1().RESTClient().Get().
-		Resource("humans").
-		Namespace(p.namespace).
-		Do(ctx).Into(&humanList); err == nil {
-		for _, human := range humanList.Items {
-			for _, accessibleTeam := range human.Spec.AccessibleTeams {
-				if accessibleTeam == req.TeamName && human.Status.MatrixUserID != "" {
-					teamInvites = append(teamInvites, human.Status.MatrixUserID)
-				}
-			}
-		}
-	}
-
 	teamPowerLevels := map[string]int{
 		managerMatrixID: 100,
 		adminMatrixID:   100,

--- a/hiclaw-controller/internal/service/provisioner.go
+++ b/hiclaw-controller/internal/service/provisioner.go
@@ -637,10 +637,13 @@ func (p *Provisioner) ProvisionTeamRooms(ctx context.Context, req TeamRoomReques
 	if err := p.k8sClient.CoreV1().RESTClient().Get().
 		Resource("humans").
 		Namespace(p.namespace).
-		Do(ctx).Into(&humanList); err == nil {
+		Do(ctx).Into(&humanList); err != nil {
+		logger.Error(err, "failed to list humans for team invites", "team", req.TeamName, "namespace", p.namespace)
+	} else {
 		for _, human := range humanList.Items {
 			for _, accessibleTeam := range human.Spec.AccessibleTeams {
 				if accessibleTeam == req.TeamName && human.Status.MatrixUserID != "" {
+					logger.Info("adding human to team invites", "human", human.Name, "team", req.TeamName)
 					teamInvites = append(teamInvites, human.Status.MatrixUserID)
 				}
 			}

--- a/hiclaw-controller/internal/service/provisioner.go
+++ b/hiclaw-controller/internal/service/provisioner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hiclaw/hiclaw-controller/internal/matrix"
 	"github.com/hiclaw/hiclaw-controller/internal/oss"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -75,6 +76,7 @@ type ProvisionerConfig struct {
 	OSSAdmin     oss.StorageAdminClient // nil in incluster/cloud mode
 	Creds        CredentialStore
 	K8sClient    kubernetes.Interface
+	K8sCRClient  client.Client // controller-runtime client for CRD operations
 	KubeMode     string
 	Namespace    string
 	AuthAudience string
@@ -134,6 +136,7 @@ type Provisioner struct {
 	ossAdmin       oss.StorageAdminClient
 	creds          CredentialStore
 	k8sClient      kubernetes.Interface
+	k8sCRClient   client.Client // controller-runtime client for CRD operations
 	kubeMode       string
 	namespace      string
 	authAudience   string
@@ -166,6 +169,7 @@ func NewProvisioner(cfg ProvisionerConfig) *Provisioner {
 		ossAdmin:          cfg.OSSAdmin,
 		creds:             cfg.Creds,
 		k8sClient:         cfg.K8sClient,
+		k8sCRClient:       cfg.K8sCRClient,
 		kubeMode:          cfg.KubeMode,
 		namespace:         cfg.Namespace,
 		authAudience:      cfg.AuthAudience,
@@ -634,10 +638,7 @@ func (p *Provisioner) ProvisionTeamRooms(ctx context.Context, req TeamRoomReques
 
 	// Add Humans that have this team in their accessibleTeams
 	var humanList v1beta1.HumanList
-	if err := p.k8sClient.CoreV1().RESTClient().Get().
-		Resource("humans").
-		Namespace(p.namespace).
-		Do(ctx).Into(&humanList); err != nil {
+	if err := p.k8sCRClient.List(ctx, &humanList, client.InNamespace(p.namespace)); err != nil {
 		logger.Error(err, "failed to list humans for team invites", "team", req.TeamName, "namespace", p.namespace)
 	} else {
 		for _, human := range humanList.Items {

--- a/hiclaw-controller/internal/service/provisioner.go
+++ b/hiclaw-controller/internal/service/provisioner.go
@@ -626,11 +626,27 @@ func (p *Provisioner) ProvisionTeamRooms(ctx context.Context, req TeamRoomReques
 	adminMatrixID := p.matrix.UserID(p.adminUser)
 	leaderMatrixID := p.matrix.UserID(req.LeaderName)
 
-	// Team Room: Leader + Admin + all Workers
+	// Team Room: Leader + Admin + all Workers + Humans with this team in accessibleTeams
 	teamInvites := []string{adminMatrixID, leaderMatrixID}
 	for _, wn := range req.WorkerNames {
 		teamInvites = append(teamInvites, p.matrix.UserID(wn))
 	}
+
+	// Add Humans that have this team in their accessibleTeams
+	var humanList v1beta1.HumanList
+	if err := p.k8sClient.CoreV1().RESTClient().Get().
+		Resource("humans").
+		Namespace(p.namespace).
+		Do(ctx).Into(&humanList); err == nil {
+		for _, human := range humanList.Items {
+			for _, accessibleTeam := range human.Spec.AccessibleTeams {
+				if accessibleTeam == req.TeamName && human.Status.MatrixUserID != "" {
+					teamInvites = append(teamInvites, human.Status.MatrixUserID)
+				}
+			}
+		}
+	}
+
 	teamPowerLevels := map[string]int{
 		managerMatrixID: 100,
 		adminMatrixID:   100,


### PR DESCRIPTION
# Fix: Human phantom removal from Team room and removal after controller restart

## Bug Description

Human with `accessibleTeams: ["team-name"]` is being kicked from Team room with message:
```
"You were removed from Team: team-name by admin 💕 Reason: removed from desired member set"
```

This happens:
1. After hiclaw-controller restart
2. When Team's `Status.TeamRoomID` is temporarily empty (team not yet provisioned)

## Root Causes

### Issue 1: Humans not added to team invites (RBAC error)

`ProvisionTeamRooms` used `k8sClient.CoreV1().RESTClient().Get().Resource("humans")` which calls core API group (`/api/v1/...`), but RBAC only allows `hiclaw.io` group.

**Result:** "humans is forbidden" error → Humans never added to `teamInvites`

**Fix:** Use `k8sCRClient.List()` (controller-runtime client) with proper CRD API group.

### Issue 2: Human controller kicks human when TeamRoomID is empty

In `reconcileHumanRooms`, `buildDesiredHumanRooms` skips teams with empty `TeamRoomID`:
```go
if team.Status.TeamRoomID != "" {
    desired[team.Status.TeamRoomID] = struct{}{}
}
```

When Team's `TeamRoomID` is empty (not yet provisioned), the room is not in `desired`. The removal loop then kicks the human because the room "is not desired".

**Fix:** Check if room belongs to a team still in `accessibleTeams` before kicking, regardless of `TeamRoomID` status.

## Changes

### 1. `provisioner.go` - Fix Human listing API
- Added `k8sCRClient client.Client` field to `Provisioner`
- Changed Human listing from REST client to controller-runtime client
- Humans with matching `accessibleTeams` are now properly added to team invites

### 2. `human_scope.go` - Add protection helper
- Added `isRoomFromAccessibleTeam()` function that returns `true` if:
  - Team is in `accessibleTeams` AND
  - `TeamRoomID` matches OR `TeamRoomID` is empty (team not provisioned yet)

### 3. `human_reconcile_rooms.go` - Fix kick protection
- Before kicking, check if room belongs to accessible team
- If API error occurs, skip kick for safety (transient error)
- Only kick if room is NOT in accessible teams

## Test Cases

1. Human with `accessibleTeams: ["team-that-doesnt-exist-yet"]` → should NOT be kicked
2. After team provisions and `TeamRoomID` is set → Human joins correctly
3. Remove team from `accessibleTeams` → Human IS kicked correctly
4. Restart controller → Human stays in team room