### PR TITLE
feat(install): swap runtime selection order to make QwenPaw the default

### DIFF
--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -799,7 +799,7 @@ function Wait-ManagerReady {
     $elapsed = 0
     Write-Log (Get-Msg "install.wait_ready" -f $Timeout)
 
-    $runtime = if ($script:config.MANAGER_RUNTIME) { $script:config.MANAGER_RUNTIME } else { "openclaw" }
+    $runtime = if ($script:config.MANAGER_RUNTIME) { $script:config.MANAGER_RUNTIME } else { "copaw" }
 
     while ($elapsed -lt $Timeout) {
         try {
@@ -2028,22 +2028,22 @@ function Step-Workspace {
 function Step-Runtime {
     Write-Log (Get-Msg "worker_runtime.title")
     Write-Host ""
-    Write-Host "  1) $(Get-Msg 'worker_runtime.openclaw')"
-    Write-Host "  2) $(Get-Msg 'worker_runtime.copaw')"
+    Write-Host "  1) $(Get-Msg 'worker_runtime.copaw')"
+    Write-Host "  2) $(Get-Msg 'worker_runtime.openclaw')"
     Write-Host "  3) $(Get-Msg 'worker_runtime.hermes')"
     Write-Host ""
 
     if ($script:HICLAW_NON_INTERACTIVE) {
-        $script:config.DEFAULT_WORKER_RUNTIME = if ($env:HICLAW_DEFAULT_WORKER_RUNTIME) { $env:HICLAW_DEFAULT_WORKER_RUNTIME } else { "openclaw" }
+        $script:config.DEFAULT_WORKER_RUNTIME = if ($env:HICLAW_DEFAULT_WORKER_RUNTIME) { $env:HICLAW_DEFAULT_WORKER_RUNTIME } else { "copaw" }
     } elseif ($script:HICLAW_UPGRADE -and $env:HICLAW_DEFAULT_WORKER_RUNTIME) {
         Write-Log (Get-Msg "prompt.upgrade_keep" -f (Get-Msg "worker_runtime.title_short"), $env:HICLAW_DEFAULT_WORKER_RUNTIME)
         $rtChoice = Read-Host (Get-Msg "worker_runtime.choice")
         if ($rtChoice -eq "b") { $script:StepResult = "back"; return }
         if ($rtChoice) {
             $script:config.DEFAULT_WORKER_RUNTIME = switch ($rtChoice) {
-                "2" { "copaw" }
+                "2" { "openclaw" }
                 "3" { "hermes" }
-                default { "openclaw" }
+                default { "copaw" }
             }
         } else {
             $script:config.DEFAULT_WORKER_RUNTIME = $env:HICLAW_DEFAULT_WORKER_RUNTIME
@@ -2055,9 +2055,9 @@ function Step-Runtime {
         if ($rtChoice -eq "b") { $script:StepResult = "back"; return }
         $rtChoice = if ($rtChoice) { $rtChoice } else { "1" }
         $script:config.DEFAULT_WORKER_RUNTIME = switch ($rtChoice) {
-            "2" { "copaw" }
+            "2" { "openclaw" }
             "3" { "hermes" }
-            default { "openclaw" }
+            default { "copaw" }
         }
     }
     Write-Log (Get-Msg "worker_runtime.selected" -f $script:config.DEFAULT_WORKER_RUNTIME)
@@ -2066,18 +2066,18 @@ function Step-Runtime {
 function Step-ManagerRuntime {
     Write-Log (Get-Msg "manager_runtime.title")
     Write-Host ""
-    Write-Host "  1) $(Get-Msg 'manager_runtime.openclaw')"
-    Write-Host "  2) $(Get-Msg 'manager_runtime.copaw')"
+    Write-Host "  1) $(Get-Msg 'manager_runtime.copaw')"
+    Write-Host "  2) $(Get-Msg 'manager_runtime.openclaw')"
     Write-Host ""
 
     if ($script:HICLAW_NON_INTERACTIVE) {
-        $script:config.MANAGER_RUNTIME = if ($env:HICLAW_MANAGER_RUNTIME) { $env:HICLAW_MANAGER_RUNTIME } else { "openclaw" }
+        $script:config.MANAGER_RUNTIME = if ($env:HICLAW_MANAGER_RUNTIME) { $env:HICLAW_MANAGER_RUNTIME } else { "copaw" }
     } elseif ($script:HICLAW_UPGRADE -and $env:HICLAW_MANAGER_RUNTIME) {
         Write-Log (Get-Msg "prompt.upgrade_keep" -f (Get-Msg "manager_runtime.title_short"), $env:HICLAW_MANAGER_RUNTIME)
         $mrChoice = Read-Host (Get-Msg "manager_runtime.choice")
         if ($mrChoice -eq "b") { $script:StepResult = "back"; return }
         if ($mrChoice) {
-            $script:config.MANAGER_RUNTIME = if ($mrChoice -eq "2") { "copaw" } else { "openclaw" }
+            $script:config.MANAGER_RUNTIME = if ($mrChoice -eq "2") { "openclaw" } else { "copaw" }
         } else {
             $script:config.MANAGER_RUNTIME = $env:HICLAW_MANAGER_RUNTIME
         }
@@ -2087,7 +2087,7 @@ function Step-ManagerRuntime {
         $mrChoice = Read-Host (Get-Msg "manager_runtime.choice")
         if ($mrChoice -eq "b") { $script:StepResult = "back"; return }
         $mrChoice = if ($mrChoice) { $mrChoice } else { "1" }
-        $script:config.MANAGER_RUNTIME = if ($mrChoice -eq "2") { "copaw" } else { "openclaw" }
+        $script:config.MANAGER_RUNTIME = if ($mrChoice -eq "2") { "openclaw" } else { "copaw" }
     }
     Write-Log (Get-Msg "manager_runtime.selected" -f $script:config.MANAGER_RUNTIME)
 }
@@ -2392,9 +2392,9 @@ function Install-Manager {
     }
 
     # ── State machine ─────────────────────────────────────────────────────────
-    $_steps = @("Step-Lang", "Step-Mode", "Step-Existing", "Step-Llm", "Step-Admin",
+    $_steps = @("Step-Lang", "Step-Mode", "Step-Existing", "Step-Llm", "Step-ManagerRuntime", "Step-Runtime", "Step-Admin",
                 "Step-Network", "Step-Ports", "Step-Domains", "Step-Github", "Step-Skills",
-                "Step-Volume", "Step-Workspace", "Step-ManagerRuntime", "Step-Runtime", "Step-E2ee", "Step-DockerProxy", "Step-Idle",
+                "Step-Volume", "Step-Workspace", "Step-E2ee", "Step-DockerProxy", "Step-Idle",
                 "Step-Hostshare")
     $_stepHistory = [System.Collections.Generic.List[int]]::new()
     $_stepIdx = 0
@@ -2437,7 +2437,7 @@ function Install-Manager {
         Write-Log (Get-Msg "workspace.dir_label" -f $script:config.WORKSPACE_DIR)
     }
     if (-not $script:config.DEFAULT_WORKER_RUNTIME) {
-        $script:config.DEFAULT_WORKER_RUNTIME = if ($env:HICLAW_DEFAULT_WORKER_RUNTIME) { $env:HICLAW_DEFAULT_WORKER_RUNTIME } else { "openclaw" }
+        $script:config.DEFAULT_WORKER_RUNTIME = if ($env:HICLAW_DEFAULT_WORKER_RUNTIME) { $env:HICLAW_DEFAULT_WORKER_RUNTIME } else { "copaw" }
         Write-Log (Get-Msg "worker_runtime.selected" -f $script:config.DEFAULT_WORKER_RUNTIME)
     }
     if (-not $script:config.MATRIX_E2EE) {
@@ -2453,7 +2453,7 @@ function Install-Manager {
         $script:config.LOCAL_ONLY = if ($env:HICLAW_LOCAL_ONLY) { $env:HICLAW_LOCAL_ONLY } else { "1" }
     }
     if (-not $script:config.MANAGER_RUNTIME) {
-        $script:config.MANAGER_RUNTIME = if ($env:HICLAW_MANAGER_RUNTIME) { $env:HICLAW_MANAGER_RUNTIME } else { "openclaw" }
+        $script:config.MANAGER_RUNTIME = if ($env:HICLAW_MANAGER_RUNTIME) { $env:HICLAW_MANAGER_RUNTIME } else { "copaw" }
     }
     if (-not $script:config.PORT_GATEWAY) {
         $script:config.PORT_GATEWAY = if ($env:HICLAW_PORT_GATEWAY) { $env:HICLAW_PORT_GATEWAY } else { "18080" }

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -1121,7 +1121,7 @@ wait_manager_ready() {
     log "$(msg install.wait_ready "${timeout}")"
 
     # Wait for Manager agent to be healthy inside the container
-    local runtime="${HICLAW_MANAGER_RUNTIME:-openclaw}"
+    local runtime="${HICLAW_MANAGER_RUNTIME:-copaw}"
     while [ "${elapsed}" -lt "${timeout}" ]; do
         case "${runtime}" in
             copaw)
@@ -2124,14 +2124,14 @@ step_workspace() {
 step_runtime() {
     log "$(msg worker_runtime.title)"
     echo ""
-    echo "  1) $(msg worker_runtime.openclaw)"
-    echo "  2) $(msg worker_runtime.copaw)"
+    echo "  1) $(msg worker_runtime.copaw)"
+    echo "  2) $(msg worker_runtime.openclaw)"
     if ! _ver_lt "${HICLAW_VERSION}" "v1.1.0"; then
         echo "  3) $(msg worker_runtime.hermes)"
     fi
     echo ""
     if [ "${HICLAW_NON_INTERACTIVE}" = "1" ]; then
-        HICLAW_DEFAULT_WORKER_RUNTIME="${HICLAW_DEFAULT_WORKER_RUNTIME:-openclaw}"
+        HICLAW_DEFAULT_WORKER_RUNTIME="${HICLAW_DEFAULT_WORKER_RUNTIME:-copaw}"
     elif [ "${HICLAW_UPGRADE}" = "1" ] && [ -n "${HICLAW_DEFAULT_WORKER_RUNTIME}" ]; then
         log "$(msg prompt.upgrade_keep "$(msg worker_runtime.title_short)" "${HICLAW_DEFAULT_WORKER_RUNTIME}")"
         local _runtime_choice
@@ -2139,13 +2139,13 @@ step_runtime() {
         if [ "${_runtime_choice}" = "b" ]; then STEP_RESULT="back"; return 0; fi
         if [ -n "${_runtime_choice}" ]; then
             case "${_runtime_choice}" in
-                2) HICLAW_DEFAULT_WORKER_RUNTIME="copaw" ;;
+                2) HICLAW_DEFAULT_WORKER_RUNTIME="openclaw" ;;
                 3) if ! _ver_lt "${HICLAW_VERSION}" "v1.1.0"; then
                        HICLAW_DEFAULT_WORKER_RUNTIME="hermes"
                    else
-                       HICLAW_DEFAULT_WORKER_RUNTIME="openclaw"
+                       HICLAW_DEFAULT_WORKER_RUNTIME="copaw"
                    fi ;;
-                *) HICLAW_DEFAULT_WORKER_RUNTIME="openclaw" ;;
+                *) HICLAW_DEFAULT_WORKER_RUNTIME="copaw" ;;
             esac
         fi
     elif [ -z "${HICLAW_DEFAULT_WORKER_RUNTIME+x}" ]; then
@@ -2154,13 +2154,13 @@ step_runtime() {
         if [ "${_runtime_choice}" = "b" ]; then STEP_RESULT="back"; return 0; fi
         _runtime_choice="${_runtime_choice:-1}"
         case "${_runtime_choice}" in
-            2) HICLAW_DEFAULT_WORKER_RUNTIME="copaw" ;;
+            2) HICLAW_DEFAULT_WORKER_RUNTIME="openclaw" ;;
             3) if ! _ver_lt "${HICLAW_VERSION}" "v1.1.0"; then
                    HICLAW_DEFAULT_WORKER_RUNTIME="hermes"
                else
-                   HICLAW_DEFAULT_WORKER_RUNTIME="openclaw"
+                   HICLAW_DEFAULT_WORKER_RUNTIME="copaw"
                fi ;;
-            *) HICLAW_DEFAULT_WORKER_RUNTIME="openclaw" ;;
+            *) HICLAW_DEFAULT_WORKER_RUNTIME="copaw" ;;
         esac
     fi
     export HICLAW_DEFAULT_WORKER_RUNTIME
@@ -2170,11 +2170,11 @@ step_runtime() {
 step_manager_runtime() {
     log "$(msg manager_runtime.title)"
     echo ""
-    echo "  1) $(msg manager_runtime.openclaw)"
-    echo "  2) $(msg manager_runtime.copaw)"
+    echo "  1) $(msg manager_runtime.copaw)"
+    echo "  2) $(msg manager_runtime.openclaw)"
     echo ""
     if [ "${HICLAW_NON_INTERACTIVE}" = "1" ]; then
-        HICLAW_MANAGER_RUNTIME="${HICLAW_MANAGER_RUNTIME:-openclaw}"
+        HICLAW_MANAGER_RUNTIME="${HICLAW_MANAGER_RUNTIME:-copaw}"
     elif [ "${HICLAW_UPGRADE}" = "1" ] && [ -n "${HICLAW_MANAGER_RUNTIME}" ]; then
         log "$(msg prompt.upgrade_keep "$(msg manager_runtime.title_short)" "${HICLAW_MANAGER_RUNTIME}")"
         local _runtime_choice
@@ -2182,8 +2182,8 @@ step_manager_runtime() {
         if [ "${_runtime_choice}" = "b" ]; then STEP_RESULT="back"; return 0; fi
         if [ -n "${_runtime_choice}" ]; then
             case "${_runtime_choice}" in
-                2) HICLAW_MANAGER_RUNTIME="copaw" ;;
-                *) HICLAW_MANAGER_RUNTIME="openclaw" ;;
+                2) HICLAW_MANAGER_RUNTIME="openclaw" ;;
+                *) HICLAW_MANAGER_RUNTIME="copaw" ;;
             esac
         fi
     elif [ -z "${HICLAW_MANAGER_RUNTIME+x}" ]; then
@@ -2192,8 +2192,8 @@ step_manager_runtime() {
         if [ "${_runtime_choice}" = "b" ]; then STEP_RESULT="back"; return 0; fi
         _runtime_choice="${_runtime_choice:-1}"
         case "${_runtime_choice}" in
-            2) HICLAW_MANAGER_RUNTIME="copaw" ;;
-            *) HICLAW_MANAGER_RUNTIME="openclaw" ;;
+            2) HICLAW_MANAGER_RUNTIME="openclaw" ;;
+            *) HICLAW_MANAGER_RUNTIME="copaw" ;;
         esac
     fi
     export HICLAW_MANAGER_RUNTIME
@@ -2439,9 +2439,9 @@ install_manager() {
     fi
 
     # ── State machine ─────────────────────────────────────────────────────────
-    local _STEPS=( step_lang step_mode step_version step_existing step_llm step_admin step_network \
-                   step_ports step_domains step_github step_skills step_volume \
-                   step_workspace step_manager_runtime step_runtime step_e2ee step_docker_proxy step_idle step_hostshare )
+    local _STEPS=( step_lang step_mode step_version step_existing step_llm step_manager_runtime step_runtime step_admin step_network 
+                   step_ports step_domains step_github step_skills step_volume 
+                   step_workspace step_e2ee step_docker_proxy step_idle step_hostshare )
     local _STEP_HISTORY=()
     local _step_idx=0
     while [ "${_step_idx}" -lt "${#_STEPS[@]}" ]; do
@@ -2478,9 +2478,9 @@ install_manager() {
     fi
     HICLAW_WORKSPACE_DIR="$(cd "${HICLAW_WORKSPACE_DIR}" 2>/dev/null && pwd || echo "${HICLAW_WORKSPACE_DIR}")"
     mkdir -p "${HICLAW_WORKSPACE_DIR}"
-    HICLAW_MANAGER_RUNTIME="${HICLAW_MANAGER_RUNTIME:-openclaw}"
+    HICLAW_MANAGER_RUNTIME="${HICLAW_MANAGER_RUNTIME:-copaw}"
     export HICLAW_MANAGER_RUNTIME
-    HICLAW_DEFAULT_WORKER_RUNTIME="${HICLAW_DEFAULT_WORKER_RUNTIME:-openclaw}"
+    HICLAW_DEFAULT_WORKER_RUNTIME="${HICLAW_DEFAULT_WORKER_RUNTIME:-copaw}"
     HICLAW_MATRIX_E2EE="${HICLAW_MATRIX_E2EE:-0}"
     export HICLAW_MATRIX_E2EE
     HICLAW_WORKER_IDLE_TIMEOUT="${HICLAW_WORKER_IDLE_TIMEOUT:-720}"
@@ -2539,7 +2539,7 @@ HICLAW_PORT_ELEMENT_WEB=${HICLAW_PORT_ELEMENT_WEB}
 HICLAW_PORT_MANAGER_CONSOLE=${HICLAW_PORT_MANAGER_CONSOLE:-18888}
 
 # Manager runtime (openclaw | copaw)
-HICLAW_MANAGER_RUNTIME=${HICLAW_MANAGER_RUNTIME:-openclaw}
+HICLAW_MANAGER_RUNTIME=${HICLAW_MANAGER_RUNTIME:-copaw}
 
 # Matrix
 HICLAW_MATRIX_DOMAIN=${HICLAW_MATRIX_DOMAIN}
@@ -2586,7 +2586,7 @@ HICLAW_COPAW_WORKER_IMAGE=${COPAW_WORKER_IMAGE}
 HICLAW_HERMES_WORKER_IMAGE=${HERMES_WORKER_IMAGE}
 
 # Default Worker runtime (openclaw | copaw | hermes)
-HICLAW_DEFAULT_WORKER_RUNTIME=${HICLAW_DEFAULT_WORKER_RUNTIME:-openclaw}
+HICLAW_DEFAULT_WORKER_RUNTIME=${HICLAW_DEFAULT_WORKER_RUNTIME:-copaw}
 
 # Matrix E2EE (0=disabled, 1=enabled; default: 0)
 HICLAW_MATRIX_E2EE=${HICLAW_MATRIX_E2EE:-0}
@@ -2941,9 +2941,9 @@ CREDEOF
             -e "HICLAW_LLM_API_KEY=${HICLAW_LLM_API_KEY}"
             -e "HICLAW_DEFAULT_MODEL=${HICLAW_DEFAULT_MODEL}"
             -e "HICLAW_MANAGER_GATEWAY_KEY=${HICLAW_MANAGER_GATEWAY_KEY}"
-            -e "HICLAW_MANAGER_RUNTIME=${HICLAW_MANAGER_RUNTIME:-openclaw}"
+            -e "HICLAW_MANAGER_RUNTIME=${HICLAW_MANAGER_RUNTIME:-copaw}"
             -e "HICLAW_MANAGER_IMAGE=$([ "${HICLAW_MANAGER_RUNTIME}" = "copaw" ] && echo "${MANAGER_COPAW_IMAGE}" || echo "${MANAGER_IMAGE}")"
-            -e "HICLAW_DEFAULT_WORKER_RUNTIME=${HICLAW_DEFAULT_WORKER_RUNTIME:-openclaw}"
+            -e "HICLAW_DEFAULT_WORKER_RUNTIME=${HICLAW_DEFAULT_WORKER_RUNTIME:-copaw}"
             -e "HICLAW_WORKER_IMAGE=${WORKER_IMAGE}"
             -e "HICLAW_COPAW_WORKER_IMAGE=${COPAW_WORKER_IMAGE}"
             -e "HICLAW_HERMES_WORKER_IMAGE=${HERMES_WORKER_IMAGE}"
@@ -3196,7 +3196,7 @@ CREDEOF
             -e HOME=/root/manager-workspace \
             -w /root/manager-workspace \
             -e HOST_ORIGINAL_HOME="${HICLAW_HOST_SHARE_DIR}" \
-            -e HICLAW_MANAGER_RUNTIME="${HICLAW_MANAGER_RUNTIME:-openclaw}" \
+            -e HICLAW_MANAGER_RUNTIME="${HICLAW_MANAGER_RUNTIME:-copaw}" \
             ${JVM_ARGS:+-e JVM_ARGS="${JVM_ARGS}"} \
             ${YOLO_ARGS} \
             ${MATRIX_DEBUG_ARGS} \


### PR DESCRIPTION
## 修改内容

将安装脚本中 Manager 和 Worker 运行时选择的默认选项从 OpenClaw 改为 QwenPaw。

### 具体变更

1. **交换 Manager 运行时选项顺序**：1) QwenPaw（默认） 2) OpenClaw
2. **交换 Worker 运行时选项顺序**：1) QwenPaw（默认） 2) OpenClaw 3) Hermes
3. **提前运行时选择步骤**：将 Manager/Worker 运行时选择移到「管理员凭据」步骤之前，让用户更早做出运行时决策
4. **同步修改 bash 和 PowerShell 脚本**：保持两个安装脚本行为一致

### 影响范围

- `install/hiclaw-install.sh`
- `install/hiclaw-install.ps1`

内部值（openclaw/copaw/hermes）未改变，仅调整了选项顺序和默认值映射。