### PR TITLE
fix(controller): preserve default object-storage access entries

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,6 +4,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 ---
 
+- fix(hiclaw-controller): preserve default object-storage access when custom non-storage entries are configured.
 - fix(copaw): skip static mc alias setup for k8s workers that use wrapper-provided credentials.
 - fix(copaw): exclude inbound Matrix thread messages from room-history context.
 - fix(copaw): align the CoPaw worker install directory with the HOME-backed workspace path.

--- a/hiclaw-controller/internal/accessresolver/resolver.go
+++ b/hiclaw-controller/internal/accessresolver/resolver.go
@@ -90,6 +90,8 @@ func (r *Resolver) resolveWorker(ctx context.Context, name string) (string, []cr
 	crEntries := w.Spec.AccessEntries
 	if len(crEntries) == 0 {
 		crEntries = DefaultEntriesForWorker()
+	} else if !hasServiceEntry(crEntries, credprovider.ServiceObjectStorage) {
+		crEntries = append(DefaultEntriesForWorker(), crEntries...)
 	}
 	runtimeName := name
 	if w.Name != "" {
@@ -147,6 +149,8 @@ func (r *Resolver) resolveTeamMember(ctx context.Context, name, teamName string)
 	}
 	if len(crEntries) == 0 {
 		crEntries = DefaultEntriesForTeamMember()
+	} else if !hasServiceEntry(crEntries, credprovider.ServiceObjectStorage) {
+		crEntries = append(DefaultEntriesForTeamMember(), crEntries...)
 	}
 
 	runtimeTeamName := teamName
@@ -184,6 +188,8 @@ func (r *Resolver) resolveManager(ctx context.Context, name string) (string, []c
 	crEntries := m.Spec.AccessEntries
 	if len(crEntries) == 0 {
 		crEntries = DefaultEntriesForManager()
+	} else if !hasServiceEntry(crEntries, credprovider.ServiceObjectStorage) {
+		crEntries = append(DefaultEntriesForManager(), crEntries...)
 	}
 	tmpl := templateCtx{kind: "Manager", name: name, namespace: r.namespace}
 	resolved, err := r.resolveEntries(crEntries, tmpl)
@@ -386,6 +392,16 @@ func copyPermissions(in []string) []string {
 	out := make([]string, len(in))
 	copy(out, in)
 	return out
+}
+
+// hasServiceEntry reports whether any entry in the list targets the given service.
+func hasServiceEntry(entries []v1beta1.AccessEntry, service string) bool {
+	for _, e := range entries {
+		if e.Service == service {
+			return true
+		}
+	}
+	return false
 }
 
 // marshalJSONDeterministic marshals m with sorted keys so that default

--- a/hiclaw-controller/internal/accessresolver/resolver_test.go
+++ b/hiclaw-controller/internal/accessresolver/resolver_test.go
@@ -98,6 +98,15 @@ func hasAllPerms(perms []string, want ...string) bool {
 	return true
 }
 
+func entryForService(entries []credprovider.AccessEntry, service string) *credprovider.AccessEntry {
+	for i := range entries {
+		if entries[i].Service == service {
+			return &entries[i]
+		}
+	}
+	return nil
+}
+
 func TestResolveWorker_CustomBucketRef(t *testing.T) {
 	worker := &v1beta1.Worker{}
 	worker.Name = "bob"
@@ -226,10 +235,16 @@ func TestResolve_AIGatewayHappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
-	if len(entries) != 1 {
+	if len(entries) != 2 {
 		t.Fatalf("got %d entries", len(entries))
 	}
-	got := entries[0]
+	if entryForService(entries, credprovider.ServiceObjectStorage) == nil {
+		t.Fatalf("missing default object-storage entry in %+v", entries)
+	}
+	got := entryForService(entries, credprovider.ServiceAIGateway)
+	if got == nil {
+		t.Fatalf("missing ai-gateway entry in %+v", entries)
+	}
 	if got.Service != credprovider.ServiceAIGateway {
 		t.Fatalf("service = %q", got.Service)
 	}
@@ -261,10 +276,16 @@ func TestResolve_AIRegistryDefaultResources(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
-	if len(entries) != 1 {
+	if len(entries) != 2 {
 		t.Fatalf("got %d entries", len(entries))
 	}
-	got := entries[0]
+	if entryForService(entries, credprovider.ServiceObjectStorage) == nil {
+		t.Fatalf("missing default object-storage entry in %+v", entries)
+	}
+	got := entryForService(entries, credprovider.ServiceAIRegistry)
+	if got == nil {
+		t.Fatalf("missing ai-registry entry in %+v", entries)
+	}
 	if got.Service != credprovider.ServiceAIRegistry {
 		t.Fatalf("service = %q", got.Service)
 	}
@@ -298,7 +319,10 @@ func TestResolve_AIRegistryCustomResources(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
-	got := entries[0]
+	got := entryForService(entries, credprovider.ServiceAIRegistry)
+	if got == nil {
+		t.Fatalf("missing ai-registry entry in %+v", entries)
+	}
 	if got.Scope.NamespaceID != "ns1" {
 		t.Fatalf("namespaceId = %q", got.Scope.NamespaceID)
 	}


### PR DESCRIPTION
## Summary
- preserve the default object-storage access entry when a CR configures custom non-object-storage entries
- keep ai-gateway / ai-registry entries alongside the default storage scope
- add focused accessresolver regression coverage and changelog entry

## Validation
- go test ./internal/accessresolver