### PR TITLE
fix(auth): cap and sweep TokenReview cache

### DIFF
--- a/hiclaw-controller/internal/app/app.go
+++ b/hiclaw-controller/internal/app/app.go
@@ -335,7 +335,7 @@ func (a *App) initFieldIndexers(ctx context.Context) error {
 	return nil
 }
 
-func (a *App) initAuth(_ context.Context) error {
+func (a *App) initAuth(ctx context.Context) error {
 	logger := ctrl.Log.WithName("app")
 
 	if a.restCfg != nil {
@@ -345,6 +345,7 @@ func (a *App) initAuth(_ context.Context) error {
 			return fmt.Errorf("create kubernetes client: %w", err)
 		}
 		authenticator := authpkg.NewTokenReviewAuthenticator(a.k8sClient, a.cfg.AuthAudience, authpkg.ResourcePrefix(a.cfg.ResourcePrefix))
+		go authenticator.StartCleanup(ctx)
 		enricher := authpkg.NewCREnricher(a.mgr.GetClient(), a.namespace)
 		authorizer := authpkg.NewAuthorizer()
 		a.authMw = authpkg.NewMiddleware(authenticator, enricher, authorizer, a.mgr.GetClient(), a.namespace)

--- a/hiclaw-controller/internal/auth/authenticator.go
+++ b/hiclaw-controller/internal/auth/authenticator.go
@@ -24,6 +24,12 @@ const (
 // does not specify one explicitly.
 const DefaultAudience = "hiclaw-controller"
 
+const (
+	defaultCacheTTL        = 5 * time.Minute
+	defaultCacheMax        = 1000
+	defaultCleanupInterval = 1 * time.Minute
+)
+
 // CallerIdentity represents the authenticated caller.
 type CallerIdentity struct {
 	Role       string // admin | manager | team-leader | worker
@@ -39,18 +45,20 @@ type Authenticator interface {
 
 // TokenReviewAuthenticator validates tokens via the K8s TokenReview API.
 //
-// TODO(auth): The cache has no max size or periodic eviction. Expired entries are
-// ignored on read but not deleted. This is fine for the expected scale (entries ≈
-// active workers), but a periodic sweep or LRU cap should be added if the number
-// of unique tokens grows significantly.
+// Cache bounds: expired entries are swept by StartCleanup at cleanupInterval,
+// and inserts past cacheMax trigger an opportunistic expired-sweep followed by
+// oldest-expiry eviction. This keeps memory usage proportional to live tokens
+// even under adversarial input.
 type TokenReviewAuthenticator struct {
 	client   kubernetes.Interface
 	audience string
 	prefix   ResourcePrefix
 
-	cacheMu  sync.RWMutex
-	cache    map[[32]byte]cachedResult
-	cacheTTL time.Duration
+	cacheMu         sync.RWMutex
+	cache           map[[32]byte]cachedResult
+	cacheTTL        time.Duration
+	cacheMax        int
+	cleanupInterval time.Duration
 }
 
 type cachedResult struct {
@@ -67,11 +75,13 @@ func NewTokenReviewAuthenticator(client kubernetes.Interface, audience string, p
 		audience = DefaultAudience
 	}
 	return &TokenReviewAuthenticator{
-		client:   client,
-		audience: audience,
-		prefix:   prefix.Or(DefaultResourcePrefix),
-		cache:    make(map[[32]byte]cachedResult),
-		cacheTTL: 5 * time.Minute,
+		client:          client,
+		audience:        audience,
+		prefix:          prefix.Or(DefaultResourcePrefix),
+		cache:           make(map[[32]byte]cachedResult),
+		cacheTTL:        defaultCacheTTL,
+		cacheMax:        defaultCacheMax,
+		cleanupInterval: defaultCleanupInterval,
 	}
 }
 
@@ -124,6 +134,11 @@ func (a *TokenReviewAuthenticator) getFromCache(key [32]byte) *CallerIdentity {
 func (a *TokenReviewAuthenticator) putInCache(key [32]byte, identity *CallerIdentity) {
 	a.cacheMu.Lock()
 	defer a.cacheMu.Unlock()
+	if a.cacheMax > 0 && len(a.cache) >= a.cacheMax {
+		if a.sweepExpiredLocked(time.Now()) == 0 {
+			a.evictOldestLocked()
+		}
+	}
 	cp := *identity
 	a.cache[key] = cachedResult{
 		identity: &cp,
@@ -136,4 +151,64 @@ func (a *TokenReviewAuthenticator) InvalidateCache() {
 	a.cacheMu.Lock()
 	defer a.cacheMu.Unlock()
 	a.cache = make(map[[32]byte]cachedResult)
+}
+
+// SweepExpired removes all entries whose expiry has passed. Returns the number
+// of removed entries. Safe to call concurrently with Authenticate.
+func (a *TokenReviewAuthenticator) SweepExpired() int {
+	a.cacheMu.Lock()
+	defer a.cacheMu.Unlock()
+	return a.sweepExpiredLocked(time.Now())
+}
+
+// StartCleanup runs SweepExpired periodically until ctx is cancelled. Intended
+// to be launched as a goroutine from app wiring. Returns immediately when the
+// cleanup interval is non-positive, leaving cache management purely
+// insert-driven.
+func (a *TokenReviewAuthenticator) StartCleanup(ctx context.Context) {
+	if a.cleanupInterval <= 0 {
+		return
+	}
+	ticker := time.NewTicker(a.cleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			a.SweepExpired()
+		}
+	}
+}
+
+// sweepExpiredLocked deletes entries whose expiry is at or before now. Caller
+// must hold a.cacheMu for write.
+func (a *TokenReviewAuthenticator) sweepExpiredLocked(now time.Time) int {
+	n := 0
+	for k, v := range a.cache {
+		if !now.Before(v.expiry) {
+			delete(a.cache, k)
+			n++
+		}
+	}
+	return n
+}
+
+// evictOldestLocked deletes the entry with the earliest expiry — equivalent to
+// LRU here because every insert uses the same TTL, so insertion order matches
+// expiry order. Caller must hold a.cacheMu for write.
+func (a *TokenReviewAuthenticator) evictOldestLocked() {
+	var oldestKey [32]byte
+	var oldestExp time.Time
+	found := false
+	for k, v := range a.cache {
+		if !found || v.expiry.Before(oldestExp) {
+			oldestKey = k
+			oldestExp = v.expiry
+			found = true
+		}
+	}
+	if found {
+		delete(a.cache, oldestKey)
+	}
 }

--- a/hiclaw-controller/internal/auth/authenticator_cache_test.go
+++ b/hiclaw-controller/internal/auth/authenticator_cache_test.go
@@ -1,0 +1,153 @@
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// newTestAuthenticator builds an authenticator with the given cache bounds.
+// k8s client is nil — these tests exercise cache eviction only, never the
+// TokenReview path.
+func newTestAuthenticator(ttl time.Duration, max int) *TokenReviewAuthenticator {
+	return &TokenReviewAuthenticator{
+		prefix:          DefaultResourcePrefix,
+		cache:           make(map[[32]byte]cachedResult),
+		cacheTTL:        ttl,
+		cacheMax:        max,
+		cleanupInterval: 10 * time.Millisecond,
+	}
+}
+
+func fakeKey(seed int) [32]byte {
+	return sha256.Sum256(fmt.Appendf(nil, "token-%d", seed))
+}
+
+func TestPutInCache_EvictsExpiredBeforeOldest(t *testing.T) {
+	a := newTestAuthenticator(50*time.Millisecond, 3)
+	id := &CallerIdentity{Role: RoleWorker, Username: "alice", WorkerName: "alice"}
+
+	a.putInCache(fakeKey(1), id)
+	a.putInCache(fakeKey(2), id)
+	a.putInCache(fakeKey(3), id)
+
+	time.Sleep(60 * time.Millisecond) // all three expire
+
+	a.putInCache(fakeKey(4), id)
+
+	a.cacheMu.RLock()
+	defer a.cacheMu.RUnlock()
+	if got := len(a.cache); got != 1 {
+		t.Fatalf("expected expired sweep to leave only the new entry, got %d entries", got)
+	}
+	if _, ok := a.cache[fakeKey(4)]; !ok {
+		t.Errorf("freshly inserted key should remain after sweep")
+	}
+}
+
+func TestPutInCache_EvictsOldestWhenAllLive(t *testing.T) {
+	a := newTestAuthenticator(10*time.Minute, 3)
+	id := &CallerIdentity{Role: RoleWorker, Username: "alice", WorkerName: "alice"}
+
+	// Insert with manual expiries so we can predict eviction order.
+	now := time.Now()
+	a.cache[fakeKey(1)] = cachedResult{identity: id, expiry: now.Add(1 * time.Minute)}
+	a.cache[fakeKey(2)] = cachedResult{identity: id, expiry: now.Add(2 * time.Minute)}
+	a.cache[fakeKey(3)] = cachedResult{identity: id, expiry: now.Add(3 * time.Minute)}
+
+	a.putInCache(fakeKey(4), id) // should kick fakeKey(1) out
+
+	a.cacheMu.RLock()
+	defer a.cacheMu.RUnlock()
+	if len(a.cache) != 3 {
+		t.Fatalf("cap exceeded: got %d entries, want 3", len(a.cache))
+	}
+	if _, ok := a.cache[fakeKey(1)]; ok {
+		t.Errorf("oldest-expiry entry should have been evicted")
+	}
+	if _, ok := a.cache[fakeKey(4)]; !ok {
+		t.Errorf("newly inserted entry missing")
+	}
+}
+
+func TestSweepExpired(t *testing.T) {
+	a := newTestAuthenticator(0, 100) // ttl=0 forces immediate expiry
+	id := &CallerIdentity{Role: RoleWorker, Username: "alice", WorkerName: "alice"}
+
+	now := time.Now()
+	a.cache[fakeKey(1)] = cachedResult{identity: id, expiry: now.Add(-time.Second)}
+	a.cache[fakeKey(2)] = cachedResult{identity: id, expiry: now.Add(-time.Second)}
+	a.cache[fakeKey(3)] = cachedResult{identity: id, expiry: now.Add(time.Hour)}
+
+	removed := a.SweepExpired()
+	if removed != 2 {
+		t.Errorf("SweepExpired removed %d, want 2", removed)
+	}
+	if _, ok := a.cache[fakeKey(3)]; !ok {
+		t.Errorf("live entry must survive sweep")
+	}
+}
+
+func TestStartCleanup_ExitsOnContextCancel(t *testing.T) {
+	a := newTestAuthenticator(10*time.Minute, 100)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		a.StartCleanup(ctx)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("StartCleanup did not exit within 1s of ctx cancel")
+	}
+}
+
+func TestStartCleanup_RemovesExpiredOnTick(t *testing.T) {
+	a := newTestAuthenticator(10*time.Millisecond, 100)
+	id := &CallerIdentity{Role: RoleWorker, Username: "alice", WorkerName: "alice"}
+	a.putInCache(fakeKey(1), id)
+	a.putInCache(fakeKey(2), id)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go a.StartCleanup(ctx)
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		a.cacheMu.RLock()
+		n := len(a.cache)
+		a.cacheMu.RUnlock()
+		if n == 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("StartCleanup did not drain expired entries within 1s")
+}
+
+func TestGetFromCache_IgnoresExpired(t *testing.T) {
+	a := newTestAuthenticator(0, 100)
+	id := &CallerIdentity{Role: RoleWorker, Username: "alice", WorkerName: "alice"}
+	a.cache[fakeKey(1)] = cachedResult{identity: id, expiry: time.Now().Add(-time.Second)}
+
+	if got := a.getFromCache(fakeKey(1)); got != nil {
+		t.Errorf("expired entry must not be returned, got %+v", got)
+	}
+}
+
+func TestCacheMaxZero_DisablesCap(t *testing.T) {
+	a := newTestAuthenticator(10*time.Minute, 0)
+	id := &CallerIdentity{Role: RoleWorker, Username: "alice", WorkerName: "alice"}
+	for i := range 50 {
+		a.putInCache(fakeKey(i), id)
+	}
+	if got := len(a.cache); got != 50 {
+		t.Errorf("cap=0 should allow unbounded growth, got %d entries", got)
+	}
+}


### PR DESCRIPTION
TokenReview 的 cache map 之前没有上限，token 持续变化时会一直涨（TODO 也提到过）。

加一个 1000 entry 的 cap，插入时先清过期项再淘汰最旧的；同时起一个 1min 的后台 sweeper，跟 app ctx 一起退出。


<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
The cache map of TokenReview had no upper limit before, and it will keep increasing when the token continues to change (TODO also mentioned).

Add a cap of 1000 entries. When inserting, first clear the expired items and then eliminate the oldest ones; at the same time, set up a 1min background sweeper and exit together with the app ctx.
