### PR TITLE
fix(install): redirect detect_timezone warnings to stderr

### DIFF
--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -112,15 +112,17 @@ detect_timezone() {
         tz=$(timedatectl show --value -p Timezone 2>/dev/null)
     fi
 
-    # If still not detected, warn and prompt user
+    # If still not detected, warn and prompt user. Diagnostics go to stderr —
+    # this function returns its value via stdout to `$(detect_timezone)`, so
+    # any echo here would leak into HICLAW_TIMEZONE and downstream image tags.
     if [ -z "${tz}" ]; then
-        echo ""
-        echo -e "\033[33m[HiClaw WARNING]\033[0m Could not detect timezone automatically."
-        echo -e "\033[33m[HiClaw]\033[0m Please enter your timezone (e.g., Asia/Shanghai, America/New_York)."
-        echo ""
+        echo "" >&2
+        echo -e "\033[33m[HiClaw WARNING]\033[0m Could not detect timezone automatically." >&2
+        echo -e "\033[33m[HiClaw]\033[0m Please enter your timezone (e.g., Asia/Shanghai, America/New_York)." >&2
+        echo "" >&2
         if [ "${HICLAW_NON_INTERACTIVE}" = "1" ]; then
             tz="Asia/Shanghai"
-            log "Using default timezone: ${tz}"
+            log "Using default timezone: ${tz}" >&2
         else
             read -e -p "Timezone [Asia/Shanghai]: " tz
             tz="${tz:-Asia/Shanghai}"


### PR DESCRIPTION
Fixes #611。

`detect_timezone()` 通过 stdout 返回时区值（`HICLAW_TIMEZONE=$(detect_timezone)`），但当三种探测全部失败、走告警分支时，里面的 `echo` 警告文本和 `log "Using default timezone..."` 也都被写到了 stdout，结果一起被 captured 进 `HICLAW_TIMEZONE`。后续这个被污染的值进入 docker 镜像 tag 拼接，触发 `repository name must be lowercase`。

修复：把 4 个警告 `echo` 和 1 个 `log` 调用统一加 `>&2`，让诊断信息走 stderr。终端用户依然能看到提示，但 captured 值变干净。

### 触发条件

`/etc/timezone`、`/etc/localtime` 软链、`timedatectl` 三种探测都失败 —— 实际场景常见于 Alpine / 极简容器 / 没装 tzdata 的最小化 Linux 镜像里跑 `install.sh`。

### 验证

修复前：`HICLAW_TIMEZONE` 长度约 233 字节，包含 `[HiClaw WARNING]...` 文本。
修复后：`HICLAW_TIMEZONE = "Asia/Shanghai"`（13 字节），warning 仍显示在 stderr。