### PR TITLE
fix(copaw): suppress missing MinIO object warnings

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,6 +4,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 ---
 
+- fix(copaw): suppress noisy warnings when optional MinIO objects do not exist.
 - fix(hiclaw-controller): preserve default object-storage access when custom non-storage entries are configured.
 - fix(copaw): skip static mc alias setup for k8s workers that use wrapper-provided credentials.
 - fix(copaw): exclude inbound Matrix thread messages from room-history context.

--- a/copaw/src/copaw_worker/sync.py
+++ b/copaw/src/copaw_worker/sync.py
@@ -97,7 +97,11 @@ def _merge_openclaw_config(remote_text: str, local_text: str) -> str:
     return json.dumps(merged, indent=2)
 
 
-def _mc(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+def _mc(
+    *args: str,
+    check: bool = True,
+    log_output: bool = True,
+) -> subprocess.CompletedProcess:
     """Run an mc command and return the result."""
     mc_bin = shutil.which("mc")
     if not mc_bin:
@@ -105,10 +109,16 @@ def _mc(*args: str, check: bool = True) -> subprocess.CompletedProcess:
     cmd = [mc_bin, *args]
     logger.info("mc cmd: %s", " ".join(cmd))
     result = subprocess.run(cmd, capture_output=True, text=True, check=check)
-    logger.info("mc stdout (%d chars): %r", len(result.stdout), result.stdout[:200])
-    if result.stderr:
-        logger.info("mc stderr: %r", result.stderr[:200])
+    if log_output:
+        logger.info("mc stdout (%d chars): %r", len(result.stdout), result.stdout[:200])
+        if result.stderr:
+            logger.info("mc stderr: %r", result.stderr[:200])
     return result
+
+
+def _looks_like_missing_object_error(stderr: str | None) -> bool:
+    text = stderr or ""
+    return "Object does not exist" in text or "The specified key does not exist" in text
 
 
 class FileSync:
@@ -201,14 +211,27 @@ class FileSync:
         """Download object content as text using mc cat."""
         self._ensure_alias()
         try:
-            result = _mc("cat", self._object_path(key), check=True)
-            return result.stdout
-        except subprocess.CalledProcessError as exc:
-            logger.debug("mc cat failed for %s: %s", key, exc.stderr)
-            return None
+            result = _mc(
+                "cat",
+                self._object_path(key),
+                check=False,
+                log_output=False,
+            )
         except Exception as exc:
             logger.debug("mc cat error for %s: %s", key, exc)
             return None
+        if result.returncode == 0:
+            return result.stdout
+        if _looks_like_missing_object_error(result.stderr):
+            logger.debug("mc cat missing object for %s: %s", key, result.stderr)
+            return None
+        logger.warning(
+            "mc cat failed returncode=%s key=%s stderr=%r",
+            result.returncode,
+            key,
+            (result.stderr or "")[:200],
+        )
+        return None
 
     def _ls(self, prefix: str) -> list[str]:
         """List objects under prefix, return list of relative names."""

--- a/copaw/tests/test_worker_sync.py
+++ b/copaw/tests/test_worker_sync.py
@@ -1,5 +1,8 @@
 """Tests for CoPaw worker file sync behavior."""
 
+import logging
+import subprocess
+
 from copaw_worker import sync
 from copaw_worker.sync import FileSync
 
@@ -23,3 +26,56 @@ def test_ensure_alias_skips_static_alias_in_k8s_mode(monkeypatch, tmp_path):
 
     assert fs._alias_set is True
     assert calls == []
+
+
+def test_cat_missing_object_is_debug_only(monkeypatch, tmp_path, caplog):
+    fs = FileSync(
+        endpoint="minio:9000",
+        access_key="tt",
+        secret_key="secret",
+        bucket="hiclaw",
+        worker_name="tt",
+        local_dir=tmp_path,
+    )
+    monkeypatch.setattr(fs, "_ensure_alias", lambda: None)
+    monkeypatch.setattr(
+        sync,
+        "_mc",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            _args,
+            1,
+            stdout="",
+            stderr="mc.bin: <ERROR> Object does not exist.",
+        ),
+    )
+    caplog.set_level(logging.WARNING)
+
+    assert fs._cat("agents/tt/config/mcporter.json") is None
+    assert "Object does not exist" not in caplog.text
+
+
+def test_cat_non_missing_failure_warns(monkeypatch, tmp_path, caplog):
+    fs = FileSync(
+        endpoint="minio:9000",
+        access_key="tt",
+        secret_key="secret",
+        bucket="hiclaw",
+        worker_name="tt",
+        local_dir=tmp_path,
+    )
+    monkeypatch.setattr(fs, "_ensure_alias", lambda: None)
+    monkeypatch.setattr(
+        sync,
+        "_mc",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            _args,
+            1,
+            stdout="",
+            stderr="AccessDenied: denied",
+        ),
+    )
+    caplog.set_level(logging.WARNING)
+
+    assert fs._cat("agents/tt/openclaw.json") is None
+    assert "mc cat failed" in caplog.text
+    assert "AccessDenied: denied" in caplog.text


### PR DESCRIPTION
## Summary
- make CoPaw FileSync._cat treat missing optional MinIO objects as debug-only misses
- keep non-missing mc cat failures as warnings
- add focused worker sync tests and changelog entry

## Validation
- git diff --cached --check
- PYTHONPATH=copaw/src python3 -c '<direct FileSync._cat missing-object/non-missing failure checks>'

Note: pytest target was attempted with uv, but local dependency setup failed while building python-olm because cmake/gmake are unavailable in this environment.