### PR TITLE
fix(helm): clean up Manager/Worker pods on helm uninstall (#779)

### DIFF
--- a/helm/hiclaw/templates/NOTES.txt
+++ b/helm/hiclaw/templates/NOTES.txt
@@ -26,7 +26,7 @@ Uninstalling
 ========================================================================
 
 By default this chart installs a pre-delete Helm hook
-(Job: {{ include "hiclaw.fullname" . }}-uninstall-cleanup) that deletes
+(Job: {{ printf "%s-uninstall-cleanup" (include "hiclaw.fullname" .) | trunc 63 | trimSuffix "-" }}) that deletes
 all Manager / Worker / Team / Human CRs first and waits for the
 controller to process their finalizers (cleaning up Pods, Matrix users,
 OSS data) before Helm removes the controller and the rest of the chart.
@@ -35,9 +35,12 @@ Normal uninstall:
   helm uninstall {{ .Release.Name }} -n {{ include "hiclaw.namespace" . }}
 
 If you pass --no-hooks (or set controller.uninstallHook.enabled=false),
-delete the CRs manually first, then uninstall the chart:
-  kubectl delete managers.hiclaw.io,workers.hiclaw.io,\
-    teams.hiclaw.io,humans.hiclaw.io --all -n {{ include "hiclaw.namespace" . }} --wait=true
+delete the CRs manually first (Manager FIRST — it owns the admin DM
+room — then the rest), then uninstall the chart:
+  kubectl delete managers.hiclaw.io --all -n {{ include "hiclaw.namespace" . }} --wait=true --ignore-not-found
+  kubectl delete workers.hiclaw.io  --all -n {{ include "hiclaw.namespace" . }} --wait=true --ignore-not-found
+  kubectl delete teams.hiclaw.io    --all -n {{ include "hiclaw.namespace" . }} --wait=true --ignore-not-found
+  kubectl delete humans.hiclaw.io   --all -n {{ include "hiclaw.namespace" . }} --wait=true --ignore-not-found
   helm uninstall {{ .Release.Name }} -n {{ include "hiclaw.namespace" . }}
 
 If the controller is already gone / the hook times out and CRs are

--- a/helm/hiclaw/templates/NOTES.txt
+++ b/helm/hiclaw/templates/NOTES.txt
@@ -20,3 +20,34 @@ Namespace: {{ include "hiclaw.namespace" . }}
    kubectl port-forward svc/higress-console 18081:8080 -n {{ include "hiclaw.namespace" . }}
 
    Then open: http://localhost:18081, same Username and Password as step 2
+
+========================================================================
+Uninstalling
+========================================================================
+
+By default this chart installs a pre-delete Helm hook
+(Job: {{ include "hiclaw.fullname" . }}-uninstall-cleanup) that deletes
+all Manager / Worker / Team / Human CRs first and waits for the
+controller to process their finalizers (cleaning up Pods, Matrix users,
+OSS data) before Helm removes the controller and the rest of the chart.
+
+Normal uninstall:
+  helm uninstall {{ .Release.Name }} -n {{ include "hiclaw.namespace" . }}
+
+If you pass --no-hooks (or set controller.uninstallHook.enabled=false),
+delete the CRs manually first, then uninstall the chart:
+  kubectl delete managers.hiclaw.io,workers.hiclaw.io,\
+    teams.hiclaw.io,humans.hiclaw.io --all -n {{ include "hiclaw.namespace" . }} --wait=true
+  helm uninstall {{ .Release.Name }} -n {{ include "hiclaw.namespace" . }}
+
+If the controller is already gone / the hook times out and CRs are
+stuck in Terminating, force-clear the finalizer:
+  kubectl patch managers.hiclaw.io <name> -n {{ include "hiclaw.namespace" . }} \
+    --type=merge -p '{"metadata":{"finalizers":[]}}'
+  (workers / teams / humans use the same command)
+
+Note: CRDs live under helm/hiclaw/crds/ and are NOT removed by
+helm uninstall (so a reinstall keeps existing CR definitions valid).
+To remove them as well:
+  kubectl delete crd managers.hiclaw.io workers.hiclaw.io \
+    teams.hiclaw.io humans.hiclaw.io

--- a/helm/hiclaw/templates/controller/uninstall-hook.yaml
+++ b/helm/hiclaw/templates/controller/uninstall-hook.yaml
@@ -1,8 +1,9 @@
 {{- if .Values.controller.uninstallHook.enabled }}
 {{- $name := printf "%s-uninstall-cleanup" (include "hiclaw.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- $ns := include "hiclaw.namespace" . }}
-{{- $tag := default "1.30" .Values.controller.uninstallHook.image.tag }}
-{{- $hookImage := printf "%s:%s" .Values.controller.uninstallHook.image.repository $tag }}
+{{- $ctrlTag := default .Values.global.imageTag .Values.controller.image.tag | default .Chart.AppVersion }}
+{{- $hookImage := printf "%s:%s" .Values.controller.image.repository $ctrlTag }}
+{{- $hookPullPolicy := default "IfNotPresent" .Values.controller.image.pullPolicy }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -79,7 +80,7 @@ spec:
       containers:
         - name: cleanup
           image: {{ $hookImage | quote }}
-          imagePullPolicy: {{ .Values.controller.uninstallHook.image.pullPolicy | default "IfNotPresent" }}
+          imagePullPolicy: {{ $hookPullPolicy }}
           env:
             - name: NS
               value: {{ $ns | quote }}

--- a/helm/hiclaw/templates/controller/uninstall-hook.yaml
+++ b/helm/hiclaw/templates/controller/uninstall-hook.yaml
@@ -1,0 +1,107 @@
+{{- if .Values.controller.uninstallHook.enabled }}
+{{- $name := printf "%s-uninstall-cleanup" (include "hiclaw.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- $ns := include "hiclaw.namespace" . }}
+{{- $hookImage := printf "%s:%s" .Values.controller.uninstallHook.image.repository .Values.controller.uninstallHook.image.tag }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "hiclaw.component.labels" (dict "root" . "component" "uninstall-hook") | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "hiclaw.component.labels" (dict "root" . "component" "uninstall-hook") | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["hiclaw.io"]
+    resources: ["managers", "workers", "teams", "humans"]
+    verbs: ["get", "list", "watch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "hiclaw.component.labels" (dict "root" . "component" "uninstall-hook") | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+    namespace: {{ $ns }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "hiclaw.component.labels" (dict "root" . "component" "uninstall-hook") | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.controller.uninstallHook.backoffLimit | default 1 }}
+  activeDeadlineSeconds: {{ .Values.controller.uninstallHook.activeDeadlineSeconds | default 1500 }}
+  template:
+    metadata:
+      labels:
+        {{- include "hiclaw.component.selectorLabels" (dict "root" . "component" "uninstall-hook") | nindent 8 }}
+    spec:
+      serviceAccountName: {{ $name }}
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: cleanup
+          image: {{ $hookImage | quote }}
+          imagePullPolicy: {{ .Values.controller.uninstallHook.image.pullPolicy | default "IfNotPresent" }}
+          env:
+            - name: NS
+              value: {{ $ns | quote }}
+            - name: TIMEOUT
+              value: {{ printf "%ds" (int .Values.controller.uninstallHook.timeoutSeconds) | quote }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              echo "[hiclaw-uninstall-cleanup] deleting CRs in namespace ${NS} (timeout per group: ${TIMEOUT})"
+              # Order: Manager first (it owns the admin DM room), then the
+              # rest. --ignore-not-found makes reruns idempotent. --wait=true
+              # blocks until each finalizer is processed by the controller,
+              # which is why this Job MUST run before the controller is
+              # deleted by the rest of the helm uninstall.
+              kubectl delete managers.hiclaw.io --all -n "${NS}" --wait=true --timeout="${TIMEOUT}" --ignore-not-found
+              kubectl delete workers.hiclaw.io  --all -n "${NS}" --wait=true --timeout="${TIMEOUT}" --ignore-not-found
+              kubectl delete teams.hiclaw.io    --all -n "${NS}" --wait=true --timeout="${TIMEOUT}" --ignore-not-found
+              kubectl delete humans.hiclaw.io   --all -n "${NS}" --wait=true --timeout="${TIMEOUT}" --ignore-not-found
+              echo "[hiclaw-uninstall-cleanup] done"
+          {{- with .Values.controller.uninstallHook.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/helm/hiclaw/templates/controller/uninstall-hook.yaml
+++ b/helm/hiclaw/templates/controller/uninstall-hook.yaml
@@ -1,7 +1,8 @@
 {{- if .Values.controller.uninstallHook.enabled }}
 {{- $name := printf "%s-uninstall-cleanup" (include "hiclaw.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- $ns := include "hiclaw.namespace" . }}
-{{- $hookImage := printf "%s:%s" .Values.controller.uninstallHook.image.repository .Values.controller.uninstallHook.image.tag }}
+{{- $tag := default "1.30" .Values.controller.uninstallHook.image.tag }}
+{{- $hookImage := printf "%s:%s" .Values.controller.uninstallHook.image.repository $tag }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -12,7 +13,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-failed,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -24,7 +25,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-failed,hook-succeeded
 rules:
   - apiGroups: ["hiclaw.io"]
     resources: ["managers", "workers", "teams", "humans"]
@@ -40,7 +41,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-failed,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -60,7 +61,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-failed,hook-succeeded
 spec:
   backoffLimit: {{ .Values.controller.uninstallHook.backoffLimit | default 1 }}
   activeDeadlineSeconds: {{ .Values.controller.uninstallHook.activeDeadlineSeconds | default 1500 }}
@@ -83,7 +84,7 @@ spec:
             - name: NS
               value: {{ $ns | quote }}
             - name: TIMEOUT
-              value: {{ printf "%ds" (int .Values.controller.uninstallHook.timeoutSeconds) | quote }}
+              value: {{ printf "%ds" (.Values.controller.uninstallHook.timeoutSeconds | default 300 | int) | quote }}
           command:
             - /bin/sh
             - -c

--- a/helm/hiclaw/templates/controller/uninstall-hook.yaml
+++ b/helm/hiclaw/templates/controller/uninstall-hook.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.controller.uninstallHook.enabled }}
 {{- $name := printf "%s-uninstall-cleanup" (include "hiclaw.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- $ns := include "hiclaw.namespace" . }}
-{{- $ctrlTag := default .Values.global.imageTag .Values.controller.image.tag | default .Chart.AppVersion }}
+{{- $ctrlTag := include "hiclaw.imageTag" (dict "tag" .Values.controller.image.tag "global" .Values.global "root" $) }}
 {{- $hookImage := printf "%s:%s" .Values.controller.image.repository $ctrlTag }}
 {{- $hookPullPolicy := default "IfNotPresent" .Values.controller.image.pullPolicy }}
 apiVersion: v1

--- a/helm/hiclaw/values.yaml
+++ b/helm/hiclaw/values.yaml
@@ -189,6 +189,21 @@ controller:
     annotations: {}
   env: {}
   timezone: "Asia/Shanghai"
+  uninstallHook:
+    # When enabled, helm uninstall first runs a Job that deletes all
+    # Manager/Worker/Team/Human CRs while the controller is still alive,
+    # so the controller's finalizer logic can clean up Pods, Matrix users,
+    # and OSS data. Set to false to skip auto-cleanup (you must then
+    # delete those CRs manually before `helm uninstall`).
+    enabled: true
+    image:
+      repository: bitnami/kubectl
+      tag: "1.30"
+      pullPolicy: IfNotPresent
+    timeoutSeconds: 300         # per-resource-group `kubectl delete --wait` timeout
+    backoffLimit: 1
+    activeDeadlineSeconds: 1500 # hard ceiling: 4 groups × timeoutSeconds + headroom
+    resources: {}               # override if your cluster has tight quotas
 
 # ── Manager Agent (CRD-driven) ────────────────────────────────────────────
 # When enabled, the controller creates a Manager CR at startup. The

--- a/helm/hiclaw/values.yaml
+++ b/helm/hiclaw/values.yaml
@@ -195,11 +195,10 @@ controller:
     # so the controller's finalizer logic can clean up Pods, Matrix users,
     # and OSS data. Set to false to skip auto-cleanup (you must then
     # delete those CRs manually before `helm uninstall`).
+    #
+    # The hook reuses the controller image (which ships kubectl) so it
+    # does not depend on Docker Hub being reachable from the cluster.
     enabled: true
-    image:
-      repository: bitnami/kubectl
-      tag: "1.30"
-      pullPolicy: IfNotPresent
     timeoutSeconds: 300         # per-resource-group `kubectl delete --wait` timeout
     backoffLimit: 1
     activeDeadlineSeconds: 1500 # hard ceiling: 4 groups × timeoutSeconds + headroom

--- a/hiclaw-controller/Dockerfile
+++ b/hiclaw-controller/Dockerfile
@@ -43,7 +43,7 @@ RUN apk add --no-cache curl && \
 # ============ Final: Minimal image with all artifacts ============
 FROM ${HIGRESS_REGISTRY}/higress/alpine:3.20
 
-RUN apk add --no-cache bash jq curl unzip
+RUN apk add --no-cache bash jq curl unzip kubectl
 
 COPY --from=mc /usr/bin/mc /usr/local/bin/mc
 COPY --from=builder /hiclaw-controller /usr/local/bin/hiclaw-controller


### PR DESCRIPTION
## 背景

Issue #779 — `helm uninstall hiclaw` 之后,`hiclaw-manager` 和 Worker Pod 不会被清理,留下孤儿 CR 和 Pod。

**根因**:Helm 先把 controller Deployment 删掉,但 Manager / Worker / Team / Human CR 上的 `hiclaw.io/cleanup` finalizer 只能由 controller 处理。controller 一被删,finalizer 永远不被移除,CR 卡 Terminating,下挂的 Pod / Matrix 用户 / OSS 数据 / SA 也没人清。

## 改动

新增一个 Helm `pre-delete` hook(Job + SA + Role + RoleBinding),在 controller 还活着的时候**先按顺序删所有 Manager / Worker / Team / Human CR**,等 controller 走完 finalizer 清理流程,Helm 再继续删 controller 和其他组件。

```
helm uninstall
  ↓
pre-delete hook Job (controller 仍在)
  kubectl delete managers --all --wait=true   ← controller 处理 finalizer
  kubectl delete workers  --all --wait=true   ← 清 Pod / Matrix / OSS
  kubectl delete teams    --all --wait=true
  kubectl delete humans   --all --wait=true
  ↓
Helm 继续删 controller / higress / matrix / minio / ...
```

具体:

- **新增** `helm/hiclaw/templates/controller/uninstall-hook.yaml` — Job + SA + Role + RoleBinding,带 `helm.sh/hook: pre-delete` + `before-hook-creation,hook-failed,hook-succeeded` delete-policy
- **新增** `controller.uninstallHook.*` values(默认 `enabled: true`,提供 `timeoutSeconds` / `backoffLimit` / `activeDeadlineSeconds` / `resources` 调节口子)
- **NOTES.txt + README**:新增「Uninstalling」章节,覆盖正常卸载 / `--no-hooks` 手动卸载 / finalizer 卡死时的 force-clear / 完整删 CRD 四种路径
- **`hiclaw-controller` 镜像**:Alpine 直接 `apk add kubectl`,hook 复用 controller 镜像 — **不引入 `bitnami/kubectl` 这种外部依赖**,在拉不到 Docker Hub 的环境(例如内网 minikube)也能跑

## 设计决策

- **为什么用 hook 而不是 owner reference?** 把 Pod 的 ownerRef 指向 controller Deployment 会在每次 controller 重启时连带把 Pod 删掉,破坏 reconciliation;也不会触发 Matrix / OSS 的清理。
- **为什么删 CR 不删 CRD?** 删 CRD 同样能级联触发 finalizer,但需要 ClusterRole(更宽的 RBAC),并且会把 schema 也删掉 — 重装时 schema 没了,多 release 共享 CRD 时会互相波及。**保留 CRD 是 Helm v3 默认行为**,符合最小惊讶原则。如果运维想彻底清掉,NOTES 给了 `kubectl delete crd ...` 的命令。
- **为什么复用 controller 镜像?** controller 镜像是装 hiclaw 的人**必拉**的,加 50MB 的 kubectl 比引入 `bitnami/kubectl:1.30` 这个外部依赖更划算 — 后者在没有 Docker Hub 的环境会直接卡 ImagePullBackOff(实测复现过)。

## 失败模式与降级

| 场景 | 行为 |
|---|---|
| Hook Job 超时 | `helm uninstall` 失败,CR 卡 Terminating;NOTES 给了 force-clear finalizer 的命令 |
| `helm uninstall --no-hooks` | hook 跳过,孤儿继续存在;NOTES 给了手动 `kubectl delete managers,workers,teams,humans --all` 的步骤 |
| controller 已经被先删 | hook 删 CR 时 finalizer 没人处理 → `--wait=true` 阻塞 → `activeDeadlineSeconds` 兜底失败 → NOTES 引导到 force-clear |
| 重跑失败的 uninstall | `before-hook-creation` 删旧 Job/SA/Role,`--ignore-not-found` 让已删的 CR 是 no-op,**幂等** |

## 测试

本地 minikube 端到端验证:

1. **复现孤儿场景**:`helm install` → 等 Manager Running → `helm uninstall --no-hooks` → 留下 `hiclaw-manager` Pod 和 `manager.hiclaw.io/default` CR(✅ 重现 #779)
2. **修复后**:正常 `helm uninstall` → ~15s 完成,namespace 完全清空,无任何残留
3. **CRDs 保留**:符合设计预期,重装兼容
4. **Hook 资源自清理**:Job / SA / Role / RoleBinding 都被 `hook-succeeded` policy 自动清掉
5. **`helm template`** 渲染、`helm lint` 都通过

## Closes

Closes #779