### PR TITLE
feat(controller): propagate skills API defaults to workers

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,6 +4,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 ---
 
+- feat(hiclaw-controller): propagate controller-level skills API and Nacos auth defaults to workers.
 - fix(hiclaw-controller): preserve default object-storage access when custom non-storage entries are configured.
 - fix(copaw): skip static mc alias setup for k8s workers that use wrapper-provided credentials.
 - fix(copaw): exclude inbound Matrix thread messages from room-history context.

--- a/hiclaw-controller/internal/config/config.go
+++ b/hiclaw-controller/internal/config/config.go
@@ -190,6 +190,14 @@ type WorkerEnvDefaults struct {
 	CMSLicenseKey     string
 	CMSProject        string
 	CMSWorkspace      string
+
+	// SkillsAPIURL is propagated to workers as SKILLS_API_URL.
+	// Sourced from SKILLS_API_URL, falling back to HICLAW_SKILLS_API_URL.
+	SkillsAPIURL string
+
+	// NacosAuthType is propagated to workers as NACOS_AUTH_TYPE.
+	// Sourced from NACOS_AUTH_TYPE.
+	NacosAuthType string
 }
 
 type managerSpecEnv struct {
@@ -342,6 +350,8 @@ func LoadConfig() *Config {
 			CMSLicenseKey:     os.Getenv("HICLAW_CMS_LICENSE_KEY"),
 			CMSProject:        os.Getenv("HICLAW_CMS_PROJECT"),
 			CMSWorkspace:      os.Getenv("HICLAW_CMS_WORKSPACE"),
+			SkillsAPIURL:      envOrDefault("SKILLS_API_URL", os.Getenv("HICLAW_SKILLS_API_URL")),
+			NacosAuthType:     os.Getenv("NACOS_AUTH_TYPE"),
 		},
 	}
 

--- a/hiclaw-controller/internal/service/worker_env.go
+++ b/hiclaw-controller/internal/service/worker_env.go
@@ -132,4 +132,10 @@ func (b *WorkerEnvBuilder) applyClusterDefaults(env map[string]string) {
 	if b.defaults.CMSWorkspace != "" {
 		env["HICLAW_CMS_WORKSPACE"] = b.defaults.CMSWorkspace
 	}
+	if b.defaults.SkillsAPIURL != "" {
+		env["SKILLS_API_URL"] = b.defaults.SkillsAPIURL
+	}
+	if b.defaults.NacosAuthType != "" {
+		env["NACOS_AUTH_TYPE"] = b.defaults.NacosAuthType
+	}
 }

--- a/hiclaw-controller/internal/service/worker_env_test.go
+++ b/hiclaw-controller/internal/service/worker_env_test.go
@@ -17,6 +17,8 @@ func TestWorkerEnvBuilderBuildIncludesFinalRuntimeEnv(t *testing.T) {
 		AIGatewayURL:  "http://aigw.example.com:8080",
 		MatrixURL:     "http://matrix.example.com:8080",
 		Runtime:       "docker",
+		SkillsAPIURL:  "nacos://skills.example.com:8848/public",
+		NacosAuthType: "sts-hiclaw",
 	})
 
 	env := builder.Build("alice", &WorkerProvisionResult{
@@ -41,6 +43,8 @@ func TestWorkerEnvBuilderBuildIncludesFinalRuntimeEnv(t *testing.T) {
 		"HOME":                       "/root/hiclaw-fs/agents/alice",
 		"HICLAW_WORKER_GATEWAY_KEY":  "gateway-key",
 		"HICLAW_WORKER_MATRIX_TOKEN": "matrix-token",
+		"SKILLS_API_URL":             "nacos://skills.example.com:8848/public",
+		"NACOS_AUTH_TYPE":            "sts-hiclaw",
 	} {
 		if got := env[key]; got != want {
 			t.Fatalf("%s = %q, want %q", key, got, want)
@@ -64,6 +68,7 @@ func TestWorkerEnvBuilderBuildManagerUsesConfiguredRuntimeAndBucket(t *testing.T
 		MatrixURL:     "http://matrix.example.com:8080",
 		AdminUser:     "admin",
 		Runtime:       "docker",
+		SkillsAPIURL:  "nacos://skills.example.com:8848/public",
 	})
 
 	env := builder.BuildManager("manager", &ManagerProvisionResult{
@@ -81,6 +86,7 @@ func TestWorkerEnvBuilderBuildManagerUsesConfiguredRuntimeAndBucket(t *testing.T
 		"HICLAW_FS_BUCKET":           "hiclaw-fs",
 		"HICLAW_RUNTIME":             "docker",
 		"HICLAW_ADMIN_USER":          "admin",
+		"SKILLS_API_URL":             "nacos://skills.example.com:8848/public",
 	} {
 		if got := env[key]; got != want {
 			t.Fatalf("%s = %q, want %q", key, got, want)


### PR DESCRIPTION
## Summary
- add controller WorkerEnv defaults for SKILLS_API_URL and NACOS_AUTH_TYPE
- propagate those defaults into worker and manager container environments
- cover the propagated env values in worker env tests and add a changelog entry

## Validation
- go test ./internal/config ./internal/service
- git diff --check

Note: the earlier CoPaw model-preflight notification candidate was not submitted because it depends on the broader CoPaw health/preflight framework that is not yet on open-source main.