### PR TITLE
fix(legacy): preserve user plugin customizations on Manager config push

### DIFF
--- a/hiclaw-controller/internal/service/legacy.go
+++ b/hiclaw-controller/internal/service/legacy.go
@@ -102,17 +102,21 @@ func (l *LegacyCompat) PutManagerConfig(configJSON []byte) error {
 	ctx := context.Background()
 	key := l.managerAgentPrefix() + "/openclaw.json"
 
-	// Read existing config to preserve groupAllowFrom additions
+	// Read existing config to preserve user customizations on top of the
+	// generated defaults: groupAllowFrom additions plus user-modified plugin
+	// entries (e.g. memory-core dreaming schedule, extra load paths).
 	existingData, err := l.OSS.GetObject(ctx, key)
 	if err == nil && len(existingData) > 0 {
 		var existingCfg map[string]interface{}
 		var newCfg map[string]interface{}
 		if json.Unmarshal(existingData, &existingCfg) == nil && json.Unmarshal(configJSON, &newCfg) == nil {
 			mergeGroupAllowFrom(existingCfg, newCfg)
-			merged, err := json.MarshalIndent(newCfg, "", "  ")
-			if err == nil {
+			if merged, mErr := json.MarshalIndent(newCfg, "", "  "); mErr == nil {
 				configJSON = merged
 			}
+		}
+		if pluginMerged, pErr := mergeUserPluginConfig(configJSON, existingData); pErr == nil {
+			configJSON = pluginMerged
 		}
 	}
 

--- a/hiclaw-controller/internal/service/legacy.go
+++ b/hiclaw-controller/internal/service/legacy.go
@@ -115,7 +115,9 @@ func (l *LegacyCompat) PutManagerConfig(configJSON []byte) error {
 				configJSON = merged
 			}
 		}
-		if pluginMerged, pErr := mergeUserPluginConfig(configJSON, existingData); pErr == nil {
+		if pluginMerged, pErr := mergeUserPluginConfig(configJSON, existingData); pErr != nil {
+			fmt.Printf("warning: plugin config merge failed for %s, using generated config: %v\n", key, pErr)
+		} else {
 			configJSON = pluginMerged
 		}
 	}

--- a/hiclaw-controller/internal/service/legacy.go
+++ b/hiclaw-controller/internal/service/legacy.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hiclaw/hiclaw-controller/internal/oss"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // LegacyCompat handles backward-compatible operations that only apply in
@@ -116,7 +117,7 @@ func (l *LegacyCompat) PutManagerConfig(configJSON []byte) error {
 			}
 		}
 		if pluginMerged, pErr := mergeUserPluginConfig(configJSON, existingData); pErr != nil {
-			fmt.Printf("warning: plugin config merge failed for %s, using generated config: %v\n", key, pErr)
+			log.Log.WithName("legacy").Error(pErr, "plugin config merge failed, using generated config", "key", key)
 		} else {
 			configJSON = pluginMerged
 		}

--- a/hiclaw-controller/internal/service/legacy_test.go
+++ b/hiclaw-controller/internal/service/legacy_test.go
@@ -1,0 +1,99 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hiclaw/hiclaw-controller/internal/oss/ossfake"
+)
+
+func TestPutManagerConfig_PreservesUserPluginEntries(t *testing.T) {
+	fake := ossfake.NewMemory()
+	ctx := context.Background()
+
+	// Seed OSS with an existing manager openclaw.json that has user customizations:
+	// memory-core dreaming schedule + an extra plugin load path.
+	existing := []byte(`{
+		"channels": {"matrix": {"groupAllowFrom": ["@worker1:hiclaw.local"]}},
+		"plugins": {
+			"load": {"paths": ["/opt/openclaw/extensions/matrix", "/home/user/my-plugins"]},
+			"entries": {
+				"memory-core": {
+					"enabled": true,
+					"config": {"dreaming": {"enabled": true, "frequency": "0 */6 * * *", "timezone": "Asia/Shanghai"}}
+				}
+			}
+		}
+	}`)
+	if err := fake.PutObject(ctx, "agents/manager/openclaw.json", existing); err != nil {
+		t.Fatalf("seed OSS: %v", err)
+	}
+
+	lc := NewLegacyCompat(LegacyConfig{
+		OSS:          fake,
+		MatrixDomain: "hiclaw.local",
+		ManagerName:  "manager",
+		// AgentFSDir intentionally empty — writeManagerLocalConfig becomes a no-op.
+	})
+
+	// Controller regenerates config from CR spec. Defaults overwrite memory-core
+	// with a daily schedule and drop the user's custom load path.
+	generated := []byte(`{
+		"channels": {"matrix": {"groupAllowFrom": []}},
+		"plugins": {
+			"load": {"paths": ["/opt/openclaw/extensions/matrix"]},
+			"entries": {
+				"memory-core": {
+					"enabled": true,
+					"config": {"dreaming": {"enabled": true, "frequency": "0 3 * * *", "timezone": "UTC"}}
+				}
+			}
+		}
+	}`)
+
+	if err := lc.PutManagerConfig(generated); err != nil {
+		t.Fatalf("PutManagerConfig: %v", err)
+	}
+
+	out, err := fake.GetObject(ctx, "agents/manager/openclaw.json")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	plugins := got["plugins"].(map[string]interface{})
+	entries := plugins["entries"].(map[string]interface{})
+	mc := entries["memory-core"].(map[string]interface{})
+	cfg := mc["config"].(map[string]interface{})
+	dreaming := cfg["dreaming"].(map[string]interface{})
+	if dreaming["frequency"] != "0 */6 * * *" {
+		t.Errorf("user dreaming.frequency lost: got %v", dreaming["frequency"])
+	}
+	if dreaming["timezone"] != "Asia/Shanghai" {
+		t.Errorf("user dreaming.timezone lost: got %v", dreaming["timezone"])
+	}
+
+	load := plugins["load"].(map[string]interface{})
+	paths := load["paths"].([]interface{})
+	foundUserPath := false
+	for _, p := range paths {
+		if p == "/home/user/my-plugins" {
+			foundUserPath = true
+		}
+	}
+	if !foundUserPath {
+		t.Errorf("user plugin load path lost: paths=%v", paths)
+	}
+
+	// Regression: groupAllowFrom merge must still work.
+	channels := got["channels"].(map[string]interface{})
+	matrix := channels["matrix"].(map[string]interface{})
+	allow := matrix["groupAllowFrom"].([]interface{})
+	if len(allow) != 1 || allow[0] != "@worker1:hiclaw.local" {
+		t.Errorf("groupAllowFrom merge broken: got %v", allow)
+	}
+}

