### PR TITLE
fix(install): pass stream idle timeout on Windows

### DIFF
--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -3127,6 +3127,9 @@ function Install-Manager {
         if ($config.OPENAI_BASE_URL) {
             $ctrlArgs += @("-e", "HICLAW_OPENAI_BASE_URL=$($config.OPENAI_BASE_URL)")
         }
+        if ($env:HICLAW_AI_STREAM_IDLE_TIMEOUT_SECONDS) {
+            $ctrlArgs += @("-e", "HICLAW_AI_STREAM_IDLE_TIMEOUT_SECONDS=$($env:HICLAW_AI_STREAM_IDLE_TIMEOUT_SECONDS)")
+        }
         if ($script:HICLAW_LANGUAGE) {
             $ctrlArgs += @("-e", "HICLAW_LANGUAGE=$($script:HICLAW_LANGUAGE)")
         }


### PR DESCRIPTION
## Summary
- pass HICLAW_AI_STREAM_IDLE_TIMEOUT_SECONDS through to the controller container in the PowerShell installer
- keep Windows installer behavior aligned with the controller stream idle timeout setting

## Tests
- git diff --cached --check
- pwsh Parser::ParseFile install/hiclaw-install.ps1