### PR TITLE
fix: 修复清理文件锁或worker导致API提供商配置被覆盖的问题 || fix: Fixed the issue where clearing file locks or workers caused the API provider configuration to be overwritten

### DIFF
--- a/manager/scripts/init/setup-higress.sh
+++ b/manager/scripts/init/setup-higress.sh
@@ -253,13 +253,11 @@ if [ -n "${HICLAW_LLM_API_KEY}" ]; then
     existing_route_resp=$(higress_get /v1/ai/routes/default-ai-route)
     if [ -n "${existing_route_resp}" ]; then
         # Extract the AiRoute object from the response wrapper (.data), then patch:
-        #   - upstreams[0].provider: reflect current LLM provider
         #   - domains: ensure internal local domain is always present
         #   - headerControl.request.add: inject User-Agent header (add = set if absent, don't overwrite)
-        # Preserve all other fields (especially authConfig.allowedConsumers and version).
+        # Preserve all other fields (especially upstreams[0].provider, authConfig.allowedConsumers and version).
         patched=$(echo "${existing_route_resp}" | jq --argjson domains "${AI_ROUTE_DOMAINS}" '
             .data
-            | .upstreams[0].provider = "'"${LLM_PROVIDER}"'"
             | .domains = $domains
             | .headerControl.enabled = true
             | .headerControl.request.add = [{"key":"user-agent","value":"HiClaw/'"${HICLAW_VERSION}"'"}]


### PR DESCRIPTION
**问题描述**
清理文件锁或清理worker会导致API提供商的配置从自定义URL被覆盖为默认的qwen，导致大模型请求超时。

**问题根因**
`setup-higress.sh` 在更新现有 AI route 时会无条件强制覆盖 provider 配置：
```bash
| .upstreams[0].provider = ""  # 强制覆盖 provider
```
当用户使用自定义 provider（如 openai-compat）但没有设置 `HICLAW_LLM_PROVIDER` 环境变量时，配置会被覆盖为默认值 qwen。

**修复方案**
保留现有的 provider 配置，不再强制覆盖，只更新 domains 和 headerControl 配置。

**关联 issue**
#507

**测试建议**
1. 配置自定义 API provider（如阿里云的 openai-compat）
2. 清理文件锁或清理 worker 触发 Manager 重启
3. 验证 provider 配置保持不变
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
**Problem description**
Cleaning file locks or cleaning workers can cause the API provider's configuration to be overwritten from a custom URL to the default qwen, causing large model request timeouts.

**Root cause of the problem**
`setup-higress.sh` will unconditionally force overwriting of provider configuration when updating existing AI routes:
```bash
| .upstreams[0].provider = "" # Force coverage of provider
```
When the user uses a custom provider (such as openai-compat) but does not set the `HICLAW_LLM_PROVIDER` environment variable, the configuration will be overwritten to the default value of qwen.

**Repair**
Keep the existing provider configuration, no longer force overwrite, only update the domains and headerControl configuration.

**Associated issue**
#507

**TESTING ADVICE**
1. Configure a custom API provider (such as Alibaba Cloud's openai-compat)
2. Clear file locks or clean workers to trigger Manager restart
3. Verify that the provider configuration remains unchanged
