### PR TITLE
fix(agent): quote coding CLI skill frontmatter

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -12,3 +12,4 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 - feat(hiclaw-controller): support Nacos remote skills and per-URI Nacos package auth with `authType=nacos|sts-hiclaw|none`, including `ai-registry` STS access scope.
 - fix(hiclaw-controller): use UUID STS session names for credential-provider requests while logging the original caller label for traceability.
 - fix(copaw-worker): pin the bundled Nacos CLI package to `@nacos-group/cli@1.0.5-beta.1`.
+- fix(manager): quote coding CLI skill frontmatter descriptions that contain colons.

--- a/manager/agent/skills-alpha/coding-cli-management/SKILL.md
+++ b/manager/agent/skills-alpha/coding-cli-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coding-cli-management
-description: Execute AI coding CLI tools (Claude Code / Gemini CLI / qodercli) on behalf of Workers. Use when a Worker sends a coding-request: message, asking Manager to run coding operations in their workspace.
+description: "Execute AI coding CLI tools (Claude Code / Gemini CLI / qodercli) on behalf of Workers. Use when a Worker sends a coding-request: message, asking Manager to run coding operations in their workspace."
 ---
 
 # Coding CLI Management


### PR DESCRIPTION
## Summary
- quote the coding CLI skill frontmatter description so the embedded `coding-request:` text is valid YAML
- keep the latest open-source main behavior for team leader skills; the removed `team-coordination` skill is not reintroduced
- record the manager image-facing change in the unreleased changelog

## Validation
- `python3` frontmatter read check for `manager/agent/skills-alpha/coding-cli-management/SKILL.md`
- `git diff --check`
