### PR TITLE
fix(controller): 别把新建 Worker 当成 spec 变更 || fix(controller): Don’t regard the new Worker as a spec change

### DIFF
--- a/hiclaw-controller/internal/controller/worker_controller.go
+++ b/hiclaw-controller/internal/controller/worker_controller.go
@@ -260,12 +260,16 @@ func (r *WorkerReconciler) workerMemberContext(w *v1beta1.Worker) MemberContext 
 				"hiclaw.io/role":        role.String(),
 			},
 		),
-		// For Worker CR, spec change is detected the classic way:
-		// Generation increments on every spec mutation; ObservedGeneration
-		// is written after a successful reconcile. Status defaults to 0
-		// on a freshly created Worker, which correctly marks the first
-		// reconcile as "changed" so the initial container is created.
-		SpecChanged:          w.Generation != w.Status.ObservedGeneration,
+		// SpecChanged is gated on ObservedGeneration > 0 so a brand-new
+		// Worker (Generation=1, ObservedGeneration=0) reports
+		// SpecChanged=false. Initial creation then goes through the
+		// StatusNotFound branch in ensureMemberContainerPresent
+		// unambiguously. Without the gate, a second reconcile queued by
+		// the finalizer write can read a stale informer cache
+		// (ObservedGeneration still 0) after the just-created container
+		// is already Running, fall into the spec-change branch, and Delete
+		// the container via force=true (SIGKILL, exit 137).
+		SpecChanged:          w.Status.ObservedGeneration > 0 && w.Generation != w.Status.ObservedGeneration,
 		IsUpdate:             w.Status.Phase != "" && w.Status.Phase != "Pending" && w.Status.Phase != "Failed",
 		TeamName:             w.Annotations["hiclaw.io/team"],
 		TeamLeaderName:       w.Annotations["hiclaw.io/team-leader"],

--- a/hiclaw-controller/internal/controller/worker_controller_test.go
+++ b/hiclaw-controller/internal/controller/worker_controller_test.go
@@ -106,3 +106,45 @@ func TestWorkerMemberContext_NilLabelsSafe(t *testing.T) {
 		t.Fatalf("expected exactly the 2 system labels on nil-labels Worker, got %v", mctx.PodLabels)
 	}
 }
+
+// TestWorkerMemberContext_SpecChangedGate locks in the brand-new-worker
+// guard. The "brand new" case is the load-bearing one: a second reconcile
+// queued by the finalizer write can read a stale informer cache and see
+// the just-created container as Running while ObservedGeneration is still
+// 0. Without the gate, SpecChanged=true on that intervening pass causes
+// ensureMemberContainerPresent to Delete (force=true → SIGKILL) the
+// container right after first create.
+func TestWorkerMemberContext_SpecChangedGate(t *testing.T) {
+	r := &WorkerReconciler{ControllerName: "ctl-x"}
+
+	cases := []struct {
+		name     string
+		gen      int64
+		observed int64
+		want     bool
+	}{
+		// Brand-new Worker: never reconciled. Must NOT report SpecChanged
+		// even though Generation > ObservedGeneration — that delta is the
+		// "we have never observed this resource" signal, not a user edit.
+		{"brand_new", 1, 0, false},
+		// First reconcile committed: no edit pending.
+		{"observed_no_edit", 1, 1, false},
+		// User edit after first reconcile: spec genuinely diverged.
+		{"observed_with_edit", 2, 1, true},
+		// Periodic resync with no spec change.
+		{"resync_no_edit", 5, 5, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := &v1beta1.Worker{}
+			w.Name = "solo"
+			w.Generation = tc.gen
+			w.Status.ObservedGeneration = tc.observed
+			mctx := r.workerMemberContext(w)
+			if mctx.SpecChanged != tc.want {
+				t.Fatalf("SpecChanged for (gen=%d, observed=%d): got %v, want %v",
+					tc.gen, tc.observed, mctx.SpecChanged, tc.want)
+			}
+		})
+	}
+}

