### PR TITLE
fix(controller): clarify leaderWorkerSpec runtime hardcode (#761)

### DIFF
--- a/hiclaw-controller/internal/controller/team_controller.go
+++ b/hiclaw-controller/internal/controller/team_controller.go
@@ -830,6 +830,11 @@ func hashMemberSourceSpec(t *v1beta1.Team, role MemberRole, name string) string 
 
 // leaderWorkerSpec projects a LeaderSpec into WorkerSpec with merged channel
 // policy (team leader can @ all members + admin).
+// Note: Runtime is hardcoded to "copaw" intentionally because:
+//   1. LeaderSpec has no runtime field defined
+//   2. The team-leader-agent/ template only ships a CoPaw build
+// To support other runtimes, runtime field needs to be added to LeaderSpec
+// and corresponding leader templates need to be shipped for hermes/openclaw.
 func leaderWorkerSpec(t *v1beta1.Team) v1beta1.WorkerSpec {
 	policy := mergeChannelPolicy(t.Spec.ChannelPolicy, t.Spec.Leader.ChannelPolicy)
 	workerNames := make([]string, 0, len(t.Spec.Workers))


### PR DESCRIPTION
## Summary

This PR adds a clarifying comment to `leaderWorkerSpec()` in the team controller, explaining why the Runtime is hardcoded to "copaw":

1. `LeaderSpec` has no runtime field defined in the API types
2. The `team-leader-agent/` template only ships a CoPaw build

## Background

Issue #761 reported that Team member Workers were ignoring the `runtime` field and always using "copaw". The main fix for this issue (changing `teamWorkerSpecToWorkerSpec()` to pass through `w.Runtime`) was already applied in the upstream repository.

This PR addresses the secondary request in the issue comments to add a comment explaining the intentional hardcode in `leaderWorkerSpec()`.

## Changes

- `hiclaw-controller/internal/controller/team_controller.go`: Added explanatory comment above `leaderWorkerSpec()` function

## Related Issues

- #761 (Team member Worker runtime is hardcoded to "copaw")
- #690 (same pattern of Team CR field dropping for spec.env)