### PR TITLE
fix(install): 拉镜像失败时增加重试 || fix(install): Add retry when pulling the image fails

### DIFF
--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -2609,7 +2609,19 @@ EOF
             fi
         fi
         log "$(msg "${_pull_key}" "${_img}")"
-        ${DOCKER_CMD} pull "${_img}"
+        local _attempt=1
+        while [ $_attempt -le 3 ]; do
+            if ${DOCKER_CMD} pull "${_img}"; then
+                return 0
+            fi
+            if [ $_attempt -lt 3 ]; then
+                log "Pull failed (attempt ${_attempt}/3), retrying in 5s..."
+                sleep 5
+            fi
+            _attempt=$((_attempt + 1))
+        done
+        error "Failed to pull ${_img} after 3 attempts"
+        return 1
     }
 
     # Embedded controller image (resolve versioned tag, fallback to latest)


### PR DESCRIPTION
## 问题

安装时 `docker pull` 遇到网络抖动会直接退出，导致整个安装流程中断。

## 改动

`_pull_image()` 失败后最多重试 3 次，每次间隔 5s，3 次全失败才报错退出。
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Question

During installation, `docker pull` will exit directly if it encounters network jitter, causing the entire installation process to be interrupted.

## Changes

`_pull_image()` will retry up to 3 times after failure, with an interval of 5s each time. It will exit with an error after all 3 failures.
