### PR TITLE
feat(install): support keep-all upgrade mode and enter-to-keep for all params

### DIFF
--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -245,6 +245,12 @@ $script:Messages = @{
     "install.existing.stopping_workers" = @{ zh = "停止并移除现有 worker 容器..."; en = "Stopping and removing existing worker containers..." }
     "install.existing.removed" = @{ zh = "  已移除: {0}"; en = "  Removed: {0}" }
 
+    # --- Upgrade mode sub-menu ---
+    "upgrade.mode.prompt" = @{ zh = "请选择升级方式："; en = "Select upgrade mode:" }
+    "upgrade.mode.keep_all" = @{ zh = "  1) 保留所有参数，一键升级（推荐）"; en = "  1) Keep all parameters, quick upgrade (recommended)" }
+    "upgrade.mode.confirm_each" = @{ zh = "  2) 逐个确认参数（可修改）"; en = "  2) Confirm each parameter (can modify)" }
+    "upgrade.mode.back" = @{ zh = "  3) 返回"; en = "  3) Back" }
+
     # --- Clean reinstall messages ---
     "install.reinstall.performing" = @{ zh = "执行全新重装..."; en = "Performing clean reinstall..." }
     "install.reinstall.warn_stop" = @{ zh = "警告: 以下运行中的容器将被停止:"; en = "WARNING: The following running containers will be stopped:" }
@@ -322,9 +328,9 @@ $script:Messages = @{
     "llm.provider.selected_qwen" = @{ zh = "  提供商: 阿里云百炼"; en = "  Provider: Alibaba Cloud Bailian" }
     "llm.provider.selected_openai" = @{ zh = "  提供商: {0}（OpenAI 兼容）"; en = "  Provider: {0} (OpenAI-compatible)" }
     "llm.provider.invalid" = @{ zh = "无效选择: {0}（请输入 1 或 2）"; en = "Invalid choice: {0} (please enter 1 or 2)" }
-    "llm.qwen.model_prompt" = @{ zh = "默认模型 ID [qwen3.6-plus]"; en = "Default Model ID [qwen3.6-plus]" }
-    "llm.openai.base_url_prompt" = @{ zh = "Base URL（例如 https://api.openai.com/v1）"; en = "Base URL (e.g., https://api.openai.com/v1)" }
-    "llm.openai.model_prompt" = @{ zh = "默认模型 ID [gpt-5.4]"; en = "Default Model ID [gpt-5.4]" }
+    "llm.qwen.model_prompt" = @{ zh = "默认模型 ID"; en = "Default Model ID" }
+    "llm.openai.base_url_prompt" = @{ zh = "Base URL"; en = "Base URL" }
+    "llm.openai.model_prompt" = @{ zh = "默认模型 ID"; en = "Default Model ID" }
     "llm.openai.base_url_label" = @{ zh = "  Base URL: {0}"; en = "  Base URL: {0}" }
 
     # --- Custom model parameters ---
@@ -1196,6 +1202,34 @@ function Read-Prompt {
     return $value
 }
 
+# Load current parameter values from env file for upgrade mode display
+function Load-CurrentParamsFromEnv {
+    $envFile = $script:HICLAW_ENV_FILE
+    if (Test-Path $envFile) {
+        $content = Get-Content $envFile
+        $content | ForEach-Object {
+            if ($_ -match "^HICLAW_LLM_PROVIDER=(.*)$") {
+                $script:config.LLM_PROVIDER = $Matches[1].Trim()
+            }
+            if ($_ -match "^HICLAW_OPENAI_BASE_URL=(.*)$") {
+                $script:config.OPENAI_BASE_URL = $Matches[1].Trim()
+            }
+            if ($_ -match "^HICLAW_DEFAULT_MODEL=(.*)$") {
+                $script:config.DEFAULT_MODEL = $Matches[1].Trim()
+            }
+            if ($_ -match "^HICLAW_EMBEDDING_MODEL=(.*)$") {
+                $script:config.EMBEDDING_MODEL = $Matches[1].Trim()
+            }
+            if ($_ -match "^HICLAW_WORKSPACE_DIR=(.*)$") {
+                $script:config.WORKSPACE_DIR = $Matches[1].Trim()
+            }
+            if ($_ -match "^HICLAW_HOST_SHARE_DIR=(.*)$") {
+                $script:config.HOST_SHARE_DIR = $Matches[1].Trim()
+            }
+        }
+    }
+}
+
 # ============================================================
 # OpenAI-Compatible Provider
 # ============================================================
@@ -1377,6 +1411,14 @@ function Test-ShouldSkipStep {
         "Step-Existing" {
             return (-not (Test-Path $script:HICLAW_ENV_FILE))
         }
+        # Keep-All upgrade mode: skip all config steps, values are already loaded
+        { $_ -in @("Step-Llm", "Step-Admin", "Step-Network", "Step-Ports", "Step-Domains",
+                    "Step-Github", "Step-Skills", "Step-Volume", "Step-Workspace",
+                    "Step-Runtime", "Step-ManagerRuntime", "Step-E2ee", "Step-DockerProxy",
+                    "Step-Idle", "Step-Hostshare") } {
+            if ($script:HICLAW_UPGRADE -and $env:HICLAW_UPGRADE_KEEP_ALL -eq "1") { return $true }
+            return $false
+        }
         { $_ -in @("Step-Volume", "Step-Workspace") } {
             if ($script:HICLAW_NON_INTERACTIVE) { return $true }
             if ($script:HICLAW_QUICKSTART) { return $true }
@@ -1551,6 +1593,35 @@ function Step-Existing {
             $script:HICLAW_UPGRADE = $true
             Write-Log (Get-Msg "install.existing.upgrading")
 
+            # Show upgrade mode sub-menu (unless already set via env var)
+            if ($env:HICLAW_UPGRADE_KEEP_ALL -ne "1") {
+                Write-Host ""
+                Write-Host (Get-Msg "upgrade.mode.prompt")
+                Write-Host (Get-Msg "upgrade.mode.keep_all")
+                Write-Host (Get-Msg "upgrade.mode.confirm_each")
+                Write-Host (Get-Msg "upgrade.mode.back")
+                Write-Host ""
+                $upgradeModeChoice = Read-Host (Get-Msg "install.existing.prompt")
+                $upgradeModeChoice = if ($upgradeModeChoice) { $upgradeModeChoice } else { "1" }
+                switch -Regex ($upgradeModeChoice) {
+                    "^(1|keep)$" {
+                        $env:HICLAW_UPGRADE_KEEP_ALL = "1"
+                    }
+                    "^(2|confirm)$" {
+                        $env:HICLAW_UPGRADE_KEEP_ALL = "0"
+                    }
+                    "^(3|b)$" {
+                        $script:StepResult = "back"
+                        return
+                    }
+                    default {
+                        $env:HICLAW_UPGRADE_KEEP_ALL = "0"
+                    }
+                }
+            }
+            # Load current parameters for both Keep-All and confirm-each modes
+            Load-CurrentParamsFromEnv
+
             if ($runningManager -or $runningWorkers) {
                 Write-Host ""
                 Write-Host "$($script:ESC)[33m$(Get-Msg 'install.existing.warn_manager_stop')$($script:ESC)[0m"
@@ -1681,12 +1752,17 @@ function Step-Llm {
     Write-Host (Get-Msg "llm.provider.openai_compat")
     Write-Host ""
 
-    if ($script:HICLAW_QUICKSTART) {
+    # If upgrade mode with loaded provider, show current as default
+    if ($script:HICLAW_UPGRADE -and $script:config.LLM_PROVIDER) {
+        $defaultProvider = if ($script:config.LLM_PROVIDER -eq "openai-compat") { "2" } else { "1" }
+        $providerChoice = Read-Host "$(Get-Msg 'llm.provider.select') [${defaultProvider}]"
+        $providerChoice = if ($providerChoice) { $providerChoice } else { $defaultProvider }
+    } elseif ($script:HICLAW_QUICKSTART) {
         $providerChoice = Read-Host "$(Get-Msg 'llm.provider.select') [1]"
     } else {
         $providerChoice = Read-Host (Get-Msg "llm.provider.select")
+        $providerChoice = if ($providerChoice) { $providerChoice } else { "1" }
     }
-    $providerChoice = if ($providerChoice) { $providerChoice } else { "1" }
     if ($providerChoice -eq "b") { $script:StepResult = "back"; return }
 
     switch -Regex ($providerChoice) {
@@ -1703,7 +1779,18 @@ function Step-Llm {
                 Write-Host (Get-Msg "llm.codingplan.model.kimi")
                 Write-Host (Get-Msg "llm.codingplan.model.minimax")
                 Write-Host ""
-                if ($script:HICLAW_QUICKSTART) {
+                # If upgrade with loaded model, show current as default
+                if ($script:HICLAW_UPGRADE -and $script:config.DEFAULT_MODEL) {
+                    $defaultModel = switch ($script:config.DEFAULT_MODEL) {
+                        "qwen3.6-plus" { "1" }
+                        "glm-5"         { "2" }
+                        "kimi-k2.5"     { "3" }
+                        "MiniMax-M2.5"  { "4" }
+                        default         { "1" }
+                    }
+                    $codingPlanModelChoice = Read-Host "$(Get-Msg 'llm.codingplan.model.select') [${defaultModel}]"
+                    $codingPlanModelChoice = if ($codingPlanModelChoice) { $codingPlanModelChoice } else { $defaultModel }
+                } elseif ($script:HICLAW_QUICKSTART) {
                     $codingPlanModelChoice = Read-Host "$(Get-Msg 'llm.codingplan.model.select') [1]"
                 } else {
                     $codingPlanModelChoice = Read-Host (Get-Msg "llm.codingplan.model.select")
@@ -1744,7 +1831,18 @@ function Step-Llm {
                     Write-Host (Get-Msg "llm.codingplan.model.kimi")
                     Write-Host (Get-Msg "llm.codingplan.model.minimax")
                     Write-Host ""
-                    if ($script:HICLAW_QUICKSTART) {
+                    # If upgrade with loaded model, show current as default
+                    if ($script:HICLAW_UPGRADE -and $script:config.DEFAULT_MODEL) {
+                        $defaultModel = switch ($script:config.DEFAULT_MODEL) {
+                            "qwen3.6-plus" { "1" }
+                            "glm-5"         { "2" }
+                            "kimi-k2.5"     { "3" }
+                            "MiniMax-M2.5"  { "4" }
+                            default         { "1" }
+                        }
+                        $codingPlanModelChoice = Read-Host "$(Get-Msg 'llm.codingplan.model.select') [${defaultModel}]"
+                        $codingPlanModelChoice = if ($codingPlanModelChoice) { $codingPlanModelChoice } else { $defaultModel }
+                    } elseif ($script:HICLAW_QUICKSTART) {
                         $codingPlanModelChoice = Read-Host "$(Get-Msg 'llm.codingplan.model.select') [1]"
                     } else {
                         $codingPlanModelChoice = Read-Host (Get-Msg "llm.codingplan.model.select")
@@ -1764,9 +1862,13 @@ function Step-Llm {
                     $script:config.LLM_PROVIDER = "qwen"
                     $script:config.OPENAI_BASE_URL = ""
                     Write-Host ""
-                    $qwenModelInput = Read-Host (Get-Msg "llm.qwen.model_prompt")
+                    if ($script:HICLAW_UPGRADE -and $script:config.DEFAULT_MODEL) {
+                        $qwenModelInput = Read-Host "$(Get-Msg 'llm.qwen.model_prompt') [${script:config.DEFAULT_MODEL}]"
+                    } else {
+                        $qwenModelInput = Read-Host (Get-Msg "llm.qwen.model_prompt")
+                    }
                     if ($qwenModelInput -eq "b") { $script:StepResult = "back"; return }
-                    $script:config.DEFAULT_MODEL = if ($qwenModelInput) { $qwenModelInput } elseif ($env:HICLAW_DEFAULT_MODEL) { $env:HICLAW_DEFAULT_MODEL } else { "qwen3.6-plus" }
+                    $script:config.DEFAULT_MODEL = if ($qwenModelInput) { $qwenModelInput } elseif ($script:config.DEFAULT_MODEL) { $script:config.DEFAULT_MODEL } else { "qwen3.6-plus" }
                     Write-Log (Get-Msg "llm.provider.selected_qwen")
                     Request-CustomModelParams $script:config.DEFAULT_MODEL
                     if ($script:StepResult -eq "back") { return }
@@ -1775,9 +1877,13 @@ function Step-Llm {
                     $script:config.LLM_PROVIDER = "openai-compat"
                     $script:config.OPENAI_BASE_URL = "https://coding.dashscope.aliyuncs.com/v1"
                     Write-Host ""
-                    $codingModelInput = Read-Host (Get-Msg "llm.qwen.model_prompt")
+                    if ($script:HICLAW_UPGRADE -and $script:config.DEFAULT_MODEL) {
+                        $codingModelInput = Read-Host "$(Get-Msg 'llm.qwen.model_prompt') [${script:config.DEFAULT_MODEL}]"
+                    } else {
+                        $codingModelInput = Read-Host (Get-Msg "llm.qwen.model_prompt")
+                    }
                     if ($codingModelInput -eq "b") { $script:StepResult = "back"; return }
-                    $script:config.DEFAULT_MODEL = if ($codingModelInput) { $codingModelInput } elseif ($env:HICLAW_DEFAULT_MODEL) { $env:HICLAW_DEFAULT_MODEL } else { "qwen3.6-plus" }
+                    $script:config.DEFAULT_MODEL = if ($codingModelInput) { $codingModelInput } elseif ($script:config.DEFAULT_MODEL) { $script:config.DEFAULT_MODEL } else { "qwen3.6-plus" }
                     Write-Log (Get-Msg "llm.provider.selected_codingplan_legacy")
                     Request-CustomModelParams $script:config.DEFAULT_MODEL
                     if ($script:StepResult -eq "back") { return }
@@ -1819,12 +1925,44 @@ function Step-Llm {
             $script:config.LLM_PROVIDER = "openai-compat"
             Write-Log (Get-Msg "llm.provider.selected_openai" -f $script:config.LLM_PROVIDER)
             Write-Host ""
-            $urlInput = Read-Host (Get-Msg "llm.openai.base_url_prompt")
-            if ($urlInput -eq "b") { $script:StepResult = "back"; return }
-            $script:config.OPENAI_BASE_URL = $urlInput
-            $modelInput = Read-Host (Get-Msg "llm.openai.model_prompt")
-            if ($modelInput -eq "b") { $script:StepResult = "back"; return }
-            $script:config.DEFAULT_MODEL = if ($modelInput) { $modelInput } else { "gpt-5.4" }
+            if ($script:HICLAW_UPGRADE -and $env:HICLAW_UPGRADE_KEEP_ALL -eq "1") {
+                Write-Log (Get-Msg "prompt.upgrade_keep" -f (Get-Msg "llm.openai.base_url_prompt"), $script:config.OPENAI_BASE_URL)
+            } else {
+                $currentUrl = $script:config.OPENAI_BASE_URL
+                # Use base prompt without embedded default when showing current value
+                if ($currentUrl) {
+                    $urlInput = Read-Host "$(Get-Msg 'llm.openai.base_url_prompt') [$currentUrl]"
+                } else {
+                    $urlInput = Read-Host "$(Get-Msg 'llm.openai.base_url_prompt') [https://api.openai.com/v1]"
+                }
+                if ($urlInput -eq "b") { $script:StepResult = "back"; return }
+                if ($urlInput) {
+                    $script:config.OPENAI_BASE_URL = $urlInput
+                } elseif ($currentUrl) {
+                    $script:config.OPENAI_BASE_URL = $currentUrl
+                } else {
+                    $script:config.OPENAI_BASE_URL = "https://api.openai.com/v1"
+                }
+            }
+            if ($script:HICLAW_UPGRADE -and $env:HICLAW_UPGRADE_KEEP_ALL -eq "1") {
+                Write-Log (Get-Msg "prompt.upgrade_keep" -f (Get-Msg "llm.openai.model_prompt"), $script:config.DEFAULT_MODEL)
+            } else {
+                $currentModel = $script:config.DEFAULT_MODEL
+                # Use base prompt without embedded default when showing current value
+                if ($currentModel) {
+                    $modelInput = Read-Host "Default Model ID [${currentModel}]"
+                } else {
+                    $modelInput = Read-Host (Get-Msg 'llm.openai.model_prompt')
+                }
+                if ($modelInput -eq "b") { $script:StepResult = "back"; return }
+                if ($modelInput) {
+                    $script:config.DEFAULT_MODEL = $modelInput
+                } elseif ($currentModel) {
+                    $script:config.DEFAULT_MODEL = $currentModel
+                } else {
+                    $script:config.DEFAULT_MODEL = "gpt-5.4"
+                }
+            }
             Write-Log (Get-Msg "llm.openai.base_url_label" -f $script:config.OPENAI_BASE_URL)
             Write-Log (Get-Msg "llm.model.label" -f $script:config.DEFAULT_MODEL)
             Request-CustomModelParams $script:config.DEFAULT_MODEL
@@ -1838,6 +1976,17 @@ function Step-Llm {
         default {
             Write-Error (Get-Msg "llm.provider.invalid" -f $providerChoice)
         }
+    }
+
+    # Skip to embedding if Keep-All mode handled LLM params
+    if ($skipToEmbedding) {
+        # Skip embedding selection, use loaded value (already in $script:config.EMBEDDING_MODEL)
+        if ($script:config.EMBEDDING_MODEL) {
+            Write-Log (Get-Msg "llm.embedding.title")
+            Write-Log (Get-Msg "llm.model.label" -f $script:config.EMBEDDING_MODEL)
+            Write-Log ""
+        }
+        return
     }
 
     # --- Embedding model (optional, auto-tested) ---
@@ -1858,13 +2007,20 @@ function Step-Llm {
             $script:config.EMBEDDING_MODEL = "text-embedding-v4"
         }
         "2" {
-            $embCustom = Read-Host (Get-Msg "llm.embedding.custom_prompt")
-            if ($embCustom -eq "b") { $script:StepResult = "back"; return }
-            if ($embCustom) {
-                $script:config.EMBEDDING_MODEL = $embCustom
+            if ($script:HICLAW_UPGRADE -and $env:HICLAW_UPGRADE_KEEP_ALL -eq "1") {
+                Write-Log (Get-Msg "prompt.upgrade_keep" -f (Get-Msg "llm.embedding.custom_prompt"), $script:config.EMBEDDING_MODEL)
             } else {
-                $script:config.EMBEDDING_MODEL = ""
-                Write-Log (Get-Msg "llm.embedding.disabled")
+                $currentEmb = $script:config.EMBEDDING_MODEL
+                $embCustom = Read-Host (Get-Msg "llm.embedding.custom_prompt")
+                if ($embCustom -eq "b") { $script:StepResult = "back"; return }
+                if ($embCustom) {
+                    $script:config.EMBEDDING_MODEL = $embCustom
+                } else {
+                    $script:config.EMBEDDING_MODEL = $currentEmb
+                    if (-not $script:config.EMBEDDING_MODEL) {
+                        Write-Log (Get-Msg "llm.embedding.disabled")
+                    }
+                }
             }
         }
         "3" {
@@ -2016,9 +2172,16 @@ function Step-Workspace {
     }
     # ─────────────────────────────────────────────────────────────────
     $defaultWorkspace = "$env:USERPROFILE\hiclaw-manager"
-    $wsInput = Read-Host (Get-Msg "workspace.dir_prompt" -f $defaultWorkspace)
-    if ($wsInput -eq "b") { $script:StepResult = "back"; return }
-    $script:config.WORKSPACE_DIR = if ($wsInput) { $wsInput } else { $defaultWorkspace }
+    if ($script:HICLAW_UPGRADE -and $env:HICLAW_UPGRADE_KEEP_ALL -eq "1") {
+        Write-Log (Get-Msg "prompt.upgrade_keep" -f (Get-Msg "workspace.dir_prompt" -f $defaultWorkspace), $script:config.WORKSPACE_DIR)
+        $wsInput = if ($script:config.WORKSPACE_DIR) { $script:config.WORKSPACE_DIR } else { $defaultWorkspace }
+    } else {
+        $currentWs = $script:config.WORKSPACE_DIR
+        $wsInput = Read-Host (Get-Msg "workspace.dir_prompt" -f $defaultWorkspace)
+        if ($wsInput -eq "b") { $script:StepResult = "back"; return }
+        $wsInput = if ($wsInput) { $wsInput } else { if ($currentWs) { $currentWs } else { $defaultWorkspace } }
+    }
+    $script:config.WORKSPACE_DIR = $wsInput
     if (-not (Test-Path $script:config.WORKSPACE_DIR)) {
         New-Item -ItemType Directory -Path $script:config.WORKSPACE_DIR -Force | Out-Null
     }
@@ -2233,9 +2396,14 @@ function Step-Hostshare {
         return
     }
     # ─────────────────────────────────────────────────────────────────
-    $shareInput = Read-Host (Get-Msg "host_share.prompt" -f $env:USERPROFILE)
+    $currentShare = $script:config.HOST_SHARE_DIR
+    if ($currentShare) {
+        $shareInput = Read-Host "$(Get-Msg 'host_share.prompt' -f $env:USERPROFILE) [${currentShare}]"
+    } else {
+        $shareInput = Read-Host (Get-Msg 'host_share.prompt' -f $env:USERPROFILE)
+    }
     if ($shareInput -eq "b") { $script:StepResult = "back"; return }
-    $script:config.HOST_SHARE_DIR = if ($shareInput) { $shareInput } else { $env:USERPROFILE }
+    $script:config.HOST_SHARE_DIR = if ($shareInput) { $shareInput } else { if ($currentShare) { $currentShare } else { $env:USERPROFILE } }
 }
 
 # ============================================================

--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -1413,13 +1413,14 @@ function Test-ShouldSkipStep {
         }
         # Keep-All upgrade mode: skip all config steps, values are already loaded
         { $_ -in @("Step-Llm", "Step-Admin", "Step-Network", "Step-Ports", "Step-Domains",
-                    "Step-Github", "Step-Skills", "Step-Volume", "Step-Workspace",
+                    "Step-Github", "Step-Skills",
                     "Step-Runtime", "Step-ManagerRuntime", "Step-E2ee", "Step-DockerProxy",
                     "Step-Idle", "Step-Hostshare") } {
             if ($script:HICLAW_UPGRADE -and $env:HICLAW_UPGRADE_KEEP_ALL -eq "1") { return $true }
             return $false
         }
         { $_ -in @("Step-Volume", "Step-Workspace") } {
+            if ($script:HICLAW_UPGRADE -and $env:HICLAW_UPGRADE_KEEP_ALL -eq "1") { return $true }
             if ($script:HICLAW_NON_INTERACTIVE) { return $true }
             if ($script:HICLAW_QUICKSTART) { return $true }
             return $false
@@ -1948,9 +1949,8 @@ function Step-Llm {
                 Write-Log (Get-Msg "prompt.upgrade_keep" -f (Get-Msg "llm.openai.model_prompt"), $script:config.DEFAULT_MODEL)
             } else {
                 $currentModel = $script:config.DEFAULT_MODEL
-                # Use base prompt without embedded default when showing current value
                 if ($currentModel) {
-                    $modelInput = Read-Host "Default Model ID [${currentModel}]"
+                    $modelInput = Read-Host "$(Get-Msg 'llm.openai.model_prompt') [${currentModel}]"
                 } else {
                     $modelInput = Read-Host (Get-Msg 'llm.openai.model_prompt')
                 }

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -232,6 +232,15 @@ msg() {
         "install.mode.manual_selected.en") text="Manual mode selected - you will choose LLM provider and customize options" ;;
         "install.mode.invalid.zh") text="无效选择，默认使用快速开始模式" ;;
         "install.mode.invalid.en") text="Invalid choice, defaulting to Quick Start mode" ;;
+        # --- Upgrade mode sub-menu ---
+        "upgrade.mode.prompt.zh") text="请选择升级方式：" ;;
+        "upgrade.mode.prompt.en") text="Select upgrade mode:" ;;
+        "upgrade.mode.keep_all.zh") text="  1) 保留所有参数，一键升级（推荐）" ;;
+        "upgrade.mode.keep_all.en") text="  1) Keep all parameters, quick upgrade (recommended)" ;;
+        "upgrade.mode.confirm_each.zh") text="  2) 逐个确认参数（可修改）" ;;
+        "upgrade.mode.confirm_each.en") text="  2) Confirm each parameter (can modify)" ;;
+        "upgrade.mode.back.zh") text="  3) 返回" ;;
+        "upgrade.mode.back.en") text="  3) Back" ;;
         # --- Version selection ---
         "install.version.title.zh") text="--- 版本选择 ---" ;;
         "install.version.title.en") text="--- Version Selection ---" ;;
@@ -434,12 +443,12 @@ msg() {
         "llm.provider.selected_openai.en") text="  Provider: %s (OpenAI-compatible)" ;;
         "llm.provider.invalid.zh") text="无效选择: %s（请输入 1 或 2）" ;;
         "llm.provider.invalid.en") text="Invalid choice: %s (please enter 1 or 2)" ;;
-        "llm.qwen.model_prompt.zh") text="默认模型 ID [qwen3.6-plus]" ;;
-        "llm.qwen.model_prompt.en") text="Default Model ID [qwen3.6-plus]" ;;
-        "llm.openai.base_url_prompt.zh") text="Base URL（例如 https://api.openai.com/v1）" ;;
-        "llm.openai.base_url_prompt.en") text="Base URL (e.g., https://api.openai.com/v1)" ;;
-        "llm.openai.model_prompt.zh") text="默认模型 ID [gpt-5.4]" ;;
-        "llm.openai.model_prompt.en") text="Default Model ID [gpt-5.4]" ;;
+        "llm.qwen.model_prompt.zh") text="默认模型 ID" ;;
+        "llm.qwen.model_prompt.en") text="Default Model ID" ;;
+        "llm.openai.base_url_prompt.zh") text="Base URL" ;;
+        "llm.openai.base_url_prompt.en") text="Base URL" ;;
+        "llm.openai.model_prompt.zh") text="默认模型 ID" ;;
+        "llm.openai.model_prompt.en") text="Default Model ID" ;;
         "llm.openai.base_url_label.zh") text="  Base URL: %s" ;;
         "llm.openai.base_url_label.en") text="  Base URL: %s" ;;
         # --- Custom model parameters ---
