### PR TITLE
feat(copaw): make ReAct max iterations configurable

### DIFF
--- a/copaw/src/copaw_worker/templates/agent.manager.json
+++ b/copaw/src/copaw_worker/templates/agent.manager.json
@@ -21,5 +21,8 @@
       "group_allow_from": [],
       "groups": {}
     }
+  },
+  "running": {
+    "max_iters": 200
   }
 }

--- a/copaw/src/copaw_worker/templates/agent.worker.json
+++ b/copaw/src/copaw_worker/templates/agent.worker.json
@@ -20,5 +20,7 @@
       "groups": {}
     }
   },
-  "running": {}
+  "running": {
+    "max_iters": 200
+  }
 }

--- a/copaw/src/matrix/config.py
+++ b/copaw/src/matrix/config.py
@@ -26,6 +26,9 @@ from ..constant import (
 )
 from ..providers.models import ModelSlotConfig
 
+# React loop max iterations — configurable via environment variable.
+REACT_MAX_ITERS = max(1, int(os.environ.get("COPAW_REACT_MAX_ITERS", "200")))
+
 
 def generate_short_agent_id() -> str:
     """Generate a 6-character short UUID for agent identification.
@@ -474,10 +477,11 @@ class AgentsRunningConfig(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     max_iters: int = Field(
-        default=100,
+        default=REACT_MAX_ITERS,
         ge=1,
         description=(
-            "Maximum number of reasoning-acting iterations for ReAct agent"
+            "Maximum number of reasoning-acting iterations for ReAct agent. "
+            "Override via COPAW_REACT_MAX_ITERS env var or agent config JSON."
         ),
     )
 


### PR DESCRIPTION
## Summary

- make CoPaw ReAct loop max iterations configurable through `COPAW_REACT_MAX_ITERS`
- seed manager and worker agent templates with `running.max_iters: 200`
- keep agent config JSON override behavior through the existing `running.max_iters` field

## Validation

- `python3 -m json.tool copaw/src/copaw_worker/templates/agent.manager.json`
- `python3 -m json.tool copaw/src/copaw_worker/templates/agent.worker.json`
- `git diff --check opensource/main..HEAD`

Attempted `uv run --project copaw --with pytest pytest tests/test_bridge.py tests/test_channel_mention.py -q` and the same with Python 3.11, but local dependency setup failed while building `python-olm` because this environment lacks cmake/gmake and the bundled libolm build fails under the local toolchain.