### PR TITLE
test(controller): cover team leader ready auth

### DIFF
--- a/hiclaw-controller/internal/auth/authorizer_test.go
+++ b/hiclaw-controller/internal/auth/authorizer_test.go
@@ -29,6 +29,7 @@ func TestAuthorizer_TeamLeaderOwnTeam(t *testing.T) {
 
 	allowedCases := []AuthzRequest{
 		{Action: ActionGet, ResourceKind: "worker", ResourceName: "alpha-dev", ResourceTeam: "alpha-team"},
+		{Action: ActionReady, ResourceKind: "worker", ResourceName: "alpha-lead", ResourceTeam: "alpha-team"},
 		{Action: ActionCreate, ResourceKind: "worker", ResourceTeam: "alpha-team"},
 		{Action: ActionWake, ResourceKind: "worker", ResourceName: "alpha-dev", ResourceTeam: "alpha-team"},
 		{Action: ActionSleep, ResourceKind: "worker", ResourceName: "alpha-dev", ResourceTeam: "alpha-team"},


### PR DESCRIPTION
## Summary
- add coverage for a Team Leader reporting readiness for its own worker resource

## Tests
- git diff --cached --check
- go test ./internal/auth (from hiclaw-controller/)