### PR TITLE
chore(controller): graceful shutdown for HTTP server and background goroutines

### DIFF
--- a/hiclaw-controller/cmd/controller/main.go
+++ b/hiclaw-controller/cmd/controller/main.go
@@ -6,12 +6,15 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/hiclaw/hiclaw-controller/internal/app"
 	"github.com/hiclaw/hiclaw-controller/internal/config"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
+
+const shutdownTimeout = 10 * time.Second
 
 func main() {
 	ctrl.SetLogger(zap.New())
@@ -29,8 +32,20 @@ func main() {
 
 	fmt.Println("hiclaw-controller is running. Press Ctrl+C to stop.")
 
-	if err := application.Start(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "controller exited with error: %v\n", err)
+	startErr := application.Start(ctx)
+
+	// Start returns once ctx is cancelled (signal) or the manager fails.
+	// Stop is called with a fresh deadlined context so the HTTP server and
+	// background goroutines get a bounded grace window even after SIGTERM
+	// has already cancelled the parent ctx.
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer stopCancel()
+	if err := application.Stop(stopCtx); err != nil {
+		fmt.Fprintf(os.Stderr, "graceful shutdown error: %v\n", err)
+	}
+
+	if startErr != nil {
+		fmt.Fprintf(os.Stderr, "controller exited with error: %v\n", startErr)
 		os.Exit(1)
 	}
 }

--- a/hiclaw-controller/internal/app/app.go
+++ b/hiclaw-controller/internal/app/app.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sync"
 
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
 	"github.com/hiclaw/hiclaw-controller/internal/accessresolver"
@@ -45,6 +46,10 @@ type App struct {
 	mgr ctrl.Manager
 
 	httpServer *server.HTTPServer
+
+	// wg tracks all background goroutines launched from Start so Stop can
+	// wait for them to drain before returning.
+	wg sync.WaitGroup
 
 	// --- Build-time intermediates (populated during init*, consumed by later init* steps) ---
 	scheme    *runtime.Scheme
@@ -108,18 +113,20 @@ func New(ctx context.Context, cfg *config.Config) (*App, error) {
 }
 
 // Start runs the HTTP server and controller manager. Blocks until ctx is cancelled.
+// Call Stop afterwards to drain background goroutines and shut the HTTP server
+// down gracefully.
 func (a *App) Start(ctx context.Context) error {
 	logger := ctrl.Log.WithName("app")
 
-	go func() {
+	a.wg.Go(func() {
 		if err := a.httpServer.Start(); err != nil {
 			logger.Error(err, "HTTP server failed")
 		}
-	}()
+	})
 
 	// Run cluster initialization only after this instance becomes the leader.
 	// In embedded mode (no leader election) Elected() closes immediately.
-	go func() {
+	a.wg.Go(func() {
 		<-a.mgr.Elected()
 		logger.Info("elected as leader, running cluster initialization")
 
@@ -169,9 +176,26 @@ func (a *App) Start(ctx context.Context) error {
 			"kubeMode", a.cfg.KubeMode,
 			"httpAddr", a.cfg.HTTPAddr,
 		)
-	}()
+	})
 
 	return a.mgr.Start(ctx)
+}
+
+// Stop performs a graceful shutdown: the HTTP server stops accepting new
+// connections and is given ctx to finish in-flight requests, then we wait
+// for every background goroutine launched from Start to exit. Safe to call
+// after Start returns. The caller is expected to bound ctx with a timeout.
+func (a *App) Stop(ctx context.Context) error {
+	logger := ctrl.Log.WithName("app")
+	var firstErr error
+	if a.httpServer != nil {
+		if err := a.httpServer.Shutdown(ctx); err != nil {
+			logger.Error(err, "HTTP server shutdown")
+			firstErr = err
+		}
+	}
+	a.wg.Wait()
+	return firstErr
 }
 
 // =========================================================================
@@ -556,11 +580,11 @@ func (a *App) startEmbedded(ctx context.Context) (*rest.Config, error) {
 	if err := fw.InitialSync(ctx); err != nil {
 		logger.Error(err, "initial sync failed (non-fatal)")
 	}
-	go func() {
+	a.wg.Go(func() {
 		if err := fw.Watch(ctx); err != nil && ctx.Err() == nil {
 			logger.Error(err, "file watcher stopped unexpectedly")
 		}
-	}()
+	})
 	logger.Info("file watcher started", "dir", cfg.ConfigDir)
 
 	return restCfg, nil

--- a/hiclaw-controller/internal/server/http.go
+++ b/hiclaw-controller/internal/server/http.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+	"errors"
 	"net/http"
 
 	authpkg "github.com/hiclaw/hiclaw-controller/internal/auth"
@@ -29,13 +31,21 @@ type ServerDeps struct {
 
 // HTTPServer serves the unified controller REST API.
 type HTTPServer struct {
-	Addr string
-	Mux  *http.ServeMux
+	Addr   string
+	Mux    *http.ServeMux
+	server *http.Server
 }
 
 func NewHTTPServer(addr string, deps ServerDeps) *HTTPServer {
 	mux := http.NewServeMux()
-	s := &HTTPServer{Addr: addr, Mux: mux}
+	s := &HTTPServer{
+		Addr: addr,
+		Mux:  mux,
+		server: &http.Server{
+			Addr:    addr,
+			Handler: mux,
+		},
+	}
 
 	mw := deps.AuthMw
 
@@ -114,5 +124,14 @@ func NewHTTPServer(addr string, deps ServerDeps) *HTTPServer {
 func (s *HTTPServer) Start() error {
 	logger := log.Log.WithName("http-server")
 	logger.Info("starting unified REST API server", "addr", s.Addr)
-	return http.ListenAndServe(s.Addr, s.Mux)
+	if err := s.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+// Shutdown gracefully stops the HTTP server, waiting for in-flight requests
+// to finish or ctx to be cancelled. Idempotent.
+func (s *HTTPServer) Shutdown(ctx context.Context) error {
+	return s.server.Shutdown(ctx)
 }

--- a/hiclaw-controller/internal/server/http_lifecycle_test.go
+++ b/hiclaw-controller/internal/server/http_lifecycle_test.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestHTTPServer_StartSwallowsErrServerClosed verifies the production
+// invariant that Start returns nil (not http.ErrServerClosed) once Shutdown
+// has closed the server. Without this, the goroutine that watches Start's
+// return value in app.Start would log a spurious error on every shutdown.
+func TestHTTPServer_StartSwallowsErrServerClosed(t *testing.T) {
+	s := &HTTPServer{
+		Addr:   "127.0.0.1:0",
+		Mux:    http.NewServeMux(),
+		server: &http.Server{Addr: "127.0.0.1:0", Handler: http.NewServeMux()},
+	}
+	// Pre-close so the subsequent ListenAndServe immediately returns
+	// ErrServerClosed without binding a port.
+	_ = s.server.Close()
+
+	if err := s.Start(); err != nil {
+		t.Fatalf("Start should swallow ErrServerClosed, got %v", err)
+	}
+}
+
+// TestHTTPServer_ShutdownStopsStart exercises the full lifecycle: Start
+// runs in a goroutine, Shutdown is called with a deadlined ctx, and Start
+// must return cleanly within the deadline.
+func TestHTTPServer_ShutdownStopsStart(t *testing.T) {
+	s := &HTTPServer{
+		Addr: "127.0.0.1:0",
+		Mux:  http.NewServeMux(),
+	}
+	s.server = &http.Server{Addr: s.Addr, Handler: s.Mux}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Start() }()
+
+	time.Sleep(50 * time.Millisecond) // let ListenAndServe bind
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := s.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown error: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Start returned %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return within 2s of Shutdown")
+	}
+}


### PR DESCRIPTION
之前 SIGTERM 之后 mgr.Start 返回 main 直接退出，HTTP server 还卡在 ListenAndServe 里没人 Shutdown，后台两个 goroutine（leader-elected init、file watcher）也没人 Wait。

改成用 WaitGroup 跟踪所有后台 goroutine，main 收到信号后再用 10s 超时 ctx 调 `app.Stop()`：先 `server.Shutdown` 优雅排空请求，再 `wg.Wait` 等后台退出。HTTP server 改用 `http.Server` 结构体，`Start` 把 `ErrServerClosed` 吞掉避免误报。带 server 生命周期单测。
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
After SIGTERM, mgr.Start returns to main and exits directly. The HTTP server is still stuck in ListenAndServe and no one is shutting down. There are two goroutines (leader-elected init, file watcher) in the background and no one is waiting.

Change to use WaitGroup to track all background goroutines. After main receives the signal, use 10s timeout ctx to call `app.Stop()`: first `server.Shutdown` to drain the request gracefully, and then `wg.Wait` to wait for the background to exit. HTTP server uses the `http.Server` structure instead, and `Start` swallows `ErrServerClosed` to avoid false positives. Single test with server life cycle.