@@ -1228,6 +1237,19 @@ read_secret() {
     echo
 }
 
+# Load current parameter values from env file for upgrade mode display
+load_current_params_from_env() {
+    local env_file="${HICLAW_ENV_FILE:-${HOME}/hiclaw-manager.env}"
+    if [ -f "${env_file}" ]; then
+        HICLAW_LLM_PROVIDER=$(grep '^HICLAW_LLM_PROVIDER=' "${env_file}" 2>/dev/null | cut -d= -f2-)
+        HICLAW_OPENAI_BASE_URL=$(grep '^HICLAW_OPENAI_BASE_URL=' "${env_file}" 2>/dev/null | cut -d= -f2-)
+        HICLAW_DEFAULT_MODEL=$(grep '^HICLAW_DEFAULT_MODEL=' "${env_file}" 2>/dev/null | cut -d= -f2-)
+        HICLAW_EMBEDDING_MODEL=$(grep '^HICLAW_EMBEDDING_MODEL=' "${env_file}" 2>/dev/null | cut -d= -f2-)
+        HICLAW_WORKSPACE_DIR=$(grep '^HICLAW_WORKSPACE_DIR=' "${env_file}" 2>/dev/null | cut -d= -f2-)
+        HICLAW_HOST_SHARE_DIR=$(grep '^HICLAW_HOST_SHARE_DIR=' "${env_file}" 2>/dev/null | cut -d= -f2-)
+    fi
+}
+
 # In non-interactive mode, uses default or errors if required and no default.
 # Usage: prompt VAR_NAME "Prompt text" "default" [true=secret]
 prompt() {
@@ -1462,6 +1484,10 @@ should_skip_step() {
             local _env="${HICLAW_ENV_FILE:-${HOME}/hiclaw-manager.env}"
             [ ! -f "${_env}" ] && return 0
             ;;
+        # Keep-All upgrade mode: skip all config steps, values are already loaded
+        step_llm|step_admin|step_network|step_ports|step_domains|step_github|step_skills|step_volume|step_workspace|step_runtime|step_manager_runtime|step_e2ee|step_docker_proxy|step_idle|step_hostshare)
+            [ "${HICLAW_UPGRADE}" = "1" ] && [ "${HICLAW_UPGRADE_KEEP_ALL}" = "1" ] && return 0
+            ;;
         step_volume|step_workspace)
             [ "${HICLAW_NON_INTERACTIVE}" = "1" ] && return 0
             [ "${HICLAW_QUICKSTART}" = "1" ] && return 0