--- a/tests/test-02-create-worker.sh
+++ b/tests/test-02-create-worker.sh
@@ -55,9 +55,25 @@ wait_for_session_stable 5 60
 # Snapshot metrics baseline before sending message (to calculate delta later)
 METRICS_BASELINE=$(snapshot_baseline)
 
-# Send create worker request
+# Send create worker request.
+#
+# Why the prompt is so explicit: worker-management/SKILL.md instructs Manager
+# to ask admin for FOUR inputs (name / runtime / SOUL / skills) before running
+# `hiclaw create worker`, and to NOT invent defaults. A vague prompt that only
+# names the worker is therefore a coin flip — sometimes the LLM follows
+# SKILL.md strictly and replies with a 4-question confirmation, never calling
+# the CLI, and downstream assertions (consumer / SOUL.md) silently fail. We
+# avoid that by spelling out all four inputs and telling Manager to skip
+# confirmation, so the test exercises actual Worker creation rather than the
+# LLM's confirmation-loop behavior.
 matrix_send_message "${ADMIN_TOKEN}" "${DM_ROOM}" \
-    "Please create a new Worker for frontend development tasks. The worker's name (username) must be exactly 'alice'. She should have access to GitHub MCP."
+    "Please create a new Worker now using these exact values — do not ask me to confirm any of them:
+- name: alice
+- runtime: use the install default (do not ask, just pick whatever the env says)
+- SOUL/role: Frontend developer specializing in modern web frameworks, responsive design, and clean UI implementation
+- skills: github-operations (file-sync / task-progress / project-participation are auto-included, no need to ask)
+
+Proceed immediately and tell me when she is created."
 
 log_info "Waiting for Manager to create Worker Alice..."
 


### PR DESCRIPTION
新 Worker 的 \`Generation=1, ObservedGeneration=0\`，原来 \`SpecChanged\` 直接 true。

第一次 reconcile 走 \`StatusNotFound\` 创建容器没问题，但 finalizer patch 触发的第二次 reconcile 从 informer cache 读到的 OG 可能还是 0（status patch 还没刷到 cache）。这时容器已经 Running，又一次 SpecChanged=true 命中 \`member_reconcile.go:285-295\` 的 spec-change 分支 → \`wb.Delete(force=true)\` → 容器活 3 秒被 SIGKILL（exit 137） → \`test-02-create-worker\` copaw probe flake。

修法：\`SpecChanged\` 加一个 \`ObservedGeneration > 0\` 的 gate，brand-new 状态明确返回 false，初次创建只走 StatusNotFound。team 路径用 SpecHash 解决同一个 race，那是因为 Team CR 一个 Generation 覆盖多个 member 需要按成员单独算变更；standalone Worker 1:1，Generation 本身够用，只是要把"从没看过"和"用户改了"区分开。

closes #860
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
The new Worker's \`Generation=1, ObservedGeneration=0\`, the original \`SpecChanged\` is directly true.

The first reconcile uses \`StatusNotFound\` and there is no problem in creating the container, but the second reconcile triggered by the finalizer patch may still read OG from the informer cache as 0 (the status patch has not yet been flushed to the cache). At this time, the container is already Running, and SpecChanged=true hits the spec-change branch of \`member_reconcile.go:285-295\` again → \`wb.Delete(force=true)\` → The container is alive for 3 seconds and is SIGKILL (exit 137) → \`test-02-create-worker\` copaw probe flake.

Fix: \`SpecChanged\` Add a gate with \`ObservedGeneration > 0\`, the brand-new status will clearly return false, and only StatusNotFound will be used for the first creation. The team path uses SpecHash to solve the same race. This is because one Generation of Team CR covers multiple members and changes need to be calculated individually by member; standalone Worker 1:1, Generation itself is enough, but it is necessary to distinguish between "never seen" and "user changed".

closes #860
