### PR TITLE
fix(manager): hot-reload groupAllowFrom when Workers are created

### DIFF
--- a/hiclaw-controller/internal/app/app.go
+++ b/hiclaw-controller/internal/app/app.go
@@ -435,11 +435,15 @@ func (a *App) initServiceLayer(_ context.Context) error {
 
 	a.envBuilder = service.NewWorkerEnvBuilder(cfg.WorkerEnv)
 
-	if cfg.KubeMode == "embedded" {
+	if a.oss != nil {
+		agentFSDir := ""
+		if cfg.KubeMode == "embedded" {
+			agentFSDir = cfg.AgentFSDir()
+		}
 		a.legacy = service.NewLegacyCompat(service.LegacyConfig{
 			OSS:          a.oss,
 			MatrixDomain: cfg.MatrixDomain,
-			AgentFSDir:   cfg.AgentFSDir(),
+			AgentFSDir:   agentFSDir,
 		})
 	}
 

--- a/manager/scripts/init/start-copaw-manager.sh
+++ b/manager/scripts/init/start-copaw-manager.sh
@@ -207,17 +207,21 @@ fi
 (
     _prev_hash=$(md5sum "${OPENCLAW_JSON}" 2>/dev/null | awk '{print $1}')
     while true; do
-        sleep 30
+        sleep 60
         _curr_hash=$(md5sum "${OPENCLAW_JSON}" 2>/dev/null | awk '{print $1}')
         if [ -n "${_curr_hash}" ] && [ "${_curr_hash}" != "${_prev_hash}" ]; then
             log "openclaw.json changed, re-bridging..."
-            PYTHONPATH="/opt/hiclaw/copaw/src:${PYTHONPATH:-}" \
+            _bridge_out=$(PYTHONPATH="/opt/hiclaw/copaw/src:${PYTHONPATH:-}" \
                 python3 -m copaw_worker.bridge \
                     --profile manager \
                     --openclaw-json "${OPENCLAW_JSON}" \
-                    --working-dir "${COPAW_WORKING_DIR}" 2>&1 | while IFS= read -r line; do log "  [re-bridge] ${line}"; done
-            _prev_hash="${_curr_hash}"
-            log "Re-bridge complete"
+                    --working-dir "${COPAW_WORKING_DIR}" 2>&1)
+            if [ $? -eq 0 ]; then
+                _prev_hash="${_curr_hash}"
+                log "Re-bridge complete"
+            else
+                log "Re-bridge failed, will retry on next cycle: ${_bridge_out}"
+            fi
         fi
     done
 ) &

--- a/manager/scripts/init/start-copaw-manager.sh
+++ b/manager/scripts/init/start-copaw-manager.sh
@@ -202,7 +202,29 @@ PYEOF
 fi
 
 # ============================================================
-# 9. Launch CoPaw Manager (app mode with hot-reload)
+# 9. Background: watch openclaw.json for changes and re-bridge
+# ============================================================
+(
+    _prev_hash=$(md5sum "${OPENCLAW_JSON}" 2>/dev/null | awk '{print $1}')
+    while true; do
+        sleep 30
+        _curr_hash=$(md5sum "${OPENCLAW_JSON}" 2>/dev/null | awk '{print $1}')
+        if [ -n "${_curr_hash}" ] && [ "${_curr_hash}" != "${_prev_hash}" ]; then
+            log "openclaw.json changed, re-bridging..."
+            PYTHONPATH="/opt/hiclaw/copaw/src:${PYTHONPATH:-}" \
+                python3 -m copaw_worker.bridge \
+                    --profile manager \
+                    --openclaw-json "${OPENCLAW_JSON}" \
+                    --working-dir "${COPAW_WORKING_DIR}" 2>&1 | while IFS= read -r line; do log "  [re-bridge] ${line}"; done
+            _prev_hash="${_curr_hash}"
+            log "Re-bridge complete"
+        fi
+    done
+) &
+log "openclaw.json watcher started (PID: $!)"
+
+# ============================================================
+# 10. Launch CoPaw Manager (app mode with hot-reload)
 # ============================================================
 export COPAW_WORKING_DIR="${COPAW_WORKING_DIR}"
 

--- a/manager/scripts/init/start-manager-agent.sh
+++ b/manager/scripts/init/start-manager-agent.sh
@@ -1170,13 +1170,14 @@ if [ "${HICLAW_RUNTIME}" = "aliyun" ]; then
     ) &
     log "Local→OSS sync started (PID: $!)"
 
-    # OSS → Local: periodic pull (shared data, agent configs)
+    # OSS → Local: periodic pull (shared data, agent configs, manager openclaw.json)
     (
         while true; do
             sleep 300
             ensure_mc_credentials 2>/dev/null || true
             mc mirror "${HICLAW_STORAGE_PREFIX}/shared/" /root/hiclaw-fs/shared/ --overwrite --newer-than "5m" 2>/dev/null || true
             mc mirror "${HICLAW_STORAGE_PREFIX}/agents/" /root/hiclaw-fs/agents/ --overwrite --newer-than "5m" 2>/dev/null || true
+            mc cp "${HICLAW_STORAGE_PREFIX}/manager/openclaw.json" /root/manager-workspace/openclaw.json 2>/dev/null || true
         done
     ) &
     log "OSS→Local sync started (every 5m, PID: $!)"
@@ -1202,13 +1203,14 @@ if [ "${HICLAW_RUNTIME}" = "k8s" ]; then
     ) &
     log "Local→MinIO sync started (PID: $!)"
 
