### PR TITLE
fix: phantom kick bug for accessibleWorkers when worker hasn't been provisioned yet.

### DIFF
--- a/hiclaw-controller/internal/controller/human_reconcile_rooms.go
+++ b/hiclaw-controller/internal/controller/human_reconcile_rooms.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"context"
 
+	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -77,6 +79,30 @@ func (r *HumanReconciler) reconcileHumanRooms(ctx context.Context, s *humanScope
 			kept = append(kept, rid)
 			continue
 		}
+
+		// Check if this room belongs to a worker that is still in AccessibleWorkers
+		// If so, don't kick - the worker might not be provisioned yet
+		found := false
+		for _, accessibleWorker := range h.Spec.AccessibleWorkers {
+			var worker v1beta1.Worker
+			if err := r.Get(ctx, client.ObjectKey{Name: accessibleWorker, Namespace: h.Namespace}, &worker); err == nil {
+				if worker.Status.RoomID == rid {
+					kept = append(kept, rid)
+					found = true
+					break
+				}
+			}
+			// Also check team workers
+			if teamRoomID := findTeamWorkerRoomID(ctx, r.Client, h.Namespace, accessibleWorker); teamRoomID == rid {
+				kept = append(kept, rid)
+				found = true
+				break
+			}
+		}
+		if found {
+			continue
+		}
+
 		if err := r.Provisioner.KickFromRoom(ctx, rid, matrixUserID, "access revoked"); err != nil {
 			logger.Error(err, "failed to kick human from room", "room", rid)
 			kept = append(kept, rid)

--- a/hiclaw-controller/internal/controller/human_reconcile_rooms.go
+++ b/hiclaw-controller/internal/controller/human_reconcile_rooms.go
@@ -3,8 +3,6 @@ package controller
 import (
 	"context"
 
-	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -80,26 +78,17 @@ func (r *HumanReconciler) reconcileHumanRooms(ctx context.Context, s *humanScope
 			continue
 		}
 
-		// Check if this room belongs to a worker that is still in AccessibleWorkers
-		// If so, don't kick - the worker might not be provisioned yet
-		found := false
-		for _, accessibleWorker := range h.Spec.AccessibleWorkers {
-			var worker v1beta1.Worker
-			if err := r.Get(ctx, client.ObjectKey{Name: accessibleWorker, Namespace: h.Namespace}, &worker); err == nil {
-				if worker.Status.RoomID == rid {
-					kept = append(kept, rid)
-					found = true
-					break
-				}
-			}
-			// Also check team workers
-			if teamRoomID := findTeamWorkerRoomID(ctx, r.Client, h.Namespace, accessibleWorker); teamRoomID == rid {
-				kept = append(kept, rid)
-				found = true
-				break
-			}
+		// Check if this room belongs to a worker still in AccessibleWorkers
+		// If API error, skip kick for safety. If worker exists but not provisioned yet,
+		// skip kick to avoid phantom removal.
+		inWorker, err := isRoomFromAccessibleWorker(ctx, r.Client, h.Namespace, rid, h.Spec.AccessibleWorkers)
+		if err != nil {
+			logger.Error(err, "transient error checking accessible workers; skipping kick for safety", "room", rid)
+			kept = append(kept, rid)
+			continue
 		}
-		if found {
+		if inWorker {
+			kept = append(kept, rid)
 			continue
 		}
 

--- a/hiclaw-controller/internal/controller/human_scope.go
+++ b/hiclaw-controller/internal/controller/human_scope.go
@@ -57,15 +57,23 @@ func computeHumanPhase(h *v1beta1.Human, reconcileErr error) string {
 // Status.Rooms set.
 func buildDesiredHumanRooms(ctx context.Context, c client.Client, h *v1beta1.Human) map[string]struct{} {
 	desired := make(map[string]struct{})
+
+	// Handle workers (standalone + team)
 	for _, workerName := range h.Spec.AccessibleWorkers {
+		// Check standalone worker first
 		var worker v1beta1.Worker
-		if err := c.Get(ctx, client.ObjectKey{Name: workerName, Namespace: h.Namespace}, &worker); err != nil {
-			continue
+		if err := c.Get(ctx, client.ObjectKey{Name: workerName, Namespace: h.Namespace}, &worker); err == nil {
+			if worker.Status.RoomID != "" {
+				desired[worker.Status.RoomID] = struct{}{}
+			}
 		}
-		if worker.Status.RoomID != "" {
-			desired[worker.Status.RoomID] = struct{}{}
+		// Also check if this is a team worker
+		if roomID := findTeamWorkerRoomID(ctx, c, h.Namespace, workerName); roomID != "" {
+			desired[roomID] = struct{}{}
 		}
 	}
+
+	// Handle teams
 	for _, teamName := range h.Spec.AccessibleTeams {
 		var team v1beta1.Team
 		if err := c.Get(ctx, client.ObjectKey{Name: teamName, Namespace: h.Namespace}, &team); err != nil {
@@ -76,4 +84,20 @@ func buildDesiredHumanRooms(ctx context.Context, c client.Client, h *v1beta1.Hum
 		}
 	}
 	return desired
+}
+
+// findTeamWorkerRoomID looks up a team worker's room ID from Team.Status.Members
+func findTeamWorkerRoomID(ctx context.Context, c client.Client, ns, workerName string) string {
+	var teamList v1beta1.TeamList
+	if err := c.List(ctx, &teamList, client.InNamespace(ns)); err != nil {
+		return ""
+	}
+	for _, t := range teamList.Items {
+		for _, member := range t.Status.Members {
+			if member.Name == workerName {
+				return member.RoomID
+			}
+		}
+	}
+	return ""
 }

--- a/hiclaw-controller/internal/controller/human_scope.go
+++ b/hiclaw-controller/internal/controller/human_scope.go
@@ -57,23 +57,15 @@ func computeHumanPhase(h *v1beta1.Human, reconcileErr error) string {
 // Status.Rooms set.
 func buildDesiredHumanRooms(ctx context.Context, c client.Client, h *v1beta1.Human) map[string]struct{} {
 	desired := make(map[string]struct{})
-
-	// Handle workers (standalone + team)
 	for _, workerName := range h.Spec.AccessibleWorkers {
-		// Check standalone worker first
 		var worker v1beta1.Worker
-		if err := c.Get(ctx, client.ObjectKey{Name: workerName, Namespace: h.Namespace}, &worker); err == nil {
-			if worker.Status.RoomID != "" {
-				desired[worker.Status.RoomID] = struct{}{}
-			}
+		if err := c.Get(ctx, client.ObjectKey{Name: workerName, Namespace: h.Namespace}, &worker); err != nil {
+			continue
 		}
-		// Also check if this is a team worker
-		if roomID := findTeamWorkerRoomID(ctx, c, h.Namespace, workerName); roomID != "" {
-			desired[roomID] = struct{}{}
+		if worker.Status.RoomID != "" {
+			desired[worker.Status.RoomID] = struct{}{}
 		}
 	}
-
-	// Handle teams
 	for _, teamName := range h.Spec.AccessibleTeams {
 		var team v1beta1.Team
 		if err := c.Get(ctx, client.ObjectKey{Name: teamName, Namespace: h.Namespace}, &team); err != nil {
@@ -86,18 +78,26 @@ func buildDesiredHumanRooms(ctx context.Context, c client.Client, h *v1beta1.Hum
 	return desired
 }
 
-// findTeamWorkerRoomID looks up a team worker's room ID from Team.Status.Members
-func findTeamWorkerRoomID(ctx context.Context, c client.Client, ns, workerName string) string {
-	var teamList v1beta1.TeamList
-	if err := c.List(ctx, &teamList, client.InNamespace(ns)); err != nil {
-		return ""
-	}
-	for _, t := range teamList.Items {
-		for _, member := range t.Status.Members {
-			if member.Name == workerName {
-				return member.RoomID
-			}
+// isRoomFromAccessibleWorker checks if roomID belongs to a worker still in accessibleWorkers.
+// Returns (true, nil) if worker is in accessibleWorkers AND roomID matches.
+// Returns (true, nil) if worker is in accessibleWorkers AND RoomID is empty (worker not provisioned yet).
+// Returns (false, err) if API fails - caller should skip kick for safety.
+// Returns (false, nil) if roomID doesn't match any accessible worker (safe to kick).
+func isRoomFromAccessibleWorker(ctx context.Context, c client.Client, ns, roomID string, accessibleWorkers []string) (bool, error) {
+	for _, workerName := range accessibleWorkers {
+		var worker v1beta1.Worker
+		if err := c.Get(ctx, client.ObjectKey{Name: workerName, Namespace: ns}, &worker); err != nil {
+			return false, err
+		}
+		// Exact match - room belongs to this worker
+		if worker.Status.RoomID == roomID {
+			return true, nil
+		}
+		// Worker exists in accessibleWorkers but hasn't been provisioned yet
+		// Don't kick - room might be the worker's future room
+		if worker.Status.RoomID == "" {
+			return true, nil
 		}
 	}
-	return ""
+	return false, nil
 }


### PR DESCRIPTION
## Summary

Fix phantom kick bug for `accessibleWorkers` when worker hasn't been provisioned yet.

## Bug

Human with `accessibleWorkers: ["worker-name"]` was being kicked from worker room when worker's `Status.RoomID` was empty.

## Root Cause

No protection check before kicking - the code would kick any room not in `desired`, regardless of whether the worker was still in `accessibleWorkers`.

## Fix

1. Added `isRoomFromAccessibleWorker` helper in `human_scope.go`:
   - Returns `true` if roomID matches worker's RoomID (exact match)
   - Returns `true` if worker has empty RoomID (not provisioned yet - don't kick)
   - Returns error on API failure (skip kick for safety)

2. Updated `reconcileHumanRooms` in `human_reconcile_rooms.go`:
   - Check with `isRoomFromAccessibleWorker` before kicking
   - Skip kick if API error (transient error)
   - Only kick if room is NOT in accessible workers

## Files Changed

- `human_scope.go`: Added `isRoomFromAccessibleWorker` helper
- `human_reconcile_rooms.go`: Applied worker check before kick

## Test

1. Worker with empty RoomID → Human NOT kicked
2. Worker provisioned → Human joins correctly  
3. Worker removed from accessibleWorkers → Human IS kicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)