### PR TITLE
fix(install): add non-interactive deep-defense guards to step functions

### DIFF
--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -1990,6 +1990,13 @@ function Step-Skills {
 
 function Step-Volume {
     Write-Log (Get-Msg "data.title")
+    # ── Non-interactive guard (deep defense) ──────────────────────────
+    if ($script:HICLAW_NON_INTERACTIVE) {
+        $script:config.DATA_DIR = if ($env:HICLAW_DATA_DIR) { $env:HICLAW_DATA_DIR } else { "hiclaw-data" }
+        Write-Log "  $(Get-Msg 'data.volume_using' -f $script:config.DATA_DIR) (non-interactive, skipped)"
+        return
+    }
+    # ─────────────────────────────────────────────────────────────────
     $dataDirInput = Read-Host (Get-Msg "data.volume_prompt")
     if ($dataDirInput -eq "b") { $script:StepResult = "back"; return }
     $script:config.DATA_DIR = if ($dataDirInput) { $dataDirInput } else { "hiclaw-data" }
@@ -1998,6 +2005,16 @@ function Step-Volume {
 
 function Step-Workspace {
     Write-Log (Get-Msg "workspace.title")
+    # ── Non-interactive guard (deep defense) ──────────────────────────
+    if ($script:HICLAW_NON_INTERACTIVE) {
+        $script:config.WORKSPACE_DIR = if ($env:HICLAW_WORKSPACE_DIR) { $env:HICLAW_WORKSPACE_DIR } else { "$env:USERPROFILE\hiclaw-manager" }
+        if (-not (Test-Path $script:config.WORKSPACE_DIR)) {
+            New-Item -ItemType Directory -Path $script:config.WORKSPACE_DIR -Force | Out-Null
+        }
+        Write-Log "  $(Get-Msg 'workspace.dir_label' -f $script:config.WORKSPACE_DIR) (non-interactive, skipped)"
+        return
+    }
+    # ─────────────────────────────────────────────────────────────────
     $defaultWorkspace = "$env:USERPROFILE\hiclaw-manager"
     $wsInput = Read-Host (Get-Msg "workspace.dir_prompt" -f $defaultWorkspace)
     if ($wsInput -eq "b") { $script:StepResult = "back"; return }
@@ -2078,6 +2095,13 @@ function Step-ManagerRuntime {
 function Step-E2ee {
     Write-Host ""
     Write-Log (Get-Msg "matrix_e2ee.title")
+    # ── Non-interactive guard (deep defense) ──────────────────────────
+    if ($script:HICLAW_NON_INTERACTIVE) {
+        $script:config.MATRIX_E2EE = if ($env:HICLAW_MATRIX_E2EE) { $env:HICLAW_MATRIX_E2EE } else { "0" }
+        Write-Log "  $(Get-Msg 'matrix_e2ee.title_short') = $($script:config.MATRIX_E2EE) (non-interactive, skipped)"
+        return
+    }
+    # ─────────────────────────────────────────────────────────────────
     Write-Host ""
     Write-Host "  $(Get-Msg 'matrix_e2ee.desc')"
     Write-Host ""
@@ -2116,6 +2140,14 @@ function Step-DockerProxy {
         $script:config.DOCKER_PROXY = "0"
         return
     }
+
+    # ── Non-interactive guard (deep defense) ──────────────────────────
+    if ($script:HICLAW_NON_INTERACTIVE) {
+        $script:config.DOCKER_PROXY = if ($env:HICLAW_DOCKER_PROXY) { $env:HICLAW_DOCKER_PROXY } else { "0" }
+        Write-Log "  $(Get-Msg 'docker_proxy.title_short') = $($script:config.DOCKER_PROXY) (non-interactive, skipped)"
+        return
+    }
+    # ─────────────────────────────────────────────────────────────────
 
     Write-Host ""
     Write-Log (Get-Msg "docker_proxy.title")
@@ -2170,6 +2202,13 @@ function Step-DockerProxy {
 }
 
 function Step-Idle {
+    # ── Non-interactive guard (deep defense) ──────────────────────────
+    if ($script:HICLAW_NON_INTERACTIVE) {
+        $script:config.WORKER_IDLE_TIMEOUT = if ($env:HICLAW_WORKER_IDLE_TIMEOUT) { $env:HICLAW_WORKER_IDLE_TIMEOUT } else { "720" }
+        Write-Log "  $(Get-Msg 'idle_timeout.label') = $($script:config.WORKER_IDLE_TIMEOUT) (non-interactive, skipped)"
+        return
+    }
+    # ─────────────────────────────────────────────────────────────────
     if ($script:HICLAW_UPGRADE -and $env:HICLAW_WORKER_IDLE_TIMEOUT) {
         Write-Log (Get-Msg "prompt.upgrade_keep" -f (Get-Msg "idle_timeout.label"), $env:HICLAW_WORKER_IDLE_TIMEOUT)
         $idleInput = Read-Host (Get-Msg "idle_timeout.prompt")
@@ -2187,6 +2226,13 @@ function Step-Idle {
 }
 
 function Step-Hostshare {
+    # ── Non-interactive guard (deep defense) ──────────────────────────
+    if ($script:HICLAW_NON_INTERACTIVE) {
+        $script:config.HOST_SHARE_DIR = if ($env:HICLAW_HOST_SHARE_DIR) { $env:HICLAW_HOST_SHARE_DIR } else { $env:USERPROFILE }
+        Write-Log "  $(Get-Msg 'host_share.label') = $($script:config.HOST_SHARE_DIR) (non-interactive, skipped)"
+        return
+    }
+    # ─────────────────────────────────────────────────────────────────
     $shareInput = Read-Host (Get-Msg "host_share.prompt" -f $env:USERPROFILE)
     if ($shareInput -eq "b") { $script:StepResult = "back"; return }
     $script:config.HOST_SHARE_DIR = if ($shareInput) { $shareInput } else { $env:USERPROFILE }

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -2078,6 +2078,14 @@ step_skills() {
 
 step_volume() {
     log "$(msg data.title)"
+    # ── Non-interactive guard (deep defense) ──────────────────────────
+    if [ "${HICLAW_NON_INTERACTIVE}" = "1" ]; then
+        HICLAW_DATA_DIR="${HICLAW_DATA_DIR:-hiclaw-data}"
+        log "  $(msg data.volume_using "${HICLAW_DATA_DIR}") (non-interactive, skipped)"
+        export HICLAW_DATA_DIR
+        return 0
+    fi
+    # ─────────────────────────────────────────────────────────────────
     if [ -z "${HICLAW_DATA_DIR+x}" ]; then
         local _input
         read -e -p "$(msg data.volume_prompt): " _input
@@ -2091,6 +2099,16 @@ step_volume() {
 
 step_workspace() {
     log "$(msg workspace.title)"
+    # ── Non-interactive guard (deep defense) ──────────────────────────
+    if [ "${HICLAW_NON_INTERACTIVE}" = "1" ]; then
+        HICLAW_WORKSPACE_DIR="${HICLAW_WORKSPACE_DIR:-${HOME}/hiclaw-manager}"
+        HICLAW_WORKSPACE_DIR="$(cd "${HICLAW_WORKSPACE_DIR}" 2>/dev/null && pwd || echo "${HICLAW_WORKSPACE_DIR}")"
+        mkdir -p "${HICLAW_WORKSPACE_DIR}"
+        log "  $(msg workspace.dir_label "${HICLAW_WORKSPACE_DIR}") (non-interactive, skipped)"
+        export HICLAW_WORKSPACE_DIR
+        return 0
+    fi
+    # ─────────────────────────────────────────────────────────────────
     if [ -z "${HICLAW_WORKSPACE_DIR+x}" ]; then
         local _input
         read -e -p "$(msg workspace.dir_prompt "${HOME}/hiclaw-manager"): " _input
@@ -2185,6 +2203,14 @@ step_manager_runtime() {
 step_e2ee() {
     log ""
     log "$(msg matrix_e2ee.title)"
+    # ── Non-interactive guard (deep defense) ──────────────────────────
+    if [ "${HICLAW_NON_INTERACTIVE}" = "1" ]; then
+        HICLAW_MATRIX_E2EE="${HICLAW_MATRIX_E2EE:-0}"
+        log "  $(msg matrix_e2ee.title_short) = ${HICLAW_MATRIX_E2EE} (non-interactive, skipped)"
+        export HICLAW_MATRIX_E2EE
+        return 0
+    fi
+    # ─────────────────────────────────────────────────────────────────
     echo ""
     echo -e "  $(msg matrix_e2ee.desc)"
     echo ""
@@ -2228,6 +2254,15 @@ step_docker_proxy() {
         HICLAW_DOCKER_PROXY="0"
         return 0
     fi
+
+    # ── Non-interactive guard (deep defense) ──────────────────────────
+    if [ "${HICLAW_NON_INTERACTIVE}" = "1" ]; then
+        HICLAW_DOCKER_PROXY="${HICLAW_DOCKER_PROXY:-0}"
+        log "  $(msg docker_proxy.title_short) = ${HICLAW_DOCKER_PROXY} (non-interactive, skipped)"
+        export HICLAW_DOCKER_PROXY
+        return 0
+    fi
+    # ─────────────────────────────────────────────────────────────────
 
     echo ""
     echo -e "  \033[1m$(msg docker_proxy.title)\033[0m"
@@ -2288,6 +2323,14 @@ step_docker_proxy() {
 }
 
 step_idle() {
+    # ── Non-interactive guard (deep defense) ──────────────────────────
+    if [ "${HICLAW_NON_INTERACTIVE}" = "1" ]; then
+        HICLAW_WORKER_IDLE_TIMEOUT="${HICLAW_WORKER_IDLE_TIMEOUT:-720}"
+        log "  $(msg idle_timeout.label) = ${HICLAW_WORKER_IDLE_TIMEOUT} (non-interactive, skipped)"
+        export HICLAW_WORKER_IDLE_TIMEOUT
+        return 0
+    fi
+    # ─────────────────────────────────────────────────────────────────
     if [ "${HICLAW_UPGRADE}" = "1" ] && [ -n "${HICLAW_WORKER_IDLE_TIMEOUT}" ]; then
         log "$(msg prompt.upgrade_keep "$(msg idle_timeout.label)" "${HICLAW_WORKER_IDLE_TIMEOUT}")"
         local _idle_timeout
@@ -2306,6 +2349,14 @@ step_idle() {
 }
 
 step_hostshare() {
+    # ── Non-interactive guard (deep defense) ──────────────────────────
+    if [ "${HICLAW_NON_INTERACTIVE}" = "1" ]; then
+        HICLAW_HOST_SHARE_DIR="${HICLAW_HOST_SHARE_DIR:-${HOME}}"
+        log "  $(msg host_share.label) = ${HICLAW_HOST_SHARE_DIR} (non-interactive, skipped)"
+        export HICLAW_HOST_SHARE_DIR
+        return 0
+    fi
+    # ─────────────────────────────────────────────────────────────────
     local _share_dir
     read -e -p "$(msg host_share.prompt "$HOME"): " _share_dir
     if [ "${_share_dir}" = "b" ]; then STEP_RESULT="back"; return 0; fi


### PR DESCRIPTION
Make sure non-interactive installation can work properly without user intervention or reading input from stdin.