-    # MinIO → Local: periodic pull (shared data, agent configs)
+    # MinIO → Local: periodic pull (shared data, agent configs, manager openclaw.json)
     (
         while true; do
             sleep 300
             mc mirror "${HICLAW_STORAGE_PREFIX}/shared/" /root/hiclaw-fs/shared/ --overwrite --newer-than "5m" 2>/dev/null || true
             mc mirror "${HICLAW_STORAGE_PREFIX}/agents/" /root/hiclaw-fs/agents/ --overwrite --newer-than "5m" 2>/dev/null || true
             mc mirror "${HICLAW_STORAGE_PREFIX}/hiclaw-config/" /root/hiclaw-fs/hiclaw-config/ --overwrite --newer-than "15s" 2>/dev/null || true
+            mc cp "${HICLAW_STORAGE_PREFIX}/manager/openclaw.json" /root/manager-workspace/openclaw.json 2>/dev/null || true
         done
     ) &
     log "MinIO→Local sync started (every 5m, PID: $!)"

--- a/manager/scripts/init/start-manager-agent.sh
+++ b/manager/scripts/init/start-manager-agent.sh
@@ -1173,14 +1173,14 @@ if [ "${HICLAW_RUNTIME}" = "aliyun" ]; then
     # OSS → Local: periodic pull (shared data, agent configs, manager openclaw.json)
     (
         while true; do
-            sleep 300
+            sleep 60
             ensure_mc_credentials 2>/dev/null || true
-            mc mirror "${HICLAW_STORAGE_PREFIX}/shared/" /root/hiclaw-fs/shared/ --overwrite --newer-than "5m" 2>/dev/null || true
-            mc mirror "${HICLAW_STORAGE_PREFIX}/agents/" /root/hiclaw-fs/agents/ --overwrite --newer-than "5m" 2>/dev/null || true
+            mc mirror "${HICLAW_STORAGE_PREFIX}/shared/" /root/hiclaw-fs/shared/ --overwrite --newer-than "1m" 2>/dev/null || true
+            mc mirror "${HICLAW_STORAGE_PREFIX}/agents/" /root/hiclaw-fs/agents/ --overwrite --newer-than "1m" 2>/dev/null || true
             mc cp "${HICLAW_STORAGE_PREFIX}/manager/openclaw.json" /root/manager-workspace/openclaw.json 2>/dev/null || true
         done
     ) &
-    log "OSS→Local sync started (every 5m, PID: $!)"
+    log "OSS→Local sync started (every 60s, PID: $!)"
 fi
 
 # K8s mode: start background file sync (workspace ↔ MinIO)
@@ -1206,14 +1206,14 @@ if [ "${HICLAW_RUNTIME}" = "k8s" ]; then
     # MinIO → Local: periodic pull (shared data, agent configs, manager openclaw.json)
     (
         while true; do
-            sleep 300
-            mc mirror "${HICLAW_STORAGE_PREFIX}/shared/" /root/hiclaw-fs/shared/ --overwrite --newer-than "5m" 2>/dev/null || true
-            mc mirror "${HICLAW_STORAGE_PREFIX}/agents/" /root/hiclaw-fs/agents/ --overwrite --newer-than "5m" 2>/dev/null || true
-            mc mirror "${HICLAW_STORAGE_PREFIX}/hiclaw-config/" /root/hiclaw-fs/hiclaw-config/ --overwrite --newer-than "15s" 2>/dev/null || true
+            sleep 60
+            mc mirror "${HICLAW_STORAGE_PREFIX}/shared/" /root/hiclaw-fs/shared/ --overwrite --newer-than "1m" 2>/dev/null || true
+            mc mirror "${HICLAW_STORAGE_PREFIX}/agents/" /root/hiclaw-fs/agents/ --overwrite --newer-than "1m" 2>/dev/null || true
+            mc mirror "${HICLAW_STORAGE_PREFIX}/hiclaw-config/" /root/hiclaw-fs/hiclaw-config/ --overwrite --newer-than "1m" 2>/dev/null || true
             mc cp "${HICLAW_STORAGE_PREFIX}/manager/openclaw.json" /root/manager-workspace/openclaw.json 2>/dev/null || true
         done
     ) &
-    log "MinIO→Local sync started (every 5m, PID: $!)"
+    log "MinIO→Local sync started (every 60s, PID: $!)"
 fi
 
 # ============================================================


### PR DESCRIPTION
## Summary
- **Manager watcher**: Add background loop in `start-copaw-manager.sh` that monitors `openclaw.json` for changes (md5 poll every 30s) and re-runs bridge to update `agent.json`. CoPaw's AgentConfigWatcher hot-reloads automatically.
- **Controller K8s fix**: Enable `LegacyCompat` in incluster mode so `UpdateManagerGroupAllowFrom` writes to MinIO when Workers are created (previously was a no-op due to nil LegacyCompat).
- **Sync loop**: Add `mc cp` of `manager/openclaw.json` in K8s/cloud MinIO→Local sync loops so the watcher can detect changes.
- **Test metrics**: Add CoPaw metrics collection via `token_usage.json` for integration tests.

## Problem
When Controller creates a new Worker, it adds the Worker's Matrix ID to Manager's `openclaw.json` `groupAllowFrom`. However, Manager's CoPaw reads `agent.json` (not `openclaw.json`), and the bridge that converts openclaw→agent only ran once at startup. Result: Workers' @mentions to Manager were silently ignored.

In K8s mode, `LegacyCompat` was nil so `UpdateManagerGroupAllowFrom` was a complete no-op.

## Test plan
- [ ] Embedded mode: create Worker → verify Manager's `agent.json` `group_allow_from` includes new Worker within 30s
- [ ] K8s mode: create Worker → verify MinIO `manager/openclaw.json` has `groupAllowFrom` updated
- [ ] K8s mode: verify sync loop pulls openclaw.json → watcher re-bridges → CoPaw picks up change
- [ ] Verify bridge is idempotent (repeated runs don't corrupt agent.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)