### PR TITLE
feat(controller): separate CR names from runtime worker names

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -15,3 +15,4 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 - fix(hiclaw-controller): preserve runtime-mutated package files during reconcile by seeding package/base files without overwriting existing storage objects.
 - fix(copaw): stop Matrix typing indicators when a run completes without sending a message or is cancelled.
 - fix(manager): quote coding CLI skill frontmatter descriptions that contain colons.
+- feat(controller): separate CR resource names from runtime worker names across controller identity, credentials, storage defaults, and readiness reporting.

--- a/copaw/scripts/copaw-worker-entrypoint.sh
+++ b/copaw/scripts/copaw-worker-entrypoint.sh
@@ -16,6 +16,7 @@ set -e
 source /opt/hiclaw/scripts/lib/hiclaw-env.sh 2>/dev/null || true
 
 WORKER_NAME="${HICLAW_WORKER_NAME:?HICLAW_WORKER_NAME is required}"
+WORKER_CR_NAME="${HICLAW_WORKER_CR_NAME:-${WORKER_NAME}}"
 INSTALL_DIR="/root/.hiclaw-worker"
 
 log() {
@@ -82,13 +83,14 @@ _start_readiness_reporter() {
         fi
 
         # Report ready to controller via hiclaw CLI
-        hiclaw worker report-ready
+        hiclaw worker report-ready --name "${WORKER_CR_NAME}"
     ) &
     log "Background readiness reporter started (PID: $!)"
 }
 
 VENV="/opt/venv/copaw"
 log "Starting copaw-worker: ${WORKER_NAME}"
+log "  Worker CR name: ${WORKER_CR_NAME}"
 log "  FS endpoint: ${FS_ENDPOINT}"
 log "  Install dir: ${INSTALL_DIR}"
 log "  CoPaw venv: ${VENV}"
@@ -128,6 +130,7 @@ CONSOLE_PORT="${HICLAW_CONSOLE_PORT:-8088}"
 # Build command
 CMD_ARGS=(
     --name "${WORKER_NAME}"
+    --cr-name "${WORKER_CR_NAME}"
     --fs "${FS_ENDPOINT}"
     --fs-key "${FS_ACCESS_KEY}"
     --fs-secret "${FS_SECRET_KEY}"

--- a/copaw/src/copaw_worker/cli.py
+++ b/copaw/src/copaw_worker/cli.py
@@ -23,6 +23,7 @@ def main() -> None:
 
     def _run(
         name: str = typer.Option(..., "--name", help="Worker name"),
+        cr_name: Optional[str] = typer.Option(None, "--cr-name", help="Worker CR name"),
         fs: str = typer.Option(..., "--fs", help="MinIO endpoint"),
         fs_key: str = typer.Option(..., "--fs-key", help="MinIO access key"),
         fs_secret: str = typer.Option(..., "--fs-secret", help="MinIO secret key"),
@@ -34,6 +35,7 @@ def main() -> None:
         """Start the CoPaw Worker and connect to Matrix."""
         config = WorkerConfig(
             worker_name=name,
+            worker_cr_name=cr_name,
             minio_endpoint=fs,
             minio_access_key=fs_key,
             minio_secret_key=fs_secret,

--- a/copaw/src/copaw_worker/config.py
+++ b/copaw/src/copaw_worker/config.py
@@ -16,8 +16,10 @@ class WorkerConfig:
         sync_interval: int = 300,
         install_dir: Path | None = None,
         console_port: int = 8088,
+        worker_cr_name: str | None = None,
     ) -> None:
         self.worker_name = worker_name
+        self.worker_cr_name = worker_cr_name or worker_name
         self.minio_endpoint = minio_endpoint
         self.minio_access_key = minio_access_key
         self.minio_secret_key = minio_secret_key

--- a/copaw/src/copaw_worker/sync.py
+++ b/copaw/src/copaw_worker/sync.py
@@ -121,6 +121,7 @@ class FileSync:
         secret_key: str,
         bucket: str,
         worker_name: str,
+        worker_cr_name: Optional[str] = None,
         secure: bool = False,
         local_dir: Optional[Path] = None,
     ) -> None:
@@ -129,12 +130,14 @@ class FileSync:
         self.secret_key = secret_key
         self.bucket = bucket
         self.worker_name = worker_name
+        self.worker_cr_name = worker_cr_name or worker_name
         self._secure = secure
         self.local_dir = local_dir or Path.home() / ".copaw-worker" / worker_name
         self.local_dir.mkdir(parents=True, exist_ok=True)
         self._prefix = f"agents/{worker_name}"
         self._alias_set = False
         self._cloud_mode = os.environ.get("HICLAW_RUNTIME") == "aliyun"
+        self._worker_info: dict[str, Any] | None = None
 
     # ------------------------------------------------------------------
     # mc alias management
@@ -265,6 +268,34 @@ class FileSync:
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
+
+    def _get_worker_info(self) -> dict[str, Any]:
+        """Return authoritative worker metadata from the HiClaw controller."""
+        if self._worker_info is not None:
+            return self._worker_info
+
+        hiclaw_bin = shutil.which("hiclaw")
+        if not hiclaw_bin:
+            raise RuntimeError("hiclaw CLI not found; cannot resolve worker storage scope")
+
+        try:
+            result = subprocess.run(
+                [hiclaw_bin, "get", "workers", self.worker_cr_name, "-o", "json"],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=10,
+            )
+            worker = json.loads(result.stdout)
+        except Exception as exc:
+            raise RuntimeError(
+                f"failed to query worker metadata for {self.worker_cr_name}: {exc}",
+            ) from exc
+
+        if not isinstance(worker, dict):
+            raise RuntimeError(f"invalid worker metadata for {self.worker_cr_name}")
+        self._worker_info = worker
+        return worker
 
     def _get_team_id(self) -> Optional[str]:
         """Read team name from AGENTS.md team-context section."""

--- a/copaw/src/copaw_worker/worker.py
+++ b/copaw/src/copaw_worker/worker.py
@@ -81,6 +81,7 @@ class Worker:
             secret_key=self.config.minio_secret_key,
             bucket=self.config.minio_bucket,
             worker_name=self.worker_name,
+            worker_cr_name=self.config.worker_cr_name,
             secure=self.config.minio_secure,
             local_dir=self.config.install_dir / self.worker_name,
         )

--- a/helm/hiclaw/crds/humans.hiclaw.io.yaml
+++ b/helm/hiclaw/crds/humans.hiclaw.io.yaml
@@ -18,6 +18,9 @@ spec:
               properties:
                 displayName:
                   type: string
+                username:
+                  type: string
+                  description: Matrix localpart for this human (fallback to metadata.name)
                 email:
                   type: string
                   format: email
@@ -49,6 +52,9 @@ spec:
                 initialPassword:
                   type: string
                   description: "Generated password, shown once on creation"
+                displayNameSyncedGeneration:
+                  type: integer
+                  format: int64
                 rooms:
                   type: array
                   items:

--- a/helm/hiclaw/crds/teams.hiclaw.io.yaml
+++ b/helm/hiclaw/crds/teams.hiclaw.io.yaml
@@ -18,6 +18,9 @@ spec:
               properties:
                 description:
                   type: string
+                teamName:
+                  type: string
+                  description: Runtime/storage team identity. Defaults to metadata.name.
                 peerMentions:
                   type: boolean
                   description: "Whether team workers can @mention each other in group rooms (default: true)"

--- a/helm/hiclaw/crds/teams.hiclaw.io.yaml
+++ b/helm/hiclaw/crds/teams.hiclaw.io.yaml
@@ -57,6 +57,9 @@ spec:
                   properties:
                     name:
                       type: string
+                    workerName:
+                      type: string
+                      description: Runtime identity for leader (Matrix localpart, OSS path key). Defaults to leader.name.
                     model:
                       type: string
                     identity:
@@ -175,6 +178,9 @@ spec:
                     properties:
                       name:
                         type: string
+                      workerName:
+                        type: string
+                        description: Runtime identity for worker (Matrix localpart, OSS path key). Defaults to worker.name.
                       model:
                         type: string
                       runtime:
@@ -361,6 +367,9 @@ spec:
                       name:
                         type: string
                         description: "Member's canonical name (matches spec.leader.name or spec.workers[i].name)."
+                      runtimeName:
+                        type: string
+                        description: "Member runtime identity key (Matrix localpart, OSS path key). Empty falls back to name."
                       role:
                         type: string
                         enum: [team_leader, worker]

--- a/helm/hiclaw/crds/workers.hiclaw.io.yaml
+++ b/helm/hiclaw/crds/workers.hiclaw.io.yaml
@@ -29,6 +29,9 @@ spec:
                 image:
                   type: string
                   description: Custom Docker image for this worker
+                workerName:
+                  type: string
+                  description: Business/runtime identity for Matrix localpart and OSS path key (fallback to metadata.name)
                 identity:
                   type: string
                   description: Worker public identity (generates IDENTITY.md; merged into SOUL.md for copaw and hermes)

--- a/helm/hiclaw/templates/controller/deployment.yaml
+++ b/helm/hiclaw/templates/controller/deployment.yaml
@@ -61,6 +61,8 @@ spec:
             */}}
             - name: HICLAW_RESOURCE_PREFIX
               value: {{ .Values.controller.resourcePrefix | default "hiclaw-" | quote }}
+            - name: HICLAW_RESOURCE_AUTOPREFIX
+              value: {{ .Values.controller.resourceAutoPrefix | default true | quote }}
             - name: HICLAW_WORKER_BACKEND
               value: {{ .Values.controller.workerBackend | quote }}
             - name: HICLAW_K8S_NAMESPACE

--- a/helm/hiclaw/values.yaml
+++ b/helm/hiclaw/values.yaml
@@ -184,6 +184,7 @@ controller:
       memory: 512Mi
   workerBackend: "k8s"        # k8s | sae
   resourcePrefix: "hiclaw-"
+  resourceAutoPrefix: true
   serviceAccount:
     create: true
     name: ""

