### PR TITLE
fix(install): update GitHub repo URL to agentscope-ai/HiClaw and bump stable fallback to v1.1.1

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -12,7 +12,7 @@ One-click installation script for HiClaw Manager and Worker Agents.
 ### macOS / Linux
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/higress-group/hiclaw/main/install/hiclaw-install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/agentscope-ai/HiClaw/main/install/hiclaw-install.sh)
 ```
 
 ### Windows (PowerShell 7+)

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -50,7 +50,7 @@
 set -e
 
 HICLAW_VERSION="${HICLAW_VERSION:-}"
-HICLAW_KNOWN_STABLE_VERSION="v1.1.0"   # fallback if GitHub API is unreachable
+HICLAW_KNOWN_STABLE_VERSION="v1.1.1"   # fallback if GitHub API is unreachable
 
 # Returns 0 (true) if $1 < $2 using semver order; "latest" is treated as greatest
 _ver_lt() {
@@ -1584,7 +1584,7 @@ step_version() {
     local _fetched
     _fetched=$(curl -sf --max-time 5 \
         -H "Accept: application/vnd.github+json" \
-        "https://api.github.com/repos/alibaba/hiclaw/releases/latest" \
+        "https://api.github.com/repos/agentscope-ai/HiClaw/releases/latest" \
         2>/dev/null | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
     if [ -n "${_fetched}" ]; then
         HICLAW_KNOWN_STABLE_VERSION="${_fetched}"


### PR DESCRIPTION
## Summary

- Fix GitHub API URL in version query: `alibaba/hiclaw` → `agentscope-ai/HiClaw` (line 1587 of `install/hiclaw-install.sh`)
- Bump hardcoded fallback stable version: `v1.1.0` → `v1.1.1` (line 53)
- Update install README download URL: `higress-group/hiclaw` → `agentscope-ai/HiClaw`

## Problem

Users running the install script were seeing:
```
无法查询 GitHub，使用内置版本 v1.1.0
```
because the GitHub API was querying the old `alibaba/hiclaw` repo which no longer has releases.

## Test plan

- [x] Manually verified `curl https://api.github.com/repos/agentscope-ai/HiClaw/releases/latest` returns `v1.1.1`
- [x] Version query in script now correctly returns `v1.1.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)