### PR TITLE
fix(copaw): seed worker heartbeat interval

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,6 +4,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 ---
 
+- fix(copaw): seed the CoPaw worker agent heartbeat interval at 10 minutes.
 - fix(manager): agent docs and jq examples use `roomID` for `hiclaw get workers` / `hiclaw create worker` JSON (CLI field name), not `room_id`
 - fix(controller): add `+kubebuilder:subresource:status` on CR types; patch Worker finalizers instead of full `Update`; exponential backoff on REST update conflict retries
 - fix(manager): document runtime-aware Worker dispatch (avoid @worker text in admin DM only); update task-management references, AGENTS.md, HEARTBEAT.md, channel-management skill

--- a/copaw/src/copaw_worker/templates/agent.worker.json
+++ b/copaw/src/copaw_worker/templates/agent.worker.json
@@ -7,6 +7,10 @@
     "SOUL.md",
     "PROFILE.md"
   ],
+  "heartbeat": {
+    "enabled": true,
+    "every": "10m"
+  },
   "channels": {
     "console": {
       "enabled": true


### PR DESCRIPTION
## Summary
- seed the CoPaw worker agent template with a 10-minute heartbeat interval
- record the image-affecting template change in the unreleased changelog

## Validation
- jq empty copaw/src/copaw_worker/templates/agent.worker.json
- git diff --check opensource/main..HEAD