@@ -1654,6 +1680,35 @@ step_existing() {
         1|upgrade)
             HICLAW_UPGRADE=1
             log "$(msg install.existing.upgrading)"
+            # Show upgrade mode sub-menu (unless already set via env var)
+            if [ "${HICLAW_UPGRADE_KEEP_ALL:-0}" != "1" ]; then
+                echo ""
+                echo "$(msg upgrade.mode.prompt)"
+                echo "$(msg upgrade.mode.keep_all)"
+                echo "$(msg upgrade.mode.confirm_each)"
+                echo "$(msg upgrade.mode.back)"
+                echo ""
+                local UPGRADE_MODE_CHOICE
+                read -e -p "$(msg install.existing.prompt): " UPGRADE_MODE_CHOICE
+                UPGRADE_MODE_CHOICE="${UPGRADE_MODE_CHOICE:-1}"
+                case "${UPGRADE_MODE_CHOICE}" in
+                    1|keep)
+                        HICLAW_UPGRADE_KEEP_ALL=1
+                        ;;
+                    2|confirm)
+                        HICLAW_UPGRADE_KEEP_ALL=0
+                        ;;
+                    3|b)
+                        STEP_RESULT="back"
+                        return 0
+                        ;;
+                    *)
+                        HICLAW_UPGRADE_KEEP_ALL=0
+                        ;;
+                esac
+            fi
+            # Load current parameters for both Keep-All and confirm-each modes
+            load_current_params_from_env
             if [ -n "${running_manager}" ] || [ -n "${running_workers}" ]; then
                 echo ""
                 echo -e "\033[33m$(msg install.existing.warn_manager_stop)\033[0m"
