### PR TITLE
feat(controller): export per-CRD reconcile metrics

### DIFF
--- a/hiclaw-controller/go.mod
+++ b/hiclaw-controller/go.mod
@@ -8,12 +8,16 @@ require (
 	github.com/alibabacloud-go/tea v1.3.13
 	github.com/aliyun/credentials-go v1.4.12
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/go-logr/logr v1.4.3
 	github.com/k3s-io/kine v0.13.5
+	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.0
+	go.uber.org/zap v1.27.0
 	k8s.io/api v0.35.3
 	k8s.io/apiextensions-apiserver v0.35.3
 	k8s.io/apimachinery v0.35.3
 	k8s.io/client-go v0.35.3
+	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	sigs.k8s.io/controller-runtime v0.21.0
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -39,7 +43,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
@@ -67,6 +70,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-sqlite3 v1.14.24 // indirect
 	github.com/minio/highwayhash v1.0.2 // indirect
@@ -81,7 +85,6 @@ require (
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
@@ -111,7 +114,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.36.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
@@ -135,7 +137,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
-	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect

--- a/hiclaw-controller/internal/controller/human_controller.go
+++ b/hiclaw-controller/internal/controller/human_controller.go
@@ -2,8 +2,10 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	"github.com/hiclaw/hiclaw-controller/internal/metrics"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -27,6 +29,9 @@ type HumanReconciler struct {
 }
 
 func (r *HumanReconciler) Reconcile(ctx context.Context, req reconcile.Request) (retres reconcile.Result, reterr error) {
+	start := time.Now()
+	defer func() { metrics.Observe("human", start, reterr) }()
+
 	logger := log.FromContext(ctx)
 
 	var human v1beta1.Human

--- a/hiclaw-controller/internal/controller/manager_controller.go
+++ b/hiclaw-controller/internal/controller/manager_controller.go
@@ -3,10 +3,12 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
 	"github.com/hiclaw/hiclaw-controller/internal/auth"
 	"github.com/hiclaw/hiclaw-controller/internal/backend"
+	"github.com/hiclaw/hiclaw-controller/internal/metrics"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -70,6 +72,9 @@ func (r *ManagerReconciler) managerContainerName(name string) string {
 }
 
 func (r *ManagerReconciler) Reconcile(ctx context.Context, req reconcile.Request) (retres reconcile.Result, reterr error) {
+	start := time.Now()
+	defer func() { metrics.Observe("manager", start, reterr) }()
+
 	logger := log.FromContext(ctx)
 
 	var mgr v1beta1.Manager

--- a/hiclaw-controller/internal/controller/team_controller.go
+++ b/hiclaw-controller/internal/controller/team_controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hiclaw/hiclaw-controller/internal/auth"
 	"github.com/hiclaw/hiclaw-controller/internal/backend"
 	"github.com/hiclaw/hiclaw-controller/internal/executor"
+	"github.com/hiclaw/hiclaw-controller/internal/metrics"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -73,7 +74,10 @@ type TeamReconciler struct {
 	ResourcePrefix auth.ResourcePrefix
 }
 
-func (r *TeamReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+func (r *TeamReconciler) Reconcile(ctx context.Context, req reconcile.Request) (retres reconcile.Result, reterr error) {
+	start := time.Now()
+	defer func() { metrics.Observe("team", start, reterr) }()
+
 	logger := log.FromContext(ctx)
 
 	var team v1beta1.Team

--- a/hiclaw-controller/internal/controller/worker_controller.go
+++ b/hiclaw-controller/internal/controller/worker_controller.go
@@ -7,6 +7,7 @@ import (
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
 	"github.com/hiclaw/hiclaw-controller/internal/auth"
 	"github.com/hiclaw/hiclaw-controller/internal/backend"
+	"github.com/hiclaw/hiclaw-controller/internal/metrics"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -55,6 +56,9 @@ type WorkerReconciler struct {
 }
 
 func (r *WorkerReconciler) Reconcile(ctx context.Context, req reconcile.Request) (retres reconcile.Result, reterr error) {
+	start := time.Now()
+	defer func() { metrics.Observe("worker", start, reterr) }()
+
 	logger := log.FromContext(ctx)
 
 	var worker v1beta1.Worker

--- a/hiclaw-controller/internal/metrics/metrics.go
+++ b/hiclaw-controller/internal/metrics/metrics.go
@@ -1,0 +1,74 @@
+// Package metrics defines hiclaw-specific Prometheus metrics and registers
+// them with the controller-runtime metrics registry, which exposes them on
+// the metrics endpoint configured by ctrl.Options.Metrics.BindAddress.
+//
+// controller-runtime already exports generic reconcile metrics (controller_
+// runtime_reconcile_total etc.); these hiclaw_* metrics carry the CRD kind
+// as a label so we can dashboard per-CRD signals without parsing the
+// controller name.
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const subsystem = "hiclaw"
+
+var (
+	// ReconcileDuration is a histogram of Reconcile latencies in seconds,
+	// partitioned by CRD kind and outcome ("success" or "error").
+	ReconcileDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: subsystem,
+			Name:      "reconcile_duration_seconds",
+			Help:      "Time spent in a single Reconcile call, partitioned by CRD kind and outcome.",
+			Buckets:   prometheus.ExponentialBuckets(0.01, 2, 12),
+		},
+		[]string{"kind", "result"},
+	)
+
+	// ReconcileTotal counts Reconcile invocations, partitioned by CRD kind
+	// and outcome. The success counter doubles as a liveness signal — if it
+	// stops advancing for a kind that has live CRs, the controller is
+	// either deadlocked or starved.
+	ReconcileTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: subsystem,
+			Name:      "reconcile_total",
+			Help:      "Number of Reconcile calls, partitioned by CRD kind and outcome.",
+		},
+		[]string{"kind", "result"},
+	)
+
+	// ReconcileErrors counts Reconcile invocations that returned a non-nil
+	// error. Redundant with ReconcileTotal{result="error"} but kept
+	// separate so alerts can be written against a single-label series.
+	ReconcileErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: subsystem,
+			Name:      "reconcile_errors_total",
+			Help:      "Number of Reconcile calls that returned an error.",
+		},
+		[]string{"kind"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(ReconcileDuration, ReconcileTotal, ReconcileErrors)
+}
+
+// Observe records duration and outcome for a single Reconcile call. Intended
+// to be invoked from a deferred closure so it sees the final value of the
+// named error return.
+func Observe(kind string, start time.Time, err error) {
+	result := "success"
+	if err != nil {
+		result = "error"
+		ReconcileErrors.WithLabelValues(kind).Inc()
+	}
+	ReconcileDuration.WithLabelValues(kind, result).Observe(time.Since(start).Seconds())
+	ReconcileTotal.WithLabelValues(kind, result).Inc()
+}

--- a/hiclaw-controller/internal/metrics/metrics_test.go
+++ b/hiclaw-controller/internal/metrics/metrics_test.go
@@ -1,0 +1,50 @@
+package metrics
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestObserve_SuccessIncrementsSuccessSeries(t *testing.T) {
+	ReconcileTotal.Reset()
+	ReconcileErrors.Reset()
+
+	Observe("worker", time.Now().Add(-10*time.Millisecond), nil)
+
+	if got := testutil.ToFloat64(ReconcileTotal.WithLabelValues("worker", "success")); got != 1 {
+		t.Errorf("success counter = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(ReconcileTotal.WithLabelValues("worker", "error")); got != 0 {
+		t.Errorf("error counter must stay at 0 on success, got %v", got)
+	}
+	if got := testutil.ToFloat64(ReconcileErrors.WithLabelValues("worker")); got != 0 {
+		t.Errorf("ReconcileErrors must stay at 0 on success, got %v", got)
+	}
+}
+
+func TestObserve_ErrorIncrementsBothErrorSeries(t *testing.T) {
+	ReconcileTotal.Reset()
+	ReconcileErrors.Reset()
+
+	Observe("team", time.Now(), errors.New("boom"))
+
+	if got := testutil.ToFloat64(ReconcileTotal.WithLabelValues("team", "error")); got != 1 {
+		t.Errorf("reconcile_total{result=error} = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(ReconcileErrors.WithLabelValues("team")); got != 1 {
+		t.Errorf("reconcile_errors_total = %v, want 1", got)
+	}
+}
+
+func TestObserve_RecordsDuration(t *testing.T) {
+	ReconcileDuration.Reset()
+	start := time.Now().Add(-50 * time.Millisecond)
+	Observe("manager", start, nil)
+
+	if got := testutil.CollectAndCount(ReconcileDuration); got == 0 {
+		t.Error("ReconcileDuration histogram recorded no samples")
+	}
+}


### PR DESCRIPTION
controller-runtime 自带的 `reconcile_total` 没有按 CRD kind 拆，看仪表盘还要从 controller 名拼。

新加 `internal/metrics` 包，三个 hiclaw 前缀的指标注册到 controller-runtime 的 metrics.Registry，会自动暴露在 metrics 端口：

- `hiclaw_reconcile_duration_seconds{kind,result}` histogram
- `hiclaw_reconcile_total{kind,result}` counter
- `hiclaw_reconcile_errors_total{kind}` counter

worker / team / human / manager 四个 reconciler 入口加一行 `defer Observe` 埋点，team 顺手改成命名返回。
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
The `reconcile_total` that comes with controller-runtime is not disassembled according to CRD kind. To view the dashboard, you have to spell it out from the controller name.

The `internal/metrics` package is added, and the three hiclaw prefixed indicators are registered to the metrics.Registry of controller-runtime and will be automatically exposed on the metrics port:

- `hiclaw_reconcile_duration_seconds{kind,result}` histogram
- `hiclaw_reconcile_total{kind,result}` counter
- `hiclaw_reconcile_errors_total{kind}` counter

Add a line of `defer Observe` to the four reconciler entries of worker / team / human / manager, and the team can easily change the name and return it.
