### PR TITLE
[codex] prepare v1.1.2 changelog

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -1,44 +1,131 @@
 # Changelog (Unreleased)
 
-Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `openclaw-base/`, `hiclaw-controller/` here before the next release.
+Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `openclaw-base/`, `hiclaw-controller/`, and release-facing install/chart changes here before the next release.
 
 ---
 
-- feat(copaw): add runtime hooks, task/message/file-sync tools, health probes, and refreshed Worker coordination builtins.
-- fix(copaw): keep WorkerConfig CLI startup arguments aligned with the CoPaw worker API port and sync interval.
-- fix(copaw): make direct CoPaw worker readiness-check replies explicit and align the ZIP import probe prompt.
-- fix(copaw): restore MatrixChannel thread-relation helpers used by `copaw channels send`.
-- fix(copaw): avoid swallowing fresh Matrix messages during first-start sync token initialization.
-- fix(copaw): gate Worker readiness on Matrix channel startup so probes do not pass before messages can be handled.
-- fix(copaw): answer Matrix runtime readiness probes directly once the channel is receiving mentioned messages.
-- fix(copaw): handle targeted Matrix readiness probes before the normal agent dispatch and policy path.
-- fix(manager): keep task state registration compatible with legacy finite-task arguments used by Manager agents.
-- fix(manager): auto-join local workers into project rooms after Matrix invite and register project rooms in Manager Matrix config so CoPaw/Hermes project coordination can continue.
-- fix(hiclaw-controller): apply the configured AI stream idle timeout to the self-hosted Higress gateway.
-- feat(team-leader): refresh Team Leader coordination prompts and built-in skills for project, task, file-sharing, communication, organization, and mcporter workflows.
-- fix(team-leader): keep legacy Team Leader skill names and helper scripts available for existing workspaces and integration tests.
-- refactor(team-leader): remove legacy Team Leader skill aliases after migrating docs and integration checks to canonical project, task, and coordination skills.
+**What's New**
 
