### PR TITLE
fix: preserve AI route provider config on Manager restart

### DIFF
--- a/manager/scripts/init/setup-higress.sh
+++ b/manager/scripts/init/setup-higress.sh
@@ -259,7 +259,6 @@ if [ -n "${HICLAW_LLM_API_KEY}" ]; then
         # Preserve all other fields (especially authConfig.allowedConsumers and version).
         patched=$(echo "${existing_route_resp}" | jq --argjson domains "${AI_ROUTE_DOMAINS}" '
             .data
-            | .upstreams[0].provider = "'"${LLM_PROVIDER}"'"
             | .domains = $domains
             | .headerControl.enabled = true
             | .headerControl.request.add = [{"key":"user-agent","value":"HiClaw/'"${HICLAW_VERSION}"'"}]


### PR DESCRIPTION
## Summary
Fix for Issue #507: Clear file lock or clean worker causes API provider configuration to change from custom URL to official OpenAI URL.

### Problem
When mc mirror completes file synchronization, there is a race condition where file reads can occur before the file is fully written to disk. This causes `UnicodeDecodeError` when reading multi-byte UTF-8 characters at the end of files.

### Root Cause
`setup-higress.sh` line 262 unconditionally overwrites `upstreams[0].provider` with the current `LLM_PROVIDER` env var on every Manager restart. When `HICLAW_LLM_PROVIDER` is not set, it defaults to `qwen`, overwriting any custom provider configuration set via Higress Console.

### Solution
Remove the unconditional provider override in the jq patch. The AI Gateway route already stores the correct provider - we should only update domains and headerControl on restarts, preserving the provider setting.

### Files Changed
- `manager/scripts/init/setup-higress.sh` - Removed provider override line

### Verification
After this fix:
1. User configures custom provider (e.g., openai-compat with custom URL)
2. Manager restarts (file lock cleared or worker cleaned)
3. Provider configuration is preserved correctly

Fixes #507