### PR TITLE
fix(helm): disable Tuwunel default displayname suffix

### DIFF
--- a/helm/hiclaw/templates/matrix/tuwunel-statefulset.yaml
+++ b/helm/hiclaw/templates/matrix/tuwunel-statefulset.yaml
@@ -44,6 +44,10 @@ spec:
               value: "true"
             - name: CONDUWUIT_DB_POOL_WORKERS_LIMIT
               value: "32"
+            # Keep Matrix profile display names equal to HiClaw identities by
+            # default; Tuwunel otherwise appends its built-in "💕" suffix.
+            - name: CONDUWUIT_NEW_USER_DISPLAYNAME_SUFFIX
+              value: {{ .Values.matrix.tuwunel.newUserDisplayNameSuffix | default "" | quote }}
             - name: CONDUWUIT_SERVER_NAME
               value: {{ include "hiclaw.tuwunel.serverName" . | quote }}
             - name: CONDUWUIT_REGISTRATION_TOKEN

--- a/helm/hiclaw/values.yaml
+++ b/helm/hiclaw/values.yaml
@@ -33,6 +33,7 @@ matrix:
       repository: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/tuwunel
       tag: "20260216"
       pullPolicy: IfNotPresent
+    newUserDisplayNameSuffix: ""  # empty disables Tuwunel's default "💕" suffix
     replicaCount: 1
     resources:
       requests:

--- a/manager/scripts/init/start-tuwunel.sh
+++ b/manager/scripts/init/start-tuwunel.sh
@@ -13,6 +13,9 @@ export CONDUWUIT_REGISTRATION_TOKEN="${HICLAW_REGISTRATION_TOKEN}"
 export CONDUWUIT_ALLOW_LEGACY_MEDIA=true
 export CONDUWUIT_ALLOW_UNSTABLE_ROOM_VERSIONS=true
 export CONDUWUIT_DB_POOL_WORKERS_LIMIT=32
+# Disable Tuwunel's default new-user displayname suffix ("💕") so Matrix
+# profiles match the HiClaw worker/human/manager names exactly.
+export CONDUWUIT_NEW_USER_DISPLAYNAME_SUFFIX="${CONDUWUIT_NEW_USER_DISPLAYNAME_SUFFIX:-}"
 # Increase default cache capacity to prevent RocksDB thrashing (tuwunel#123)
 export CONDUWUIT_CACHE_CAPACITY_MODIFIER="${CONDUWUIT_CACHE_CAPACITY_MODIFIER:-2.0}"
 


### PR DESCRIPTION
## What changed

- Exposes `matrix.tuwunel.newUserDisplayNameSuffix` in Helm values.
- Passes `CONDUWUIT_NEW_USER_DISPLAYNAME_SUFFIX` to managed Tuwunel.
- Sets the same default in the local manager startup script.

## Why

Tuwunel appends a built-in display name suffix by default. HiClaw identities should keep Matrix display names equal to the configured Manager, Worker, and Human names.

## Compatibility

Default value is empty, which disables the suffix. Existing deployments that want a suffix can set `matrix.tuwunel.newUserDisplayNameSuffix` explicitly.

## Validation

- `git diff --check opensource/main..HEAD`