-- feat(hiclaw-controller): propagate controller-level skills API and Nacos auth defaults to workers.
-- fix(hiclaw-controller): let inline Worker SOUL config override package-seeded SOUL.md during package updates.
-- fix(copaw): suppress noisy warnings when optional MinIO objects do not exist.
-- fix(hiclaw-controller): preserve default object-storage access when custom non-storage entries are configured.
-- fix(copaw): skip static mc alias setup for k8s workers that use wrapper-provided credentials.
-- fix(copaw): exclude inbound Matrix thread messages from room-history context.
-- fix(copaw): align the CoPaw worker install directory with the HOME-backed workspace path.
-- fix(copaw): seed the CoPaw worker agent heartbeat interval at 10 minutes.
-- feat(agent): add non-overridable credential file access prohibition to CoPaw worker and team leader agent prompts.
-- fix(manager): agent docs and jq examples use `roomID` for `hiclaw get workers` / `hiclaw create worker` JSON (CLI field name), not `room_id`
-- fix(controller): add `+kubebuilder:subresource:status` on CR types; patch Worker finalizers instead of full `Update`; exponential backoff on REST update conflict retries
-- fix(manager): document runtime-aware Worker dispatch (avoid @worker text in admin DM only); update task-management references, AGENTS.md, HEARTBEAT.md, channel-management skill
-- fix(manager): separate runtime-specific AGENTS/HEARTBEAT for OpenClaw vs CoPaw; remove cross-runtime references from manager agent docs
-- refactor(api)!: restructure `spec.mcpServers` on Worker/Manager/Team CRDs to `[]{name,url,transport}`; drop controller-side MCP gateway authorization; `mcporter-servers.json` is written from the CRD (see `docs/declarative-resource-management.md`)
-- feat(hiclaw-controller): support Nacos remote skills and per-URI Nacos package auth with `authType=nacos|sts-hiclaw|none`, including `ai-registry` STS access scope.
-- fix(hiclaw-controller): use UUID STS session names for credential-provider requests while logging the original caller label for traceability.
-- fix(copaw-worker): pin the bundled Nacos CLI package to `@nacos-group/cli@1.0.5-beta.1`.
-- fix(hiclaw-controller): preserve runtime-mutated package files during reconcile by seeding package/base files without overwriting existing storage objects.
-- fix(copaw): stop Matrix typing indicators when a run completes without sending a message or is cancelled.
-- fix(copaw): require slash-prefixed runtime control commands and normalize Element double-slash commands.
-- fix(manager): quote coding CLI skill frontmatter descriptions that contain colons.
-- feat(controller): separate CR resource names from runtime worker names across controller identity, credentials, storage defaults, and readiness reporting.
-- feat(controller): support Team human coordinator members, team-admin-owned Matrix rooms, and leader/worker remote skills; document coordinators as Team Room participants only.
+- **QwenPaw-first local install flow**: The installer now presents QwenPaw as the default worker runtime, supports keep-all upgrades with enter-to-keep prompts for existing parameters, and improves non-interactive guardrails for scripted installs.
+
+- **Team human coordinators**: Team resources can include human coordinator members, with team-admin-owned Matrix rooms and updated Team Leader / Worker prompts so coordination stays inside the Team Room.
+
+- **Team Leader coordination refresh**: Team Leader built-ins were refreshed for project planning, DAG task execution, file sharing, communication, organization, mcporter usage, and worker lifecycle coordination. Worker-style anti-loop reply rules were mirrored for Team Leader, and legacy Team Leader skill aliases were removed after migration.
+
+- **CoPaw runtime coordination tools**: CoPaw workers now include runtime hooks and tools for task flow, project flow, messaging, file sync, output sanitizing, credential guarding, health probes, richer readiness handling, and configurable ReAct iteration limits.
+
+- **Nacos remote skills and credentials**: The controller can pass skills API defaults and per-package Nacos authentication to workers, including `authType=nacos|sts-hiclaw|none` and `ai-registry` STS access scope.
+
+- **Worker identity separation**: Controller resource names are separated from runtime worker names across identity, credentials, storage defaults, and readiness reporting, making CR naming and agent-facing names less tightly coupled.
+
+- **Controller observability**: Controller-side reconcile metrics, graceful HTTP/background goroutine shutdown, and test diagnostics were added to make runtime and CI failures easier to inspect.
+
+**Bug Fixes**
+
+- **Installer robustness**: Rootless Podman socket detection, retry behavior for too-short admin passwords, multi-line error output, GitHub repository URL defaults, stable fallback version handling, and Windows stream-idle-timeout propagation were corrected.
+
+- **Helm cleanup and Matrix display names**: Helm uninstall now cleans up Manager/Worker pods, and Tuwunel's default display-name suffix is disabled in the chart.
+
+- **Manager worker lifecycle API**: Manager local container operations now use the controller's `/api/v1` paths, and `groupAllowFrom` is hot-reloaded when Workers are created.
+
+- **Agent-facing docs and safeguards**: Agent prompts and skills now use `roomID` for `hiclaw get workers` / `hiclaw create worker` JSON, quote colon-containing frontmatter descriptions, and explicitly prohibit direct credential file access in CoPaw worker and Team Leader prompts.
+
+- **CoPaw message handling**: CoPaw workers avoid swallowing fresh Matrix messages during startup, handle targeted readiness probes directly, stop typing indicators on empty/cancelled runs, require slash-prefixed control commands, normalize Element double-slash commands, and use display names in mention bodies.
+
+- **CoPaw storage and context sync**: CoPaw workers align the install directory with the HOME-backed workspace path, seed the heartbeat interval at 10 minutes, skip static `mc` alias setup for k8s wrapper credentials, exclude inbound Matrix thread messages from room-history context, and suppress noisy warnings for optional missing MinIO objects.
+
+- **Controller config preservation**: Reconcile now preserves runtime-mutated package files, default object-storage access entries, and user plugin customizations while still applying controller-managed defaults.
+
+- **Gateway and auth stability**: The configured AI stream idle timeout is applied to the self-hosted Higress gateway, observability/stream-timeout env is propagated during bootstrap, and TokenReview cache entries are capped and swept.
+
+---
+
+**新增功能**
+
+- **本地安装默认优先 QwenPaw**: 安装脚本现在优先展示 QwenPaw 作为默认 Worker 运行时，升级时支持 keep-all 和回车保留已有参数，并强化了非交互模式下的防误执行保护。
+
+- **Team 支持人类协调员**: Team 资源支持声明人类协调员成员，Team Room 由 team-admin 归属，并同步更新 Team Leader / Worker 提示词，确保协作收敛在 Team Room 中。
+
+- **Team Leader 协作能力刷新**: Team Leader 内置能力围绕项目规划、DAG 任务执行、文件共享、沟通、组织、mcporter 使用和 Worker 生命周期协作重新整理；同步 Worker 的 anti-loop 回复规则；迁移完成后移除了旧的 Team Leader 技能别名。
+
+- **CoPaw 运行时协作工具**: CoPaw Worker 新增任务流、项目流、消息、文件同步、输出清洗、凭据保护、健康探针、更完整的就绪检查相关 hooks / tools，并支持配置 ReAct 最大迭代次数。
+
+- **Nacos 远程技能与凭据**: 控制器可向 Worker 传递 skills API 默认值和每个包的 Nacos 认证配置，支持 `authType=nacos|sts-hiclaw|none` 以及 `ai-registry` STS 权限范围。
+
+- **Worker 身份解耦**: 控制器资源名与运行时 Worker 名称在身份、凭据、存储默认值和就绪状态中解耦，降低 CR 名称与 Agent 对外名称的耦合。
+
+- **控制器可观测性**: 增加控制器 reconcile 指标、HTTP 服务与后台 goroutine 的优雅退出，以及测试失败诊断信息，便于排查运行时和 CI 问题。
+
+**Bug 修复**
+
+- **安装脚本稳健性**: 修复 rootless Podman socket 检测、管理员密码过短时的重试、多行错误输出、GitHub 仓库 URL 默认值、稳定版本 fallback，以及 Windows 下 stream idle timeout 的传递。
+
+- **Helm 清理与 Matrix 显示名**: Helm 卸载时会清理 Manager/Worker Pod；Chart 中关闭 Tuwunel 默认 display-name suffix。
+
+- **Manager Worker 生命周期 API**: Manager 本地容器操作改为使用控制器 `/api/v1` 路径，并在 Worker 创建后热更新 `groupAllowFrom`。
+
+- **Agent 文档与安全边界**: Agent 提示词和技能统一使用 `roomID` 解析 `hiclaw get workers` / `hiclaw create worker` JSON，修复含冒号 frontmatter 描述的引用，并在 CoPaw Worker 与 Team Leader 提示词中加入不可覆盖的凭据文件直接访问禁令。
+
+- **CoPaw 消息处理**: CoPaw Worker 避免启动时吞掉新 Matrix 消息，直接处理定向就绪探针，空回复或取消运行时停止 typing indicator，要求运行时控制命令以 slash 开头，兼容 Element 双 slash，并在 mention 文本中使用显示名。
+
+- **CoPaw 存储与上下文同步**: CoPaw Worker 安装目录与 HOME 工作区对齐，默认心跳间隔设为 10 分钟；在 k8s wrapper 凭据场景跳过静态 `mc` alias；房间历史上下文排除入站 Matrix thread 消息；缺失可选 MinIO 对象时不再输出噪声警告。
+
+- **控制器配置保留**: Reconcile 过程保留运行时已变更的包文件、默认对象存储访问项和用户插件自定义配置，同时继续下发控制器托管默认值。
+
+- **网关与认证稳定性**: 自托管 Higress 网关应用配置的 AI stream idle timeout；启动时传递 observability / stream-timeout 环境变量；TokenReview 缓存增加容量上限和清理机制。
+
+---
+
+- fix(install): add non-interactive deep-defense guards to step functions ([6cbec18](https://github.com/agentscope-ai/HiClaw/commit/6cbec18))
+- chore(helm): bump chart to 1.1.1 and update repo URLs ([fd09d98](https://github.com/agentscope-ai/HiClaw/commit/fd09d98))
+- fix(install): update GitHub repo URL to agentscope-ai/HiClaw and bump stable fallback to v1.1.1 ([f39601a](https://github.com/agentscope-ai/HiClaw/commit/f39601a))
+- fix(helm): clean up Manager/Worker pods on helm uninstall ([6570402](https://github.com/agentscope-ai/HiClaw/commit/6570402))
+- fix(manager): align container-api.sh paths with controller /api/v1 ([5c9a653](https://github.com/agentscope-ai/HiClaw/commit/5c9a653))
+- feat(install): swap runtime selection order to make QwenPaw the default ([d3e33e8](https://github.com/agentscope-ai/HiClaw/commit/d3e33e8))
+- feat(install): support keep-all upgrade mode and enter-to-keep for all params ([c9ab98f](https://github.com/agentscope-ai/HiClaw/commit/c9ab98f))
+- fix(agent): use roomID when parsing hiclaw get workers JSON output ([efcb544](https://github.com/agentscope-ai/HiClaw/commit/efcb544))
+- fix(install): make error() multi-line safe by splitting exit into die() ([e21ac83](https://github.com/agentscope-ai/HiClaw/commit/e21ac83))
+- fix(install): retry on too-short admin password instead of exiting ([19777eb](https://github.com/agentscope-ai/HiClaw/commit/19777eb))
+- fix(auth): cap and sweep TokenReview cache ([2991d06](https://github.com/agentscope-ai/HiClaw/commit/2991d06))
+- chore(controller): graceful shutdown for HTTP server and background goroutines ([fc99788](https://github.com/agentscope-ai/HiClaw/commit/fc99788))
+- feat(controller): export per-CRD reconcile metrics ([5d7e721](https://github.com/agentscope-ai/HiClaw/commit/5d7e721))
+- fix(legacy): preserve user plugin customizations on Manager config push ([f07a32f](https://github.com/agentscope-ai/HiClaw/commit/f07a32f))
+- fix(helm): disable Tuwunel default displayname suffix ([ab5cdcf](https://github.com/agentscope-ai/HiClaw/commit/ab5cdcf))
+- feat(controller): support Nacos remote skills with STS auth ([fb01fe6](https://github.com/agentscope-ai/HiClaw/commit/fb01fe6))
+- fix(bootstrap): propagate observability and stream timeout env ([df98989](https://github.com/agentscope-ai/HiClaw/commit/df98989))
+- fix(agent): quote coding CLI skill frontmatter ([bd11844](https://github.com/agentscope-ai/HiClaw/commit/bd11844))
+- feat(install): optimize container runtime socket detection for rootless podman ([b1f103b](https://github.com/agentscope-ai/HiClaw/commit/b1f103b))
+- fix(copaw): stop typing indicator on empty completion ([78418b5](https://github.com/agentscope-ai/HiClaw/commit/78418b5))
+- fix(copaw): use display name instead of MXID in mention body ([02ff138](https://github.com/agentscope-ai/HiClaw/commit/02ff138))
+- fix(controller): preserve runtime package files on reconcile ([8cb9f46](https://github.com/agentscope-ai/HiClaw/commit/8cb9f46))
+- feat(copaw): make ReAct max iterations configurable ([933a600](https://github.com/agentscope-ai/HiClaw/commit/933a600))
+- feat(controller): separate CR names from runtime worker names ([12da1ce](https://github.com/agentscope-ai/HiClaw/commit/12da1ce))
+- fix(copaw): require slash-prefixed control commands ([e94aceb](https://github.com/agentscope-ai/HiClaw/commit/e94aceb))
+- feat(agent): prohibit direct credential file access ([046537b](https://github.com/agentscope-ai/HiClaw/commit/046537b))
+- fix(manager): hot-reload groupAllowFrom when Workers are created ([94bde15](https://github.com/agentscope-ai/HiClaw/commit/94bde15))
+- fix(copaw): seed worker heartbeat interval ([ec0f57d](https://github.com/agentscope-ai/HiClaw/commit/ec0f57d))
+- fix(copaw): align install dir with worker home ([c0bca77](https://github.com/agentscope-ai/HiClaw/commit/c0bca77))
+- fix(copaw): exclude inbound thread messages from room history ([8d6a852](https://github.com/agentscope-ai/HiClaw/commit/8d6a852))
+- fix(copaw): skip mc alias setup in k8s mode ([fc1b934](https://github.com/agentscope-ai/HiClaw/commit/fc1b934))
+- fix(controller): preserve default object-storage access entries ([a940d94](https://github.com/agentscope-ai/HiClaw/commit/a940d94))
+- fix(copaw): suppress missing MinIO object warnings ([53d270e](https://github.com/agentscope-ai/HiClaw/commit/53d270e))
+- feat(controller): propagate skills API defaults to workers ([e4a3506](https://github.com/agentscope-ai/HiClaw/commit/e4a3506))
+- feat(team-leader): refresh coordination builtins ([bfd99cd](https://github.com/agentscope-ai/HiClaw/commit/bfd99cd))
+- fix(controller): apply Higress stream idle timeout ([8d81c9f](https://github.com/agentscope-ai/HiClaw/commit/8d81c9f))
+- feat(controller): support team human coordinators ([16e87c2](https://github.com/agentscope-ai/HiClaw/commit/16e87c2))
+- feat(copaw): add runtime coordination tools ([4a2ced6](https://github.com/agentscope-ai/HiClaw/commit/4a2ced6))
+- fix(install): pass stream idle timeout on Windows ([fece949](https://github.com/agentscope-ai/HiClaw/commit/fece949))
+- refactor(team-leader): remove legacy skill aliases ([67a6daf](https://github.com/agentscope-ai/HiClaw/commit/67a6daf))
+- fix(team-leader): mirror worker's anti-loop reply rules ([2a7cd17](https://github.com/agentscope-ai/HiClaw/commit/2a7cd17))
+
+**Also in this window (docs / repo metadata / tests; not image-facing)**
+
+- chore: archive changelog for v1.1.1 ([d62aecb](https://github.com/agentscope-ai/HiClaw/commit/d62aecb))
+- Revert "chore: archive changelog for v1.1.1" ([c78b469](https://github.com/agentscope-ai/HiClaw/commit/c78b469))
+- chore: remove duplicate CLAUDE.md entry from .gitignore ([8c262f7](https://github.com/agentscope-ai/HiClaw/commit/8c262f7))
+- feat(test): add CoPaw metrics collection via token_usage.json ([724d80b](https://github.com/agentscope-ai/HiClaw/commit/724d80b))
+- docs(copaw): add CredAgent config reference ([9bae51d](https://github.com/agentscope-ai/HiClaw/commit/9bae51d))
+- test(controller): cover team leader ready auth ([41ac30b](https://github.com/agentscope-ai/HiClaw/commit/41ac30b))
+- docs(controller): note Nacos auth type example ([d522966](https://github.com/agentscope-ai/HiClaw/commit/d522966))
+- docs: sync zh-CN architecture docs ([58cdded](https://github.com/agentscope-ai/HiClaw/commit/58cdded))
+- test: dump diagnostics on wait/probe failures ([e07feb8](https://github.com/agentscope-ai/HiClaw/commit/e07feb8))


### PR DESCRIPTION
## Summary

- Rewrite `changelog/current.md` into the same release-note structure used by `v1.1.1`.
- Organize the expected `v1.1.2` highlights into English and Chinese sections.
- Keep the raw commit list and separate docs/test/repo-metadata entries from image-facing release content.

## Why

This prepares the changelog that the Release workflow will read when the `v1.1.2` tag is pushed. The workflow extracts content below the first `---` in `changelog/current.md`, then archives it into `changelog/v1.1.2.md` after release.

## Validation

- `git diff --cached --check`
- Verified the Release workflow extraction command shape with `awk '/^---$/{found=1; next} found{print}' changelog/current.md`.
