### PR TITLE
fix(controller): use host arch when TARGETARCH is unset

### DIFF
--- a/hiclaw-controller/Dockerfile
+++ b/hiclaw-controller/Dockerfile
@@ -29,10 +29,15 @@ FROM ${HIGRESS_REGISTRY}/higress/mc:20260216 AS mc
 # ============ Stage 3: Download kube-apiserver (native arch to avoid QEMU TLS bugs) ============
 FROM --platform=$BUILDPLATFORM ${HIGRESS_REGISTRY}/higress/alpine:3.20 AS kube-bin
 ARG KUBE_VERSION=v1.31.3
-ARG TARGETARCH=amd64
+# TARGETARCH is auto-injected by buildx for multi-arch builds. For plain
+# `docker build` (no buildx) it is unset, so fall back to `uname -m` —
+# safe here because the stage is pinned to BUILDPLATFORM and a non-buildx
+# build is always single-arch == host arch.
+ARG TARGETARCH
 RUN apk add --no-cache curl && \
+    ARCH="${TARGETARCH:-$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')}" && \
     curl -fSL -o /kube-apiserver \
-      "https://dl.k8s.io/release/${KUBE_VERSION}/bin/linux/${TARGETARCH}/kube-apiserver" && \
+      "https://dl.k8s.io/release/${KUBE_VERSION}/bin/linux/${ARCH}/kube-apiserver" && \
     chmod +x /kube-apiserver
 
 # ============ Final: Minimal image with all artifacts ============


### PR DESCRIPTION
## What

#751 报的 ARM 启动报错 \`kube-apiserver: exec format error\` —— 根因是 \`hiclaw-controller/Dockerfile\` 里 \`ARG TARGETARCH=amd64\` 写了硬默认值。在 buildx 多架构构建里 BuildKit 会注入 TARGETARCH，默认值无害；但 \`make build\` 走的是普通 \`docker build\`，TARGETARCH 不会被注入，ARM 上 build 出来的镜像里塞的是 amd64 的 kube-apiserver。

## Fix

去掉默认值 + \`uname -m\` 兜底。stage 已经 pin 到 \`--platform=\$BUILDPLATFORM\`，非 buildx 构建必然是单架构 == 宿主机架构，\`uname -m\` 取值正确。多架构 buildx 行为不变。

## Verify

ARM Mac 本地 \`make build-hiclaw-controller\`：
- \`file /usr/local/bin/kube-apiserver\` → \`ELF 64-bit ARM aarch64\`
- \`kube-apiserver --version\` → \`Kubernetes v1.31.3\`

Fixes #751