@@ -1777,20 +1832,40 @@ step_llm() {
         [ -n "${HICLAW_OPENAI_BASE_URL+x}" ] && export HICLAW_OPENAI_BASE_URL
         return 0
     fi
-    echo ""
-    echo "$(msg llm.providers_title)"
-    echo "$(msg llm.provider.alibaba)"
-    echo "$(msg llm.provider.openai_compat)"
-    echo ""
-    local PROVIDER_CHOICE
-    if [ "${HICLAW_QUICKSTART}" = "1" ]; then
-        read -e -p "$(msg llm.provider.select) [1]: " PROVIDER_CHOICE
-        PROVIDER_CHOICE="${PROVIDER_CHOICE:-1}"
+
+    # Upgrade Keep-All mode: skip provider selection, use loaded values
+    local SKIP_TO_EMBEDDING=0
+    if [ "${HICLAW_UPGRADE}" = "1" ] && [ "${HICLAW_UPGRADE_KEEP_ALL}" = "1" ] && [ -n "${HICLAW_LLM_PROVIDER}" ]; then
+        log "$(msg llm.provider.label "${HICLAW_LLM_PROVIDER}")"
+        log "$(msg llm.openai.base_url_label "${HICLAW_OPENAI_BASE_URL}")"
+        log "$(msg llm.model.label "${HICLAW_DEFAULT_MODEL}")"
+        PROVIDER_CHOICE="${HICLAW_LLM_PROVIDER}"
+        SKIP_TO_EMBEDDING=1
     else
-        read -e -p "$(msg llm.provider.select): " PROVIDER_CHOICE
-        PROVIDER_CHOICE="${PROVIDER_CHOICE:-1}"
+        echo ""
+        echo "$(msg llm.providers_title)"
+        echo "$(msg llm.provider.alibaba)"
+        echo "$(msg llm.provider.openai_compat)"
+        echo ""
+        local PROVIDER_CHOICE
+        # If upgrade mode with loaded provider, show current as default
+        if [ "${HICLAW_UPGRADE}" = "1" ] && [ -n "${HICLAW_LLM_PROVIDER}" ]; then
+            local _prov_display
+            case "${HICLAW_LLM_PROVIDER}" in
+                openai-compat) _prov_display="2" ;;
+                *)             _prov_display="1" ;;
+            esac
+            read -e -p "$(msg llm.provider.select) [${_prov_display}]: " PROVIDER_CHOICE
+            PROVIDER_CHOICE="${PROVIDER_CHOICE:-${_prov_display}}"
+        elif [ "${HICLAW_QUICKSTART}" = "1" ]; then
+            read -e -p "$(msg llm.provider.select) [1]: " PROVIDER_CHOICE
+            PROVIDER_CHOICE="${PROVIDER_CHOICE:-1}"
+        else
+            read -e -p "$(msg llm.provider.select): " PROVIDER_CHOICE
+            PROVIDER_CHOICE="${PROVIDER_CHOICE:-1}"
+        fi
+        if [ "${PROVIDER_CHOICE}" = "b" ]; then STEP_RESULT="back"; return 0; fi
     fi