--- a/hiclaw-controller/api/v1beta1/types.go
+++ b/hiclaw-controller/api/v1beta1/types.go
@@ -89,8 +89,9 @@ type Worker struct {
 
 type WorkerSpec struct {
 	Model         string              `json:"model"`
-	Runtime       string              `json:"runtime,omitempty"` // openclaw | copaw | hermes (default: openclaw)
-	Image         string              `json:"image,omitempty"`   // custom Docker image
+	Runtime       string              `json:"runtime,omitempty"`    // openclaw | copaw | hermes (default: openclaw)
+	Image         string              `json:"image,omitempty"`      // custom Docker image
+	WorkerName    string              `json:"workerName,omitempty"` // business/runtime identity (Matrix localpart, OSS path key)
 	Identity      string              `json:"identity,omitempty"`
 	Soul          string              `json:"soul,omitempty"`
 	Agents        string              `json:"agents,omitempty"`
@@ -150,6 +151,15 @@ func (s WorkerSpec) DesiredState() string {
 		return *s.State
 	}
 	return "Running"
+}
+
+// EffectiveWorkerName returns the runtime identity key for a Worker.
+// Empty WorkerName falls back to metadata.name supplied by caller.
+func (s WorkerSpec) EffectiveWorkerName(metadataName string) string {
+	if s.WorkerName != "" {
+		return s.WorkerName
+	}
+	return metadataName
 }
 
 // ExposePort defines a container port to expose via the Higress gateway.
@@ -389,6 +399,7 @@ type Human struct {
 
 type HumanSpec struct {
 	DisplayName       string   `json:"displayName"`
+	Username          string   `json:"username,omitempty"`
 	Email             string   `json:"email,omitempty"`
 	PermissionLevel   int      `json:"permissionLevel"` // 1=Admin, 2=Team, 3=Worker
 	AccessibleTeams   []string `json:"accessibleTeams,omitempty"`
@@ -397,12 +408,22 @@ type HumanSpec struct {
 }
 
 type HumanStatus struct {
-	Phase           string   `json:"phase,omitempty"` // Pending/Active/Failed
-	MatrixUserID    string   `json:"matrixUserID,omitempty"`
-	InitialPassword string   `json:"initialPassword,omitempty"` // Set on creation, shown once
-	Rooms           []string `json:"rooms,omitempty"`
-	EmailSent       bool     `json:"emailSent,omitempty"`
-	Message         string   `json:"message,omitempty"`
+	Phase                       string   `json:"phase,omitempty"` // Pending/Active/Failed
+	MatrixUserID                string   `json:"matrixUserID,omitempty"`
+	InitialPassword             string   `json:"initialPassword,omitempty"` // Set on creation, shown once
+	DisplayNameSyncedGeneration int64    `json:"displayNameSyncedGeneration,omitempty"`
+	Rooms                       []string `json:"rooms,omitempty"`
+	EmailSent                   bool     `json:"emailSent,omitempty"`
+	Message                     string   `json:"message,omitempty"`
+}
+
+// EffectiveUsername returns the Matrix localpart for a Human.
+// Empty username falls back to metadata.name supplied by caller.
+func (s HumanSpec) EffectiveUsername(metadataName string) string {
+	if s.Username != "" {
+		return s.Username
+	}
+	return metadataName
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/hiclaw-controller/api/v1beta1/types.go
+++ b/hiclaw-controller/api/v1beta1/types.go
@@ -217,11 +217,19 @@ type Team struct {
 
 type TeamSpec struct {
 	Description   string             `json:"description,omitempty"`
+	TeamName      string             `json:"teamName,omitempty"`
 	Admin         *TeamAdminSpec     `json:"admin,omitempty"`
 	Leader        LeaderSpec         `json:"leader"`
 	Workers       []TeamWorkerSpec   `json:"workers,omitempty"`
 	PeerMentions  *bool              `json:"peerMentions,omitempty"`  // default true
 	ChannelPolicy *ChannelPolicySpec `json:"channelPolicy,omitempty"` // team-wide overrides
+}
+
+func (s TeamSpec) EffectiveTeamName(metadataName string) string {
+	if s.TeamName != "" {
+		return s.TeamName
+	}
+	return metadataName
 }
 
 type TeamAdminSpec struct {

--- a/hiclaw-controller/api/v1beta1/types.go
+++ b/hiclaw-controller/api/v1beta1/types.go
@@ -231,6 +231,7 @@ type TeamAdminSpec struct {
 
 type LeaderSpec struct {
 	Name              string                   `json:"name"`
+	WorkerName        string                   `json:"workerName,omitempty"`
 	Model             string                   `json:"model,omitempty"`
 	Identity          string                   `json:"identity,omitempty"`
 	Soul              string                   `json:"soul,omitempty"`
@@ -267,6 +268,7 @@ type TeamLeaderHeartbeatSpec struct {
 
 type TeamWorkerSpec struct {
 	Name          string              `json:"name"`
+	WorkerName    string              `json:"workerName,omitempty"`
 	Model         string              `json:"model,omitempty"`
 	Runtime       string              `json:"runtime,omitempty"`
 	Image         string              `json:"image,omitempty"`
@@ -296,6 +298,24 @@ type TeamWorkerSpec struct {
 	// system labels (see WorkerSpec.Labels godoc). omitempty preserves
 	// hashMemberSourceSpec stability for existing Teams.
 	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// EffectiveWorkerName returns the runtime identity key for a team leader.
+// Empty workerName falls back to spec.name supplied by caller.
+func (s LeaderSpec) EffectiveWorkerName() string {
+	if s.WorkerName != "" {
+		return s.WorkerName
+	}
+	return s.Name
+}
+
+// EffectiveWorkerName returns the runtime identity key for a team worker.
+// Empty workerName falls back to spec.name supplied by caller.
+func (s TeamWorkerSpec) EffectiveWorkerName() string {
+	if s.WorkerName != "" {
+		return s.WorkerName
+	}
+	return s.Name
 }
 
 type TeamStatus struct {
@@ -340,6 +360,9 @@ type TeamMemberStatus struct {
 	// Team.Spec.Workers[i].Name). Uniquely identifies the entry within
 	// Team.Status.Members.
 	Name string `json:"name"`
+	// RuntimeName is the member's runtime identity key (Matrix localpart,
+	// OSS path key, room alias key). Empty falls back to Name.
+	RuntimeName string `json:"runtimeName,omitempty"`
 	// Role is "team_leader" or "worker". Mirrors MemberContext.Role and the
 	// synthesized WorkerResponse.Role exposed via /api/v1/workers/<name>.
 	Role string `json:"role,omitempty"`

--- a/hiclaw-controller/cmd/hiclaw/create.go
+++ b/hiclaw-controller/cmd/hiclaw/create.go
@@ -223,6 +223,7 @@ func renderWorkerStatusSummary(resp *workerResp) string {
 func createTeamCmd() *cobra.Command {
 	var (
 		name                 string
+		teamName             string
 		leaderName           string
 		leaderModel          string
 		leaderHeartbeatEvery string
@@ -274,6 +275,7 @@ func createTeamCmd() *cobra.Command {
 				"leader":  leader,
 				"workers": workerList,
 			}
+			setIfNotEmpty(req, "teamName", teamName)
 			setIfNotEmpty(req, "description", description)
 
 			client := NewAPIClient()
@@ -287,6 +289,7 @@ func createTeamCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", "Team name (required)")
+	cmd.Flags().StringVar(&teamName, "team-name", "", "Runtime/storage team name (defaults to --name)")
 	cmd.Flags().StringVar(&leaderName, "leader-name", "", "Leader worker name (required)")
 	cmd.Flags().StringVar(&leaderModel, "leader-model", "", "Leader LLM model")
 	cmd.Flags().StringVar(&leaderHeartbeatEvery, "leader-heartbeat-every", "", "Leader heartbeat interval (e.g. 30m)")

--- a/hiclaw-controller/cmd/hiclaw/get.go
+++ b/hiclaw-controller/cmd/hiclaw/get.go
@@ -307,6 +307,7 @@ type workerListResp struct {
 
 type teamResp struct {
 	Name              string             `json:"name"`
+	TeamName          string             `json:"teamName,omitempty"`
 	Phase             string             `json:"phase"`
 	Description       string             `json:"description,omitempty"`
 	LeaderName        string             `json:"leaderName"`
@@ -387,6 +388,7 @@ func workerDetail(w workerResp) []KeyValue {
 func teamDetail(t teamResp) []KeyValue {
 	return []KeyValue{
 		{"Name", t.Name},
+		{"TeamName", t.TeamName},
 		{"Phase", or(t.Phase, "Pending")},
 		{"Description", t.Description},
 		{"Leader", t.LeaderName},

--- a/hiclaw-controller/cmd/hiclaw/update.go
+++ b/hiclaw-controller/cmd/hiclaw/update.go
@@ -109,6 +109,7 @@ func updateWorkerCmd() *cobra.Command {
 func updateTeamCmd() *cobra.Command {
 	var (
 		name                 string
+		teamName             string
 		description          string
 		leaderModel          string
 		leaderHeartbeatEvery string
@@ -129,6 +130,7 @@ func updateTeamCmd() *cobra.Command {
 			}
 
 			req := map[string]interface{}{}
+			setIfNotEmpty(req, "teamName", teamName)
 			setIfNotEmpty(req, "description", description)
 			leader := map[string]interface{}{}
 			setIfNotEmpty(leader, "model", leaderModel)
@@ -158,6 +160,7 @@ func updateTeamCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", "Team name (required)")
+	cmd.Flags().StringVar(&teamName, "team-name", "", "Runtime/storage team name")
 	cmd.Flags().StringVar(&description, "description", "", "Team description")
 	cmd.Flags().StringVar(&leaderModel, "leader-model", "", "Leader LLM model")
 	cmd.Flags().StringVar(&leaderHeartbeatEvery, "leader-heartbeat-every", "", "Leader heartbeat interval (e.g. 30m)")

--- a/hiclaw-controller/cmd/hiclaw/worker_cmd.go
+++ b/hiclaw-controller/cmd/hiclaw/worker_cmd.go
@@ -233,13 +233,16 @@ func workerReportReadyCmd() *cobra.Command {
   # Custom heartbeat interval
   hiclaw worker report-ready --heartbeat --interval 30s
 
-Worker name is read from --name or HICLAW_WORKER_NAME env var.`,
+Worker name is read from --name, HICLAW_WORKER_CR_NAME, or HICLAW_WORKER_NAME env var.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if name == "" {
+				name = os.Getenv("HICLAW_WORKER_CR_NAME")
+			}
 			if name == "" {
 				name = os.Getenv("HICLAW_WORKER_NAME")
 			}
 			if name == "" {
-				return fmt.Errorf("--name or HICLAW_WORKER_NAME is required")
+				return fmt.Errorf("--name, HICLAW_WORKER_CR_NAME, or HICLAW_WORKER_NAME is required")
 			}
 
 			heartbeat := cmd.Flags().Changed("heartbeat") || cmd.Flags().Changed("interval")
@@ -282,7 +285,7 @@ Worker name is read from --name or HICLAW_WORKER_NAME env var.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&name, "name", "", "Worker name (default: HICLAW_WORKER_NAME env)")
+	cmd.Flags().StringVar(&name, "name", "", "Worker name (default: HICLAW_WORKER_CR_NAME or HICLAW_WORKER_NAME env)")
 	cmd.Flags().Bool("heartbeat", false, "Send periodic heartbeat after initial ready report")
 	cmd.Flags().DurationVar(&interval, "interval", 60*time.Second, "Heartbeat interval (requires --heartbeat)")
 	return cmd

--- a/hiclaw-controller/config/crd/humans.hiclaw.io.yaml
+++ b/hiclaw-controller/config/crd/humans.hiclaw.io.yaml
@@ -18,6 +18,9 @@ spec:
               properties:
                 displayName:
                   type: string
+                username:
+                  type: string
+                  description: Matrix localpart for this human (fallback to metadata.name)
                 email:
                   type: string
                   format: email
@@ -49,6 +52,9 @@ spec:
                 initialPassword:
                   type: string
                   description: "Generated password, shown once on creation"
+                displayNameSyncedGeneration:
+                  type: integer
+                  format: int64
                 rooms:
                   type: array
                   items:

--- a/hiclaw-controller/config/crd/teams.hiclaw.io.yaml
+++ b/hiclaw-controller/config/crd/teams.hiclaw.io.yaml
@@ -18,6 +18,9 @@ spec:
               properties:
                 description:
                   type: string
+                teamName:
+                  type: string
+                  description: Runtime/storage team identity. Defaults to metadata.name.
                 peerMentions:
                   type: boolean
                   description: "Whether team workers can @mention each other in group rooms (default: true)"

--- a/hiclaw-controller/config/crd/teams.hiclaw.io.yaml
+++ b/hiclaw-controller/config/crd/teams.hiclaw.io.yaml
@@ -57,6 +57,9 @@ spec:
                   properties:
                     name:
                       type: string
+                    workerName:
+                      type: string
+                      description: Runtime identity for leader (Matrix localpart, OSS path key). Defaults to leader.name.
                     model:
                       type: string
                     identity:
@@ -175,6 +178,9 @@ spec:
                     properties:
                       name:
                         type: string
+                      workerName:
+                        type: string
+                        description: Runtime identity for worker (Matrix localpart, OSS path key). Defaults to worker.name.
                       model:
                         type: string
                       runtime:
@@ -361,6 +367,9 @@ spec:
                       name:
                         type: string
                         description: "Member's canonical name (matches spec.leader.name or spec.workers[i].name)."
+                      runtimeName:
+                        type: string
+                        description: "Member runtime identity key (Matrix localpart, OSS path key). Empty falls back to name."
                       role:
                         type: string
                         enum: [team_leader, worker]

--- a/hiclaw-controller/config/crd/workers.hiclaw.io.yaml
+++ b/hiclaw-controller/config/crd/workers.hiclaw.io.yaml
@@ -29,6 +29,9 @@ spec:
                 image:
                   type: string
                   description: Custom Docker image for this worker
+                workerName:
+                  type: string
+                  description: Business/runtime identity for Matrix localpart and OSS path key (fallback to metadata.name)
                 identity:
                   type: string
                   description: Worker public identity (generates IDENTITY.md; merged into SOUL.md for copaw and hermes)

--- a/hiclaw-controller/internal/accessresolver/resolver.go
+++ b/hiclaw-controller/internal/accessresolver/resolver.go
@@ -91,7 +91,11 @@ func (r *Resolver) resolveWorker(ctx context.Context, name string) (string, []cr
 	if len(crEntries) == 0 {
 		crEntries = DefaultEntriesForWorker()
 	}
-	tmpl := templateCtx{kind: "Worker", name: name, namespace: r.namespace}
+	runtimeName := name
+	if w.Name != "" {
+		runtimeName = w.Spec.EffectiveWorkerName(w.Name)
+	}
+	tmpl := templateCtx{kind: "Worker", name: runtimeName, namespace: r.namespace}
 	resolved, err := r.resolveEntries(crEntries, tmpl)
 	if err != nil {
 		return "", nil, fmt.Errorf("worker %q: %w", name, err)
@@ -126,14 +130,17 @@ func (r *Resolver) resolveTeamMember(ctx context.Context, name, teamName string)
 
 	var crEntries []v1beta1.AccessEntry
 	kind := "TeamWorker"
+	runtimeName := name
 	switch {
 	case team.Spec.Leader.Name == name && team.Spec.Leader.Name != "":
 		crEntries = team.Spec.Leader.AccessEntries
 		kind = "TeamLeader"
+		runtimeName = team.Spec.Leader.EffectiveWorkerName()
 	default:
 		for _, w := range team.Spec.Workers {
 			if w.Name == name {
 				crEntries = w.AccessEntries
+				runtimeName = w.EffectiveWorkerName()
 				break
 			}
 		}
@@ -142,7 +149,7 @@ func (r *Resolver) resolveTeamMember(ctx context.Context, name, teamName string)
 		crEntries = DefaultEntriesForTeamMember()
 	}
 
-	tmpl := templateCtx{kind: kind, name: name, namespace: r.namespace, team: teamName}
+	tmpl := templateCtx{kind: kind, name: runtimeName, namespace: r.namespace, team: teamName}
 	resolved, err := r.resolveEntries(crEntries, tmpl)
 	if err != nil {
 		return "", nil, fmt.Errorf("team member %q (team %q): %w", name, teamName, err)

--- a/hiclaw-controller/internal/accessresolver/resolver.go
+++ b/hiclaw-controller/internal/accessresolver/resolver.go
@@ -132,13 +132,13 @@ func (r *Resolver) resolveTeamMember(ctx context.Context, name, teamName string)
 	kind := "TeamWorker"
 	runtimeName := name
 	switch {
-	case team.Spec.Leader.Name == name && team.Spec.Leader.Name != "":
+	case leaderMatches(team.Spec.Leader, name):
 		crEntries = team.Spec.Leader.AccessEntries
 		kind = "TeamLeader"
 		runtimeName = team.Spec.Leader.EffectiveWorkerName()
 	default:
 		for _, w := range team.Spec.Workers {
-			if w.Name == name {
+			if teamWorkerMatches(w, name) {
 				crEntries = w.AccessEntries
 				runtimeName = w.EffectiveWorkerName()
 				break
@@ -158,6 +158,14 @@ func (r *Resolver) resolveTeamMember(ctx context.Context, name, teamName string)
 	// session-name shape because their ServiceAccount name on the
 	// pod is still hiclaw-worker-<name> (see auth.ResourcePrefix.SAName).
 	return r.prefix.WorkerSessionName(name), resolved, nil
+}
+
+func leaderMatches(leader v1beta1.LeaderSpec, name string) bool {
+	return leader.Name == name || (leader.WorkerName != "" && leader.WorkerName == name)
+}
+
+func teamWorkerMatches(worker v1beta1.TeamWorkerSpec, name string) bool {
+	return worker.Name == name || (worker.WorkerName != "" && worker.WorkerName == name)
 }
 
 func (r *Resolver) resolveManager(ctx context.Context, name string) (string, []credprovider.AccessEntry, error) {

--- a/hiclaw-controller/internal/accessresolver/resolver.go
+++ b/hiclaw-controller/internal/accessresolver/resolver.go
@@ -149,7 +149,11 @@ func (r *Resolver) resolveTeamMember(ctx context.Context, name, teamName string)
 		crEntries = DefaultEntriesForTeamMember()
 	}
 
-	tmpl := templateCtx{kind: kind, name: runtimeName, namespace: r.namespace, team: teamName}
+	runtimeTeamName := teamName
+	if team.Name != "" {
+		runtimeTeamName = team.Spec.EffectiveTeamName(team.Name)
+	}
+	tmpl := templateCtx{kind: kind, name: runtimeName, namespace: r.namespace, team: runtimeTeamName}
 	resolved, err := r.resolveEntries(crEntries, tmpl)
 	if err != nil {
 		return "", nil, fmt.Errorf("team member %q (team %q): %w", name, teamName, err)

--- a/hiclaw-controller/internal/accessresolver/resolver_test.go
+++ b/hiclaw-controller/internal/accessresolver/resolver_test.go
@@ -471,6 +471,36 @@ func TestResolveTeamLeader_DefaultEntries(t *testing.T) {
 	}
 }
 
+func TestResolveTeamLeader_DefaultEntriesUseRuntimeWorkerName(t *testing.T) {
+	team := newAlphaTeam()
+	team.Spec.Leader.WorkerName = "runtime-lead"
+	c := newFakeClient(t, team)
+
+	r := New(c, testNS, "hiclaw-test", "", auth.DefaultResourcePrefix)
+	session, entries, err := r.ResolveForCaller(context.Background(), &auth.CallerIdentity{
+		Role:       auth.RoleTeamLeader,
+		Username:   "runtime-lead",
+		WorkerName: "runtime-lead",
+		Team:       "alpha",
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if session != "hiclaw-worker-runtime-lead" {
+		t.Fatalf("session = %q, want hiclaw-worker-runtime-lead", session)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 default entry, got %d", len(entries))
+	}
+	got := entries[0].Scope.Prefixes
+	if !hasPrefix(got, "agents/runtime-lead/*") {
+		t.Fatalf("runtime workerName prefix not found in %+v", got)
+	}
+	if hasPrefix(got, "agents/lead/*") {
+		t.Fatalf("CR leader name leaked into OSS prefixes: %+v", got)
+	}
+}
+
 func TestResolveTeamWorker_DefaultEntries(t *testing.T) {
 	team := newAlphaTeam()
 	c := newFakeClient(t, team)
@@ -502,6 +532,36 @@ func TestResolveTeamWorker_DefaultEntries(t *testing.T) {
 	}
 	if !hasAllPerms(e.Permissions, "read", "write", "list", "delete") {
 		t.Fatalf("expected RW permissions, got %+v", e.Permissions)
+	}
+}
+
+func TestResolveTeamWorker_DefaultEntriesUseRuntimeWorkerName(t *testing.T) {
+	team := newAlphaTeam()
+	team.Spec.Workers[0].WorkerName = "runtime-w1"
+	c := newFakeClient(t, team)
+
+	r := New(c, testNS, "hiclaw-test", "", auth.DefaultResourcePrefix)
+	session, entries, err := r.ResolveForCaller(context.Background(), &auth.CallerIdentity{
+		Role:       auth.RoleWorker,
+		Username:   "runtime-w1",
+		WorkerName: "runtime-w1",
+		Team:       "alpha",
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if session != "hiclaw-worker-runtime-w1" {
+		t.Fatalf("session = %q, want hiclaw-worker-runtime-w1", session)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 default entry, got %d", len(entries))
+	}
+	got := entries[0].Scope.Prefixes
+	if !hasPrefix(got, "agents/runtime-w1/*") {
+		t.Fatalf("runtime workerName prefix not found in %+v", got)
+	}
+	if hasPrefix(got, "agents/w1/*") {
+		t.Fatalf("CR worker name leaked into OSS prefixes: %+v", got)
 	}
 }
 

--- a/hiclaw-controller/internal/accessresolver/resolver_test.go
+++ b/hiclaw-controller/internal/accessresolver/resolver_test.go
@@ -307,6 +307,48 @@ func TestResolve_AIRegistryCustomResources(t *testing.T) {
 	}
 }
 
+func TestResolve_DefaultObjectStorageUsesRuntimeWorkerName(t *testing.T) {
+	worker := &v1beta1.Worker{}
+	worker.Name = "worker-cr-name"
+	worker.Namespace = testNS
+	worker.Spec.WorkerName = "worker-runtime-name"
+	// No accessEntries -> resolver applies default object-storage scope.
+	worker.Spec.AccessEntries = nil
+	c := newFakeClient(t, worker)
+
+	r := New(c, testNS, "hiclaw-test", "", auth.DefaultResourcePrefix)
+	_, entries, err := r.ResolveForCaller(context.Background(), &auth.CallerIdentity{
+		Role: auth.RoleWorker, Username: "worker-cr-name", WorkerName: "worker-runtime-name",
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("expected at least one entry, got %d", len(entries))
+	}
+	var got *credprovider.AccessEntry
+	for i := range entries {
+		if entries[i].Service == credprovider.ServiceObjectStorage {
+			got = &entries[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("missing object-storage entry in %+v", entries)
+	}
+	want := "agents/worker-runtime-name/*"
+	found := false
+	for _, p := range got.Scope.Prefixes {
+		if p == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("runtime workerName prefix not found, want %q in %+v", want, got.Scope.Prefixes)
+	}
+}
+
 func TestResolve_AIGatewayNoDefault(t *testing.T) {
 	worker := &v1beta1.Worker{}
 	worker.Name = "gw-bot2"

--- a/hiclaw-controller/internal/accessresolver/resolver_test.go
+++ b/hiclaw-controller/internal/accessresolver/resolver_test.go
@@ -501,6 +501,30 @@ func TestResolveTeamLeader_DefaultEntriesUseRuntimeWorkerName(t *testing.T) {
 	}
 }
 
+func TestResolveTeamLeader_DefaultEntriesUseRuntimeTeamName(t *testing.T) {
+	team := newAlphaTeam()
+	team.Name = "magic-cn-plt4rw3f909-team001"
+	team.Spec.TeamName = "team001"
+	c := newFakeClient(t, team)
+
+	r := New(c, testNS, "hiclaw-test", "", auth.DefaultResourcePrefix)
+	_, entries, err := r.ResolveForCaller(context.Background(), &auth.CallerIdentity{
+		Role:     auth.RoleTeamLeader,
+		Username: "lead",
+		Team:     "magic-cn-plt4rw3f909-team001",
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	got := entries[0].Scope.Prefixes
+	if !hasPrefix(got, "teams/team001/*") {
+		t.Fatalf("runtime teamName prefix not found in %+v", got)
+	}
+	if hasPrefix(got, "teams/magic-cn-plt4rw3f909-team001/*") {
+		t.Fatalf("CR team name leaked into OSS prefixes: %+v", got)
+	}
+}
+
 func TestResolveTeamWorker_DefaultEntries(t *testing.T) {
 	team := newAlphaTeam()
 	c := newFakeClient(t, team)

--- a/hiclaw-controller/internal/app/app.go
+++ b/hiclaw-controller/internal/app/app.go
@@ -325,8 +325,8 @@ func (a *App) initControllerManager(ctx context.Context) error {
 // initFieldIndexers registers cache field indexers used for efficient reverse
 // lookups by auth enrichment and, in the future, admission/validation.
 //
-//   - teams.spec.leader.name  -> list Team by leader name
-//   - teams.spec.workerNames  -> list Team by any worker name (custom virtual field)
+//   - teams.spec.leader.name  -> list Team by leader name or runtime workerName
+//   - teams.spec.workerNames  -> list Team by any worker name or runtime workerName
 func (a *App) initFieldIndexers(ctx context.Context) error {
 	if a.mgr == nil {
 		return nil
@@ -337,10 +337,11 @@ func (a *App) initFieldIndexers(ctx context.Context) error {
 		if !ok {
 			return nil
 		}
-		if team.Spec.Leader.Name == "" {
+		names := uniqueNonEmpty(team.Spec.Leader.Name, team.Spec.Leader.WorkerName)
+		if len(names) == 0 {
 			return nil
 		}
-		return []string{team.Spec.Leader.Name}
+		return names
 	}); err != nil {
 		return fmt.Errorf("index team leader name: %w", err)
 	}
@@ -349,17 +350,31 @@ func (a *App) initFieldIndexers(ctx context.Context) error {
 		if !ok {
 			return nil
 		}
-		names := make([]string, 0, len(team.Spec.Workers))
+		names := make([]string, 0, len(team.Spec.Workers)*2)
 		for _, w := range team.Spec.Workers {
-			if w.Name != "" {
-				names = append(names, w.Name)
-			}
+			names = append(names, uniqueNonEmpty(w.Name, w.WorkerName)...)
 		}
 		return names
 	}); err != nil {
 		return fmt.Errorf("index team worker names: %w", err)
 	}
 	return nil
+}
+
+func uniqueNonEmpty(values ...string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
 }
 
 func (a *App) initAuth(ctx context.Context) error {

--- a/hiclaw-controller/internal/auth/authorizer.go
+++ b/hiclaw-controller/internal/auth/authorizer.go
@@ -90,7 +90,7 @@ func (a *Authorizer) authorizeTeamLeaderWorkerAction(caller *CallerIdentity, req
 		return nil // handler filters by team
 	case ActionCreate, ActionUpdate:
 		return a.requireSameTeam(caller, req)
-	case ActionWake, ActionSleep, ActionEnsureReady, ActionStatus:
+	case ActionWake, ActionSleep, ActionEnsureReady, ActionReady, ActionStatus:
 		return a.requireSameTeam(caller, req)
 	default:
 		return deny(caller, req)

--- a/hiclaw-controller/internal/auth/authorizer_test.go
+++ b/hiclaw-controller/internal/auth/authorizer_test.go
@@ -33,6 +33,7 @@ func TestAuthorizer_TeamLeaderOwnTeam(t *testing.T) {
 		{Action: ActionWake, ResourceKind: "worker", ResourceName: "alpha-dev", ResourceTeam: "alpha-team"},
 		{Action: ActionSleep, ResourceKind: "worker", ResourceName: "alpha-dev", ResourceTeam: "alpha-team"},
 		{Action: ActionEnsureReady, ResourceKind: "worker", ResourceName: "alpha-dev", ResourceTeam: "alpha-team"},
+		{Action: ActionReady, ResourceKind: "worker", ResourceName: "alpha-dev", ResourceTeam: "alpha-team"},
 		{Action: ActionList, ResourceKind: "worker"},
 		{Action: ActionGet, ResourceKind: "status"},
 	}
@@ -49,6 +50,7 @@ func TestAuthorizer_TeamLeaderCrossTeamDenied(t *testing.T) {
 
 	deniedCases := []AuthzRequest{
 		{Action: ActionGet, ResourceKind: "worker", ResourceName: "beta-dev", ResourceTeam: "beta-team"},
+		{Action: ActionReady, ResourceKind: "worker", ResourceName: "beta-dev", ResourceTeam: "beta-team"},
 		{Action: ActionWake, ResourceKind: "worker", ResourceName: "beta-dev", ResourceTeam: "beta-team"},
 		{Action: ActionDelete, ResourceKind: "team", ResourceName: "beta-team"},
 		{Action: ActionGateway, ResourceKind: "gateway"},

--- a/hiclaw-controller/internal/auth/enricher.go
+++ b/hiclaw-controller/internal/auth/enricher.go
@@ -53,6 +53,9 @@ func (e *CREnricher) EnrichIdentity(ctx context.Context, identity *CallerIdentit
 	err := e.client.Get(ctx, key, &worker)
 	switch {
 	case err == nil:
+		runtimeName := worker.Spec.EffectiveWorkerName(worker.Name)
+		identity.Username = runtimeName
+		identity.WorkerName = runtimeName
 		if role := worker.Annotations["hiclaw.io/role"]; role == "team_leader" {
 			identity.Role = RoleTeamLeader
 		}
@@ -67,18 +70,29 @@ func (e *CREnricher) EnrichIdentity(ctx context.Context, identity *CallerIdentit
 	// 2. Worker CR missing — fall back to Team CR reverse lookup. A worker
 	//    name can only belong to one team at a time; the same is true for
 	//    leaders (a leader is not referenced as a worker in its own Team).
-	if leaderTeam, ok, lerr := e.lookupTeamByField(ctx, teamLeaderNameField, identity.Username); lerr != nil {
+	if team, ok, lerr := e.lookupTeamByField(ctx, teamLeaderNameField, identity.Username); lerr != nil {
 		return fmt.Errorf("enrich identity: lookup team leader %q: %w", identity.Username, lerr)
 	} else if ok {
 		identity.Role = RoleTeamLeader
-		identity.Team = leaderTeam
+		identity.Team = team.Name
+		runtimeName := team.Spec.Leader.EffectiveWorkerName()
+		identity.Username = runtimeName
+		identity.WorkerName = runtimeName
 		return nil
 	}
 
-	if workerTeam, ok, werr := e.lookupTeamByField(ctx, teamWorkerNameField, identity.Username); werr != nil {
+	if team, ok, werr := e.lookupTeamByField(ctx, teamWorkerNameField, identity.Username); werr != nil {
 		return fmt.Errorf("enrich identity: lookup team worker %q: %w", identity.Username, werr)
 	} else if ok {
-		identity.Team = workerTeam
+		identity.Team = team.Name
+		for _, w := range team.Spec.Workers {
+			if w.Name == identity.Username {
+				runtimeName := w.EffectiveWorkerName()
+				identity.Username = runtimeName
+				identity.WorkerName = runtimeName
+				break
+			}
+		}
 		return nil
 	}
 
@@ -88,16 +102,16 @@ func (e *CREnricher) EnrichIdentity(ctx context.Context, identity *CallerIdentit
 	return nil
 }
 
-func (e *CREnricher) lookupTeamByField(ctx context.Context, field, value string) (string, bool, error) {
+func (e *CREnricher) lookupTeamByField(ctx context.Context, field, value string) (*v1beta1.Team, bool, error) {
 	var list v1beta1.TeamList
 	if err := e.client.List(ctx, &list,
 		client.InNamespace(e.namespace),
 		client.MatchingFieldsSelector{Selector: fields.OneTermEqualSelector(field, value)},
 	); err != nil {
-		return "", false, err
+		return nil, false, err
 	}
 	if len(list.Items) == 0 {
-		return "", false, nil
+		return nil, false, nil
 	}
-	return list.Items[0].Name, true, nil
+	return &list.Items[0], true, nil
 }

--- a/hiclaw-controller/internal/auth/enricher.go
+++ b/hiclaw-controller/internal/auth/enricher.go
@@ -54,7 +54,6 @@ func (e *CREnricher) EnrichIdentity(ctx context.Context, identity *CallerIdentit
 	switch {
 	case err == nil:
 		runtimeName := worker.Spec.EffectiveWorkerName(worker.Name)
-		identity.Username = runtimeName
 		identity.WorkerName = runtimeName
 		if role := worker.Annotations["hiclaw.io/role"]; role == "team_leader" {
 			identity.Role = RoleTeamLeader
@@ -76,7 +75,6 @@ func (e *CREnricher) EnrichIdentity(ctx context.Context, identity *CallerIdentit
 		identity.Role = RoleTeamLeader
 		identity.Team = team.Name
 		runtimeName := team.Spec.Leader.EffectiveWorkerName()
-		identity.Username = runtimeName
 		identity.WorkerName = runtimeName
 		return nil
 	}
@@ -88,7 +86,6 @@ func (e *CREnricher) EnrichIdentity(ctx context.Context, identity *CallerIdentit
 		for _, w := range team.Spec.Workers {
 			if w.Name == identity.Username {
 				runtimeName := w.EffectiveWorkerName()
-				identity.Username = runtimeName
 				identity.WorkerName = runtimeName
 				break
 			}

--- a/hiclaw-controller/internal/auth/enricher_test.go
+++ b/hiclaw-controller/internal/auth/enricher_test.go
@@ -1,0 +1,148 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCREnricher_StandaloneWorkerCRNameMapsToRuntimeWorkerName(t *testing.T) {
+	scheme := newAuthTestScheme(t)
+	worker := &v1beta1.Worker{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "alpha-worker-testmcp",
+			Namespace: "default",
+		},
+		Spec: v1beta1.WorkerSpec{
+			WorkerName: "testmcp",
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(worker).
+		Build()
+	enricher := NewCREnricher(k8sClient, "default")
+
+	identity := &CallerIdentity{
+		Role:       RoleWorker,
+		Username:   "alpha-worker-testmcp",
+		WorkerName: "alpha-worker-testmcp",
+	}
+	if err := enricher.EnrichIdentity(context.Background(), identity); err != nil {
+		t.Fatalf("EnrichIdentity: %v", err)
+	}
+
+	if identity.Username != "testmcp" || identity.WorkerName != "testmcp" {
+		t.Fatalf("identity=%+v, want runtime workerName testmcp", identity)
+	}
+}
+
+func TestCREnricher_TeamMemberCRNameMapsToRuntimeWorkerName(t *testing.T) {
+	scheme := newAuthTestScheme(t)
+	team := &v1beta1.Team{}
+	team.Name = "alpha-team"
+	team.Namespace = "default"
+	team.Spec.Leader = v1beta1.LeaderSpec{
+		Name:       "alpha-worker-lead",
+		WorkerName: "lead",
+	}
+	team.Spec.Workers = []v1beta1.TeamWorkerSpec{
+		{Name: "alpha-worker-dev", WorkerName: "dev"},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(team).
+		WithIndex(&v1beta1.Team{}, teamLeaderNameField, indexTeamLeaderNames).
+		WithIndex(&v1beta1.Team{}, teamWorkerNameField, indexTeamWorkerNames).
+		Build()
+	enricher := NewCREnricher(k8sClient, "default")
+
+	identity := &CallerIdentity{
+		Role:       RoleWorker,
+		Username:   "alpha-worker-dev",
+		WorkerName: "alpha-worker-dev",
+	}
+	if err := enricher.EnrichIdentity(context.Background(), identity); err != nil {
+		t.Fatalf("EnrichIdentity: %v", err)
+	}
+
+	if identity.Team != "alpha-team" {
+		t.Fatalf("Team=%q, want alpha-team", identity.Team)
+	}
+	if identity.Username != "dev" || identity.WorkerName != "dev" {
+		t.Fatalf("identity=%+v, want runtime workerName dev", identity)
+	}
+}
+
+func TestCREnricher_TeamLeaderCRNameMapsToRuntimeWorkerName(t *testing.T) {
+	scheme := newAuthTestScheme(t)
+	team := &v1beta1.Team{}
+	team.Name = "alpha-team"
+	team.Namespace = "default"
+	team.Spec.Leader = v1beta1.LeaderSpec{
+		Name:       "alpha-worker-lead",
+		WorkerName: "lead",
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(team).
+		WithIndex(&v1beta1.Team{}, teamLeaderNameField, indexTeamLeaderNames).
+		WithIndex(&v1beta1.Team{}, teamWorkerNameField, indexTeamWorkerNames).
+		Build()
+	enricher := NewCREnricher(k8sClient, "default")
+
+	identity := &CallerIdentity{
+		Role:       RoleWorker,
+		Username:   "alpha-worker-lead",
+		WorkerName: "alpha-worker-lead",
+	}
+	if err := enricher.EnrichIdentity(context.Background(), identity); err != nil {
+		t.Fatalf("EnrichIdentity: %v", err)
+	}
+
+	if identity.Role != RoleTeamLeader || identity.Team != "alpha-team" {
+		t.Fatalf("identity=%+v, want team leader in alpha-team", identity)
+	}
+	if identity.Username != "lead" || identity.WorkerName != "lead" {
+		t.Fatalf("identity=%+v, want runtime workerName lead", identity)
+	}
+}
+
+func newAuthTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	return scheme
+}
+
+func indexTeamLeaderNames(obj client.Object) []string {
+	team, ok := obj.(*v1beta1.Team)
+	if !ok || team.Spec.Leader.Name == "" {
+		return nil
+	}
+	return []string{team.Spec.Leader.Name}
+}
+
+func indexTeamWorkerNames(obj client.Object) []string {
+	team, ok := obj.(*v1beta1.Team)
+	if !ok {
+		return nil
+	}
+	names := make([]string, 0, len(team.Spec.Workers))
+	for _, w := range team.Spec.Workers {
+		if w.Name != "" {
+			names = append(names, w.Name)
+		}
+	}
+	return names
+}

--- a/hiclaw-controller/internal/auth/enricher_test.go
+++ b/hiclaw-controller/internal/auth/enricher_test.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestCREnricher_StandaloneWorkerCRNameMapsToRuntimeWorkerName(t *testing.T) {
+func TestCREnricher_StandaloneWorkerKeepsCRNameAndStoresRuntimeWorkerName(t *testing.T) {
 	scheme := newAuthTestScheme(t)
 	worker := &v1beta1.Worker{
 		ObjectMeta: metav1.ObjectMeta{
@@ -38,12 +38,12 @@ func TestCREnricher_StandaloneWorkerCRNameMapsToRuntimeWorkerName(t *testing.T) 
 		t.Fatalf("EnrichIdentity: %v", err)
 	}
 
-	if identity.Username != "testmcp" || identity.WorkerName != "testmcp" {
-		t.Fatalf("identity=%+v, want runtime workerName testmcp", identity)
+	if identity.Username != "alpha-worker-testmcp" || identity.WorkerName != "testmcp" {
+		t.Fatalf("identity=%+v, want CR username alpha-worker-testmcp and runtime workerName testmcp", identity)
 	}
 }
 
-func TestCREnricher_TeamMemberCRNameMapsToRuntimeWorkerName(t *testing.T) {
+func TestCREnricher_TeamMemberKeepsCRNameAndStoresRuntimeWorkerName(t *testing.T) {
 	scheme := newAuthTestScheme(t)
 	team := &v1beta1.Team{}
 	team.Name = "alpha-team"
@@ -76,12 +76,12 @@ func TestCREnricher_TeamMemberCRNameMapsToRuntimeWorkerName(t *testing.T) {
 	if identity.Team != "alpha-team" {
 		t.Fatalf("Team=%q, want alpha-team", identity.Team)
 	}
-	if identity.Username != "dev" || identity.WorkerName != "dev" {
-		t.Fatalf("identity=%+v, want runtime workerName dev", identity)
+	if identity.Username != "alpha-worker-dev" || identity.WorkerName != "dev" {
+		t.Fatalf("identity=%+v, want CR username alpha-worker-dev and runtime workerName dev", identity)
 	}
 }
 
-func TestCREnricher_TeamLeaderCRNameMapsToRuntimeWorkerName(t *testing.T) {
+func TestCREnricher_TeamLeaderKeepsCRNameAndStoresRuntimeWorkerName(t *testing.T) {
 	scheme := newAuthTestScheme(t)
 	team := &v1beta1.Team{}
 	team.Name = "alpha-team"
@@ -111,8 +111,8 @@ func TestCREnricher_TeamLeaderCRNameMapsToRuntimeWorkerName(t *testing.T) {
 	if identity.Role != RoleTeamLeader || identity.Team != "alpha-team" {
 		t.Fatalf("identity=%+v, want team leader in alpha-team", identity)
 	}
-	if identity.Username != "lead" || identity.WorkerName != "lead" {
-		t.Fatalf("identity=%+v, want runtime workerName lead", identity)
+	if identity.Username != "alpha-worker-lead" || identity.WorkerName != "lead" {
+		t.Fatalf("identity=%+v, want CR username alpha-worker-lead and runtime workerName lead", identity)
 	}
 }
 

--- a/hiclaw-controller/internal/backend/docker.go
+++ b/hiclaw-controller/internal/backend/docker.go
@@ -35,9 +35,6 @@ type DockerBackend struct {
 
 // NewDockerBackend creates a DockerBackend that talks to the given Docker socket.
 func NewDockerBackend(config DockerConfig, containerPrefix string) *DockerBackend {
-	if containerPrefix == "" {
-		containerPrefix = DefaultContainerPrefix
-	}
 	transport := &http.Transport{
 		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
 			return net.Dial("unix", config.SocketPath)

--- a/hiclaw-controller/internal/backend/kubernetes.go
+++ b/hiclaw-controller/internal/backend/kubernetes.go
@@ -110,9 +110,6 @@ func NewK8sBackend(config K8sConfig, containerPrefix string, scheme *runtime.Sch
 // NewK8sBackendWithClient creates a Kubernetes backend with a custom client.
 // scheme may be nil in tests that don't set CreateRequest.Owner.
 func NewK8sBackendWithClient(client K8sCoreClient, config K8sConfig, containerPrefix string, scheme *runtime.Scheme) *K8sBackend {
-	if containerPrefix == "" {
-		containerPrefix = DefaultContainerPrefix
-	}
 	if config.Namespace == "" {
 		config.Namespace = detectK8sNamespace()
 	}

--- a/hiclaw-controller/internal/backend/registry.go
+++ b/hiclaw-controller/internal/backend/registry.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 )
 
-// DefaultContainerPrefix is the baked-in default for worker container/pod
-// names when no prefix is supplied — used as a last-resort fallback in
-// NewDockerBackend / NewK8sBackend. Production callers always pass
-// cfg.ContainerPrefix (which itself is derived from HICLAW_RESOURCE_PREFIX).
+// DefaultContainerPrefix is the legacy baked-in worker container/pod prefix.
+// New constructors no longer force this fallback when prefix is empty;
+// LoadConfig controls defaulting through HICLAW_RESOURCE_AUTOPREFIX and
+// HICLAW_RESOURCE_PREFIX.
 const DefaultContainerPrefix = "hiclaw-worker-"
 
 // Registry holds all available worker backends and provides auto-detection.

--- a/hiclaw-controller/internal/config/config.go
+++ b/hiclaw-controller/internal/config/config.go
@@ -34,6 +34,11 @@ type Config struct {
 	// session names). Intentionally does NOT cover OPENCLAW_MDNS_HOSTNAME,
 	// CMS service name, or install-script hardcoded names.
 	ResourcePrefix string
+	// ResourceAutoPrefix controls whether controller should auto-derive
+	// resource/container prefixes. When false, default hiclaw-* prefixes are
+	// disabled unless explicit HICLAW_PROXY_CONTAINER_PREFIX is provided.
+	// Set via HICLAW_RESOURCE_AUTOPREFIX. Default true.
+	ResourceAutoPrefix bool
 
 	// Docker proxy (embedded mode only)
 	SocketPath      string
@@ -212,11 +217,17 @@ func LoadConfig() *Config {
 		}
 	}
 
-	resourcePrefix := envOrDefault("HICLAW_RESOURCE_PREFIX", "hiclaw-")
-	// ContainerPrefix defaults to "${resourcePrefix}worker-". HICLAW_PROXY_CONTAINER_PREFIX
-	// remains as an explicit override for callers that want to diverge the
-	// Docker-proxy container-name whitelist from the tenant prefix (rare).
-	containerPrefix := envOrDefault("HICLAW_PROXY_CONTAINER_PREFIX", resourcePrefix+"worker-")
+	resourceAutoPrefix := envBoolDefault("HICLAW_RESOURCE_AUTOPREFIX", true)
+	resourcePrefix := ""
+	if resourceAutoPrefix {
+		resourcePrefix = envOrDefault("HICLAW_RESOURCE_PREFIX", "hiclaw-")
+	}
+	// ContainerPrefix defaults to "${resourcePrefix}worker-" when auto-prefix
+	// is enabled. HICLAW_PROXY_CONTAINER_PREFIX remains an explicit override.
+	containerPrefix := os.Getenv("HICLAW_PROXY_CONTAINER_PREFIX")
+	if containerPrefix == "" && resourceAutoPrefix {
+		containerPrefix = resourcePrefix + "worker-"
+	}
 
 	cfg := &Config{
 		KubeMode:  envOrDefault("HICLAW_KUBE_MODE", "embedded"),
@@ -226,7 +237,8 @@ func LoadConfig() *Config {
 		CRDDir:    envOrDefault("HICLAW_CRD_DIR", "/opt/hiclaw/config/crd"),
 		SkillsDir: envOrDefault("HICLAW_SKILLS_DIR", "/opt/hiclaw/agent/skills"),
 
-		ResourcePrefix: resourcePrefix,
+		ResourcePrefix:     resourcePrefix,
+		ResourceAutoPrefix: resourceAutoPrefix,
 
 		SocketPath:      envOrDefault("HICLAW_PROXY_SOCKET", "/var/run/docker.sock"),
 		ContainerPrefix: containerPrefix,
@@ -474,6 +486,14 @@ func envOrDefaultInt(key string, defaultVal int) int {
 
 func envBool(key string) bool {
 	v := os.Getenv(key)
+	return v == "1" || v == "true" || v == "True" || v == "TRUE"
+}
+
+func envBoolDefault(key string, defaultVal bool) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultVal
+	}
 	return v == "1" || v == "true" || v == "True" || v == "TRUE"
 }
 

--- a/hiclaw-controller/internal/config/config_test.go
+++ b/hiclaw-controller/internal/config/config_test.go
@@ -195,3 +195,31 @@ func TestManagerAgentEnvForwardsAbstractInfraEnv(t *testing.T) {
 		}
 	}
 }
+
+func TestLoadConfigDisablesAutoPrefix(t *testing.T) {
+	t.Setenv("HICLAW_RESOURCE_AUTOPREFIX", "false")
+	t.Setenv("HICLAW_RESOURCE_PREFIX", "hiclaw-")
+
+	cfg := LoadConfig()
+
+	if cfg.ResourceAutoPrefix {
+		t.Fatal("ResourceAutoPrefix = true, want false")
+	}
+	if cfg.ResourcePrefix != "" {
+		t.Fatalf("ResourcePrefix = %q, want empty", cfg.ResourcePrefix)
+	}
+	if cfg.ContainerPrefix != "" {
+		t.Fatalf("ContainerPrefix = %q, want empty", cfg.ContainerPrefix)
+	}
+}
+
+func TestLoadConfigAutoPrefixDisabledKeepsExplicitContainerPrefix(t *testing.T) {
+	t.Setenv("HICLAW_RESOURCE_AUTOPREFIX", "false")
+	t.Setenv("HICLAW_PROXY_CONTAINER_PREFIX", "custom-worker-")
+
+	cfg := LoadConfig()
+
+	if cfg.ContainerPrefix != "custom-worker-" {
+		t.Fatalf("ContainerPrefix = %q, want %q", cfg.ContainerPrefix, "custom-worker-")
+	}
+}

--- a/hiclaw-controller/internal/controller/human_controller.go
+++ b/hiclaw-controller/internal/controller/human_controller.go
@@ -43,6 +43,7 @@ func (r *HumanReconciler) Reconcile(ctx context.Context, req reconcile.Request) 
 
 	s := &humanScope{
 		human:     &human,
+		username:  human.Spec.EffectiveUsername(human.Name),
 		patchBase: patchBase,
 	}
 

--- a/hiclaw-controller/internal/controller/human_reconcile_delete.go
+++ b/hiclaw-controller/internal/controller/human_reconcile_delete.go
@@ -26,7 +26,7 @@ func (r *HumanReconciler) reconcileHumanDelete(ctx context.Context, s *humanScop
 
 	humanUserID := h.Status.MatrixUserID
 	if humanUserID == "" {
-		humanUserID = r.Provisioner.MatrixUserID(h.Name)
+		humanUserID = r.Provisioner.MatrixUserID(s.username)
 	}
 	for _, roomID := range h.Status.Rooms {
 		if err := r.Provisioner.ForceLeaveRoom(ctx, humanUserID, roomID); err != nil {

--- a/hiclaw-controller/internal/controller/human_reconcile_infra.go
+++ b/hiclaw-controller/internal/controller/human_reconcile_infra.go
@@ -34,20 +34,45 @@ import (
 // the user may have rotated via Element.
 func (r *HumanReconciler) reconcileHumanInfra(ctx context.Context, s *humanScope) error {
 	h := s.human
+	username := s.username
+	expectedUserID := r.Provisioner.MatrixUserID(username)
 
-	if h.Status.MatrixUserID != "" {
-		return nil
+	needsProvision := h.Status.MatrixUserID == "" || h.Status.MatrixUserID != expectedUserID
+	if needsProvision {
+		creds, err := r.Provisioner.EnsureHumanUser(ctx, username)
+		if err != nil {
+			return fmt.Errorf("matrix registration failed: %w", err)
+		}
+		h.Status.MatrixUserID = creds.UserID
+		h.Status.InitialPassword = creds.Password
+		s.userToken = creds.AccessToken
+
+		log.FromContext(ctx).Info("human created",
+			"name", h.Name, "username", username, "matrixUserID", creds.UserID)
 	}
 
-	creds, err := r.Provisioner.EnsureHumanUser(ctx, h.Name)
-	if err != nil {
-		return fmt.Errorf("matrix registration failed: %w", err)
+	// Sync Matrix profile displayName on first provisioning and when spec changes.
+	shouldSyncDisplayName := needsProvision || h.Status.DisplayNameSyncedGeneration != h.Generation
+	if shouldSyncDisplayName {
+		token := s.userToken
+		if token == "" && h.Status.InitialPassword != "" {
+			if t, err := r.Provisioner.LoginAsHuman(ctx, username, h.Status.InitialPassword); err == nil {
+				token = t
+				s.userToken = t
+			} else {
+				log.FromContext(ctx).Info("human login failed before displayName sync; skipping this cycle",
+					"name", h.Name, "username", username, "err", err.Error())
+			}
+		}
+		if token != "" {
+			if err := r.Provisioner.SetDisplayName(ctx, h.Status.MatrixUserID, token, h.Spec.DisplayName); err != nil {
+				log.FromContext(ctx).Error(err, "failed to sync human displayName (non-fatal)",
+					"name", h.Name, "username", username)
+			} else {
+				h.Status.DisplayNameSyncedGeneration = h.Generation
+			}
+		}
 	}
-	h.Status.MatrixUserID = creds.UserID
-	h.Status.InitialPassword = creds.Password
-	s.userToken = creds.AccessToken
 
-	log.FromContext(ctx).Info("human created",
-		"name", h.Name, "matrixUserID", creds.UserID)
 	return nil
 }

--- a/hiclaw-controller/internal/controller/human_reconcile_rooms.go
+++ b/hiclaw-controller/internal/controller/human_reconcile_rooms.go
@@ -37,7 +37,7 @@ func (r *HumanReconciler) reconcileHumanRooms(ctx context.Context, s *humanScope
 
 	matrixUserID := h.Status.MatrixUserID
 	if matrixUserID == "" {
-		matrixUserID = r.Provisioner.MatrixUserID(h.Name)
+		matrixUserID = r.Provisioner.MatrixUserID(s.username)
 	}
 
 	// Start with currently-observed rooms; we'll prune removals below.
@@ -59,7 +59,7 @@ func (r *HumanReconciler) reconcileHumanRooms(ctx context.Context, s *humanScope
 		token := r.ensureUserToken(ctx, s)
 		if token == "" {
 			logger.V(1).Info("user token unavailable; invite-only this cycle",
-				"room", rid, "human", h.Name)
+				"room", rid, "human", h.Name, "username", s.username)
 			continue
 		}
 		if err := r.Provisioner.JoinRoomAs(ctx, rid, token); err != nil {
@@ -111,7 +111,7 @@ func (r *HumanReconciler) ensureUserToken(ctx context.Context, s *humanScope) st
 		return ""
 	}
 
-	token, err := r.Provisioner.LoginAsHuman(ctx, s.human.Name, s.human.Status.InitialPassword)
+	token, err := r.Provisioner.LoginAsHuman(ctx, s.username, s.human.Status.InitialPassword)
 	if err != nil {
 		log.FromContext(ctx).Info("human login with stored password failed; continuing with admin-only room management",
 			"name", s.human.Name, "err", err.Error())

--- a/hiclaw-controller/internal/controller/human_scope.go
+++ b/hiclaw-controller/internal/controller/human_scope.go
@@ -13,6 +13,7 @@ import (
 // function and mirrors the scope pattern used by managerScope.
 type humanScope struct {
 	human     *v1beta1.Human
+	username  string
 	patchBase client.Patch
 
 	// userToken is the Human's own Matrix access token for this reconcile

--- a/hiclaw-controller/internal/controller/member_reconcile.go
+++ b/hiclaw-controller/internal/controller/member_reconcile.go
@@ -33,10 +33,11 @@ func (r MemberRole) String() string { return string(r) }
 // per Team member directly from the Team CR without ever materializing a
 // Worker CR.
 type MemberContext struct {
-	Name      string
-	Namespace string
-	Role      MemberRole
-	Spec      v1beta1.WorkerSpec
+	Name        string // Kubernetes resource identity (CR/Pod/SA key)
+	RuntimeName string // business/runtime identity (Matrix/OSS/room alias key)
+	Namespace   string
+	Role        MemberRole
+	Spec        v1beta1.WorkerSpec
 
 	// Generation / ObservedGeneration are metadata included in logs to aid
 	// debugging. They are NOT used for spec-change detection — callers must
@@ -144,7 +145,7 @@ type MemberDeps struct {
 // RoomID, and ProvResult into state.
 func ReconcileMemberInfra(ctx context.Context, d MemberDeps, m MemberContext, state *MemberState) (reconcile.Result, error) {
 	if m.ExistingMatrixUserID != "" {
-		refreshResult, err := d.Provisioner.RefreshCredentials(ctx, m.Name)
+		refreshResult, err := d.Provisioner.RefreshCredentials(ctx, m.RuntimeName)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("refresh credentials: %w", err)
 		}
@@ -173,10 +174,10 @@ func ReconcileMemberInfra(ctx context.Context, d MemberDeps, m MemberContext, st
 		return reconcile.Result{}, nil
 	}
 
-	log.FromContext(ctx).Info("provisioning member infrastructure", "name", m.Name, "role", m.Role)
+	log.FromContext(ctx).Info("provisioning member infrastructure", "name", m.Name, "runtimeName", m.RuntimeName, "role", m.Role)
 
 	provResult, err := d.Provisioner.ProvisionWorker(ctx, service.WorkerProvisionRequest{
-		Name:           m.Name,
+		Name:           m.RuntimeName,
 		Role:           m.Role.String(),
 		TeamName:       m.TeamName,
 		TeamLeaderName: m.TeamLeaderName,
@@ -209,15 +210,15 @@ func ReconcileMemberConfig(ctx context.Context, d MemberDeps, m MemberContext, s
 	}
 	logger := log.FromContext(ctx)
 
-	if err := d.Deployer.DeployPackage(ctx, m.Name, m.Spec.Package, m.IsUpdate); err != nil {
+	if err := d.Deployer.DeployPackage(ctx, m.RuntimeName, m.Spec.Package, m.IsUpdate); err != nil {
 		return fmt.Errorf("deploy package: %w", err)
 	}
-	if err := d.Deployer.WriteInlineConfigs(m.Name, m.Spec); err != nil {
+	if err := d.Deployer.WriteInlineConfigs(m.RuntimeName, m.Spec); err != nil {
 		return fmt.Errorf("write inline configs: %w", err)
 	}
 
 	if err := d.Deployer.DeployWorkerConfig(ctx, service.WorkerDeployRequest{
-		Name:              m.Name,
+		Name:              m.RuntimeName,
 		Spec:              m.Spec,
 		Role:              m.Role.String(),
 		TeamName:          m.TeamName,
@@ -233,7 +234,7 @@ func ReconcileMemberConfig(ctx context.Context, d MemberDeps, m MemberContext, s
 		return fmt.Errorf("deploy worker config: %w", err)
 	}
 
-	if err := d.Deployer.PushOnDemandSkills(ctx, m.Name, m.Spec.Skills, m.Spec.RemoteSkills); err != nil {
+	if err := d.Deployer.PushOnDemandSkills(ctx, m.RuntimeName, m.Spec.Skills, m.Spec.RemoteSkills); err != nil {
 		logger.Info("skill push failed", "error", err)
 	}
 	return nil
@@ -368,7 +369,7 @@ func createMemberContainer(ctx context.Context, d MemberDeps, m MemberContext, s
 		state.ProvResult = prov
 	}
 
-	workerEnv := d.EnvBuilder.Build(m.Name, prov)
+	workerEnv := d.EnvBuilder.Build(m.RuntimeName, prov)
 	mergeUserEnv(workerEnv, m.Spec.Env, logger, string(m.Role)+"/"+m.Name)
 	saName := d.ResourcePrefix.SAName(authpkg.RoleWorker, m.Name)
 
@@ -434,19 +435,19 @@ func ReconcileMemberDelete(ctx context.Context, d MemberDeps, m MemberContext) e
 	logger := log.FromContext(ctx)
 	logger.Info("deleting member", "name", m.Name, "role", m.Role)
 
-	if err := d.Provisioner.LeaveAllWorkerRooms(ctx, m.Name); err != nil {
-		logger.Error(err, "member leave-all-rooms failed (non-fatal)", "name", m.Name)
+	if err := d.Provisioner.LeaveAllWorkerRooms(ctx, m.RuntimeName); err != nil {
+		logger.Error(err, "member leave-all-rooms failed (non-fatal)", "name", m.Name, "runtimeName", m.RuntimeName)
 	}
 	if m.ExistingRoomID != "" {
 		if err := d.Provisioner.DeleteWorkerRoom(ctx, m.ExistingRoomID); err != nil {
 			logger.Error(err, "member room delete command failed (non-fatal)",
-				"name", m.Name, "roomID", m.ExistingRoomID)
+				"name", m.Name, "runtimeName", m.RuntimeName, "roomID", m.ExistingRoomID)
 		}
 	}
 
 	isTeamWorker := m.Role == RoleTeamWorker || m.Role == RoleTeamLeader
 	if err := d.Provisioner.DeprovisionWorker(ctx, service.WorkerDeprovisionRequest{
-		Name:         m.Name,
+		Name:         m.RuntimeName,
 		IsTeamWorker: isTeamWorker,
 		ExposedPorts: m.CurrentExposedPorts,
 		ExposeSpec:   m.Spec.Expose,
@@ -474,21 +475,21 @@ func ReconcileMemberDelete(ctx context.Context, d MemberDeps, m MemberContext) e
 		}
 	}
 
-	if err := d.Deployer.CleanupOSSData(ctx, m.Name); err != nil {
-		logger.Error(err, "failed to clean up OSS agent data (non-fatal)", "name", m.Name)
+	if err := d.Deployer.CleanupOSSData(ctx, m.RuntimeName); err != nil {
+		logger.Error(err, "failed to clean up OSS agent data (non-fatal)", "name", m.Name, "runtimeName", m.RuntimeName)
 	}
-	if err := d.Provisioner.DeleteCredentials(ctx, m.Name); err != nil {
-		logger.Error(err, "failed to delete credentials (non-fatal)", "name", m.Name)
+	if err := d.Provisioner.DeleteCredentials(ctx, m.RuntimeName); err != nil {
+		logger.Error(err, "failed to delete credentials (non-fatal)", "name", m.Name, "runtimeName", m.RuntimeName)
 	}
 	if err := d.Provisioner.DeleteServiceAccount(ctx, m.Name); err != nil {
 		logger.Error(err, "failed to delete ServiceAccount (non-fatal)", "name", m.Name)
 	}
 	// Every worker (standalone, team leader, team worker) owns a per-worker
 	// comm room created by ProvisionWorker. Release its alias here so a
-	// future Worker/Team CR with the same name can reclaim it cleanly —
-	// the underlying room is left intact to preserve history.
-	if err := d.Provisioner.DeleteWorkerRoomAlias(ctx, m.Name); err != nil {
-		logger.Error(err, "failed to delete worker room alias (non-fatal)", "name", m.Name)
+	// future Worker/Team CR with the same runtime identity can reclaim it
+	// cleanly — the underlying room is left intact to preserve history.
+	if err := d.Provisioner.DeleteWorkerRoomAlias(ctx, m.RuntimeName); err != nil {
+		logger.Error(err, "failed to delete worker room alias (non-fatal)", "name", m.Name, "runtimeName", m.RuntimeName)
 	}
 	return nil
 }

--- a/hiclaw-controller/internal/controller/member_reconcile.go
+++ b/hiclaw-controller/internal/controller/member_reconcile.go
@@ -73,7 +73,7 @@ type MemberContext struct {
 	Heartbeat *agentconfig.HeartbeatConfig
 
 	// ExistingMatrixUserID is non-empty when prior provisioning has recorded a
-	// Matrix user; the Infra phase then uses RefreshCredentials instead of
+	// Matrix user; the Infra phase then uses RefreshWorkerCredentials instead of
 	// ProvisionWorker.
 	ExistingMatrixUserID string
 	// ExistingRoomID is the last-observed RoomID from the owning CR's status.
@@ -145,7 +145,7 @@ type MemberDeps struct {
 // RoomID, and ProvResult into state.
 func ReconcileMemberInfra(ctx context.Context, d MemberDeps, m MemberContext, state *MemberState) (reconcile.Result, error) {
 	if m.ExistingMatrixUserID != "" {
-		refreshResult, err := d.Provisioner.RefreshCredentials(ctx, m.RuntimeName)
+		refreshResult, err := d.Provisioner.RefreshWorkerCredentials(ctx, m.Name, m.RuntimeName)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("refresh credentials: %w", err)
 		}
@@ -178,6 +178,7 @@ func ReconcileMemberInfra(ctx context.Context, d MemberDeps, m MemberContext, st
 
 	provResult, err := d.Provisioner.ProvisionWorker(ctx, service.WorkerProvisionRequest{
 		Name:           m.RuntimeName,
+		CredentialName: m.Name,
 		Role:           m.Role.String(),
 		TeamName:       m.TeamName,
 		TeamLeaderName: m.TeamLeaderName,
@@ -354,7 +355,7 @@ func createMemberContainer(ctx context.Context, d MemberDeps, m MemberContext, s
 
 	prov := state.ProvResult
 	if prov == nil || prov.MatrixToken == "" {
-		refreshResult, err := d.Provisioner.RefreshCredentials(ctx, m.Name)
+		refreshResult, err := d.Provisioner.RefreshWorkerCredentials(ctx, m.Name, m.RuntimeName)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("refresh credentials for container: %w", err)
 		}
@@ -479,7 +480,7 @@ func ReconcileMemberDelete(ctx context.Context, d MemberDeps, m MemberContext) e
 	if err := d.Deployer.CleanupOSSData(ctx, m.RuntimeName); err != nil {
 		logger.Error(err, "failed to clean up OSS agent data (non-fatal)", "name", m.Name, "runtimeName", m.RuntimeName)
 	}
-	if err := d.Provisioner.DeleteCredentials(ctx, m.RuntimeName); err != nil {
+	if err := d.Provisioner.DeleteWorkerCredentials(ctx, m.Name); err != nil {
 		logger.Error(err, "failed to delete credentials (non-fatal)", "name", m.Name, "runtimeName", m.RuntimeName)
 	}
 	if err := d.Provisioner.DeleteServiceAccount(ctx, m.Name); err != nil {

--- a/hiclaw-controller/internal/controller/member_reconcile.go
+++ b/hiclaw-controller/internal/controller/member_reconcile.go
@@ -370,6 +370,7 @@ func createMemberContainer(ctx context.Context, d MemberDeps, m MemberContext, s
 	}
 
 	workerEnv := d.EnvBuilder.Build(m.RuntimeName, prov)
+	workerEnv["HICLAW_WORKER_CR_NAME"] = m.Name
 	mergeUserEnv(workerEnv, m.Spec.Env, logger, string(m.Role)+"/"+m.Name)
 	saName := d.ResourcePrefix.SAName(authpkg.RoleWorker, m.Name)
 

--- a/hiclaw-controller/internal/controller/team_controller.go
+++ b/hiclaw-controller/internal/controller/team_controller.go
@@ -128,18 +128,21 @@ func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Tea
 	}
 
 	workerNames := make([]string, 0, len(t.Spec.Workers))
+	workerRuntimeNames := make([]string, 0, len(t.Spec.Workers))
 	for _, w := range t.Spec.Workers {
 		workerNames = append(workerNames, w.Name)
+		workerRuntimeNames = append(workerRuntimeNames, w.EffectiveWorkerName())
 	}
 	if err := validateTeamRuntimeNames(t); err != nil {
 		return r.failTeam(ctx, t, patchBase, err.Error())
 	}
+	leaderRuntimeName := t.Spec.Leader.EffectiveWorkerName()
 
 	// --- Step 1: Team-level infrastructure ---
 	rooms, err := r.Provisioner.ProvisionTeamRooms(ctx, service.TeamRoomRequest{
 		TeamName:    t.Name,
-		LeaderName:  t.Spec.Leader.Name,
-		WorkerNames: workerNames,
+		LeaderName:  leaderRuntimeName,
+		WorkerNames: workerRuntimeNames,
 		AdminSpec:   t.Spec.Admin,
 	})
 	if err != nil {
@@ -196,7 +199,7 @@ func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Tea
 			Namespace:           t.Namespace,
 			Role:                role,
 			TeamName:            t.Name,
-			TeamLeaderName:      t.Spec.Leader.Name,
+			TeamLeaderName:      leaderRuntimeName,
 			ExistingRoomID:      ms.RoomID,
 			CurrentExposedPorts: ms.ExposedPorts,
 		}
@@ -206,6 +209,28 @@ func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Tea
 		r.removeLegacyMember(ctx, runtimeName)
 	}
 	pruneMembers(&t.Status, desiredNames)
+
+	// --- Step 3.5: Leader coordination context + SOUL.md template ---
+	// Must run before member reconciliation so renderAndPushSoulTemplate
+	// pushes the final SOUL.md to MinIO before the leader container starts
+	// and before DeployWorkerConfig would otherwise race with it.
+	var teamAdminID string
+	if t.Spec.Admin != nil {
+		teamAdminID = t.Spec.Admin.MatrixUserID
+	}
+	if err := r.Deployer.InjectCoordinationContext(ctx, service.CoordinationDeployRequest{
+		LeaderName:        leaderRuntimeName,
+		Role:              RoleTeamLeader.String(),
+		TeamName:          t.Name,
+		TeamRoomID:        rooms.TeamRoomID,
+		LeaderDMRoomID:    rooms.LeaderDMRoomID,
+		HeartbeatEvery:    leaderHeartbeatEvery(t),
+		WorkerIdleTimeout: t.Spec.Leader.WorkerIdleTimeout,
+		TeamWorkers:       workerRuntimeNames,
+		TeamAdminID:       teamAdminID,
+	}); err != nil {
+		logger.Error(err, "leader coordination context injection failed (non-fatal)")
+	}
 
 	// --- Step 4: Reconcile each desired member (leader first) ---
 	//
@@ -248,27 +273,9 @@ func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Tea
 		r.reconcileLegacyMember(ctx, t, m, ms)
 	}
 
-	// --- Step 5: Leader-specific hooks (coordination, groupAllowFrom, registry) ---
-	var teamAdminID string
-	if t.Spec.Admin != nil {
-		teamAdminID = t.Spec.Admin.MatrixUserID
-	}
-	if err := r.Deployer.InjectCoordinationContext(ctx, service.CoordinationDeployRequest{
-		LeaderName:        t.Spec.Leader.Name,
-		Role:              RoleTeamLeader.String(),
-		TeamName:          t.Name,
-		TeamRoomID:        rooms.TeamRoomID,
-		LeaderDMRoomID:    rooms.LeaderDMRoomID,
-		HeartbeatEvery:    leaderHeartbeatEvery(t),
-		WorkerIdleTimeout: t.Spec.Leader.WorkerIdleTimeout,
-		TeamWorkers:       workerNames,
-		TeamAdminID:       teamAdminID,
-	}); err != nil {
-		logger.Error(err, "leader coordination context injection failed (non-fatal)")
-	}
-
+	// --- Step 5: Registry updates ---
 	if r.Legacy != nil && r.Legacy.Enabled() {
-		leaderMatrixID := r.Legacy.MatrixUserID(t.Spec.Leader.Name)
+		leaderMatrixID := r.Legacy.MatrixUserID(leaderRuntimeName)
 		if err := r.Legacy.UpdateManagerGroupAllowFrom(leaderMatrixID, true); err != nil {
 			logger.Error(err, "failed to update Manager groupAllowFrom for team leader (non-fatal)")
 		}
@@ -472,7 +479,7 @@ func (r *TeamReconciler) handleDelete(ctx context.Context, t *v1beta1.Team) erro
 			Namespace:           t.Namespace,
 			Role:                role,
 			TeamName:            t.Name,
-			TeamLeaderName:      t.Spec.Leader.Name,
+			TeamLeaderName:      t.Spec.Leader.EffectiveWorkerName(),
 			ExistingRoomID:      existingRoomID,
 			CurrentExposedPorts: exposed,
 		}
@@ -504,7 +511,7 @@ func (r *TeamReconciler) handleDelete(ctx context.Context, t *v1beta1.Team) erro
 
 	if r.Legacy != nil && r.Legacy.Enabled() {
 		if t.Spec.Leader.Name != "" {
-			leaderMatrixID := r.Legacy.MatrixUserID(t.Spec.Leader.Name)
+			leaderMatrixID := r.Legacy.MatrixUserID(t.Spec.Leader.EffectiveWorkerName())
 			if err := r.Legacy.UpdateManagerGroupAllowFrom(leaderMatrixID, false); err != nil {
 				logger.Error(err, "failed to revoke Manager groupAllowFrom (non-fatal)")
 			}
@@ -751,7 +758,7 @@ func buildDesiredMembers(t *v1beta1.Team, controllerName string) []MemberContext
 			SpecChanged:       memberSpecChanged(t, RoleTeamWorker, w.Name),
 			IsUpdate:          workerObserved,
 			TeamName:          t.Name,
-			TeamLeaderName:    t.Spec.Leader.Name,
+			TeamLeaderName:    t.Spec.Leader.EffectiveWorkerName(),
 			TeamAdminMatrixID: teamAdminMatrixID(t),
 			PodLabels:         memberLabels(RoleTeamWorker, w.Labels),
 			Owner:             t,
@@ -865,12 +872,12 @@ func leaderWorkerSpec(t *v1beta1.Team) v1beta1.WorkerSpec {
 	policy := mergeChannelPolicy(t.Spec.ChannelPolicy, t.Spec.Leader.ChannelPolicy)
 	workerNames := make([]string, 0, len(t.Spec.Workers))
 	for _, w := range t.Spec.Workers {
-		workerNames = append(workerNames, w.Name)
+		workerNames = append(workerNames, w.EffectiveWorkerName())
 	}
 	policy = appendGroupAllowExtra(policy, workerNames...)
-	if t.Spec.Admin != nil && t.Spec.Admin.Name != "" {
-		policy = appendGroupAllowExtra(policy, t.Spec.Admin.Name)
-		policy = appendDmAllowExtra(policy, t.Spec.Admin.Name)
+	if adminID := teamAdminMatrixID(t); adminID != "" {
+		policy = appendGroupAllowExtra(policy, adminID)
+		policy = appendDmAllowExtra(policy, adminID)
 	}
 	return v1beta1.WorkerSpec{
 		Model:         t.Spec.Leader.Model,
@@ -901,15 +908,15 @@ func leaderWorkerSpec(t *v1beta1.Team) v1beta1.WorkerSpec {
 // resolution chain used by standalone Worker CRs.
 func teamWorkerSpecToWorkerSpec(t *v1beta1.Team, w v1beta1.TeamWorkerSpec) v1beta1.WorkerSpec {
 	policy := mergeChannelPolicy(t.Spec.ChannelPolicy, w.ChannelPolicy)
-	policy = appendGroupAllowExtra(policy, t.Spec.Leader.Name)
-	if t.Spec.Admin != nil && t.Spec.Admin.Name != "" {
-		policy = appendGroupAllowExtra(policy, t.Spec.Admin.Name)
+	policy = appendGroupAllowExtra(policy, t.Spec.Leader.EffectiveWorkerName())
+	if adminID := teamAdminMatrixID(t); adminID != "" {
+		policy = appendGroupAllowExtra(policy, adminID)
 	}
 	peerMentions := t.Spec.PeerMentions == nil || *t.Spec.PeerMentions
 	if peerMentions {
 		for _, peer := range t.Spec.Workers {
 			if peer.Name != w.Name {
-				policy = appendGroupAllowExtra(policy, peer.Name)
+				policy = appendGroupAllowExtra(policy, peer.EffectiveWorkerName())
 			}
 		}
 	}

--- a/hiclaw-controller/internal/controller/team_controller.go
+++ b/hiclaw-controller/internal/controller/team_controller.go
@@ -181,6 +181,7 @@ func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Tea
 		}
 		staleCtx := MemberContext{
 			Name:                ms.Name,
+			RuntimeName:         ms.Name,
 			Namespace:           t.Namespace,
 			Role:                RoleTeamWorker,
 			TeamName:            t.Name,
@@ -455,6 +456,7 @@ func (r *TeamReconciler) handleDelete(ctx context.Context, t *v1beta1.Team) erro
 		}
 		mctx := MemberContext{
 			Name:                name,
+			RuntimeName:         name,
 			Namespace:           t.Namespace,
 			Role:                role,
 			TeamName:            t.Name,
@@ -698,6 +700,7 @@ func buildDesiredMembers(t *v1beta1.Team, controllerName string) []MemberContext
 	}
 	members = append(members, MemberContext{
 		Name:              t.Spec.Leader.Name,
+		RuntimeName:       t.Spec.Leader.Name,
 		Namespace:         t.Namespace,
 		Role:              RoleTeamLeader,
 		Spec:              leaderSpec,
@@ -717,6 +720,7 @@ func buildDesiredMembers(t *v1beta1.Team, controllerName string) []MemberContext
 		spec := teamWorkerSpecToWorkerSpec(t, w)
 		members = append(members, MemberContext{
 			Name:              w.Name,
+			RuntimeName:       w.Name,
 			Namespace:         t.Namespace,
 			Role:              RoleTeamWorker,
 			Spec:              spec,

--- a/hiclaw-controller/internal/controller/team_controller.go
+++ b/hiclaw-controller/internal/controller/team_controller.go
@@ -136,11 +136,12 @@ func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Tea
 	if err := validateTeamRuntimeNames(t); err != nil {
 		return r.failTeam(ctx, t, patchBase, err.Error())
 	}
+	teamRuntimeName := t.Spec.EffectiveTeamName(t.Name)
 	leaderRuntimeName := t.Spec.Leader.EffectiveWorkerName()
 
 	// --- Step 1: Team-level infrastructure ---
 	rooms, err := r.Provisioner.ProvisionTeamRooms(ctx, service.TeamRoomRequest{
-		TeamName:    t.Name,
+		TeamName:    teamRuntimeName,
 		LeaderName:  leaderRuntimeName,
 		WorkerNames: workerRuntimeNames,
 		AdminSpec:   t.Spec.Admin,
@@ -151,8 +152,8 @@ func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Tea
 	t.Status.TeamRoomID = rooms.TeamRoomID
 	t.Status.LeaderDMRoomID = rooms.LeaderDMRoomID
 
-	if err := r.Deployer.EnsureTeamStorage(ctx, t.Name); err != nil {
-		logger.Error(err, "team shared storage init failed (non-fatal)", "name", t.Name)
+	if err := r.Deployer.EnsureTeamStorage(ctx, teamRuntimeName); err != nil {
+		logger.Error(err, "team shared storage init failed (non-fatal)", "name", t.Name, "teamName", teamRuntimeName)
 	}
 
 	// --- Step 2: Write local inline configs (shared FS with agents) ---
@@ -198,7 +199,7 @@ func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Tea
 			RuntimeName:         runtimeName,
 			Namespace:           t.Namespace,
 			Role:                role,
-			TeamName:            t.Name,
+			TeamName:            teamRuntimeName,
 			TeamLeaderName:      leaderRuntimeName,
 			ExistingRoomID:      ms.RoomID,
 			CurrentExposedPorts: ms.ExposedPorts,
@@ -221,7 +222,7 @@ func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Tea
 	if err := r.Deployer.InjectCoordinationContext(ctx, service.CoordinationDeployRequest{
 		LeaderName:        leaderRuntimeName,
 		Role:              RoleTeamLeader.String(),
-		TeamName:          t.Name,
+		TeamName:          teamRuntimeName,
 		TeamRoomID:        rooms.TeamRoomID,
 		LeaderDMRoomID:    rooms.LeaderDMRoomID,
 		HeartbeatEvery:    leaderHeartbeatEvery(t),
@@ -280,7 +281,7 @@ func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Tea
 			logger.Error(err, "failed to update Manager groupAllowFrom for team leader (non-fatal)")
 		}
 		if err := r.Legacy.UpdateTeamsRegistry(service.TeamRegistryEntry{
-			Name:           t.Name,
+			Name:           teamRuntimeName,
 			Leader:         t.Spec.Leader.Name,
 			Workers:        workerNames,
 			TeamRoomID:     rooms.TeamRoomID,
@@ -438,6 +439,7 @@ func (r *TeamReconciler) writeInlineConfigs(t *v1beta1.Team) error {
 func (r *TeamReconciler) handleDelete(ctx context.Context, t *v1beta1.Team) error {
 	logger := log.FromContext(ctx)
 	logger.Info("deleting team", "name", t.Name)
+	teamRuntimeName := t.Spec.EffectiveTeamName(t.Name)
 
 	deps := MemberDeps{
 		Provisioner:    r.Provisioner,
@@ -478,7 +480,7 @@ func (r *TeamReconciler) handleDelete(ctx context.Context, t *v1beta1.Team) erro
 			RuntimeName:         name,
 			Namespace:           t.Namespace,
 			Role:                role,
-			TeamName:            t.Name,
+			TeamName:            teamRuntimeName,
 			TeamLeaderName:      t.Spec.Leader.EffectiveWorkerName(),
 			ExistingRoomID:      existingRoomID,
 			CurrentExposedPorts: exposed,
@@ -516,7 +518,7 @@ func (r *TeamReconciler) handleDelete(ctx context.Context, t *v1beta1.Team) erro
 				logger.Error(err, "failed to revoke Manager groupAllowFrom (non-fatal)")
 			}
 		}
-		if err := r.Legacy.RemoveFromTeamsRegistry(ctx, t.Name); err != nil {
+		if err := r.Legacy.RemoveFromTeamsRegistry(ctx, teamRuntimeName); err != nil {
 			logger.Error(err, "failed to remove team from registry (non-fatal)")
 		}
 	}
@@ -526,7 +528,7 @@ func (r *TeamReconciler) handleDelete(ctx context.Context, t *v1beta1.Team) erro
 	// leave on their own schedule), but a fresh Team CR with the same name
 	// must get a clean alias so CreateRoom resolves a new room instead of
 	// reattaching to the old one.
-	if err := r.Provisioner.DeleteTeamRoomAliases(ctx, t.Name, t.Spec.Leader.EffectiveWorkerName()); err != nil {
+	if err := r.Provisioner.DeleteTeamRoomAliases(ctx, teamRuntimeName, t.Spec.Leader.EffectiveWorkerName()); err != nil {
 		logger.Error(err, "failed to delete team room aliases (non-fatal)")
 	}
 
@@ -579,7 +581,7 @@ func (r *TeamReconciler) reconcileLegacyMember(ctx context.Context, t *v1beta1.T
 		Deployment:   "local",
 		Skills:       m.Spec.Skills,
 		Role:         m.Role.String(),
-		TeamID:       nilIfEmpty(t.Name),
+		TeamID:       nilIfEmpty(t.Spec.EffectiveTeamName(t.Name)),
 		Image:        nilIfEmpty(m.Spec.Image),
 	}
 	if err := r.Legacy.UpdateWorkersRegistry(entry); err != nil {
@@ -687,6 +689,7 @@ func observedMemberNames(s *v1beta1.TeamStatus) []string {
 // is intentionally excluded so adding/removing a peer does NOT recreate the
 // other members — only the newly added member gets a fresh container.
 func buildDesiredMembers(t *v1beta1.Team, controllerName string) []MemberContext {
+	teamRuntimeName := t.Spec.EffectiveTeamName(t.Name)
 	isObserved := func(name string) bool {
 		if ms := t.Status.MemberByName(name); ms != nil {
 			return ms.Observed
@@ -737,7 +740,7 @@ func buildDesiredMembers(t *v1beta1.Team, controllerName string) []MemberContext
 		Generation:        t.Generation,
 		SpecChanged:       memberSpecChanged(t, RoleTeamLeader, t.Spec.Leader.Name),
 		IsUpdate:          leaderObserved,
-		TeamName:          t.Name,
+		TeamName:          teamRuntimeName,
 		TeamLeaderName:    "",
 		TeamAdminMatrixID: teamAdminMatrixID(t),
 		PodLabels:         memberLabels(RoleTeamLeader, t.Spec.Leader.Labels),
@@ -757,7 +760,7 @@ func buildDesiredMembers(t *v1beta1.Team, controllerName string) []MemberContext
 			Generation:        t.Generation,
 			SpecChanged:       memberSpecChanged(t, RoleTeamWorker, w.Name),
 			IsUpdate:          workerObserved,
-			TeamName:          t.Name,
+			TeamName:          teamRuntimeName,
 			TeamLeaderName:    t.Spec.Leader.EffectiveWorkerName(),
 			TeamAdminMatrixID: teamAdminMatrixID(t),
 			PodLabels:         memberLabels(RoleTeamWorker, w.Labels),

--- a/hiclaw-controller/internal/controller/team_controller.go
+++ b/hiclaw-controller/internal/controller/team_controller.go
@@ -131,6 +131,9 @@ func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Tea
 	for _, w := range t.Spec.Workers {
 		workerNames = append(workerNames, w.Name)
 	}
+	if err := validateTeamRuntimeNames(t); err != nil {
+		return r.failTeam(ctx, t, patchBase, err.Error())
+	}
 
 	// --- Step 1: Team-level infrastructure ---
 	rooms, err := r.Provisioner.ProvisionTeamRooms(ctx, service.TeamRoomRequest{
@@ -179,11 +182,19 @@ func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Tea
 		if _, keep := desiredNames[ms.Name]; keep {
 			continue
 		}
+		runtimeName := ms.RuntimeName
+		if runtimeName == "" {
+			runtimeName = ms.Name
+		}
+		role := RoleTeamWorker
+		if ms.Role == RoleTeamLeader.String() || ms.Name == t.Spec.Leader.Name {
+			role = RoleTeamLeader
+		}
 		staleCtx := MemberContext{
 			Name:                ms.Name,
-			RuntimeName:         ms.Name,
+			RuntimeName:         runtimeName,
 			Namespace:           t.Namespace,
-			Role:                RoleTeamWorker,
+			Role:                role,
 			TeamName:            t.Name,
 			TeamLeaderName:      t.Spec.Leader.Name,
 			ExistingRoomID:      ms.RoomID,
@@ -192,7 +203,7 @@ func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Tea
 		if err := ReconcileMemberDelete(ctx, deps, staleCtx); err != nil {
 			logger.Error(err, "failed to remove stale team member (non-fatal)", "name", ms.Name)
 		}
-		r.removeLegacyMember(ctx, ms.Name)
+		r.removeLegacyMember(ctx, runtimeName)
 	}
 	pruneMembers(&t.Status, desiredNames)
 
@@ -323,7 +334,7 @@ func (r *TeamReconciler) reconcileMember(ctx context.Context, deps MemberDeps, m
 	// Pre-populate ExistingMatrixUserID when we've already provisioned the
 	// member before, forcing the Refresh path instead of Provision.
 	if m.IsUpdate {
-		m.ExistingMatrixUserID = r.Provisioner.MatrixUserID(m.Name)
+		m.ExistingMatrixUserID = r.Provisioner.MatrixUserID(m.RuntimeName)
 	}
 
 	if _, err := ReconcileMemberInfra(ctx, deps, m, state); err != nil {
@@ -336,6 +347,7 @@ func (r *TeamReconciler) reconcileMember(ctx context.Context, deps MemberDeps, m
 	if state.MatrixUserID != "" {
 		ms.MatrixUserID = state.MatrixUserID
 	}
+	ms.RuntimeName = m.RuntimeName
 	if err := EnsureMemberServiceAccount(ctx, deps, m); err != nil {
 		return err
 	}
@@ -464,8 +476,12 @@ func (r *TeamReconciler) handleDelete(ctx context.Context, t *v1beta1.Team) erro
 			ExistingRoomID:      existingRoomID,
 			CurrentExposedPorts: exposed,
 		}
+		if ms := t.Status.MemberByName(name); ms != nil && ms.RuntimeName != "" {
+			mctx.RuntimeName = ms.RuntimeName
+		}
 		if role == RoleTeamLeader {
 			mctx.Spec = leaderWorkerSpec(t)
+			mctx.RuntimeName = t.Spec.Leader.EffectiveWorkerName()
 		} else {
 			// For "observed but no longer in Spec.Workers" entries (stale),
 			// the inner loop finds no match and mctx.Spec stays zero. The
@@ -483,7 +499,7 @@ func (r *TeamReconciler) handleDelete(ctx context.Context, t *v1beta1.Team) erro
 			logger.Error(err, "member cleanup failed (non-fatal)", "name", name)
 			errs = append(errs, err)
 		}
-		r.removeLegacyMember(ctx, name)
+		r.removeLegacyMember(ctx, mctx.RuntimeName)
 	}
 
 	if r.Legacy != nil && r.Legacy.Enabled() {
@@ -538,6 +554,10 @@ func (r *TeamReconciler) reconcileLegacyMember(ctx context.Context, t *v1beta1.T
 		return
 	}
 	logger := log.FromContext(ctx)
+	runtimeName := m.RuntimeName
+	if runtimeName == "" {
+		runtimeName = m.Name
+	}
 
 	roomID := ""
 	if ms != nil {
@@ -545,8 +565,8 @@ func (r *TeamReconciler) reconcileLegacyMember(ctx context.Context, t *v1beta1.T
 	}
 
 	entry := service.WorkerRegistryEntry{
-		Name:         m.Name,
-		MatrixUserID: r.Legacy.MatrixUserID(m.Name),
+		Name:         runtimeName,
+		MatrixUserID: r.Legacy.MatrixUserID(runtimeName),
 		RoomID:       roomID,
 		Runtime:      m.Spec.Runtime,
 		Deployment:   "local",
@@ -556,19 +576,22 @@ func (r *TeamReconciler) reconcileLegacyMember(ctx context.Context, t *v1beta1.T
 		Image:        nilIfEmpty(m.Spec.Image),
 	}
 	if err := r.Legacy.UpdateWorkersRegistry(entry); err != nil {
-		logger.Error(err, "workers-registry update failed (non-fatal)", "name", m.Name)
+		logger.Error(err, "workers-registry update failed (non-fatal)", "name", m.Name, "runtimeName", runtimeName)
 	}
 }
 
 // removeLegacyMember deletes a team member from workers-registry.json. Used
 // by both the stale-member cleanup in reconcileTeamNormal and the full team
 // deletion in handleDelete. No-op when Legacy is disabled.
-func (r *TeamReconciler) removeLegacyMember(ctx context.Context, name string) {
+func (r *TeamReconciler) removeLegacyMember(ctx context.Context, runtimeName string) {
 	if r.Legacy == nil || !r.Legacy.Enabled() {
 		return
 	}
-	if err := r.Legacy.RemoveFromWorkersRegistry(name); err != nil {
-		log.FromContext(ctx).Error(err, "workers-registry remove failed (non-fatal)", "name", name)
+	if runtimeName == "" {
+		return
+	}
+	if err := r.Legacy.RemoveFromWorkersRegistry(runtimeName); err != nil {
+		log.FromContext(ctx).Error(err, "workers-registry remove failed (non-fatal)", "runtimeName", runtimeName)
 	}
 }
 
@@ -700,7 +723,7 @@ func buildDesiredMembers(t *v1beta1.Team, controllerName string) []MemberContext
 	}
 	members = append(members, MemberContext{
 		Name:              t.Spec.Leader.Name,
-		RuntimeName:       t.Spec.Leader.Name,
+		RuntimeName:       t.Spec.Leader.EffectiveWorkerName(),
 		Namespace:         t.Namespace,
 		Role:              RoleTeamLeader,
 		Spec:              leaderSpec,
@@ -720,7 +743,7 @@ func buildDesiredMembers(t *v1beta1.Team, controllerName string) []MemberContext
 		spec := teamWorkerSpecToWorkerSpec(t, w)
 		members = append(members, MemberContext{
 			Name:              w.Name,
-			RuntimeName:       w.Name,
+			RuntimeName:       w.EffectiveWorkerName(),
 			Namespace:         t.Namespace,
 			Role:              RoleTeamWorker,
 			Spec:              spec,
@@ -852,6 +875,7 @@ func leaderWorkerSpec(t *v1beta1.Team) v1beta1.WorkerSpec {
 	return v1beta1.WorkerSpec{
 		Model:         t.Spec.Leader.Model,
 		Runtime:       "copaw",
+		WorkerName:    t.Spec.Leader.WorkerName,
 		Identity:      t.Spec.Leader.Identity,
 		Soul:          t.Spec.Leader.Soul,
 		Agents:        t.Spec.Leader.Agents,
@@ -892,6 +916,7 @@ func teamWorkerSpecToWorkerSpec(t *v1beta1.Team, w v1beta1.TeamWorkerSpec) v1bet
 	return v1beta1.WorkerSpec{
 		Model:         w.Model,
 		Runtime:       w.Runtime,
+		WorkerName:    w.WorkerName,
 		Image:         w.Image,
 		Identity:      w.Identity,
 		Soul:          w.Soul,
@@ -905,6 +930,20 @@ func teamWorkerSpecToWorkerSpec(t *v1beta1.Team, w v1beta1.TeamWorkerSpec) v1bet
 		State:         w.State,
 		Env:           w.Env,
 	}
+}
+
+func validateTeamRuntimeNames(t *v1beta1.Team) error {
+	seen := map[string]string{}
+	leaderRuntime := t.Spec.Leader.EffectiveWorkerName()
+	seen[leaderRuntime] = "leader[" + t.Spec.Leader.Name + "]"
+	for _, w := range t.Spec.Workers {
+		runtimeName := w.EffectiveWorkerName()
+		if owner, ok := seen[runtimeName]; ok {
+			return fmt.Errorf("duplicate team runtime workerName %q between %s and worker[%s]", runtimeName, owner, w.Name)
+		}
+		seen[runtimeName] = "worker[" + w.Name + "]"
+	}
+	return nil
 }
 
 func teamAdminMatrixID(t *v1beta1.Team) string {

--- a/hiclaw-controller/internal/controller/team_controller.go
+++ b/hiclaw-controller/internal/controller/team_controller.go
@@ -526,7 +526,7 @@ func (r *TeamReconciler) handleDelete(ctx context.Context, t *v1beta1.Team) erro
 	// leave on their own schedule), but a fresh Team CR with the same name
 	// must get a clean alias so CreateRoom resolves a new room instead of
 	// reattaching to the old one.
-	if err := r.Provisioner.DeleteTeamRoomAliases(ctx, t.Name, t.Spec.Leader.Name); err != nil {
+	if err := r.Provisioner.DeleteTeamRoomAliases(ctx, t.Name, t.Spec.Leader.EffectiveWorkerName()); err != nil {
 		logger.Error(err, "failed to delete team room aliases (non-fatal)")
 	}
 

--- a/hiclaw-controller/internal/controller/team_controller_test.go
+++ b/hiclaw-controller/internal/controller/team_controller_test.go
@@ -112,6 +112,62 @@ func TestTeamWorkerSpecToWorkerSpec_RuntimePassthrough(t *testing.T) {
 	}
 }
 
+func TestBuildDesiredMembers_RuntimeWorkerNamesDriveMatrixPolicy(t *testing.T) {
+	team := &v1beta1.Team{}
+	team.Name = "alpha"
+	team.Spec.Leader = v1beta1.LeaderSpec{
+		Name:       "alpha-worker-lead",
+		WorkerName: "lead",
+		Model:      "gpt-4o",
+	}
+	team.Spec.Workers = []v1beta1.TeamWorkerSpec{
+		{Name: "alpha-worker-dev", WorkerName: "dev", Model: "gpt-4o"},
+		{Name: "alpha-worker-qa", WorkerName: "qa", Model: "gpt-4o"},
+	}
+	team.Spec.Admin = &v1beta1.TeamAdminSpec{
+		Name:         "alpha-human-yhf",
+		MatrixUserID: "@yhf:example.com",
+	}
+
+	members := buildDesiredMembers(team, "")
+	byName := map[string]MemberContext{}
+	for _, m := range members {
+		byName[m.Name] = m
+	}
+
+	if got := byName["alpha-worker-lead"].RuntimeName; got != "lead" {
+		t.Fatalf("leader RuntimeName=%q, want lead", got)
+	}
+	if got := byName["alpha-worker-dev"].RuntimeName; got != "dev" {
+		t.Fatalf("worker RuntimeName=%q, want dev", got)
+	}
+	if got := byName["alpha-worker-dev"].TeamLeaderName; got != "lead" {
+		t.Fatalf("worker TeamLeaderName=%q, want lead", got)
+	}
+
+	leaderAllow := byName["alpha-worker-lead"].Spec.ChannelPolicy.GroupAllowExtra
+	if !stringSliceContains(leaderAllow, "dev") || !stringSliceContains(leaderAllow, "qa") {
+		t.Fatalf("leader groupAllowExtra=%v, want runtime worker names dev/qa", leaderAllow)
+	}
+	if stringSliceContains(leaderAllow, "alpha-worker-dev") {
+		t.Fatalf("leader groupAllowExtra=%v must not use CR worker name", leaderAllow)
+	}
+	if !stringSliceContains(leaderAllow, "@yhf:example.com") || stringSliceContains(leaderAllow, "alpha-human-yhf") {
+		t.Fatalf("leader groupAllowExtra=%v must use admin MatrixUserID, not admin CR name", leaderAllow)
+	}
+
+	devAllow := byName["alpha-worker-dev"].Spec.ChannelPolicy.GroupAllowExtra
+	if !stringSliceContains(devAllow, "lead") || !stringSliceContains(devAllow, "qa") {
+		t.Fatalf("dev groupAllowExtra=%v, want runtime leader/peer names lead/qa", devAllow)
+	}
+	if stringSliceContains(devAllow, "alpha-worker-lead") || stringSliceContains(devAllow, "alpha-worker-qa") {
+		t.Fatalf("dev groupAllowExtra=%v must not use CR member names", devAllow)
+	}
+	if !stringSliceContains(devAllow, "@yhf:example.com") || stringSliceContains(devAllow, "alpha-human-yhf") {
+		t.Fatalf("dev groupAllowExtra=%v must use admin MatrixUserID, not admin CR name", devAllow)
+	}
+}
+
 // TestBuildDesiredMembers_SpecChangedDetection locks in the per-member
 // spec-change detection that prevents unnecessary container recreation. It
 // covers three cases on the same reconcile:
@@ -593,4 +649,13 @@ func TestBuildDesiredMembers_SystemLabelsOverrideUserLabels(t *testing.T) {
 	if got := byName["w1"].PodLabels["hiclaw.io/role"]; got != RoleTeamWorker.String() {
 		t.Errorf("w1 role got %q, want %q", got, RoleTeamWorker.String())
 	}
+}
+
+func stringSliceContains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }

--- a/hiclaw-controller/internal/controller/team_controller_test.go
+++ b/hiclaw-controller/internal/controller/team_controller_test.go
@@ -8,6 +8,7 @@ import (
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
 	"github.com/hiclaw/hiclaw-controller/internal/oss/ossfake"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
+	"github.com/hiclaw/hiclaw-controller/test/testutil/mocks"
 )
 
 func TestLeaderHeartbeatEvery(t *testing.T) {
@@ -165,6 +166,78 @@ func TestBuildDesiredMembers_RuntimeWorkerNamesDriveMatrixPolicy(t *testing.T) {
 	}
 	if !stringSliceContains(devAllow, "@yhf:example.com") || stringSliceContains(devAllow, "alpha-human-yhf") {
 		t.Fatalf("dev groupAllowExtra=%v must use admin MatrixUserID, not admin CR name", devAllow)
+	}
+}
+
+func TestReconcileMemberInfraUsesCRNameForCredentialKey(t *testing.T) {
+	prov := mocks.NewMockProvisioner()
+	state := &MemberState{}
+	member := MemberContext{
+		Name:        "alpha-worker-lead",
+		RuntimeName: "leader",
+		Role:        RoleTeamLeader,
+	}
+
+	if _, err := ReconcileMemberInfra(context.Background(), MemberDeps{Provisioner: prov}, member, state); err != nil {
+		t.Fatalf("ReconcileMemberInfra: %v", err)
+	}
+
+	if len(prov.Calls.ProvisionWorker) != 1 {
+		t.Fatalf("ProvisionWorker calls=%d, want 1", len(prov.Calls.ProvisionWorker))
+	}
+	req := prov.Calls.ProvisionWorker[0]
+	if req.Name != "leader" {
+		t.Fatalf("ProvisionWorker Name=%q, want runtime workerName leader", req.Name)
+	}
+	if req.CredentialName != "alpha-worker-lead" {
+		t.Fatalf("ProvisionWorker CredentialName=%q, want CR name alpha-worker-lead", req.CredentialName)
+	}
+}
+
+func TestReconcileMemberRefreshUsesCRNameCredentialAndRuntimeMatrixName(t *testing.T) {
+	prov := mocks.NewMockProvisioner()
+	state := &MemberState{}
+	member := MemberContext{
+		Name:                 "alpha-worker-lead",
+		RuntimeName:          "leader",
+		Role:                 RoleTeamLeader,
+		ExistingMatrixUserID: "@leader:localhost",
+	}
+
+	if _, err := ReconcileMemberInfra(context.Background(), MemberDeps{Provisioner: prov}, member, state); err != nil {
+		t.Fatalf("ReconcileMemberInfra: %v", err)
+	}
+
+	if len(prov.Calls.RefreshWorkerCredentials) != 1 {
+		t.Fatalf("RefreshWorkerCredentials calls=%d, want 1", len(prov.Calls.RefreshWorkerCredentials))
+	}
+	call := prov.Calls.RefreshWorkerCredentials[0]
+	if call.CredentialName != "alpha-worker-lead" {
+		t.Fatalf("CredentialName=%q, want CR name alpha-worker-lead", call.CredentialName)
+	}
+	if call.WorkerName != "leader" {
+		t.Fatalf("WorkerName=%q, want runtime workerName leader", call.WorkerName)
+	}
+}
+
+func TestReconcileMemberDeleteUsesCRNameForCredentialDelete(t *testing.T) {
+	prov := mocks.NewMockProvisioner()
+	deployer := mocks.NewMockDeployer()
+	member := MemberContext{
+		Name:        "alpha-worker-lead",
+		RuntimeName: "leader",
+		Role:        RoleTeamLeader,
+	}
+
+	if err := ReconcileMemberDelete(context.Background(), MemberDeps{Provisioner: prov, Deployer: deployer}, member); err != nil {
+		t.Fatalf("ReconcileMemberDelete: %v", err)
+	}
+
+	if len(prov.Calls.DeprovisionWorker) != 1 || prov.Calls.DeprovisionWorker[0].Name != "leader" {
+		t.Fatalf("DeprovisionWorker calls=%v, want runtime workerName leader", prov.Calls.DeprovisionWorker)
+	}
+	if len(prov.Calls.DeleteWorkerCredentials) != 1 || prov.Calls.DeleteWorkerCredentials[0] != "alpha-worker-lead" {
+		t.Fatalf("DeleteWorkerCredentials calls=%v, want CR name alpha-worker-lead", prov.Calls.DeleteWorkerCredentials)
 	}
 }
 

--- a/hiclaw-controller/internal/controller/team_controller_test.go
+++ b/hiclaw-controller/internal/controller/team_controller_test.go
@@ -116,6 +116,7 @@ func TestTeamWorkerSpecToWorkerSpec_RuntimePassthrough(t *testing.T) {
 func TestBuildDesiredMembers_RuntimeWorkerNamesDriveMatrixPolicy(t *testing.T) {
 	team := &v1beta1.Team{}
 	team.Name = "alpha"
+	team.Spec.TeamName = "runtime-alpha"
 	team.Spec.Leader = v1beta1.LeaderSpec{
 		Name:       "alpha-worker-lead",
 		WorkerName: "lead",
@@ -144,6 +145,11 @@ func TestBuildDesiredMembers_RuntimeWorkerNamesDriveMatrixPolicy(t *testing.T) {
 	}
 	if got := byName["alpha-worker-dev"].TeamLeaderName; got != "lead" {
 		t.Fatalf("worker TeamLeaderName=%q, want lead", got)
+	}
+	for _, m := range members {
+		if got := m.TeamName; got != "runtime-alpha" {
+			t.Fatalf("member %s TeamName=%q, want runtime-alpha", m.Name, got)
+		}
 	}
 
 	leaderAllow := byName["alpha-worker-lead"].Spec.ChannelPolicy.GroupAllowExtra

--- a/hiclaw-controller/internal/controller/worker_controller.go
+++ b/hiclaw-controller/internal/controller/worker_controller.go
@@ -180,7 +180,7 @@ func (r *WorkerReconciler) reconcileDelete(ctx context.Context, w *v1beta1.Worke
 				logger.Error(err, "failed to update Manager groupAllowFrom (non-fatal)")
 			}
 		}
-		if err := r.Legacy.RemoveFromWorkersRegistry(w.Name); err != nil {
+		if err := r.Legacy.RemoveFromWorkersRegistry(mctx.RuntimeName); err != nil {
 			logger.Error(err, "failed to remove from workers registry (non-fatal)")
 		}
 	}
@@ -217,9 +217,10 @@ func (r *WorkerReconciler) reconcileLegacy(ctx context.Context, w *v1beta1.Worke
 		}
 	}
 
+	runtimeName := w.Spec.EffectiveWorkerName(w.Name)
 	if err := r.Legacy.UpdateWorkersRegistry(service.WorkerRegistryEntry{
-		Name:         w.Name,
-		MatrixUserID: r.Provisioner.MatrixUserID(w.Name),
+		Name:         runtimeName,
+		MatrixUserID: r.Provisioner.MatrixUserID(runtimeName),
 		RoomID:       w.Status.RoomID,
 		Runtime:      w.Spec.Runtime,
 		Deployment:   "local",
@@ -242,8 +243,10 @@ func (r *WorkerReconciler) reconcileLegacy(ctx context.Context, w *v1beta1.Worke
 // is silently overridden rather than rejected.
 func (r *WorkerReconciler) workerMemberContext(w *v1beta1.Worker) MemberContext {
 	role := roleForAnnotations(w.Annotations["hiclaw.io/role"], w.Annotations["hiclaw.io/team-leader"])
+	runtimeName := w.Spec.EffectiveWorkerName(w.Name)
 	return MemberContext{
 		Name:               w.Name,
+		RuntimeName:        runtimeName,
 		Namespace:          w.Namespace,
 		Role:               role,
 		Spec:               w.Spec,

--- a/hiclaw-controller/internal/matrix/client.go
+++ b/hiclaw-controller/internal/matrix/client.go
@@ -60,6 +60,9 @@ type Client interface {
 	// Login obtains an access token for an existing user.
 	Login(ctx context.Context, username, password string) (string, error)
 
+	// SetDisplayName updates a user's profile displayname.
+	SetDisplayName(ctx context.Context, userID, accessToken, displayName string) error
+
 	// AdminCommand sends a `!admin ...` text message to the tuwunel admin
 	// bot room (#admins:<domain>). Fire-and-forget: delivery of the
 	// message is confirmed but execution of the admin action is not.
@@ -249,6 +252,19 @@ func (c *TuwunelClient) Login(ctx context.Context, username, password string) (s
 		return "", fmt.Errorf("login %s: empty access token", username)
 	}
 	return resp.AccessToken, nil
+}
+
+func (c *TuwunelClient) SetDisplayName(ctx context.Context, userID, accessToken, displayName string) error {
+	path := fmt.Sprintf("/_matrix/client/v3/profile/%s/displayname", url.PathEscape(userID))
+	body := map[string]string{"displayname": displayName}
+	statusCode, respBody, err := c.doJSON(ctx, http.MethodPut, path, accessToken, body, nil)
+	if err != nil {
+		return fmt.Errorf("set displayName for %s: %w", userID, err)
+	}
+	if statusCode != http.StatusOK {
+		return fmt.Errorf("set displayName for %s: HTTP %d: %s", userID, statusCode, truncate(respBody, 500))
+	}
+	return nil
 }
 
 func (c *TuwunelClient) CreateRoom(ctx context.Context, req CreateRoomRequest) (*RoomInfo, error) {

--- a/hiclaw-controller/internal/proxy/security.go
+++ b/hiclaw-controller/internal/proxy/security.go
@@ -77,16 +77,22 @@ func NewSecurityValidator() *SecurityValidator {
 		}
 	}
 
-	// Container name prefix: HICLAW_PROXY_CONTAINER_PREFIX takes precedence
-	// (explicit override), else derived from HICLAW_RESOURCE_PREFIX, else
-	// falls back to the baked-in "hiclaw-worker-". The Helm chart normally
-	// passes a derived HICLAW_PROXY_CONTAINER_PREFIX to Manager Pods; the
-	// HICLAW_RESOURCE_PREFIX fallback here matters for embedded/host
-	// deployments that only set the tenant prefix.
-	prefix := "hiclaw-worker-"
+	// Container name prefix: HICLAW_PROXY_CONTAINER_PREFIX takes precedence.
+	// If unset and HICLAW_RESOURCE_AUTOPREFIX=true (default), derive from
+	// HICLAW_RESOURCE_PREFIX with fallback "hiclaw-". If auto-prefix is
+	// disabled, keep prefix empty and skip prefix enforcement.
+	autoPrefix := true
+	if v := os.Getenv("HICLAW_RESOURCE_AUTOPREFIX"); v != "" {
+		autoPrefix = v == "1" || v == "true" || v == "True" || v == "TRUE"
+	}
+	prefix := ""
 	if env := os.Getenv("HICLAW_PROXY_CONTAINER_PREFIX"); env != "" {
 		prefix = env
-	} else if rp := os.Getenv("HICLAW_RESOURCE_PREFIX"); rp != "" {
+	} else if autoPrefix {
+		rp := os.Getenv("HICLAW_RESOURCE_PREFIX")
+		if rp == "" {
+			rp = "hiclaw-"
+		}
 		prefix = rp + "worker-"
 	}
 

--- a/hiclaw-controller/internal/proxy/security_test.go
+++ b/hiclaw-controller/internal/proxy/security_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"os"
 	"testing"
 )
 
@@ -9,12 +10,12 @@ func newTestValidator() *SecurityValidator {
 		AllowedRegistries: []string{},
 		ContainerPrefix:   "hiclaw-worker-",
 		DangerousCaps: map[string]bool{
-			"SYS_ADMIN":   true,
-			"SYS_PTRACE":  true,
+			"SYS_ADMIN":    true,
+			"SYS_PTRACE":   true,
 			"DAC_OVERRIDE": true,
-			"NET_ADMIN":   true,
-			"SYS_RAWIO":   true,
-			"SYS_MODULE":  true,
+			"NET_ADMIN":    true,
+			"SYS_RAWIO":    true,
+			"SYS_MODULE":   true,
 		},
 	}
 }
@@ -48,6 +49,43 @@ func TestNoHostConfig(t *testing.T) {
 	}
 	if err := v.ValidateContainerCreate(req, "hiclaw-worker-alice"); err != nil {
 		t.Errorf("expected nil HostConfig to pass, got: %v", err)
+	}
+}
+
+func TestNewSecurityValidatorRespectsAutoPrefixDisabled(t *testing.T) {
+	oldAuto := os.Getenv("HICLAW_RESOURCE_AUTOPREFIX")
+	oldContainerPrefix := os.Getenv("HICLAW_PROXY_CONTAINER_PREFIX")
+	oldResourcePrefix := os.Getenv("HICLAW_RESOURCE_PREFIX")
+	t.Cleanup(func() {
+		if oldAuto == "" {
+			os.Unsetenv("HICLAW_RESOURCE_AUTOPREFIX")
+		} else {
+			os.Setenv("HICLAW_RESOURCE_AUTOPREFIX", oldAuto)
+		}
+		if oldContainerPrefix == "" {
+			os.Unsetenv("HICLAW_PROXY_CONTAINER_PREFIX")
+		} else {
+			os.Setenv("HICLAW_PROXY_CONTAINER_PREFIX", oldContainerPrefix)
+		}
+		if oldResourcePrefix == "" {
+			os.Unsetenv("HICLAW_RESOURCE_PREFIX")
+		} else {
+			os.Setenv("HICLAW_RESOURCE_PREFIX", oldResourcePrefix)
+		}
+	})
+
+	os.Setenv("HICLAW_RESOURCE_AUTOPREFIX", "false")
+	os.Unsetenv("HICLAW_PROXY_CONTAINER_PREFIX")
+	os.Setenv("HICLAW_RESOURCE_PREFIX", "hiclaw-")
+
+	v := NewSecurityValidator()
+	if v.ContainerPrefix != "" {
+		t.Fatalf("ContainerPrefix = %q, want empty", v.ContainerPrefix)
+	}
+
+	req := ContainerCreateRequest{Image: "hiclaw/worker-agent:latest", HostConfig: &HostConfig{}}
+	if err := v.ValidateContainerCreate(req, "custom-name"); err != nil {
+		t.Fatalf("expected custom name to pass when prefix is disabled, got: %v", err)
 	}
 }
 

--- a/hiclaw-controller/internal/server/resource_handler.go
+++ b/hiclaw-controller/internal/server/resource_handler.go
@@ -163,6 +163,14 @@ func (h *ResourceHandler) GetWorker(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if ok, err := h.findStandaloneWorkerByRuntimeName(r.Context(), name, &worker); err != nil {
+		writeK8sError(w, "get worker", err)
+		return
+	} else if ok {
+		httputil.WriteJSON(w, http.StatusOK, workerToResponse(&worker))
+		return
+	}
+
 	// Fall back to synthesizing a response from the Team CR.
 	team, member, ok, terr := h.findTeamMember(r.Context(), name)
 	if terr != nil {
@@ -976,6 +984,21 @@ func teamLeaderMatches(leader v1beta1.LeaderSpec, name string) bool {
 
 func teamWorkerMatches(worker v1beta1.TeamWorkerSpec, name string) bool {
 	return worker.Name == name || (worker.WorkerName != "" && worker.WorkerName == name)
+}
+
+func (h *ResourceHandler) findStandaloneWorkerByRuntimeName(ctx context.Context, name string, out *v1beta1.Worker) (bool, error) {
+	var list v1beta1.WorkerList
+	if err := h.client.List(ctx, &list, client.InNamespace(h.namespace)); err != nil {
+		return false, err
+	}
+	for i := range list.Items {
+		w := &list.Items[i]
+		if w.Spec.WorkerName == name {
+			*out = *w
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // teamMemberToResponse synthesizes a WorkerResponse for a Team member without

--- a/hiclaw-controller/internal/server/resource_handler.go
+++ b/hiclaw-controller/internal/server/resource_handler.go
@@ -104,6 +104,7 @@ func (h *ResourceHandler) CreateWorker(w http.ResponseWriter, r *http.Request) {
 		},
 		Spec: v1beta1.WorkerSpec{
 			Model:            req.Model,
+			WorkerName:       req.WorkerName,
 			Runtime:          req.Runtime,
 			Image:            req.Image,
 			Identity:         req.Identity,
@@ -263,6 +264,9 @@ func (h *ResourceHandler) UpdateWorker(w http.ResponseWriter, r *http.Request) {
 		if req.Model != "" {
 			worker.Spec.Model = req.Model
 		}
+		if req.WorkerName != "" {
+			worker.Spec.WorkerName = req.WorkerName
+		}
 		if req.Runtime != "" {
 			worker.Spec.Runtime = req.Runtime
 		}
@@ -370,6 +374,7 @@ func (h *ResourceHandler) CreateTeam(w http.ResponseWriter, r *http.Request) {
 			ChannelPolicy: req.ChannelPolicy,
 			Leader: v1beta1.LeaderSpec{
 				Name:              req.Leader.Name,
+				WorkerName:        req.Leader.WorkerName,
 				Model:             req.Leader.Model,
 				Identity:          req.Leader.Identity,
 				Soul:              req.Leader.Soul,
@@ -387,6 +392,7 @@ func (h *ResourceHandler) CreateTeam(w http.ResponseWriter, r *http.Request) {
 	for _, tw := range req.Workers {
 		team.Spec.Workers = append(team.Spec.Workers, v1beta1.TeamWorkerSpec{
 			Name:          tw.Name,
+			WorkerName:    tw.WorkerName,
 			Model:         tw.Model,
 			Runtime:       tw.Runtime,
 			Image:         tw.Image,
@@ -477,6 +483,9 @@ func (h *ResourceHandler) UpdateTeam(w http.ResponseWriter, r *http.Request) {
 			team.Spec.ChannelPolicy = req.ChannelPolicy
 		}
 		if req.Leader != nil {
+			if req.Leader.WorkerName != "" {
+				team.Spec.Leader.WorkerName = req.Leader.WorkerName
+			}
 			if req.Leader.Model != "" {
 				team.Spec.Leader.Model = req.Leader.Model
 			}
@@ -513,6 +522,7 @@ func (h *ResourceHandler) UpdateTeam(w http.ResponseWriter, r *http.Request) {
 			for _, tw := range req.Workers {
 				team.Spec.Workers = append(team.Spec.Workers, v1beta1.TeamWorkerSpec{
 					Name:          tw.Name,
+					WorkerName:    tw.WorkerName,
 					Model:         tw.Model,
 					Runtime:       tw.Runtime,
 					Image:         tw.Image,
@@ -948,16 +958,24 @@ func (h *ResourceHandler) findTeamMember(ctx context.Context, name string) (*v1b
 	}
 	for i := range list.Items {
 		t := &list.Items[i]
-		if t.Spec.Leader.Name == name {
-			return t, name, true, nil
+		if teamLeaderMatches(t.Spec.Leader, name) {
+			return t, t.Spec.Leader.Name, true, nil
 		}
 		for _, w := range t.Spec.Workers {
-			if w.Name == name {
-				return t, name, true, nil
+			if teamWorkerMatches(w, name) {
+				return t, w.Name, true, nil
 			}
 		}
 	}
 	return nil, "", false, nil
+}
+
+func teamLeaderMatches(leader v1beta1.LeaderSpec, name string) bool {
+	return leader.Name == name || (leader.WorkerName != "" && leader.WorkerName == name)
+}
+
+func teamWorkerMatches(worker v1beta1.TeamWorkerSpec, name string) bool {
+	return worker.Name == name || (worker.WorkerName != "" && worker.WorkerName == name)
 }
 
 // teamMemberToResponse synthesizes a WorkerResponse for a Team member without

--- a/hiclaw-controller/internal/server/resource_handler.go
+++ b/hiclaw-controller/internal/server/resource_handler.go
@@ -369,6 +369,7 @@ func (h *ResourceHandler) CreateTeam(w http.ResponseWriter, r *http.Request) {
 		},
 		Spec: v1beta1.TeamSpec{
 			Description:   req.Description,
+			TeamName:      req.TeamName,
 			Admin:         req.Admin,
 			PeerMentions:  req.PeerMentions,
 			ChannelPolicy: req.ChannelPolicy,
@@ -472,6 +473,9 @@ func (h *ResourceHandler) UpdateTeam(w http.ResponseWriter, r *http.Request) {
 
 		if req.Description != "" {
 			team.Spec.Description = req.Description
+		}
+		if req.TeamName != "" {
+			team.Spec.TeamName = req.TeamName
 		}
 		if req.Admin != nil {
 			team.Spec.Admin = req.Admin
@@ -854,6 +858,7 @@ func workerToResponse(w *v1beta1.Worker) WorkerResponse {
 func teamToResponse(t *v1beta1.Team) TeamResponse {
 	resp := TeamResponse{
 		Name:              t.Name,
+		TeamName:          t.Spec.EffectiveTeamName(t.Name),
 		Phase:             t.Status.Phase,
 		Description:       t.Spec.Description,
 		LeaderName:        t.Spec.Leader.Name,

--- a/hiclaw-controller/internal/server/resource_handler.go
+++ b/hiclaw-controller/internal/server/resource_handler.go
@@ -163,14 +163,6 @@ func (h *ResourceHandler) GetWorker(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if ok, err := h.findStandaloneWorkerByRuntimeName(r.Context(), name, &worker); err != nil {
-		writeK8sError(w, "get worker", err)
-		return
-	} else if ok {
-		httputil.WriteJSON(w, http.StatusOK, workerToResponse(&worker))
-		return
-	}
-
 	// Fall back to synthesizing a response from the Team CR.
 	team, member, ok, terr := h.findTeamMember(r.Context(), name)
 	if terr != nil {
@@ -966,39 +958,16 @@ func (h *ResourceHandler) findTeamMember(ctx context.Context, name string) (*v1b
 	}
 	for i := range list.Items {
 		t := &list.Items[i]
-		if teamLeaderMatches(t.Spec.Leader, name) {
+		if t.Spec.Leader.Name == name {
 			return t, t.Spec.Leader.Name, true, nil
 		}
 		for _, w := range t.Spec.Workers {
-			if teamWorkerMatches(w, name) {
+			if w.Name == name {
 				return t, w.Name, true, nil
 			}
 		}
 	}
 	return nil, "", false, nil
-}
-
-func teamLeaderMatches(leader v1beta1.LeaderSpec, name string) bool {
-	return leader.Name == name || (leader.WorkerName != "" && leader.WorkerName == name)
-}
-
-func teamWorkerMatches(worker v1beta1.TeamWorkerSpec, name string) bool {
-	return worker.Name == name || (worker.WorkerName != "" && worker.WorkerName == name)
-}
-
-func (h *ResourceHandler) findStandaloneWorkerByRuntimeName(ctx context.Context, name string, out *v1beta1.Worker) (bool, error) {
-	var list v1beta1.WorkerList
-	if err := h.client.List(ctx, &list, client.InNamespace(h.namespace)); err != nil {
-		return false, err
-	}
-	for i := range list.Items {
-		w := &list.Items[i]
-		if w.Spec.WorkerName == name {
-			*out = *w
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 // teamMemberToResponse synthesizes a WorkerResponse for a Team member without

--- a/hiclaw-controller/internal/server/resource_handler_test.go
+++ b/hiclaw-controller/internal/server/resource_handler_test.go
@@ -270,6 +270,44 @@ func TestCreateAndUpdateTeamLeaderRuntimeConfig(t *testing.T) {
 	}
 }
 
+func TestCreateTeamPersistsRuntimeWorkerNames(t *testing.T) {
+	scheme := newServerTestScheme(t)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	handler := NewResourceHandler(k8sClient, "default", nil, "")
+
+	body := []byte(`{
+		"name":"alpha-team",
+		"leader":{"name":"lead-cr","workerName":"lead-runtime"},
+		"workers":[{"name":"dev-cr","workerName":"dev-runtime"}]
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/teams", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.CreateTeam(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, rec.Code, rec.Body.String())
+	}
+
+	var stored v1beta1.Team
+	if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "alpha-team", Namespace: "default"}, &stored); err != nil {
+		t.Fatalf("get created team: %v", err)
+	}
+	if got := stored.Spec.Leader.WorkerName; got != "lead-runtime" {
+		t.Fatalf("leader.workerName = %q, want lead-runtime", got)
+	}
+	if got := stored.Spec.Workers[0].WorkerName; got != "dev-runtime" {
+		t.Fatalf("workers[0].workerName = %q, want dev-runtime", got)
+	}
+
+	team, member, ok, err := handler.findTeamMember(context.Background(), "lead-runtime")
+	if err != nil || !ok || team.Name != "alpha-team" || member != "lead-cr" {
+		t.Fatalf("find leader by workerName = team:%v member:%q ok:%v err:%v", team, member, ok, err)
+	}
+	team, member, ok, err = handler.findTeamMember(context.Background(), "dev-runtime")
+	if err != nil || !ok || team.Name != "alpha-team" || member != "dev-cr" {
+		t.Fatalf("find worker by workerName = team:%v member:%q ok:%v err:%v", team, member, ok, err)
+	}
+}
+
 // CreateTeam must accept a payload that omits `workers` entirely (leader-only
 // team). The CRD no longer lists `workers` in its required-properties set and
 // both TeamSpec.Workers / CreateTeamRequest.Workers carry `omitempty`, so a
@@ -342,6 +380,28 @@ func TestCreateWorker_StampsControllerLabel(t *testing.T) {
 	}
 	if got := worker.Labels[v1beta1.LabelController]; got != "ctrl-a" {
 		t.Fatalf("expected controller label ctrl-a, got %q", got)
+	}
+}
+
+func TestCreateWorkerPersistsRuntimeWorkerName(t *testing.T) {
+	scheme := newServerTestScheme(t)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	handler := NewResourceHandler(k8sClient, "default", nil, "")
+
+	body := []byte(`{"name":"worker-cr","workerName":"worker-runtime"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workers", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.CreateWorker(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, rec.Code, rec.Body.String())
+	}
+
+	var stored v1beta1.Worker
+	if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "worker-cr", Namespace: "default"}, &stored); err != nil {
+		t.Fatalf("get created worker: %v", err)
+	}
+	if got := stored.Spec.WorkerName; got != "worker-runtime" {
+		t.Fatalf("worker.spec.workerName = %q, want worker-runtime", got)
 	}
 }
 

--- a/hiclaw-controller/internal/server/resource_handler_test.go
+++ b/hiclaw-controller/internal/server/resource_handler_test.go
@@ -118,6 +118,83 @@ func TestGetWorkerSynthesizesTeamMember(t *testing.T) {
 	}
 }
 
+func TestGetWorkerSynthesizesTeamMemberByRuntimeWorkerName(t *testing.T) {
+	scheme := newServerTestScheme(t)
+	team := &v1beta1.Team{}
+	team.Name = "alpha-team"
+	team.Namespace = "default"
+	team.Spec.Leader = v1beta1.LeaderSpec{Name: "alpha-worker-lead", WorkerName: "lead", Model: "qwen3.5-plus"}
+	team.Spec.Workers = []v1beta1.TeamWorkerSpec{
+		{Name: "alpha-worker-dev", WorkerName: "dev", Model: "qwen3.5-plus"},
+	}
+	team.Status.Members = []v1beta1.TeamMemberStatus{
+		{
+			Name:         "alpha-worker-dev",
+			RuntimeName:  "dev",
+			Role:         "worker",
+			RoomID:       "!dev-room:example.com",
+			MatrixUserID: "@dev:example.com",
+			Observed:     true,
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(team).Build()
+	handler := NewResourceHandler(k8sClient, "default", nil, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workers/dev", nil)
+	req.SetPathValue("name", "dev")
+	rec := httptest.NewRecorder()
+	handler.GetWorker(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	var resp WorkerResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Team != "alpha-team" || resp.Name != "alpha-worker-dev" || resp.Role != "worker" {
+		t.Fatalf("unexpected synthesized response: %+v", resp)
+	}
+	if resp.RoomID != "!dev-room:example.com" {
+		t.Errorf("RoomID=%q, want %q", resp.RoomID, "!dev-room:example.com")
+	}
+	if resp.MatrixUserID != "@dev:example.com" {
+		t.Errorf("MatrixUserID=%q, want %q", resp.MatrixUserID, "@dev:example.com")
+	}
+}
+
+func TestGetWorkerFindsStandaloneWorkerByRuntimeWorkerName(t *testing.T) {
+	scheme := newServerTestScheme(t)
+	worker := &v1beta1.Worker{}
+	worker.Name = "alpha-worker-testmcp"
+	worker.Namespace = "default"
+	worker.Spec.WorkerName = "testmcp"
+	worker.Status.Phase = "Running"
+	worker.Status.MatrixUserID = "@testmcp:example.com"
+
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(worker).Build()
+	handler := NewResourceHandler(k8sClient, "default", nil, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workers/testmcp", nil)
+	req.SetPathValue("name", "testmcp")
+	rec := httptest.NewRecorder()
+	handler.GetWorker(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+	var resp WorkerResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Name != "alpha-worker-testmcp" || resp.Phase != "Running" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if resp.MatrixUserID != "@testmcp:example.com" {
+		t.Fatalf("MatrixUserID=%q, want @testmcp:example.com", resp.MatrixUserID)
+	}
+}
+
 // /api/v1/workers must list standalone workers and synthetic team members.
 // Workers with team annotations (legacy CRs) must NOT be duplicated.
 func TestListWorkersAggregatesTeamMembers(t *testing.T) {

--- a/hiclaw-controller/internal/server/resource_handler_test.go
+++ b/hiclaw-controller/internal/server/resource_handler_test.go
@@ -118,83 +118,6 @@ func TestGetWorkerSynthesizesTeamMember(t *testing.T) {
 	}
 }
 
-func TestGetWorkerSynthesizesTeamMemberByRuntimeWorkerName(t *testing.T) {
-	scheme := newServerTestScheme(t)
-	team := &v1beta1.Team{}
-	team.Name = "alpha-team"
-	team.Namespace = "default"
-	team.Spec.Leader = v1beta1.LeaderSpec{Name: "alpha-worker-lead", WorkerName: "lead", Model: "qwen3.5-plus"}
-	team.Spec.Workers = []v1beta1.TeamWorkerSpec{
-		{Name: "alpha-worker-dev", WorkerName: "dev", Model: "qwen3.5-plus"},
-	}
-	team.Status.Members = []v1beta1.TeamMemberStatus{
-		{
-			Name:         "alpha-worker-dev",
-			RuntimeName:  "dev",
-			Role:         "worker",
-			RoomID:       "!dev-room:example.com",
-			MatrixUserID: "@dev:example.com",
-			Observed:     true,
-		},
-	}
-	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(team).Build()
-	handler := NewResourceHandler(k8sClient, "default", nil, "")
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/workers/dev", nil)
-	req.SetPathValue("name", "dev")
-	rec := httptest.NewRecorder()
-	handler.GetWorker(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
-	}
-	var resp WorkerResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if resp.Team != "alpha-team" || resp.Name != "alpha-worker-dev" || resp.Role != "worker" {
-		t.Fatalf("unexpected synthesized response: %+v", resp)
-	}
-	if resp.RoomID != "!dev-room:example.com" {
-		t.Errorf("RoomID=%q, want %q", resp.RoomID, "!dev-room:example.com")
-	}
-	if resp.MatrixUserID != "@dev:example.com" {
-		t.Errorf("MatrixUserID=%q, want %q", resp.MatrixUserID, "@dev:example.com")
-	}
-}
-
-func TestGetWorkerFindsStandaloneWorkerByRuntimeWorkerName(t *testing.T) {
-	scheme := newServerTestScheme(t)
-	worker := &v1beta1.Worker{}
-	worker.Name = "alpha-worker-testmcp"
-	worker.Namespace = "default"
-	worker.Spec.WorkerName = "testmcp"
-	worker.Status.Phase = "Running"
-	worker.Status.MatrixUserID = "@testmcp:example.com"
-
-	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(worker).Build()
-	handler := NewResourceHandler(k8sClient, "default", nil, "")
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/workers/testmcp", nil)
-	req.SetPathValue("name", "testmcp")
-	rec := httptest.NewRecorder()
-	handler.GetWorker(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
-	}
-	var resp WorkerResponse
-	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if resp.Name != "alpha-worker-testmcp" || resp.Phase != "Running" {
-		t.Fatalf("unexpected response: %+v", resp)
-	}
-	if resp.MatrixUserID != "@testmcp:example.com" {
-		t.Fatalf("MatrixUserID=%q, want @testmcp:example.com", resp.MatrixUserID)
-	}
-}
-
 // /api/v1/workers must list standalone workers and synthetic team members.
 // Workers with team annotations (legacy CRs) must NOT be duplicated.
 func TestListWorkersAggregatesTeamMembers(t *testing.T) {
@@ -373,15 +296,6 @@ func TestCreateTeamPersistsRuntimeWorkerNames(t *testing.T) {
 	}
 	if got := stored.Spec.Workers[0].WorkerName; got != "dev-runtime" {
 		t.Fatalf("workers[0].workerName = %q, want dev-runtime", got)
-	}
-
-	team, member, ok, err := handler.findTeamMember(context.Background(), "lead-runtime")
-	if err != nil || !ok || team.Name != "alpha-team" || member != "lead-cr" {
-		t.Fatalf("find leader by workerName = team:%v member:%q ok:%v err:%v", team, member, ok, err)
-	}
-	team, member, ok, err = handler.findTeamMember(context.Background(), "dev-runtime")
-	if err != nil || !ok || team.Name != "alpha-team" || member != "dev-cr" {
-		t.Fatalf("find worker by workerName = team:%v member:%q ok:%v err:%v", team, member, ok, err)
 	}
 }
 

--- a/hiclaw-controller/internal/server/resource_handler_test.go
+++ b/hiclaw-controller/internal/server/resource_handler_test.go
@@ -277,6 +277,7 @@ func TestCreateTeamPersistsRuntimeWorkerNames(t *testing.T) {
 
 	body := []byte(`{
 		"name":"alpha-team",
+		"teamName":"alpha",
 		"leader":{"name":"lead-cr","workerName":"lead-runtime"},
 		"workers":[{"name":"dev-cr","workerName":"dev-runtime"}]
 	}`)
@@ -293,6 +294,9 @@ func TestCreateTeamPersistsRuntimeWorkerNames(t *testing.T) {
 	}
 	if got := stored.Spec.Leader.WorkerName; got != "lead-runtime" {
 		t.Fatalf("leader.workerName = %q, want lead-runtime", got)
+	}
+	if got := stored.Spec.TeamName; got != "alpha" {
+		t.Fatalf("teamName = %q, want alpha", got)
 	}
 	if got := stored.Spec.Workers[0].WorkerName; got != "dev-runtime" {
 		t.Fatalf("workers[0].workerName = %q, want dev-runtime", got)

--- a/hiclaw-controller/internal/server/types.go
+++ b/hiclaw-controller/internal/server/types.go
@@ -6,6 +6,7 @@ import v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
 
 type CreateWorkerRequest struct {
 	Name          string                     `json:"name"`
+	WorkerName    string                     `json:"workerName,omitempty"`
 	Model         string                     `json:"model,omitempty"`
 	Runtime       string                     `json:"runtime,omitempty"`
 	Image         string                     `json:"image,omitempty"`
@@ -32,6 +33,7 @@ type CreateWorkerRequest struct {
 }
 
 type UpdateWorkerRequest struct {
+	WorkerName    string                     `json:"workerName,omitempty"`
 	Model         string                     `json:"model,omitempty"`
 	Runtime       string                     `json:"runtime,omitempty"`
 	Image         string                     `json:"image,omitempty"`
@@ -93,6 +95,7 @@ type CreateTeamRequest struct {
 
 type TeamLeaderRequest struct {
 	Name              string                      `json:"name"`
+	WorkerName        string                      `json:"workerName,omitempty"`
 	Model             string                      `json:"model,omitempty"`
 	Identity          string                      `json:"identity,omitempty"`
 	Soul              string                      `json:"soul,omitempty"`
@@ -112,6 +115,7 @@ type TeamLeaderHeartbeatRequest struct {
 
 type TeamWorkerRequest struct {
 	Name          string                     `json:"name"`
+	WorkerName    string                     `json:"workerName,omitempty"`
 	Model         string                     `json:"model,omitempty"`
 	Runtime       string                     `json:"runtime,omitempty"`
 	Image         string                     `json:"image,omitempty"`

--- a/hiclaw-controller/internal/server/types.go
+++ b/hiclaw-controller/internal/server/types.go
@@ -85,6 +85,7 @@ type WorkerListResponse struct {
 
 type CreateTeamRequest struct {
 	Name          string                     `json:"name"`
+	TeamName      string                     `json:"teamName,omitempty"`
 	Description   string                     `json:"description,omitempty"`
 	Admin         *v1beta1.TeamAdminSpec     `json:"admin,omitempty"`
 	Leader        TeamLeaderRequest          `json:"leader"`
@@ -131,6 +132,7 @@ type TeamWorkerRequest struct {
 }
 
 type UpdateTeamRequest struct {
+	TeamName      string                     `json:"teamName,omitempty"`
 	Description   string                     `json:"description,omitempty"`
 	Admin         *v1beta1.TeamAdminSpec     `json:"admin,omitempty"`
 	Leader        *TeamLeaderRequest         `json:"leader,omitempty"`
@@ -141,6 +143,7 @@ type UpdateTeamRequest struct {
 
 type TeamResponse struct {
 	Name               string                           `json:"name"`
+	TeamName           string                           `json:"teamName,omitempty"`
 	Phase              string                           `json:"phase"`
 	Description        string                           `json:"description,omitempty"`
 	LeaderName         string                           `json:"leaderName"`

--- a/hiclaw-controller/internal/service/credentials_test.go
+++ b/hiclaw-controller/internal/service/credentials_test.go
@@ -75,3 +75,38 @@ func TestSecretCredentialStore_AppLabelHonorsResourcePrefix(t *testing.T) {
 		t.Fatalf("expected app label %q, got %q (labels=%v)", want, got, sec.Labels)
 	}
 }
+
+func TestProvisionerLoadWorkerCredentialsMigratesLegacyRuntimeSecret(t *testing.T) {
+	client := fakeclient.NewSimpleClientset()
+	store := &SecretCredentialStore{
+		Client:         client,
+		Namespace:      "hiclaw",
+		ControllerName: "ctl-a",
+		ResourcePrefix: auth.DefaultResourcePrefix,
+	}
+	legacy := &WorkerCredentials{
+		MatrixPassword: "pw",
+		MinIOPassword:  "miniopw",
+		GatewayKey:     "gw",
+		MatrixToken:    "token",
+	}
+	if err := store.Save(context.Background(), "leader", legacy); err != nil {
+		t.Fatalf("save legacy credentials: %v", err)
+	}
+
+	p := NewProvisioner(ProvisionerConfig{Creds: store})
+	creds, err := p.loadWorkerCredentials(context.Background(), "team-a-worker-leader", "leader")
+	if err != nil {
+		t.Fatalf("loadWorkerCredentials: %v", err)
+	}
+	if creds == nil || creds.GatewayKey != "gw" {
+		t.Fatalf("migrated creds=%+v, want gateway key gw", creds)
+	}
+
+	if _, err := client.CoreV1().Secrets("hiclaw").Get(context.Background(), "hiclaw-creds-team-a-worker-leader", metav1.GetOptions{}); err != nil {
+		t.Fatalf("expected CR-name credential secret after migration: %v", err)
+	}
+	if _, err := client.CoreV1().Secrets("hiclaw").Get(context.Background(), "hiclaw-creds-leader", metav1.GetOptions{}); err != nil {
+		t.Fatalf("legacy runtime-name credential secret should remain untouched: %v", err)
+	}
+}

--- a/hiclaw-controller/internal/service/interfaces.go
+++ b/hiclaw-controller/internal/service/interfaces.go
@@ -133,14 +133,18 @@ type HumanProvisioner interface {
 	// LoginAsHuman with the stored password instead to avoid triggering
 	// the orphan-recovery password reset inside matrix.EnsureUser, which
 	// would clobber any user-initiated password change made in Element.
-	EnsureHumanUser(ctx context.Context, name string) (*HumanCredentials, error)
+	EnsureHumanUser(ctx context.Context, username string) (*HumanCredentials, error)
 
 	// LoginAsHuman obtains a fresh access token for an already-provisioned
 	// human using the caller-supplied password. Returns an error when the
 	// password no longer matches (e.g. the user changed it in Element);
 	// callers treat that as a soft failure and fall back to admin-only
 	// room management on this reconcile pass.
-	LoginAsHuman(ctx context.Context, name, password string) (string, error)
+	LoginAsHuman(ctx context.Context, username, password string) (string, error)
+
+	// SetDisplayName updates the Matrix profile displayname for the user.
+	// Requires a user-scoped access token.
+	SetDisplayName(ctx context.Context, userID, accessToken, displayName string) error
 
 	// MatrixUserID builds the full "@<name>:<domain>" form.
 	MatrixUserID(name string) string

--- a/hiclaw-controller/internal/service/interfaces.go
+++ b/hiclaw-controller/internal/service/interfaces.go
@@ -12,11 +12,13 @@ type WorkerProvisioner interface {
 	ProvisionWorker(ctx context.Context, req WorkerProvisionRequest) (*WorkerProvisionResult, error)
 	DeprovisionWorker(ctx context.Context, req WorkerDeprovisionRequest) error
 	RefreshCredentials(ctx context.Context, workerName string) (*RefreshResult, error)
+	RefreshWorkerCredentials(ctx context.Context, credentialName, workerName string) (*RefreshResult, error)
 	EnsureWorkerGatewayAuth(ctx context.Context, workerName, gatewayKey string) error
 	ReconcileExpose(ctx context.Context, workerName string, desired []v1beta1.ExposePort, current []v1beta1.ExposedPortStatus) ([]v1beta1.ExposedPortStatus, error)
 	EnsureServiceAccount(ctx context.Context, workerName string) error
 	DeleteServiceAccount(ctx context.Context, workerName string) error
 	DeleteCredentials(ctx context.Context, workerName string) error
+	DeleteWorkerCredentials(ctx context.Context, credentialName string) error
 	RequestSAToken(ctx context.Context, workerName string) (string, error)
 	// LeaveAllWorkerRooms logs in as the worker (using stored credentials,
 	// or resetting the password via admin if they are stale) and makes

--- a/hiclaw-controller/internal/service/provisioner.go
+++ b/hiclaw-controller/internal/service/provisioner.go
@@ -21,6 +21,7 @@ import (
 // WorkerProvisionRequest describes the infrastructure to provision for a worker.
 type WorkerProvisionRequest struct {
 	Name           string
+	CredentialName string
 	Role           string // "standalone" | "team_leader" | "worker"
 	TeamName       string
 	TeamLeaderName string
@@ -285,6 +286,10 @@ func (p *Provisioner) DeleteManagerRoom(ctx context.Context, roomID string) erro
 func (p *Provisioner) ProvisionWorker(ctx context.Context, req WorkerProvisionRequest) (*WorkerProvisionResult, error) {
 	logger := log.FromContext(ctx)
 	workerName := req.Name
+	credentialName := req.CredentialName
+	if credentialName == "" {
+		credentialName = workerName
+	}
 	consumerName := "worker-" + workerName
 	workerMatrixID := p.matrix.UserID(workerName)
 	managerMatrixID := p.matrix.UserID("manager")
@@ -293,7 +298,7 @@ func (p *Provisioner) ProvisionWorker(ctx context.Context, req WorkerProvisionRe
 	isTeamWorker := req.TeamLeaderName != ""
 
 	// Step 1: Load or generate credentials
-	creds, err := p.creds.Load(ctx, workerName)
+	creds, err := p.loadWorkerCredentials(ctx, credentialName, workerName)
 	if err != nil {
 		return nil, fmt.Errorf("load credentials: %w", err)
 	}
@@ -302,7 +307,7 @@ func (p *Provisioner) ProvisionWorker(ctx context.Context, req WorkerProvisionRe
 		if err != nil {
 			return nil, fmt.Errorf("generate credentials: %w", err)
 		}
-		if err := p.creds.Save(ctx, workerName, creds); err != nil {
+		if err := p.creds.Save(ctx, credentialName, creds); err != nil {
 			return nil, fmt.Errorf("save credentials: %w", err)
 		}
 	}
@@ -384,7 +389,7 @@ func (p *Provisioner) ProvisionWorker(ctx context.Context, req WorkerProvisionRe
 	// Persist the freshly-registered Matrix token. Room identity is no
 	// longer stored here — the Matrix alias is the sole source of truth
 	// and is resolved via CreateRoom on every reconcile.
-	if err := p.creds.Save(ctx, workerName, creds); err != nil {
+	if err := p.creds.Save(ctx, credentialName, creds); err != nil {
 		logger.Error(err, "failed to persist credentials (non-fatal)")
 	}
 
@@ -435,7 +440,7 @@ func (p *Provisioner) ProvisionWorker(ctx context.Context, req WorkerProvisionRe
 	}
 	if consumerResult.APIKey != "" && consumerResult.APIKey != creds.GatewayKey {
 		creds.GatewayKey = consumerResult.APIKey
-		_ = p.creds.Save(ctx, workerName, creds)
+		_ = p.creds.Save(ctx, credentialName, creds)
 	}
 
 	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName); err != nil {
@@ -521,9 +526,18 @@ func (p *Provisioner) ensureMatrixToken(ctx context.Context, matrixUsername stri
 // RefreshCredentials loads persisted credentials and obtains a Matrix token,
 // reusing the cached token when present. Used during update operations.
 func (p *Provisioner) RefreshCredentials(ctx context.Context, workerName string) (*RefreshResult, error) {
-	creds, err := p.creds.Load(ctx, workerName)
+	return p.RefreshWorkerCredentials(ctx, workerName, workerName)
+}
+
+// RefreshWorkerCredentials loads worker credentials by their owning CR key while
+// refreshing the Matrix token for the runtime worker identity.
+func (p *Provisioner) RefreshWorkerCredentials(ctx context.Context, credentialName, workerName string) (*RefreshResult, error) {
+	if credentialName == "" {
+		credentialName = workerName
+	}
+	creds, err := p.loadWorkerCredentials(ctx, credentialName, workerName)
 	if err != nil || creds == nil {
-		return nil, fmt.Errorf("credentials not found for %s", workerName)
+		return nil, fmt.Errorf("credentials not found for %s", credentialName)
 	}
 
 	hadToken := creds.MatrixToken != ""
@@ -532,7 +546,7 @@ func (p *Provisioner) RefreshCredentials(ctx context.Context, workerName string)
 		return nil, fmt.Errorf("Matrix login failed: %w", err)
 	}
 	if !hadToken {
-		if err := p.creds.Save(ctx, workerName, creds); err != nil {
+		if err := p.creds.Save(ctx, credentialName, creds); err != nil {
 			return nil, fmt.Errorf("persist matrix token: %w", err)
 		}
 	}
@@ -543,6 +557,22 @@ func (p *Provisioner) RefreshCredentials(ctx context.Context, workerName string)
 		MinIOPassword:  creds.MinIOPassword,
 		MatrixPassword: creds.MatrixPassword,
 	}, nil
+}
+
+func (p *Provisioner) loadWorkerCredentials(ctx context.Context, credentialName, workerName string) (*WorkerCredentials, error) {
+	creds, err := p.creds.Load(ctx, credentialName)
+	if err != nil || creds != nil || credentialName == workerName {
+		return creds, err
+	}
+
+	legacyCreds, err := p.creds.Load(ctx, workerName)
+	if err != nil || legacyCreds == nil {
+		return legacyCreds, err
+	}
+	if err := p.creds.Save(ctx, credentialName, legacyCreds); err != nil {
+		return nil, fmt.Errorf("migrate legacy worker credentials: %w", err)
+	}
+	return legacyCreds, nil
 }
 
 // RefreshManagerCredentials loads persisted credentials for the Manager and
@@ -756,7 +786,12 @@ func (p *Provisioner) ReconcileRoomMembership(ctx context.Context, roomID string
 
 // DeleteCredentials removes persisted credentials for a worker.
 func (p *Provisioner) DeleteCredentials(ctx context.Context, workerName string) error {
-	return p.creds.Delete(ctx, workerName)
+	return p.DeleteWorkerCredentials(ctx, workerName)
+}
+
+// DeleteWorkerCredentials removes persisted credentials for a worker-like CR.
+func (p *Provisioner) DeleteWorkerCredentials(ctx context.Context, credentialName string) error {
+	return p.creds.Delete(ctx, credentialName)
 }
 
 // DeleteTeamRoomAliases removes the room aliases that identify a team's group

--- a/hiclaw-controller/internal/service/provisioner.go
+++ b/hiclaw-controller/internal/service/provisioner.go
@@ -642,7 +642,6 @@ func (p *Provisioner) EnsureWorkerGatewayAuth(ctx context.Context, workerName, g
 	return nil
 }
 
-
 // ProvisionTeamRooms creates (or resolves) the team room and leader DM room
 // and reconciles their Matrix memberships against the desired member set.
 // Idempotency is guaranteed by the Matrix alias: repeated calls always land
@@ -1004,6 +1003,7 @@ type ManagerWelcomeRequest struct {
 //   - (true, nil)  — message was successfully delivered.
 //   - (false, nil) — manager not yet joined; caller should requeue.
 //   - (false, err) — unrecoverable error (admin login / Matrix API).
+//
 // llmAuthProbePromptTemplate renders the chat-completions body the
 // readiness probe sends. It uses the same model the Manager Agent will
 // use for its real first reply, and asks for a one-word answer so the

--- a/hiclaw-controller/internal/service/provisioner_human.go
+++ b/hiclaw-controller/internal/service/provisioner_human.go
@@ -13,10 +13,10 @@ import (
 // matrix.Client.EnsureUser — Humans have no persisted WorkerCredentials
 // envelope (unlike Workers/Managers), so the caller is responsible for
 // recording the returned password in the CR status if needed.
-func (p *Provisioner) EnsureHumanUser(ctx context.Context, name string) (*HumanCredentials, error) {
-	uc, err := p.matrix.EnsureUser(ctx, matrix.EnsureUserRequest{Username: name})
+func (p *Provisioner) EnsureHumanUser(ctx context.Context, username string) (*HumanCredentials, error) {
+	uc, err := p.matrix.EnsureUser(ctx, matrix.EnsureUserRequest{Username: username})
 	if err != nil {
-		return nil, fmt.Errorf("ensure human matrix user %s: %w", name, err)
+		return nil, fmt.Errorf("ensure human matrix user %s: %w", username, err)
 	}
 	return &HumanCredentials{
 		UserID:      uc.UserID,
@@ -31,8 +31,13 @@ func (p *Provisioner) EnsureHumanUser(ctx context.Context, name string) (*HumanC
 // fall back to EnsureUser on failure because EnsureUser's orphan-recovery
 // branch issues "!admin users reset-password", which would silently
 // overwrite any password the user changed via Element.
-func (p *Provisioner) LoginAsHuman(ctx context.Context, name, password string) (string, error) {
-	return p.matrix.Login(ctx, name, password)
+func (p *Provisioner) LoginAsHuman(ctx context.Context, username, password string) (string, error) {
+	return p.matrix.Login(ctx, username, password)
+}
+
+// SetDisplayName updates the Matrix profile displayname for a human user.
+func (p *Provisioner) SetDisplayName(ctx context.Context, userID, accessToken, displayName string) error {
+	return p.matrix.SetDisplayName(ctx, userID, accessToken, displayName)
 }
 
 // InviteToRoom invites the given Matrix user into roomID using the admin

--- a/hiclaw-controller/test/integration/controller/worker_test.go
+++ b/hiclaw-controller/test/integration/controller/worker_test.go
@@ -670,6 +670,9 @@ func TestWorkerCreate_EnvPassesToBackend(t *testing.T) {
 	if got := req.Env["HICLAW_WORKER_NAME"]; got != workerName {
 		t.Errorf("HICLAW_WORKER_NAME=%q, want %q (system wins)", got, workerName)
 	}
+	if got := req.Env["HICLAW_WORKER_CR_NAME"]; got != workerName {
+		t.Errorf("HICLAW_WORKER_CR_NAME=%q, want %q", got, workerName)
+	}
 	if got := req.Env["MOCK_ENV"]; got != "true" {
 		t.Errorf("MOCK_ENV=%q, want %q (system env preserved)", got, "true")
 	}

--- a/hiclaw-controller/test/testutil/mocks/human_provisioner.go
+++ b/hiclaw-controller/test/testutil/mocks/human_provisioner.go
@@ -22,10 +22,12 @@ type MockHumanProvisioner struct {
 	JoinRoomAsFn      func(ctx context.Context, roomID, userToken string) error
 	KickFromRoomFn    func(ctx context.Context, roomID, userID, reason string) error
 	ForceLeaveRoomFn  func(ctx context.Context, userID, roomID string) error
+	SetDisplayNameFn  func(ctx context.Context, userID, accessToken, displayName string) error
 
 	Calls struct {
 		EnsureHumanUser []string
 		LoginAsHuman    []LoginAsHumanCall
+		SetDisplayName  []SetDisplayNameCall
 		InviteToRoom    []RoomMembershipCall
 		JoinRoomAs      []JoinRoomAsCall
 		KickFromRoom    []KickFromRoomCall
@@ -37,6 +39,13 @@ type MockHumanProvisioner struct {
 type LoginAsHumanCall struct {
 	Name     string
 	Password string
+}
+
+// SetDisplayNameCall records SetDisplayName input arguments.
+type SetDisplayNameCall struct {
+	UserID      string
+	AccessToken string
+	DisplayName string
 }
 
 // RoomMembershipCall records the (RoomID, UserID) pair passed to
@@ -90,6 +99,7 @@ func (m *MockHumanProvisioner) Reset() {
 	m.JoinRoomAsFn = nil
 	m.KickFromRoomFn = nil
 	m.ForceLeaveRoomFn = nil
+	m.SetDisplayNameFn = nil
 }
 
 // ClearCalls resets call records only, preserving Fn overrides.
@@ -103,6 +113,7 @@ func (m *MockHumanProvisioner) clearCallsLocked() {
 	m.Calls = struct {
 		EnsureHumanUser []string
 		LoginAsHuman    []LoginAsHumanCall
+		SetDisplayName  []SetDisplayNameCall
 		InviteToRoom    []RoomMembershipCall
 		JoinRoomAs      []JoinRoomAsCall
 		KickFromRoom    []KickFromRoomCall
@@ -144,6 +155,17 @@ func (m *MockHumanProvisioner) MatrixUserID(name string) string {
 		return fn(name)
 	}
 	return "@" + name + ":localhost"
+}
+
+func (m *MockHumanProvisioner) SetDisplayName(ctx context.Context, userID, accessToken, displayName string) error {
+	m.mu.Lock()
+	m.Calls.SetDisplayName = append(m.Calls.SetDisplayName, SetDisplayNameCall{UserID: userID, AccessToken: accessToken, DisplayName: displayName})
+	fn := m.SetDisplayNameFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, userID, accessToken, displayName)
+	}
+	return nil
 }
 
 func (m *MockHumanProvisioner) InviteToRoom(ctx context.Context, roomID, userID string) error {

--- a/hiclaw-controller/test/testutil/mocks/provisioner.go
+++ b/hiclaw-controller/test/testutil/mocks/provisioner.go
@@ -12,38 +12,47 @@ import (
 type MockProvisioner struct {
 	mu sync.Mutex
 
-	ProvisionWorkerFn         func(ctx context.Context, req service.WorkerProvisionRequest) (*service.WorkerProvisionResult, error)
-	DeprovisionWorkerFn       func(ctx context.Context, req service.WorkerDeprovisionRequest) error
-	RefreshCredentialsFn      func(ctx context.Context, workerName string) (*service.RefreshResult, error)
-	EnsureWorkerGatewayAuthFn func(ctx context.Context, workerName, gatewayKey string) error
-	ReconcileExposeFn         func(ctx context.Context, workerName string, desired []v1beta1.ExposePort, current []v1beta1.ExposedPortStatus) ([]v1beta1.ExposedPortStatus, error)
-	EnsureServiceAccountFn    func(ctx context.Context, workerName string) error
-	DeleteServiceAccountFn    func(ctx context.Context, workerName string) error
-	DeleteCredentialsFn       func(ctx context.Context, workerName string) error
-	RequestSATokenFn          func(ctx context.Context, workerName string) (string, error)
-	LeaveAllWorkerRoomsFn     func(ctx context.Context, workerName string) error
-	DeleteWorkerRoomFn        func(ctx context.Context, roomID string) error
-	MatrixUserIDFn            func(name string) string
-	ProvisionTeamRoomsFn      func(ctx context.Context, req service.TeamRoomRequest) (*service.TeamRoomResult, error)
-	DeleteTeamRoomAliasesFn   func(ctx context.Context, teamName, leaderName string) error
-	DeleteWorkerRoomAliasFn   func(ctx context.Context, workerName string) error
+	ProvisionWorkerFn          func(ctx context.Context, req service.WorkerProvisionRequest) (*service.WorkerProvisionResult, error)
+	DeprovisionWorkerFn        func(ctx context.Context, req service.WorkerDeprovisionRequest) error
+	RefreshCredentialsFn       func(ctx context.Context, workerName string) (*service.RefreshResult, error)
+	RefreshWorkerCredentialsFn func(ctx context.Context, credentialName, workerName string) (*service.RefreshResult, error)
+	EnsureWorkerGatewayAuthFn  func(ctx context.Context, workerName, gatewayKey string) error
+	ReconcileExposeFn          func(ctx context.Context, workerName string, desired []v1beta1.ExposePort, current []v1beta1.ExposedPortStatus) ([]v1beta1.ExposedPortStatus, error)
+	EnsureServiceAccountFn     func(ctx context.Context, workerName string) error
+	DeleteServiceAccountFn     func(ctx context.Context, workerName string) error
+	DeleteCredentialsFn        func(ctx context.Context, workerName string) error
+	DeleteWorkerCredentialsFn  func(ctx context.Context, credentialName string) error
+	RequestSATokenFn           func(ctx context.Context, workerName string) (string, error)
+	LeaveAllWorkerRoomsFn      func(ctx context.Context, workerName string) error
+	DeleteWorkerRoomFn         func(ctx context.Context, roomID string) error
+	MatrixUserIDFn             func(name string) string
+	ProvisionTeamRoomsFn       func(ctx context.Context, req service.TeamRoomRequest) (*service.TeamRoomResult, error)
+	DeleteTeamRoomAliasesFn    func(ctx context.Context, teamName, leaderName string) error
+	DeleteWorkerRoomAliasFn    func(ctx context.Context, workerName string) error
 
 	Calls struct {
-		ProvisionWorker         []service.WorkerProvisionRequest
-		DeprovisionWorker       []service.WorkerDeprovisionRequest
-		RefreshCredentials      []string
-		EnsureWorkerGatewayAuth []string
-		ReconcileExpose         []string
-		EnsureServiceAccount    []string
-		DeleteServiceAccount    []string
-		DeleteCredentials       []string
-		RequestSAToken          []string
-		LeaveAllWorkerRooms     []string
-		DeleteWorkerRoom        []string
-		ProvisionTeamRooms      []service.TeamRoomRequest
-		DeleteTeamRoomAliases   []string
-		DeleteWorkerRoomAlias   []string
+		ProvisionWorker          []service.WorkerProvisionRequest
+		DeprovisionWorker        []service.WorkerDeprovisionRequest
+		RefreshCredentials       []string
+		RefreshWorkerCredentials []workerCredentialCall
+		EnsureWorkerGatewayAuth  []string
+		ReconcileExpose          []string
+		EnsureServiceAccount     []string
+		DeleteServiceAccount     []string
+		DeleteCredentials        []string
+		DeleteWorkerCredentials  []string
+		RequestSAToken           []string
+		LeaveAllWorkerRooms      []string
+		DeleteWorkerRoom         []string
+		ProvisionTeamRooms       []service.TeamRoomRequest
+		DeleteTeamRoomAliases    []string
+		DeleteWorkerRoomAlias    []string
 	}
+}
+
+type workerCredentialCall struct {
+	CredentialName string
+	WorkerName     string
 }
 
 func NewMockProvisioner() *MockProvisioner {
@@ -59,10 +68,12 @@ func (m *MockProvisioner) Reset() {
 	m.DeprovisionWorkerFn = nil
 	m.RefreshCredentialsFn = nil
 	m.EnsureWorkerGatewayAuthFn = nil
+	m.RefreshWorkerCredentialsFn = nil
 	m.ReconcileExposeFn = nil
 	m.EnsureServiceAccountFn = nil
 	m.DeleteServiceAccountFn = nil
 	m.DeleteCredentialsFn = nil
+	m.DeleteWorkerCredentialsFn = nil
 	m.RequestSATokenFn = nil
 	m.LeaveAllWorkerRoomsFn = nil
 	m.DeleteWorkerRoomFn = nil
@@ -81,20 +92,22 @@ func (m *MockProvisioner) ClearCalls() {
 
 func (m *MockProvisioner) clearCallsLocked() {
 	m.Calls = struct {
-		ProvisionWorker         []service.WorkerProvisionRequest
-		DeprovisionWorker       []service.WorkerDeprovisionRequest
-		RefreshCredentials      []string
-		EnsureWorkerGatewayAuth []string
-		ReconcileExpose         []string
-		EnsureServiceAccount    []string
-		DeleteServiceAccount    []string
-		DeleteCredentials       []string
-		RequestSAToken          []string
-		LeaveAllWorkerRooms     []string
-		DeleteWorkerRoom        []string
-		ProvisionTeamRooms      []service.TeamRoomRequest
-		DeleteTeamRoomAliases   []string
-		DeleteWorkerRoomAlias   []string
+		ProvisionWorker          []service.WorkerProvisionRequest
+		DeprovisionWorker        []service.WorkerDeprovisionRequest
+		RefreshCredentials       []string
+		RefreshWorkerCredentials []workerCredentialCall
+		EnsureWorkerGatewayAuth  []string
+		ReconcileExpose          []string
+		EnsureServiceAccount     []string
+		DeleteServiceAccount     []string
+		DeleteCredentials        []string
+		DeleteWorkerCredentials  []string
+		RequestSAToken           []string
+		LeaveAllWorkerRooms      []string
+		DeleteWorkerRoom         []string
+		ProvisionTeamRooms       []service.TeamRoomRequest
+		DeleteTeamRoomAliases    []string
+		DeleteWorkerRoomAlias    []string
 	}{}
 }
 
@@ -154,6 +167,24 @@ func (m *MockProvisioner) EnsureWorkerGatewayAuth(ctx context.Context, workerNam
 	return nil
 }
 
+func (m *MockProvisioner) RefreshWorkerCredentials(ctx context.Context, credentialName, workerName string) (*service.RefreshResult, error) {
+	m.mu.Lock()
+	m.Calls.RefreshWorkerCredentials = append(m.Calls.RefreshWorkerCredentials, workerCredentialCall{
+		CredentialName: credentialName,
+		WorkerName:     workerName,
+	})
+	fn := m.RefreshWorkerCredentialsFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, credentialName, workerName)
+	}
+	return &service.RefreshResult{
+		MatrixToken:    "mock-token-" + workerName,
+		GatewayKey:     "mock-gw-key-" + workerName,
+		MinIOPassword:  "mock-minio-pw",
+		MatrixPassword: "mock-matrix-pw",
+	}, nil
+}
 
 func (m *MockProvisioner) ReconcileExpose(ctx context.Context, workerName string, desired []v1beta1.ExposePort, current []v1beta1.ExposedPortStatus) ([]v1beta1.ExposedPortStatus, error) {
 	m.mu.Lock()
@@ -195,6 +226,17 @@ func (m *MockProvisioner) DeleteCredentials(ctx context.Context, workerName stri
 	m.mu.Unlock()
 	if fn != nil {
 		return fn(ctx, workerName)
+	}
+	return nil
+}
+
+func (m *MockProvisioner) DeleteWorkerCredentials(ctx context.Context, credentialName string) error {
+	m.mu.Lock()
+	m.Calls.DeleteWorkerCredentials = append(m.Calls.DeleteWorkerCredentials, credentialName)
+	fn := m.DeleteWorkerCredentialsFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, credentialName)
 	}
 	return nil
 }

--- a/hiclaw-controller/test/testutil/mocks/provisioner.go
+++ b/hiclaw-controller/test/testutil/mocks/provisioner.go
@@ -328,7 +328,7 @@ func (m *MockProvisioner) CallCounts() (provision, deprovision, refresh, leaveAl
 	defer m.mu.Unlock()
 	return len(m.Calls.ProvisionWorker),
 		len(m.Calls.DeprovisionWorker),
-		len(m.Calls.RefreshCredentials),
+		len(m.Calls.RefreshCredentials) + len(m.Calls.RefreshWorkerCredentials),
 		len(m.Calls.LeaveAllWorkerRooms)
 }
 

--- a/worker/scripts/worker-entrypoint.sh
+++ b/worker/scripts/worker-entrypoint.sh
@@ -346,7 +346,7 @@ if [ -n "${HICLAW_CONTROLLER_URL:-}" ]; then
         fi
 
         # Report ready to controller via hiclaw CLI
-        hiclaw worker report-ready
+        hiclaw worker report-ready --name "${HICLAW_WORKER_CR_NAME:-${WORKER_NAME}}"
     ) &
     log "Background readiness reporter started (PID: $!)"
 fi


### PR DESCRIPTION
## Summary

- separate Kubernetes CR/resource names from runtime worker names for Workers, Teams, and Humans
- use runtime names for Matrix/container/storage runtime identity while keeping CR names for controller API, credentials keys, and readiness reporting
- add Team `teamName` / member `workerName` API and CRD fields, with matching Helm CRD copies
- update CoPaw/OpenClaw worker readiness reporting to use `HICLAW_WORKER_CR_NAME` while preserving runtime `HICLAW_WORKER_NAME`

This PR is independent from #829. #829 only configures CoPaw ReAct max iterations and does not share the controller identity path changed here.

## Validation

- `git diff --check opensource/main..HEAD`
- verified `hiclaw-controller/config/crd/*.yaml` and `helm/hiclaw/crds/*.yaml` are in sync for workers, teams, and humans
- `go test ./internal/accessresolver ./internal/auth ./internal/config ./internal/controller ./internal/proxy ./internal/server ./internal/service` from `hiclaw-controller/`
- `python3 -m py_compile copaw/src/copaw_worker/cli.py copaw/src/copaw_worker/config.py copaw/src/copaw_worker/sync.py copaw/src/copaw_worker/worker.py`

Note: attempted to include `./test/integration/controller` in the Go test command, but that package requires build tags and direct `go test` reports `build constraints exclude all Go files`.