### PR TITLE
fix(install): retry on too-short admin password instead of exiting

### DIFF
--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -2053,21 +2053,36 @@ function Step-Admin {
     $script:config.ADMIN_USER = Read-Prompt -VarName "HICLAW_ADMIN_USER" -PromptText (Get-Msg "admin.username_prompt") -Default "admin"
     if ($script:StepResult -eq "back") { return }
 
-    if (-not $env:HICLAW_ADMIN_PASSWORD) {
+    # Pre-set via env var: validate; non-interactive fails fast,
+    # interactive warns and falls through to the retry prompt.
+    if ($env:HICLAW_ADMIN_PASSWORD) {
+        $script:config.ADMIN_PASSWORD = $env:HICLAW_ADMIN_PASSWORD
+        Write-Log (Get-Msg "prompt.preset" -f (Get-Msg "admin.password_prompt"))
+        if ($script:config.ADMIN_PASSWORD.Length -ge 8) {
+            Write-Log ""
+            return
+        }
+        if ($script:HICLAW_NON_INTERACTIVE) {
+            Write-Error (Get-Msg "admin.password_too_short" -f $script:config.ADMIN_PASSWORD.Length)
+        }
+        Write-Host "$($script:ESC)[31m[HiClaw ERROR]$($script:ESC)[0m $(Get-Msg "admin.password_too_short" -f $script:config.ADMIN_PASSWORD.Length)"
+        [Environment]::SetEnvironmentVariable("HICLAW_ADMIN_PASSWORD", $null, "Process")
+    }
+
+    while ($true) {
+        [Environment]::SetEnvironmentVariable("HICLAW_ADMIN_PASSWORD", $null, "Process")
         $script:config.ADMIN_PASSWORD = Read-Prompt -VarName "HICLAW_ADMIN_PASSWORD" -PromptText (Get-Msg "admin.password_prompt") -Secret -Optional
         if ($script:StepResult -eq "back") { return }
         if (-not $script:config.ADMIN_PASSWORD) {
             $randomSuffix = (New-RandomKey).Substring(0, 12)
             $script:config.ADMIN_PASSWORD = "admin$randomSuffix"
             Write-Log (Get-Msg "admin.password_generated")
+            break
         }
-    } else {
-        $script:config.ADMIN_PASSWORD = $env:HICLAW_ADMIN_PASSWORD
-        Write-Log (Get-Msg "prompt.preset" -f (Get-Msg "admin.password_prompt"))
-    }
-
-    if ($script:config.ADMIN_PASSWORD.Length -lt 8) {
-        Write-Error (Get-Msg "admin.password_too_short" -f $script:config.ADMIN_PASSWORD.Length)
+        if ($script:config.ADMIN_PASSWORD.Length -ge 8) {
+            break
+        }
+        Write-Host "$($script:ESC)[31m[HiClaw ERROR]$($script:ESC)[0m $(Get-Msg "admin.password_too_short" -f $script:config.ADMIN_PASSWORD.Length)"
     }
 
     Write-Log ""

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -2163,18 +2163,35 @@ step_llm() {
 step_admin() {
     log "$(msg admin.title)"
     prompt HICLAW_ADMIN_USER "$(msg admin.username_prompt)" "admin" || return 0
-    if [ -z "${HICLAW_ADMIN_PASSWORD}" ]; then
+
+    # Pre-set via env var: validate; in non-interactive mode fail fast,
+    # in interactive mode warn and fall through to the retry prompt.
+    if [ -n "${HICLAW_ADMIN_PASSWORD:-}" ]; then
+        log "  $(msg prompt.preset "$(msg admin.password_prompt)")"
+        if [ ${#HICLAW_ADMIN_PASSWORD} -ge 8 ]; then
+            log ""
+            return 0
+        fi
+        if [ "${HICLAW_NON_INTERACTIVE}" = "1" ]; then
+            die "$(msg admin.password_too_short "${#HICLAW_ADMIN_PASSWORD}")"
+        fi
+        error "$(msg admin.password_too_short "${#HICLAW_ADMIN_PASSWORD}")"
+        unset HICLAW_ADMIN_PASSWORD
+    fi
+
+    while true; do
+        unset HICLAW_ADMIN_PASSWORD
         prompt_optional HICLAW_ADMIN_PASSWORD "$(msg admin.password_prompt)" "true" || return 0
         if [ -z "${HICLAW_ADMIN_PASSWORD}" ]; then
             HICLAW_ADMIN_PASSWORD="admin$(openssl rand -hex 6)"
             log "$(msg admin.password_generated)"
+            break
         fi
-    else
-        log "  $(msg prompt.preset "$(msg admin.password_prompt)")"
-    fi
-    if [ ${#HICLAW_ADMIN_PASSWORD} -lt 8 ]; then
-        die "$(msg admin.password_too_short "${#HICLAW_ADMIN_PASSWORD}")"
-    fi
+        if [ ${#HICLAW_ADMIN_PASSWORD} -ge 8 ]; then
+            break
+        fi
+        error "$(msg admin.password_too_short "${#HICLAW_ADMIN_PASSWORD}")"
+    done
     log ""
 }
 


### PR DESCRIPTION
## Summary
- 输入过短的管理员密码（< 8 位）不再直接 exit，交互模式下提示并重新输入
- 非交互模式（`HICLAW_NON_INTERACTIVE=1`）保持原本 fail-fast 行为

## Test plan
- [ ] 交互安装时输入 < 8 位密码，确认能继续重试
- [ ] 留空确认仍可自动生成
- [ ] `HICLAW_NON_INTERACTIVE=1` 配合过短的预设密码，确认仍报错退出

🤖 Generated with [Claude Code](https://claude.com/claude-code)