-    if [ "${PROVIDER_CHOICE}" = "b" ]; then STEP_RESULT="back"; return 0; fi
     local ALIBABA_MODEL_CHOICE=""
     local ALIBABA_ACCESS=""
     case "${PROVIDER_CHOICE}" in
@@ -1807,7 +1882,19 @@ step_llm() {
                 echo "$(msg llm.codingplan.model.minimax)"
                 echo ""
                 local CODINGPLAN_MODEL_CHOICE
-                if [ "${HICLAW_QUICKSTART}" = "1" ]; then
+                # If upgrade with loaded model, show current as default
+                if [ "${HICLAW_UPGRADE}" = "1" ] && [ -n "${HICLAW_DEFAULT_MODEL}" ]; then
+                    local _model_default
+                    case "${HICLAW_DEFAULT_MODEL}" in
+                        qwen3.6-plus) _model_default="1" ;;
+                        glm-5)        _model_default="2" ;;
+                        kimi-k2.5)    _model_default="3" ;;
+                        MiniMax-M2.5) _model_default="4" ;;
+                        *)            _model_default="1" ;;
+                    esac
+                    read -e -p "$(msg llm.codingplan.model.select) [${_model_default}]: " CODINGPLAN_MODEL_CHOICE
+                    CODINGPLAN_MODEL_CHOICE="${CODINGPLAN_MODEL_CHOICE:-${_model_default}}"
+                elif [ "${HICLAW_QUICKSTART}" = "1" ]; then
                     read -e -p "$(msg llm.codingplan.model.select) [1]: " CODINGPLAN_MODEL_CHOICE
                     CODINGPLAN_MODEL_CHOICE="${CODINGPLAN_MODEL_CHOICE:-1}"
                 else