--- a/hiclaw-controller/internal/service/legacy_test.go
+++ b/hiclaw-controller/internal/service/legacy_test.go
@@ -97,3 +97,65 @@ func TestPutManagerConfig_PreservesUserPluginEntries(t *testing.T) {
 		t.Errorf("groupAllowFrom merge broken: got %v", allow)
 	}
 }
+
+func TestPutManagerConfig_NoExistingOSSObject(t *testing.T) {
+	fake := ossfake.NewMemory()
+	lc := NewLegacyCompat(LegacyConfig{
+		OSS:          fake,
+		MatrixDomain: "hiclaw.local",
+		ManagerName:  "manager",
+	})
+
+	generated := []byte(`{"plugins":{"entries":{"memory-core":{"enabled":true}}}}`)
+	if err := lc.PutManagerConfig(generated); err != nil {
+		t.Fatalf("PutManagerConfig: %v", err)
+	}
+
+	out, err := fake.GetObject(context.Background(), "agents/manager/openclaw.json")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	// First write: no merge happens, generated config is stored verbatim.
+	var got map[string]interface{}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	plugins := got["plugins"].(map[string]interface{})
+	entries := plugins["entries"].(map[string]interface{})
+	if _, ok := entries["memory-core"]; !ok {
+		t.Errorf("memory-core entry missing in first write: %v", entries)
+	}
+}
+
+func TestPutManagerConfig_MalformedExistingJSON_FallsBackToGenerated(t *testing.T) {
+	fake := ossfake.NewMemory()
+	ctx := context.Background()
+	if err := fake.PutObject(ctx, "agents/manager/openclaw.json", []byte("{not json")); err != nil {
+		t.Fatalf("seed OSS: %v", err)
+	}
+
+	lc := NewLegacyCompat(LegacyConfig{
+		OSS:          fake,
+		MatrixDomain: "hiclaw.local",
+		ManagerName:  "manager",
+	})
+
+	generated := []byte(`{"plugins":{"entries":{"memory-core":{"enabled":true}}}}`)
+	if err := lc.PutManagerConfig(generated); err != nil {
+		t.Fatalf("PutManagerConfig should swallow malformed existing JSON: %v", err)
+	}
+
+	out, err := fake.GetObject(ctx, "agents/manager/openclaw.json")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("written bytes should be valid JSON: %v", err)
+	}
+	// Generated config wins when existing JSON is corrupt.
+	plugins := got["plugins"].(map[string]interface{})
+	if _, ok := plugins["entries"].(map[string]interface{})["memory-core"]; !ok {
+		t.Errorf("expected generated memory-core entry, got: %v", plugins)
+	}
+}


### PR DESCRIPTION
Manager 配置 push 时只 merge `groupAllowFrom`，用户在 OSS 改的 `plugins.entries.*`（如 memory-core dreaming）和额外 `plugins.load.paths` 每次 reconcile 都会被覆盖。Worker 路径已经用 `mergeUserPluginConfig` 保护（`deployer.go:195`），这里复用同一个函数。

只过了 unit tests，e2e 待验。
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
The Manager only merges `groupAllowFrom` when configuring push. `plugins.entries.*` (such as memory-core dreaming) and additional `plugins.load.paths` changed by the user in OSS will be overwritten every time the reconciliation is performed. The Worker path has been protected with `mergeUserPluginConfig` (`deployer.go:195`), and the same function is reused here.

Only passed unit tests, e2e is yet to be verified.
