### PR TITLE
chore(changelog): archive v1.1.1 release notes

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -1,16 +1,7 @@
 # Changelog (Unreleased)
 
-Record image-affecting changes to `manager/`, `worker/`, `openclaw-base/` here before the next release.
+Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `openclaw-base/`, `hiclaw-controller/` here before the next release.
 
 ---
 
-- feat(controller): Worker package resolve/extract no longer requires `SOUL.md` in the archive or directory; missing personality is filled later by `DeployWorkerConfig` defaults or inline `spec.soul`
-- feat(controller): honor user-defined `spec.env` (`map[string]string`) on Worker, Manager, `Team.leader`, and `Team.workers[]`; variables merge with controller/backend-managed env at `createMemberContainer` / `createManagerContainer` with system keys winning on collision (dropped keys logged once at INFO); CRD exposes `env` as a string map (`additionalProperties.type=string`). `hiclaw` CLI / REST API surface for this field is deferred—use `kubectl apply` for now.
-- fix(controller): add `+kubebuilder:subresource:status` on CR types; patch Worker finalizers instead of full `Update`; exponential backoff on REST update conflict retries
-- fix(manager): document runtime-aware Worker dispatch (avoid @worker text in admin DM only); update task-management references, AGENTS.md, HEARTBEAT.md, channel-management skill
-- fix(manager): separate runtime-specific AGENTS/HEARTBEAT for OpenClaw vs CoPaw; remove cross-runtime references from manager agent docs
-- refactor(api)!: restructure `spec.mcpServers` on Worker/Manager/Team CRDs to `[]{name,url,transport}`; drop controller-side MCP gateway authorization; `mcporter-servers.json` is written from the CRD (see `docs/declarative-resource-management.md`)
-- feat(controller): support `mcpServers` on Team Leader spec; leader can now declare MCP servers the same way team workers do
-- chore(build): add `make generate` target to regenerate deepcopy functions via controller-gen and sync CRDs to Helm chart
-- fix(controller): honor `TeamWorkerSpec.Runtime` and `HICLAW_DEFAULT_WORKER_RUNTIME` for team workers in `teamWorkerSpecToWorkerSpec()` and `teamMemberToResponse()` (regression from #666 that silently forced team workers to `copaw`). Leader runtime remains `copaw` by design. Existing team pods keep their current runtime until the user edits the Team spec or deletes the pod; new/edited teams pick up the fix immediately ([af52054](https://github.com/agentscope-ai/HiClaw/commit/af52054))
 

--- a/changelog/v1.1.1.md
+++ b/changelog/v1.1.1.md
@@ -1,0 +1,125 @@
+# Changelog v1.1.1
+
+Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `openclaw-base/`, `hiclaw-controller/` here before the next release.
+
+---
+
+**What's New**
+
+- **Declarative MCP on CRDs** — `spec.mcpServers` on Worker, Manager, and Team CRs is now a list of `{name, url, transport}` entries. The controller no longer performs MCP gateway authorization for these servers; `mcporter-servers.json` is written from the CRD (see `docs/declarative-resource-management.md`). **Breaking change** for existing manifests that used the old shape.
+
+- **MCP servers on Team Leader** — The Team Leader spec accepts `mcpServers` the same way team workers do, so the leader can use MCP tools alongside workers.
+
+- **Custom environment variables** — `spec.env` (`map[string]string`) on Worker, Manager, Team leader, and `Team.workers[]` merges with controller-managed environment at container creation; system keys win on collision (dropped user keys are logged once at INFO). Use `kubectl apply` until the `hiclaw` CLI exposes this field.
+
+- **Worker packages without `SOUL.md`** — Worker package resolve/extract no longer requires `SOUL.md` in the archive or directory; missing personality is filled later from `DeployWorkerConfig` defaults or inline `spec.soul`.
+
+- **`containerManaged` on Worker** — New optional field lets you mark Workers whose containers are not managed by the controller (external lifecycle) while still participating in Matrix and declarative config where applicable.
+
+- **Team heartbeat (CoPaw)** — Team CRD carries heartbeat-related configuration; the controller provisions it and the CoPaw worker runtime consumes it for CoPaw-based teams.
+
+- **Qwen billing and default models** — Token Plan / Qwen Cloud international routing, `qwen3.6-plus` in known models, and upgrade-time credential handling updates across install scripts, Manager startup, and controller agent config generation.
+
+- **`make generate`** — Root `Makefile` adds a `generate` target that runs controller-gen in `hiclaw-controller/` and keeps Helm CRDs in sync.
+
+- **Helm: namespace-scoped controller RBAC** — Chart RBAC for the controller is scoped to a single namespace where appropriate for tighter multi-tenant deployments.
+
+**Bug Fixes**
+
+- **Kubernetes API / REST stability** — CR types declare `+kubebuilder:subresource:status`; Worker finalizers use `Patch` instead of full `Update`; the embedded REST handler maps optimistic-lock conflicts to HTTP 409 and retries with bounded backoff.
+
+- **Team worker runtime** — Team members again honor `TeamWorkerSpec.Runtime` and `HICLAW_DEFAULT_WORKER_RUNTIME` when building worker specs (fixes a regression that forced team workers to CoPaw). Leader default runtime remains CoPaw by design; existing pods keep their image until the Team spec changes or the pod is recreated.
+
+- **Manager agent docs (OpenClaw vs CoPaw)** — Runtime-aware task dispatch: avoid `@worker` mentions in admin DM-only flows; task-management and channel-management skills updated; OpenClaw and CoPaw `AGENTS.md` / `HEARTBEAT.md` paths kept runtime-specific without cross-references.
+
+- **MinIO S3 endpoint** — Scripts use the MinIO S3 API port (9000) instead of incorrectly targeting the Higress port (8080).
+
+- **Config merge and plugins** — Local-first merge for `openclaw.json` (bash + Hermes paths); dreaming enabled by default; user plugin configuration is preserved across reconcile where applicable.
+
+- **Observe recovery** — Observe-recovery is disabled so intentional local config edits are not overwritten on Manager/Worker restart.
+
+- **Mirror and build** — Ensure the agent directory exists before `mc` mirror sync; controller container build defaults `TARGETARCH` to the host architecture when unset.
+
+- **Installer** — Safer embedded image tag selection when installing older versions (avoids wrong `latest` on Apple Silicon); retries when image pulls fail; `detect_timezone` warnings go to stderr; Matrix credentials can be extracted during upgrade when the Manager container is stopped.
+
+---
+
+**新增功能**
+
+- **CRD 上的声明式 MCP** — Worker、Manager、Team 的 `spec.mcpServers` 现为 `{name, url, transport}` 列表；控制器不再为这些条目做 MCP 网关侧授权；`mcporter-servers.json` 由 CRD 写入（见 `docs/declarative-resource-management.md`）。旧字段形态**不兼容**，需更新清单。
+
+- **Team Leader 的 MCP** — Team Leader 规格可与组员一样声明 `mcpServers`。
+
+- **自定义环境变量** — Worker、Manager、Team Leader 与 `Team.workers[]` 支持 `spec.env`（字符串 map），在创建容器时与控制器托管环境合并；键冲突时以系统为准（被丢弃的用户键仅在 INFO 记录一次）。在 `hiclaw` CLI 暴露该字段前请使用 `kubectl apply`。
+
+- **Worker 包可不含 `SOUL.md`** — 解析/解压 Worker 包不再强制要求包内或目录中存在 `SOUL.md`；缺失时在后续由默认配置或 `spec.soul` 补全。
+
+- **Worker 的 `containerManaged`** — 可选字段，用于声明不由控制器管理容器生命周期的 Worker（外部托管），仍可按场景参与 Matrix 与声明式配置。
+
+- **Team 心跳（CoPaw）** — Team CRD 增加心跳相关配置，由控制器下发并由 CoPaw Worker 运行时消费。
+
+- **Qwen 计费与默认模型** — Token Plan、Qwen 国际线路、`qwen3.6-plus` 默认值及升级凭据处理，覆盖安装脚本、Manager 启动与控制器 Agent 配置生成。
+
+- **`make generate`** — 根目录 `Makefile` 增加 `generate` 目标，在 `hiclaw-controller/` 运行 controller-gen 并同步 Helm CRD。
+
+- **Helm：命名空间级 RBAC** — Chart 中将控制器 RBAC 限定在单一命名空间，便于多租户场景收紧权限。
+
+**Bug 修复**
+
+- **Kubernetes API / REST 稳定性** — CR 类型补充 `+kubebuilder:subresource:status`；Worker finalizer 使用 `Patch` 替代整对象 `Update`；内嵌 REST 对乐观锁冲突返回 HTTP 409 并带退避重试。
+
+- **Team Worker 运行时** — 构建 Worker 规格时重新遵守 `TeamWorkerSpec.Runtime` 与 `HICLAW_DEFAULT_WORKER_RUNTIME`（修复误将组员强制为 CoPaw 的回归）。Leader 默认运行时仍为 CoPaw；已运行 Pod 需改 Team 或删 Pod 后才会换新镜像。
+
+- **Manager Agent 文档（OpenClaw / CoPaw）** — 按运行时区分任务派发：管理员私聊场景避免 `@worker`；更新 task-management、channel-management；OpenClaw 与 CoPaw 的 `AGENTS.md` / `HEARTBEAT.md` 互不串引用。
+
+- **MinIO S3 端口** — 脚本固定使用 MinIO S3 API 端口 9000，不再错误指向 Higress 8080。
+
+- **配置合并与插件** — `openclaw.json` 本地优先合并（bash + Hermes）；默认开启 dreaming；对账时尽量保留用户插件配置。
+
+- **Observe recovery** — 关闭 observe-recovery，避免 Manager/Worker 重启覆盖本地有意修改的配置。
+
+- **镜像与构建** — `mc` 镜像同步前确保 agent 目录存在；构建控制器镜像时在未设置 `TARGETARCH` 时回退为宿主机架构。
+
+- **安装脚本** — 安装旧版本时避免误拉错误架构的 `embedded:latest`（Apple Silicon 等）；镜像拉取失败重试；`detect_timezone` 警告输出至 stderr；升级时若 Manager 已停，仍可抽取 Matrix 凭据。
+
+---
+
+- refactor(helm): scope controller RBAC to a single namespace ([e8865b5](https://github.com/agentscope-ai/HiClaw/commit/e8865b5))
+- feat(copaw,controller): add heartbeat config to Team CRD and wire into CoPaw runtime ([f902125](https://github.com/agentscope-ai/HiClaw/commit/f902125))
+- ci: add push-embedded target and selective image building ([1b188c5](https://github.com/agentscope-ai/HiClaw/commit/1b188c5))
+- ci: add version and targets inputs to Build Images workflow ([204d947](https://github.com/agentscope-ai/HiClaw/commit/204d947))
+- fix: rename "agent" to "OpenClaw", add QwenPaw 1.0.2 in v1.1.0 blog ([c2ee833](https://github.com/agentscope-ai/HiClaw/commit/c2ee833))
+- fix: enable dreaming by default and preserve user plugin config on reconcile ([069824e](https://github.com/agentscope-ai/HiClaw/commit/069824e))
+- feat(sync): local-first openclaw.json merge (bash + hermes) ([2442d97](https://github.com/agentscope-ai/HiClaw/commit/2442d97))
+- fix(install): extract Matrix credentials during upgrade when manager is stopped ([0d86f42](https://github.com/agentscope-ai/HiClaw/commit/0d86f42))
+- fix: MinIO S3 endpoint must use port 9000, not Higress 8080 ([88869f9](https://github.com/agentscope-ai/HiClaw/commit/88869f9))
+- fix(manager): runtime-aware task dispatch, avoid @worker in admin DM ([e1d71d9](https://github.com/agentscope-ai/HiClaw/commit/e1d71d9))
+- fix(controller): map K8s conflict to 409 and retry optimistic updates ([b3a602b](https://github.com/agentscope-ai/HiClaw/commit/b3a602b))
+- feat: Token Plan support, Qwen Cloud international, qwen3.6-plus model and upgrade credential fix ([2eec587](https://github.com/agentscope-ai/HiClaw/commit/2eec587))
+- refactor(api)!: restructure mcpServers on Worker/Manager/Team CRDs and drop controller-side MCP authorization ([bd06cd1](https://github.com/agentscope-ai/HiClaw/commit/bd06cd1))
+- fix: disable observe-recovery to preserve user config changes ([50f26c2](https://github.com/agentscope-ai/HiClaw/commit/50f26c2))
+- fix(controller): use host arch when TARGETARCH is unset ([8634358](https://github.com/agentscope-ai/HiClaw/commit/8634358))
+- fix(install): add retry when pulling the image fails ([4a7104d](https://github.com/agentscope-ai/HiClaw/commit/4a7104d))
+- feat(hiclaw-controller): honor spec.env on Worker/Manager/Team CRs ([c057739](https://github.com/agentscope-ai/HiClaw/commit/c057739))
+- feat(controller): optional SOUL.md in Worker package resolve/extract ([79b8d58](https://github.com/agentscope-ai/HiClaw/commit/79b8d58))
+- fix(controller): honor TeamWorkerSpec.Runtime and HICLAW_DEFAULT_WORKER_RUNTIME for team workers ([353c31c](https://github.com/agentscope-ai/HiClaw/commit/353c31c))
+- fix: ensure agent directory exists before mc mirror sync ([73b8b28](https://github.com/agentscope-ai/HiClaw/commit/73b8b28))
+- fix(install): avoid wrong hiclaw-embedded:latest on older version install (Apple Silicon) ([db63dc2](https://github.com/agentscope-ai/HiClaw/commit/db63dc2))
+- docs(manager): include hermes in worker-create checklist and note install-default fallback ([530ecbd](https://github.com/agentscope-ai/HiClaw/commit/530ecbd))
+- fix(install): redirect detect_timezone warnings to stderr ([ef9079d](https://github.com/agentscope-ai/HiClaw/commit/ef9079d))
+- docs: rename CoPaw to QwenPaw across docs ([1af4a85](https://github.com/agentscope-ai/HiClaw/commit/1af4a85))
+- feat(controller): ContainerManaged for non-container-managed workers ([ff0b035](https://github.com/agentscope-ai/HiClaw/commit/ff0b035))
+- feat(controller): support mcpServers on Team Leader spec; add make generate ([fac0b36](https://github.com/agentscope-ai/HiClaw/commit/fac0b36))
+
+**Also in this window (docs / repo metadata; not image-facing)**
+
+- chore: archive changelog for v1.1.0 ([593db98](https://github.com/agentscope-ai/HiClaw/commit/593db98))
+- blog: HiClaw v1.1.0 release post ([e1ad0af](https://github.com/agentscope-ai/HiClaw/commit/e1ad0af))
+- Update fallback HICLAW version to v1.1.0 ([f9912b3](https://github.com/agentscope-ai/HiClaw/commit/f9912b3))
+- docs: update README with v1.1.0 news and multi-runtime collaboration ([0da0953](https://github.com/agentscope-ai/HiClaw/commit/0da0953))
+- Update README.md ([bbb7da7](https://github.com/agentscope-ai/HiClaw/commit/bbb7da7))
+- Update README.zh-CN.md ([097276c](https://github.com/agentscope-ai/HiClaw/commit/097276c))
+- Remove customizable agent feature from README ([f7cc95a](https://github.com/agentscope-ai/HiClaw/commit/f7cc95a))
+- docs: rewrite architecture.md for v1.1.0 multi-container architecture ([4e1f667](https://github.com/agentscope-ai/HiClaw/commit/4e1f667))
+- docs: update root AGENTS.md for current layout and runtimes ([0ddc6a4](https://github.com/agentscope-ai/HiClaw/commit/0ddc6a4))
+- docs: correct QwenPaw vs CoPaw naming in FAQ ([730d1fc](https://github.com/agentscope-ai/HiClaw/commit/730d1fc))


### PR DESCRIPTION
## Summary

- Add `changelog/v1.1.1.md` with release notes (EN/ZH + commit index) aligned with prior changelog format.
- Reset `changelog/current.md` for post-release unreleased entries.

## Notes

Prepared for the v1.1.1 release window; tag can be cut after merge per maintainer workflow.

Made with [Cursor](https://cursor.com)