@@ -1831,7 +1918,21 @@ step_llm() {
                 echo "$(msg llm.alibaba.model.bailian)"
                 echo "$(msg llm.alibaba.model.codingplan_legacy)"
                 echo ""
-                if [ "${HICLAW_QUICKSTART}" = "1" ]; then
+                if [ "${HICLAW_UPGRADE}" = "1" ] && [ -n "${HICLAW_OPENAI_BASE_URL}" ]; then
+                    # Determine alibaba access type from loaded URL
+                    local _access_default="1"
+                    if echo "${HICLAW_OPENAI_BASE_URL}" | grep -q "token-plan"; then
+                        _access_default="1"
+                    elif echo "${HICLAW_OPENAI_BASE_URL}" | grep -q "dashscope"; then
+                        if echo "${HICLAW_OPENAI_BASE_URL}" | grep -q "intl"; then
+                            _access_default="3"
+                        else
+                            _access_default="2"
+                        fi
+                    fi
+                    read -e -p "$(msg llm.alibaba.model.select) [${_access_default}]: " ALIBABA_MODEL_CHOICE
+                    ALIBABA_MODEL_CHOICE="${ALIBABA_MODEL_CHOICE:-${_access_default}}"
+                elif [ "${HICLAW_QUICKSTART}" = "1" ]; then
                     read -e -p "$(msg llm.alibaba.model.select) [1]: " ALIBABA_MODEL_CHOICE
                     ALIBABA_MODEL_CHOICE="${ALIBABA_MODEL_CHOICE:-1}"
                 else
@@ -1852,7 +1953,19 @@ step_llm() {
                         echo "$(msg llm.codingplan.model.minimax)"
                         echo ""
                         local CODINGPLAN_MODEL_CHOICE
-                        if [ "${HICLAW_QUICKSTART}" = "1" ]; then
+                        # If upgrade with loaded model, show current as default
+                        if [ "${HICLAW_UPGRADE}" = "1" ] && [ -n "${HICLAW_DEFAULT_MODEL}" ]; then
+                            local _model_default
+                            case "${HICLAW_DEFAULT_MODEL}" in
+                                qwen3.6-plus) _model_default="1" ;;
+                                glm-5)        _model_default="2" ;;
+                                kimi-k2.5)    _model_default="3" ;;
+                                MiniMax-M2.5) _model_default="4" ;;
+                                *)            _model_default="1" ;;
+                            esac
+                            read -e -p "$(msg llm.codingplan.model.select) [${_model_default}]: " CODINGPLAN_MODEL_CHOICE
+                            CODINGPLAN_MODEL_CHOICE="${CODINGPLAN_MODEL_CHOICE:-${_model_default}}"
+                        elif [ "${HICLAW_QUICKSTART}" = "1" ]; then
                             read -e -p "$(msg llm.codingplan.model.select) [1]: " CODINGPLAN_MODEL_CHOICE
                             CODINGPLAN_MODEL_CHOICE="${CODINGPLAN_MODEL_CHOICE:-1}"
                         else
@@ -1875,7 +1988,11 @@ step_llm() {
                         HICLAW_LLM_PROVIDER="qwen"
                         HICLAW_OPENAI_BASE_URL=""
                         echo ""
-                        read -e -p "$(msg llm.qwen.model_prompt): " HICLAW_DEFAULT_MODEL
+                        if [ "${HICLAW_UPGRADE}" = "1" ] && [ -n "${HICLAW_DEFAULT_MODEL}" ]; then
+                            read -e -p "$(msg llm.qwen.model_prompt) [${HICLAW_DEFAULT_MODEL}]: " HICLAW_DEFAULT_MODEL
+                        else
+                            read -e -p "$(msg llm.qwen.model_prompt) [qwen3.6-plus]: " HICLAW_DEFAULT_MODEL
+                        fi
                         if [ "${HICLAW_DEFAULT_MODEL}" = "b" ]; then STEP_RESULT="back"; return 0; fi
                         HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.6-plus}"
                         log "$(msg llm.provider.selected_qwen)"
@@ -1887,7 +2004,11 @@ step_llm() {
                         HICLAW_LLM_PROVIDER="openai-compat"
                         HICLAW_OPENAI_BASE_URL="https://coding.dashscope.aliyuncs.com/v1"
                         echo ""
-                        read -e -p "$(msg llm.qwen.model_prompt): " HICLAW_DEFAULT_MODEL
+                        if [ "${HICLAW_UPGRADE}" = "1" ] && [ -n "${HICLAW_DEFAULT_MODEL}" ]; then
+                            read -e -p "$(msg llm.qwen.model_prompt) [${HICLAW_DEFAULT_MODEL}]: " HICLAW_DEFAULT_MODEL
+                        else
+                            read -e -p "$(msg llm.qwen.model_prompt): " HICLAW_DEFAULT_MODEL
+                        fi
                         if [ "${HICLAW_DEFAULT_MODEL}" = "b" ]; then STEP_RESULT="back"; return 0; fi
                         HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-qwen3.6-plus}"
                         log "$(msg llm.provider.selected_codingplan_legacy)"
