### PR TITLE
fix(openclaw-base): clone OpenClaw from higress-group fork

### DIFF
--- a/openclaw-base/Dockerfile
+++ b/openclaw-base/Dockerfile
@@ -13,7 +13,7 @@
 # Build args:
 #   HIGRESS_REGISTRY  - base image registry (default: cn-hangzhou)
 #   APT_MIRROR        - APT mirror host (default: empty; set to mirrors.aliyun.com for China)
-#   OPENCLAW_REPO_URL - OpenClaw git repository URL (default: https://github.com/johnlanni/openclaw.git)
+#   OPENCLAW_REPO_URL - OpenClaw git repository URL (default: https://github.com/higress-group/openclaw.git)
 # ============================================================
 
 ARG HIGRESS_REGISTRY=higress-registry.cn-hangzhou.cr.aliyuncs.com
@@ -28,7 +28,7 @@ ARG HTTPS_PROXY
 ARG http_proxy
 ARG https_proxy
 ARG NPM_REGISTRY=https://registry.npmjs.org/
-ARG OPENCLAW_REPO_URL=https://github.com/johnlanni/openclaw.git
+ARG OPENCLAW_REPO_URL=https://github.com/higress-group/openclaw.git
 
 # Set proxy as environment variables to ensure all tools can use them
 ENV HTTP_PROXY=${HTTP_PROXY} \


### PR DESCRIPTION
## Problem

GitHub Actions `Build Images` fails on `openclaw-base` when `git clone` runs against `johnlanni/openclaw` (auth / private repo error).

## Change

- Default `OPENCLAW_REPO_URL` to `https://github.com/higress-group/openclaw.git` (public fork).
- Branch `hiclaw-2026.4.14` and pinned commit `2f35b6fa6b65d012e3b0c9f24af3f8a4b617a6e0` are unchanged (`git ls-remote` on higress-group matches this pin).

## Note

No `changelog/current.md` update in this PR (per maintainer request).

Made with [Cursor](https://cursor.com)