### PR TITLE
docs(controller): note Nacos auth type example

### DIFF
--- a/hiclaw-controller/internal/config/config.go
+++ b/hiclaw-controller/internal/config/config.go
@@ -198,6 +198,7 @@ type WorkerEnvDefaults struct {
 
 	// NacosAuthType is propagated to workers as NACOS_AUTH_TYPE.
 	// Sourced from NACOS_AUTH_TYPE.
+	// Typical value: "sts-hiclaw".
 	NacosAuthType string
 }
 


### PR DESCRIPTION
## Summary
- document sts-hiclaw as a typical NACOS_AUTH_TYPE value for worker env defaults

## Tests
- git diff --cached --check
- go test ./internal/config (from hiclaw-controller/)