### PR TITLE
fix: include Manager in Team worker allowlists (groupAllowFrom + dmAllowFrom)

### DIFF
--- a/hiclaw-controller/internal/agentconfig/generator.go
+++ b/hiclaw-controller/internal/agentconfig/generator.go
@@ -210,11 +210,11 @@ func (g *Generator) buildMatrixChannelConfig(req WorkerConfigRequest, serverURL,
 	groupAllowFrom := []string{managerMatrixID, adminMatrixID}
 	dmAllowFrom := []string{managerMatrixID, adminMatrixID}
 
-	// Team worker: use Leader + Admin instead
+	// Team worker: include Leader + Manager + Admin
 	if req.TeamLeaderName != "" {
 		leaderMatrixID := fmt.Sprintf("@%s:%s", req.TeamLeaderName, domain)
-		groupAllowFrom = []string{leaderMatrixID, adminMatrixID}
-		dmAllowFrom = []string{leaderMatrixID, adminMatrixID}
+		groupAllowFrom = []string{leaderMatrixID, managerMatrixID, adminMatrixID}
+		dmAllowFrom = []string{leaderMatrixID, managerMatrixID, adminMatrixID}
 	}
 
 	cfg := map[string]interface{}{


### PR DESCRIPTION
## Summary

When a Team worker config is generated with a `TeamLeaderName`, the `groupAllowFrom` and `dmAllowFrom` lists were replaced with `[leader, admin]` but **accidentally dropped Manager entirely**. This caused Manager messages to be silently ignored by Team workers.

## Root Cause

In `hiclaw-controller/internal/agentconfig/generator.go`, the `if req.TeamLeaderName != ""` block overwrites the default allowlist (which includes `managerMatrixID`) with `[leaderMatrixID, adminMatrixID]`, omitting the Manager.

## Fix

Include `managerMatrixID` alongside `leaderMatrixID` and `adminMatrixID` in both `groupAllowFrom` and `dmAllowFrom` when `TeamLeaderName` is set.

## Related Issues

Fixes #784
Related to #799 (specialist worker allowlist)