@@ -1928,11 +2049,32 @@ step_llm() {
             HICLAW_LLM_PROVIDER="openai-compat"
             log "$(msg llm.provider.selected_openai "${HICLAW_LLM_PROVIDER}")"
             echo ""
-            read -e -p "$(msg llm.openai.base_url_prompt): " HICLAW_OPENAI_BASE_URL
-            if [ "${HICLAW_OPENAI_BASE_URL}" = "b" ]; then STEP_RESULT="back"; return 0; fi
-            read -e -p "$(msg llm.openai.model_prompt): " HICLAW_DEFAULT_MODEL
-            if [ "${HICLAW_DEFAULT_MODEL}" = "b" ]; then STEP_RESULT="back"; return 0; fi
-            HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-gpt-5.4}"
+            if [ "${HICLAW_UPGRADE}" = "1" ] && [ "${HICLAW_UPGRADE_KEEP_ALL}" = "1" ]; then
+                log "$(msg prompt.upgrade_keep "$(msg llm.openai.base_url_prompt)" "${HICLAW_OPENAI_BASE_URL}")"
+            else
+                _current="${HICLAW_OPENAI_BASE_URL}"
+                if [ -n "${_current}" ]; then
+                    read -e -p "$(msg llm.openai.base_url_prompt) [${_current}]: " HICLAW_OPENAI_BASE_URL
+                else
+                    read -e -p "$(msg llm.openai.base_url_prompt) [https://api.openai.com/v1]: " HICLAW_OPENAI_BASE_URL
+                fi
+                if [ "${HICLAW_OPENAI_BASE_URL}" = "b" ]; then STEP_RESULT="back"; return 0; fi
+                HICLAW_OPENAI_BASE_URL="${HICLAW_OPENAI_BASE_URL:-${_current}}"
+                [ -z "${HICLAW_OPENAI_BASE_URL}" ] && HICLAW_OPENAI_BASE_URL="https://api.openai.com/v1"
+            fi
+            if [ "${HICLAW_UPGRADE}" = "1" ] && [ "${HICLAW_UPGRADE_KEEP_ALL}" = "1" ]; then
+                log "$(msg prompt.upgrade_keep "$(msg llm.openai.model_prompt)" "${HICLAW_DEFAULT_MODEL}")"
+            else
+                _current="${HICLAW_DEFAULT_MODEL}"
+                if [ -n "${_current}" ]; then
+                    read -e -p "$(msg llm.openai.model_prompt) [${_current}]: " HICLAW_DEFAULT_MODEL
+                else
+                    read -e -p "$(msg llm.openai.model_prompt) [gpt-5.4]: " HICLAW_DEFAULT_MODEL
+                fi
+                if [ "${HICLAW_DEFAULT_MODEL}" = "b" ]; then STEP_RESULT="back"; return 0; fi
+                HICLAW_DEFAULT_MODEL="${HICLAW_DEFAULT_MODEL:-${_current}}"
+                [ -z "${HICLAW_DEFAULT_MODEL}" ] && HICLAW_DEFAULT_MODEL="gpt-5.4"
+            fi
             log "$(msg llm.openai.base_url_label "${HICLAW_OPENAI_BASE_URL}")"
             log "$(msg llm.model.label "${HICLAW_DEFAULT_MODEL}")"
             prompt_custom_model_params "${HICLAW_DEFAULT_MODEL}" || return 0
@@ -1944,6 +2086,17 @@ step_llm() {
             error "$(msg llm.provider.invalid "${PROVIDER_CHOICE}")"
             ;;
     esac
+
+    # Skip to embedding if Keep-All mode handled LLM params
+    if [ "${SKIP_TO_EMBEDDING}" = "1" ]; then
+        if [ -n "${HICLAW_EMBEDDING_MODEL}" ]; then
+            log "$(msg llm.embedding.title)"
+            log "$(msg llm.model.label "${HICLAW_EMBEDDING_MODEL}")"
+            log ""
+        fi
+        return 0
+    fi
+
     # --- Embedding model (optional, auto-tested) ---
     echo ""
     log "$(msg llm.embedding.title)"
@@ -1963,11 +2116,17 @@ step_llm() {
             HICLAW_EMBEDDING_MODEL="text-embedding-v4"
             ;;
         2)
-            read -e -p "$(msg llm.embedding.custom_prompt): " HICLAW_EMBEDDING_MODEL
-            if [ "${HICLAW_EMBEDDING_MODEL}" = "b" ]; then STEP_RESULT="back"; return 0; fi
-            if [ -z "${HICLAW_EMBEDDING_MODEL}" ]; then
-                HICLAW_EMBEDDING_MODEL=""
-                log "$(msg llm.embedding.disabled)"
+            if [ "${HICLAW_UPGRADE}" = "1" ] && [ "${HICLAW_UPGRADE_KEEP_ALL}" = "1" ]; then
+                log "$(msg prompt.upgrade_keep "$(msg llm.embedding.custom_prompt)" "${HICLAW_EMBEDDING_MODEL}")"
+            else
+                _current="${HICLAW_EMBEDDING_MODEL}"
+                if [ -n "${_current}" ]; then
+                    read -e -p "$(msg llm.embedding.custom_prompt) [${_current}]: " HICLAW_EMBEDDING_MODEL
+                else
+                    read -e -p "$(msg llm.embedding.custom_prompt): " HICLAW_EMBEDDING_MODEL
+                fi
+                if [ "${HICLAW_EMBEDDING_MODEL}" = "b" ]; then STEP_RESULT="back"; return 0; fi
+                HICLAW_EMBEDDING_MODEL="${HICLAW_EMBEDDING_MODEL:-${_current}}"
             fi
             ;;
         3)
