### PR TITLE
fix(controller): honor TeamWorkerSpec.Runtime and HICLAW_DEFAULT_WORKER_RUNTIME for team workers

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -8,4 +8,5 @@ Record image-affecting changes to `manager/`, `worker/`, `openclaw-base/` here b
 - fix(manager): document runtime-aware Worker dispatch (avoid @worker text in admin DM only); update task-management references, AGENTS.md, HEARTBEAT.md, channel-management skill
 - fix(manager): separate runtime-specific AGENTS/HEARTBEAT for OpenClaw vs CoPaw; remove cross-runtime references from manager agent docs
 - refactor(api)!: restructure `spec.mcpServers` on Worker/Manager/Team CRDs to `[]{name,url,transport}`; drop controller-side MCP gateway authorization; `mcporter-servers.json` is written from the CRD (see `docs/declarative-resource-management.md`)
+- fix(controller): honor `TeamWorkerSpec.Runtime` and `HICLAW_DEFAULT_WORKER_RUNTIME` for team workers in `teamWorkerSpecToWorkerSpec()` and `teamMemberToResponse()` (regression from #666 that silently forced team workers to `copaw`). Leader runtime remains `copaw` by design. Existing team pods keep their current runtime until the user edits the Team spec or deletes the pod; new/edited teams pick up the fix immediately ([af52054](https://github.com/agentscope-ai/HiClaw/commit/af52054))
 

--- a/hiclaw-controller/internal/controller/team_controller.go
+++ b/hiclaw-controller/internal/controller/team_controller.go
@@ -858,6 +858,13 @@ func leaderWorkerSpec(t *v1beta1.Team) v1beta1.WorkerSpec {
 //   - leader is always on the worker's groupAllow
 //   - team admin (if any) is on the worker's groupAllow
 //   - if Team.Spec.PeerMentions is true (default), all peers are groupAllow too
+//
+// Runtime is passed through from TeamWorkerSpec. An empty value is intentional
+// and means "no per-member preference" — backend.ResolveRuntime resolves it
+// against TeamReconciler.DefaultRuntime (sourced from HICLAW_DEFAULT_WORKER_RUNTIME
+// via MemberDeps.DefaultRuntime → backend.CreateRequest.RuntimeFallback),
+// falling back to RuntimeOpenClaw if neither is set. This matches the
+// resolution chain used by standalone Worker CRs.
 func teamWorkerSpecToWorkerSpec(t *v1beta1.Team, w v1beta1.TeamWorkerSpec) v1beta1.WorkerSpec {
 	policy := mergeChannelPolicy(t.Spec.ChannelPolicy, w.ChannelPolicy)
 	policy = appendGroupAllowExtra(policy, t.Spec.Leader.Name)
@@ -874,7 +881,7 @@ func teamWorkerSpecToWorkerSpec(t *v1beta1.Team, w v1beta1.TeamWorkerSpec) v1bet
 	}
 	return v1beta1.WorkerSpec{
 		Model:         w.Model,
-		Runtime:       "copaw",
+		Runtime:       w.Runtime,
 		Image:         w.Image,
 		Identity:      w.Identity,
 		Soul:          w.Soul,

--- a/hiclaw-controller/internal/controller/team_controller_test.go
+++ b/hiclaw-controller/internal/controller/team_controller_test.go
@@ -58,9 +58,57 @@ func TestBuildDesiredMembers_LeaderAndWorkers(t *testing.T) {
 		if m.PodLabels["hiclaw.io/team"] != "alpha" {
 			t.Errorf("member %s missing hiclaw.io/team label: %v", m.Name, m.PodLabels)
 		}
-		if m.Spec.Runtime != "copaw" {
-			t.Errorf("member %s runtime=%q, want copaw", m.Name, m.Spec.Runtime)
+		switch m.Role {
+		case RoleTeamLeader:
+			// Leader runtime is intentionally hardcoded to copaw in
+			// leaderWorkerSpec() because LeaderSpec has no runtime field
+			// and only the copaw team-leader agent template exists today.
+			if m.Spec.Runtime != "copaw" {
+				t.Errorf("leader %s runtime=%q, want copaw", m.Name, m.Spec.Runtime)
+			}
+		case RoleTeamWorker:
+			// Worker runtime is passed through from TeamWorkerSpec.Runtime.
+			// The fixture leaves it unset, so empty string is expected here;
+			// the downstream backend.ResolveRuntime resolves it against
+			// TeamReconciler.DefaultRuntime (from HICLAW_DEFAULT_WORKER_RUNTIME).
+			if m.Spec.Runtime != "" {
+				t.Errorf("worker %s runtime=%q, want \"\" (pass-through from TeamWorkerSpec)", m.Name, m.Spec.Runtime)
+			}
 		}
+	}
+}
+
+// TestTeamWorkerSpecToWorkerSpec_RuntimePassthrough locks in the fix for the
+// regression introduced by PR #666: team_controller must not override the
+// per-member Runtime field when projecting TeamWorkerSpec into WorkerSpec.
+//
+// Before the fix, Runtime was hardcoded to "copaw" regardless of what the
+// user declared in Team.Spec.Workers[].runtime, silently breaking
+// HICLAW_DEFAULT_WORKER_RUNTIME=hermes|openclaw installs and ignoring
+// explicit per-worker runtime pins.
+func TestTeamWorkerSpecToWorkerSpec_RuntimePassthrough(t *testing.T) {
+	team := &v1beta1.Team{}
+	team.Name = "alpha"
+	team.Spec.Leader = v1beta1.LeaderSpec{Name: "alpha-lead", Model: "gpt-4o"}
+
+	cases := []struct {
+		name    string
+		runtime string
+	}{
+		{"explicit_hermes", "hermes"},
+		{"explicit_openclaw", "openclaw"},
+		{"explicit_copaw", "copaw"},
+		{"empty_defers_to_fallback", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := v1beta1.TeamWorkerSpec{Name: "alpha-dev", Model: "gpt-4o", Runtime: tc.runtime}
+			team.Spec.Workers = []v1beta1.TeamWorkerSpec{w}
+			got := teamWorkerSpecToWorkerSpec(team, w)
+			if got.Runtime != tc.runtime {
+				t.Fatalf("runtime=%q, want %q (must be passed through verbatim; empty string is valid and resolved downstream by backend.ResolveRuntime)", got.Runtime, tc.runtime)
+			}
+		})
 	}
 }
 

--- a/hiclaw-controller/internal/server/resource_handler.go
+++ b/hiclaw-controller/internal/server/resource_handler.go
@@ -947,16 +947,23 @@ func (h *ResourceHandler) findTeamMember(ctx context.Context, name string) (*v1b
 // creating a Worker CR. Runtime fields (Phase, ContainerState, ExposedPorts)
 // are populated from Team.Status and the backend so existing consumers of
 // /api/v1/workers see consistent data.
+//
+// Runtime resolution mirrors the response contract of standalone Worker CRs
+// (see ListWorkers/GetWorker at the top of this file, which return
+// w.Spec.Runtime verbatim): leader is hardcoded "copaw" to match the
+// projection in leaderWorkerSpec(); worker is passed through from
+// TeamWorkerSpec.Runtime (possibly empty, meaning "defer to installer
+// default"), so Manager skills and `hiclaw get worker` observe the same
+// value for Team workers as they would for standalone Workers.
 func (h *ResourceHandler) teamMemberToResponse(ctx context.Context, t *v1beta1.Team, memberName string) WorkerResponse {
 	isLeader := t.Spec.Leader.Name == memberName
 	ms := t.Status.MemberByName(memberName)
 
 	resp := WorkerResponse{
-		Name:    memberName,
-		Team:    t.Name,
-		Phase:   "Pending",
-		State:   "Running",
-		Runtime: "copaw",
+		Name:  memberName,
+		Team:  t.Name,
+		Phase: "Pending",
+		State: "Running",
 	}
 	if ms != nil {
 		resp.RoomID = ms.RoomID
@@ -964,6 +971,7 @@ func (h *ResourceHandler) teamMemberToResponse(ctx context.Context, t *v1beta1.T
 	}
 	if isLeader {
 		resp.Role = "team_leader"
+		resp.Runtime = "copaw"
 		resp.Model = t.Spec.Leader.Model
 		if t.Spec.Leader.State != nil {
 			resp.State = *t.Spec.Leader.State
@@ -976,9 +984,7 @@ func (h *ResourceHandler) teamMemberToResponse(ctx context.Context, t *v1beta1.T
 			}
 			resp.Model = wk.Model
 			resp.Image = wk.Image
-			if wk.Runtime != "" {
-				resp.Runtime = wk.Runtime
-			}
+			resp.Runtime = wk.Runtime
 			if wk.State != nil {
 				resp.State = *wk.State
 			}


### PR DESCRIPTION
## Summary

Team workers have silently ignored `Team.Spec.Workers[].runtime` and `HICLAW_DEFAULT_WORKER_RUNTIME` since v1.1.0 — every team worker was forced to run on `copaw` regardless of configuration.

This PR restores the pre-v1.1.0 resolution chain that standalone `Worker` CRs already use, while keeping the `team_leader` role on `copaw` (which is an intentional design constraint, see below).

Regression introduced in #666.

## Root Cause

Two places hardcoded `Runtime: "copaw"` when projecting a `TeamWorkerSpec` into the downstream model:

1. **`internal/controller/team_controller.go`** — `teamWorkerSpecToWorkerSpec()` overwrote the per-member runtime during reconcile, so the container backend always received `copaw` as the effective runtime for team workers.
2. **`internal/server/resource_handler.go`** — `teamMemberToResponse()` also hardcoded `Runtime: "copaw"` in the API response path, so `hiclaw get worker` and Manager skills reported `copaw` for every team worker regardless of what was actually running.

The comment above `teamWorkerSpecToWorkerSpec()` already described the intended behavior ("policy merge"), but the implementation silently dropped the `Runtime` field. The `TeamWorkerSpec.Runtime` field has existed in the CRD since the Teams feature landed, so users had no way to know their `runtime: hermes` / `runtime: openclaw` declarations were being ignored.

## Fix

- `teamWorkerSpecToWorkerSpec()`: pass `w.Runtime` through verbatim. An empty string is intentional and means "no per-member preference" — `backend.ResolveRuntime(spec.Runtime, fallback)` resolves it against `TeamReconciler.DefaultRuntime` (sourced from `HICLAW_DEFAULT_WORKER_RUNTIME` via `MemberDeps.DefaultRuntime` → `backend.CreateRequest.RuntimeFallback`), falling back to `RuntimeOpenClaw` if neither is set. This matches the resolution chain used by standalone `Worker` CRs.
- `teamMemberToResponse()`: split the branch by role — `team_leader` stays `copaw` (mirrors `leaderWorkerSpec()`), `worker` passes `wk.Runtime` through (matches `ListWorkers` / `GetWorker`, which return `w.Spec.Runtime` verbatim for standalone workers).
- Leader runtime is **intentionally left hardcoded to `copaw`**: `LeaderSpec` has no `runtime` field today, and only the `copaw` `team-leader-agent` template ships in the image. Changing that is out of scope for this regression fix.

## Upgrade Impact

- **New or edited Teams**: pick up the fix immediately on the next reconcile.
- **Existing team pods**: keep their current runtime until the user edits the Team spec or deletes the pod. This is safe because `hashMemberSourceSpec()` hashes the source `TeamWorkerSpec` (which this patch does not change), so `SpecChanged` stays `false` for untouched members and no pod churn is triggered.
- No CRD changes. No API breaking changes. Controller behavior change only.

## Tests

- `TestBuildDesiredMembers_LeaderAndWorkers`: assertion split by role — leader must be `copaw`, worker must be `""` (pass-through from the fixture, which leaves `Runtime` unset).
- `TestTeamWorkerSpecToWorkerSpec_RuntimePassthrough` (new): covers four cases — `hermes`, `openclaw`, `copaw`, and empty — to lock in verbatim pass-through and prevent future regressions.
- `go build ./...` and `go test ./internal/controller/... ./internal/server/...` pass locally.

## Changelog

```
- fix(controller): honor `TeamWorkerSpec.Runtime` and `HICLAW_DEFAULT_WORKER_RUNTIME` for team workers in `teamWorkerSpecToWorkerSpec()` and `teamMemberToResponse()` (regression from #666 that silently forced team workers to `copaw`). Leader runtime remains `copaw` by design. Existing team pods keep their current runtime until the user edits the Team spec or deletes the pod; new/edited teams pick up the fix immediately
```

## References

- Regression source: #666
- Related work: #690 (same family — `spec.env` dropped in the same projection layer)
- Touches the pattern discussed in #634 (team member fields silently overwritten)

---

cc @Jing-ze @googs1025 — you've been in adjacent PRs on this projection layer, would appreciate a look.