### PR TITLE
docs: clarify Team delegation matching

### DIFF
--- a/docs/declarative-resource-management.md
+++ b/docs/declarative-resource-management.md
@@ -308,7 +308,7 @@ Key design: the Team Room does NOT include the Manager, establishing a delegatio
 ```
 Admin assigns task → Manager
   ↓
-Manager determines the task matches a Team's domain
+Manager semantically chooses a matching Team from its name, description, Leader, and Workers
   ↓
 Manager creates task spec, @mentions Leader
   ↓
@@ -320,6 +320,11 @@ Leader aggregates results, @mentions Manager
   ↓
 Manager notifies Admin
 ```
+
+Team matching is not backed by structured `domain`, `expertise`, `skills`, or
+`capabilities` fields on the Team object. Use `spec.description`, the Team name,
+Leader name, and Worker names to make the Team's responsibility clear to the
+Manager.
 
 ### Team Status
 

--- a/docs/declarative-resource-management.md
+++ b/docs/declarative-resource-management.md
@@ -321,10 +321,11 @@ Leader aggregates results, @mentions Manager
 Manager notifies Admin
 ```
 
-Team matching is not backed by structured `domain`, `expertise`, `skills`, or
-`capabilities` fields on the Team object. Use `spec.description`, the Team name,
-Leader name, and Worker names to make the Team's responsibility clear to the
-Manager.
+Team matching is not backed by structured team-level matching/filtering fields
+such as `domain`, `expertise`, or `capabilities` on the Team object. Worker-level
+`skills` can still describe individual members, but Manager delegation is based
+on semantic judgement over the Team name, `spec.description`, Leader name, and
+Worker names rather than a structured Team filter.
 
 ### Team Status
 

--- a/docs/zh-cn/declarative-resource-management.md
+++ b/docs/zh-cn/declarative-resource-management.md
@@ -319,9 +319,10 @@ Leader 汇总结果，@mention Manager
 Manager 通知 Admin
 ```
 
-Team 匹配目前没有结构化的 `domain`、`expertise`、`skills` 或
-`capabilities` 字段。建议通过 `spec.description`、Team 名称、Leader 名称和
-Worker 名称清楚表达团队职责，供 Manager 做语义判断。
+Team 匹配目前没有结构化的团队级 matching/filtering 字段，例如 `domain`、
+`expertise` 或 `capabilities`。Worker 级别的 `skills` 仍可描述单个成员，
+但 Manager 委派不是基于结构化 Team filter，而是结合 Team 名称、
+`spec.description`、Leader 名称和 Worker 名称做语义判断。
 
 ### Team 状态
 

--- a/docs/zh-cn/declarative-resource-management.md
+++ b/docs/zh-cn/declarative-resource-management.md
@@ -306,7 +306,7 @@ Leader DM:     Team Admin ↔ Leader                    ← 团队管理通道
 ```
 Admin 下发任务 → Manager
   ↓
-Manager 判断匹配某个 Team 的领域
+Manager 结合 Team 名称、描述、Leader 与 Worker 列表语义判断匹配的 Team
   ↓
 Manager 创建任务 spec，@mention Leader
   ↓
@@ -318,6 +318,10 @@ Leader 汇总结果，@mention Manager
   ↓
 Manager 通知 Admin
 ```
+
+Team 匹配目前没有结构化的 `domain`、`expertise`、`skills` 或
+`capabilities` 字段。建议通过 `spec.description`、Team 名称、Leader 名称和
+Worker 名称清楚表达团队职责，供 Manager 做语义判断。
 
 ### Team 状态
 

--- a/manager/agent/skills/team-management/references/team-lifecycle.md
+++ b/manager/agent/skills/team-management/references/team-lifecycle.md
@@ -25,9 +25,13 @@ Check status: `hiclaw get team <TEAM_NAME>`
 
 ## Task Delegation to Teams
 
-When Manager receives a task matching a team's domain:
+When Manager receives a task that semantically matches a Team's name,
+description, Leader, or Worker roster:
 
 1. Use `manage-state.sh --action add-finite --delegated-to-team <TEAM>` to track
 2. @mention the Team Leader in the Leader Room with the task
 3. Team Leader handles decomposition and assignment internally
 4. Manager only checks with Team Leader for progress (never team workers)
+
+The Team registry and Team API do not expose structured domain/expertise fields
+for automatic filtering.

--- a/manager/agent/skills/team-management/references/team-lifecycle.md
+++ b/manager/agent/skills/team-management/references/team-lifecycle.md
@@ -33,5 +33,7 @@ description, Leader, or Worker roster:
 3. Team Leader handles decomposition and assignment internally
 4. Manager only checks with Team Leader for progress (never team workers)
 
-The Team registry and Team API do not expose structured domain/expertise fields
-for automatic filtering.
+The Team registry and Team API do not expose structured team-level
+domain/expertise/capability fields for automatic filtering. Worker-level skills
+may describe individual members, but Manager delegation is not backed by a
+structured Team filter.

--- a/manager/agent/skills/team-management/references/team-task-delegation.md
+++ b/manager/agent/skills/team-management/references/team-task-delegation.md
@@ -3,16 +3,20 @@
 ## When to Delegate to a Team
 
 Delegate to a Team Leader when:
-- The task matches the team's domain/expertise
+- The task semantically matches the team's name, description, Leader, or Worker roster
 - The task is complex enough to benefit from decomposition
 - Multiple workers with different skills are needed
+
+Team matching is a Manager-side judgement based on the current Team data. The
+Team registry and Team API do not define structured `domain`, `expertise`,
+`skills`, or `capabilities` fields for filtering teams.
 
 ## Delegation Flow
 
 ```
 Manager receives task from Admin
   ↓
-Manager checks team info via `hiclaw get team <TEAM_NAME>` for matching team
+Manager checks team info via `hiclaw get team <TEAM_NAME>` and chooses a matching team
   ↓
 Manager creates task: shared/tasks/{task-id}/
   - meta.json: assigned_to = leader name

--- a/manager/agent/skills/team-management/references/team-task-delegation.md
+++ b/manager/agent/skills/team-management/references/team-task-delegation.md
@@ -8,8 +8,10 @@ Delegate to a Team Leader when:
 - Multiple workers with different skills are needed
 
 Team matching is a Manager-side judgement based on the current Team data. The
-Team registry and Team API do not define structured `domain`, `expertise`,
-`skills`, or `capabilities` fields for filtering teams.
+Team registry and Team API do not define structured team-level
+matching/filtering fields such as `domain`, `expertise`, or `capabilities`.
+Worker-level `skills` can describe individual members, but Manager delegation is
+not backed by a structured Team filter.
 
 ## Delegation Flow
 


### PR DESCRIPTION
## Summary
- clarify that Team delegation matching is a Manager-side semantic judgement
- document that Team objects/registry do not expose structured domain, expertise, skills, or capabilities fields for team filtering
- align the Manager skill references and English/Chinese declarative resource docs

## Source of truth checked
- hiclaw-controller/api/v1beta1/types.go: TeamSpec exposes description, teamName, leader, workers, but no domain/expertise matching fields
- hiclaw-controller/internal/service/legacy.go: teams-registry.json contains leader/workers/room/admin/member metadata, not domain/expertise/skills/capabilities
- manager/agent/skills/team-management/scripts/manage-teams-registry.sh: add/list/get only manage the same registry fields

Fixes #837

## Verification
- git diff --check