@@ -2109,13 +2268,21 @@ step_workspace() {
         return 0
     fi
     # ─────────────────────────────────────────────────────────────────
-    if [ -z "${HICLAW_WORKSPACE_DIR+x}" ]; then
-        local _input
-        read -e -p "$(msg workspace.dir_prompt "${HOME}/hiclaw-manager"): " _input
+    if [ "${HICLAW_UPGRADE}" = "1" ] && [ "${HICLAW_UPGRADE_KEEP_ALL}" = "1" ]; then
+        log "$(msg prompt.upgrade_keep "$(msg workspace.dir_prompt "${HOME}/hiclaw-manager")" "${HICLAW_WORKSPACE_DIR}")"
+        _input="${HICLAW_WORKSPACE_DIR}"
+    else
+        local _current="${HICLAW_WORKSPACE_DIR}"
+        if [ -n "${_current}" ]; then
+            read -e -p "$(msg workspace.dir_prompt "${HOME}/hiclaw-manager") [${_current}]: " _input
+        else
+            read -e -p "$(msg workspace.dir_prompt "${HOME}/hiclaw-manager"): " _input
+        fi
         if [ "${_input}" = "b" ]; then STEP_RESULT="back"; return 0; fi
-        HICLAW_WORKSPACE_DIR="${_input:-${HOME}/hiclaw-manager}"
-        export HICLAW_WORKSPACE_DIR
+        _input="${_input:-${_current}}"
     fi
+    HICLAW_WORKSPACE_DIR="${_input:-${HOME}/hiclaw-manager}"
+    export HICLAW_WORKSPACE_DIR
     HICLAW_WORKSPACE_DIR="$(cd "${HICLAW_WORKSPACE_DIR}" 2>/dev/null && pwd || echo "${HICLAW_WORKSPACE_DIR}")"
     mkdir -p "${HICLAW_WORKSPACE_DIR}"
     log "$(msg workspace.dir_label "${HICLAW_WORKSPACE_DIR}")"
@@ -2357,10 +2524,15 @@ step_hostshare() {
         return 0
     fi
     # ─────────────────────────────────────────────────────────────────
+    local _current="${HICLAW_HOST_SHARE_DIR}"
     local _share_dir
-    read -e -p "$(msg host_share.prompt "$HOME"): " _share_dir
+    if [ -n "${_current}" ]; then
+        read -e -p "$(msg host_share.prompt "$HOME") [${_current}]: " _share_dir
+    else
+        read -e -p "$(msg host_share.prompt "$HOME"): " _share_dir
+    fi
     if [ "${_share_dir}" = "b" ]; then STEP_RESULT="back"; return 0; fi
-    HICLAW_HOST_SHARE_DIR="${_share_dir:-$HOME}"
+    HICLAW_HOST_SHARE_DIR="${_share_dir:-${_current:-$HOME}}"
     export HICLAW_HOST_SHARE_DIR
 }
 

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -1241,12 +1241,12 @@ read_secret() {
 load_current_params_from_env() {
     local env_file="${HICLAW_ENV_FILE:-${HOME}/hiclaw-manager.env}"
     if [ -f "${env_file}" ]; then
-        HICLAW_LLM_PROVIDER=$(grep '^HICLAW_LLM_PROVIDER=' "${env_file}" 2>/dev/null | cut -d= -f2-)
-        HICLAW_OPENAI_BASE_URL=$(grep '^HICLAW_OPENAI_BASE_URL=' "${env_file}" 2>/dev/null | cut -d= -f2-)
-        HICLAW_DEFAULT_MODEL=$(grep '^HICLAW_DEFAULT_MODEL=' "${env_file}" 2>/dev/null | cut -d= -f2-)
-        HICLAW_EMBEDDING_MODEL=$(grep '^HICLAW_EMBEDDING_MODEL=' "${env_file}" 2>/dev/null | cut -d= -f2-)
-        HICLAW_WORKSPACE_DIR=$(grep '^HICLAW_WORKSPACE_DIR=' "${env_file}" 2>/dev/null | cut -d= -f2-)
-        HICLAW_HOST_SHARE_DIR=$(grep '^HICLAW_HOST_SHARE_DIR=' "${env_file}" 2>/dev/null | cut -d= -f2-)
+        [ -z "${HICLAW_LLM_PROVIDER:+x}" ] && HICLAW_LLM_PROVIDER="$(grep '^HICLAW_LLM_PROVIDER=' "${env_file}" 2>/dev/null | cut -d= -f2- | tr -d '\r')"
+        [ -z "${HICLAW_OPENAI_BASE_URL:+x}" ] && HICLAW_OPENAI_BASE_URL="$(grep '^HICLAW_OPENAI_BASE_URL=' "${env_file}" 2>/dev/null | cut -d= -f2- | tr -d '\r')"
+        [ -z "${HICLAW_DEFAULT_MODEL:+x}" ] && HICLAW_DEFAULT_MODEL="$(grep '^HICLAW_DEFAULT_MODEL=' "${env_file}" 2>/dev/null | cut -d= -f2- | tr -d '\r')"
+        [ -z "${HICLAW_EMBEDDING_MODEL:+x}" ] && HICLAW_EMBEDDING_MODEL="$(grep '^HICLAW_EMBEDDING_MODEL=' "${env_file}" 2>/dev/null | cut -d= -f2- | tr -d '\r')"
+        [ -z "${HICLAW_WORKSPACE_DIR:+x}" ] && HICLAW_WORKSPACE_DIR="$(grep '^HICLAW_WORKSPACE_DIR=' "${env_file}" 2>/dev/null | cut -d= -f2- | tr -d '\r')"
+        [ -z "${HICLAW_HOST_SHARE_DIR:+x}" ] && HICLAW_HOST_SHARE_DIR="$(grep '^HICLAW_HOST_SHARE_DIR=' "${env_file}" 2>/dev/null | cut -d= -f2- | tr -d '\r')"
     fi
 }
 
@@ -1484,13 +1484,14 @@ should_skip_step() {
             local _env="${HICLAW_ENV_FILE:-${HOME}/hiclaw-manager.env}"
             [ ! -f "${_env}" ] && return 0
             ;;
-        # Keep-All upgrade mode: skip all config steps, values are already loaded
-        step_llm|step_admin|step_network|step_ports|step_domains|step_github|step_skills|step_volume|step_workspace|step_runtime|step_manager_runtime|step_e2ee|step_docker_proxy|step_idle|step_hostshare)
+        # Keep-All upgrade mode: skip all config steps (step_volume/step_workspace handled separately)
+        step_llm|step_admin|step_network|step_ports|step_domains|step_github|step_skills|step_runtime|step_manager_runtime|step_e2ee|step_docker_proxy|step_idle|step_hostshare)
             [ "${HICLAW_UPGRADE}" = "1" ] && [ "${HICLAW_UPGRADE_KEEP_ALL}" = "1" ] && return 0
             ;;
         step_volume|step_workspace)
             [ "${HICLAW_NON_INTERACTIVE}" = "1" ] && return 0
             [ "${HICLAW_QUICKSTART}" = "1" ] && return 0
+            [ "${HICLAW_UPGRADE}" = "1" ] && [ "${HICLAW_UPGRADE_KEEP_ALL}" = "1" ] && return 0
             ;;
         step_e2ee|step_idle)
             [ "${HICLAW_NON_INTERACTIVE}" = "1" ] && return 0
@@ -1869,7 +1870,7 @@ step_llm() {
     local ALIBABA_MODEL_CHOICE=""
     local ALIBABA_ACCESS=""
     case "${PROVIDER_CHOICE}" in
-        1|alibaba-cloud)
+        1|alibaba-cloud|openai-compat)
             if [ "${HICLAW_LANGUAGE}" = "en" ]; then
                 HICLAW_LLM_PROVIDER="openai-compat"
                 HICLAW_OPENAI_BASE_URL="https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
@@ -2268,6 +2269,7 @@ step_workspace() {
         return 0
     fi
     # ─────────────────────────────────────────────────────────────────
+    local _input
     if [ "${HICLAW_UPGRADE}" = "1" ] && [ "${HICLAW_UPGRADE_KEEP_ALL}" = "1" ]; then
         log "$(msg prompt.upgrade_keep "$(msg workspace.dir_prompt "${HOME}/hiclaw-manager")" "${HICLAW_WORKSPACE_DIR}")"
         _input="${HICLAW_WORKSPACE_DIR}"


### PR DESCRIPTION
### Feature:

New "Keep All Parameters, Quick Upgrade" mode (Keep-All Upgrade Mode).          

### Problem Solved:

When an existing hiclaw installation is detected, users can now choose between:
1. Quick Upgrade — Automatically reuse existing config, skip all configuration steps
2. Confirm Each — Retains the original upgrade flow, but displays current values as defaults

### Implementation:

- Added Load-CurrentParamsFromEnv / load_current_params_from_env to read current config from the .env file.
- Modified Test-ShouldSkipStep / should_skip_step to skip 14 configuration steps in Keep-All mode.
- Configuration steps (LLM provider/model, workspace, hostshare, etc.) also display current values as defaults in non-Keep-All mode, allowing users to press Enter to retain them.