### PR TITLE
fix(copaw): skip mc alias setup in k8s mode

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,6 +4,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 ---
 
+- fix(copaw): skip static mc alias setup for k8s workers that use wrapper-provided credentials.
 - fix(copaw): seed the CoPaw worker agent heartbeat interval at 10 minutes.
 - feat(agent): add non-overridable credential file access prohibition to CoPaw worker and team leader agent prompts.
 - fix(manager): agent docs and jq examples use `roomID` for `hiclaw get workers` / `hiclaw create worker` JSON (CLI field name), not `room_id`

--- a/copaw/src/copaw_worker/sync.py
+++ b/copaw/src/copaw_worker/sync.py
@@ -137,6 +137,7 @@ class FileSync:
         self._prefix = f"agents/{worker_name}"
         self._alias_set = False
         self._cloud_mode = os.environ.get("HICLAW_RUNTIME") == "aliyun"
+        self._k8s_mode = os.environ.get("HICLAW_RUNTIME") == "k8s"
         self._worker_info: dict[str, Any] | None = None
 
     # ------------------------------------------------------------------
@@ -172,6 +173,9 @@ class FileSync:
         """
         if self._cloud_mode:
             self._refresh_cloud_credentials()
+            self._alias_set = True
+            return
+        if self._k8s_mode:
             self._alias_set = True
             return
         if self._alias_set:

--- a/copaw/tests/test_worker_sync.py
+++ b/copaw/tests/test_worker_sync.py
@@ -1,0 +1,25 @@
+"""Tests for CoPaw worker file sync behavior."""
+
+from copaw_worker import sync
+from copaw_worker.sync import FileSync
+
+
+def test_ensure_alias_skips_static_alias_in_k8s_mode(monkeypatch, tmp_path):
+    calls = []
+
+    monkeypatch.setenv("HICLAW_RUNTIME", "k8s")
+    monkeypatch.setattr(sync, "_mc", lambda *args, **_kwargs: calls.append(args))
+
+    fs = FileSync(
+        endpoint="minio:9000",
+        access_key="tt",
+        secret_key="secret",
+        bucket="hiclaw",
+        worker_name="tt",
+        local_dir=tmp_path,
+    )
+
+    fs._ensure_alias()
+
+    assert fs._alias_set is True
+    assert calls == []


### PR DESCRIPTION
## Summary
- Skip static `mc alias set` for CoPaw workers when `HICLAW_RUNTIME=k8s`
- Keep k8s workers on wrapper-provided `MC_HOST_hiclaw` credentials, avoiding short access-key rejection for worker names like `tt`
- Add a focused regression test and changelog entry

## Validation
- python3 -m py_compile copaw/src/copaw_worker/sync.py copaw/tests/test_worker_sync.py
- git diff --check

Note: direct pytest is not available in the system Python, and uv-based pytest is blocked locally by python-olm/libolm build prerequisites (cmake/gmake).