### PR TITLE
docs: expand FAQ for Worker and setup questions

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -14,8 +14,11 @@
 - [How to talk to a Worker directly](#how-to-talk-to-a-worker-directly)
 - [How to switch the Manager's model](#how-to-switch-the-managers-model)
 - [How to switch a Worker's model](#how-to-switch-a-workers-model)
+- [How to configure OpenRouter or another model provider with slashes in model names](#how-to-configure-openrouter-or-another-model-provider-with-slashes-in-model-names)
 - [How to switch a Worker's runtime](#how-to-switch-a-workers-runtime)
+- [Why does QwenPaw still use `copaw` in runtime values or image names](#why-does-qwenpaw-still-use-copaw-in-runtime-values-or-image-names)
 - [Can I connect my own agent implementation as a Worker](#can-i-connect-my-own-agent-implementation-as-a-worker)
+- [Can HiClaw connect to an existing Higress instance](#can-hiclaw-connect-to-an-existing-higress-instance)
 - [How to use the Worker Template Marketplace](#how-to-use-the-worker-template-marketplace)
 - [Does HiClaw support sending and receiving files](#does-hiclaw-support-sending-and-receiving-files)
 - [Why does Manager/Worker keep showing "typing"](#why-does-managerworker-keep-showing-typing)
@@ -266,6 +269,15 @@ If you're using a Mac with Apple Silicon (M1/M2/M3/M4) and Docker Desktop is old
 - **Docker Desktop**: Upgrade to 4.39.0 or later
 - **Podman**: Ensure Podman Engine **Server version ≥ 5.7.1** (check with `podman version`)
 
+**Case 5: Linux host with SELinux volume denial**
+
+If the detailed log, especially `mc-mirror.log`, contains `permission denied`
+for files under the mounted workspace or host-share directory on an SELinux
+enabled Linux host, the bind mount may need an SELinux relabel option. Re-run
+the installer from a workspace location where Docker/Podman is allowed to mount
+files, or add `:z` to equivalent manual bind mounts so the container can access
+the mounted path.
+
 ---
 
 ## Accessing the web UI from other devices on the LAN
@@ -289,6 +301,15 @@ http://<LAN-IP>:18080
 ```
 
 For example, if your LAN IP is `192.168.1.100`, enter `http://192.168.1.100:18080`.
+
+If the login page still reports a homeserver error:
+
+1. Confirm the installer was run with external access enabled. Local-only mode
+   binds services to `127.0.0.1`, so other devices cannot reach them.
+2. Make sure the machine firewall allows ports `18080` (Matrix/Higress gateway)
+   and `18088` (Element Web).
+3. Do not use the default `matrix-local.hiclaw.io` address from another device;
+   that name resolves to the client machine's loopback address.
 
 ---
 
@@ -338,6 +359,11 @@ The model-switch skill:
 1. Looks up the correct `contextWindow` and `maxTokens` for the target model
 2. Updates OpenClaw's config accordingly
 3. Tests connectivity before applying the change
+
+If you see `model_context_window_exceeded`, first start a new session with
+`/new` or switch to a model with a larger context window. Then verify that the
+target model's `contextWindow` in the model configuration matches the provider's
+real limit before continuing the long conversation.
 
 **Step 1: Configure Higress AI Route**
 
@@ -400,6 +426,28 @@ Reference: [Higress AI Quick Start — Console Configuration](https://higress.ai
 
 ---
 
+## How to configure OpenRouter or another model provider with slashes in model names
+
+In Higress AI route configuration, the **service name** is an internal name and
+should not be the model name. It must not contain `/`. Put provider-specific
+model prefixes such as `openrouter/` or `stepfun/` in the model matching rule
+instead.
+
+Example for OpenRouter:
+
+| Field | Value |
+|-------|-------|
+| Service name | `openrouter` |
+| Model matching rule | regex, for example `^openrouter/.*$` |
+| Protocol | `openai` |
+| Custom URL | `https://openrouter.ai/api/v1` |
+
+After the route is configured, ask Manager to use the full model name, for
+example `openrouter/stepfun-eur-1-70b`. The model name prefix is what lets
+Higress select the matching provider route.
+
+---
+
 ## How to switch a Worker's runtime
 
 HiClaw v1.1.0+ supports three Worker runtimes:
@@ -441,6 +489,20 @@ Manager will use the worker-management skill to trigger a container recreation. 
 
 ---
 
+## Why does QwenPaw still use `copaw` in runtime values or image names
+
+`QwenPaw` is the user-facing name of the Python runtime that was previously
+called `CoPaw`. Some internal compatibility names intentionally remain `copaw`,
+including the Worker CRD runtime value, image names such as
+`hiclaw-copaw-worker`, and environment values such as
+`HICLAW_MANAGER_RUNTIME=copaw`.
+
+Do not change these internal values to `qwenpaw` unless the chart, controller,
+and images explicitly support that new value. They are kept stable to avoid
+breaking existing installations, Helm values, and image pull paths.
+
+---
+
 ## Can I connect my own agent implementation as a Worker
 
 Not by adding an arbitrary new `spec.runtime` value. The Worker CRD currently
@@ -455,6 +517,28 @@ and the `spec.package` / `spec.image` fields in
 Adding a completely new runtime requires code changes in the controller,
 runtime image defaults, and the corresponding agent template wiring. It is not
 a configuration-only operation.
+
+---
+
+## Can HiClaw connect to an existing Higress instance
+
+Not with `gateway.provider=higress` today. The Helm chart validates that
+`gateway.provider=higress` uses `gateway.mode=managed`, which means HiClaw
+deploys and owns the Higress instance it uses.
+
+Do not copy an existing Higress configuration directory into the HiClaw-managed
+Higress instance. HiClaw reconciles the AI routes, consumers, and gateway
+resources it needs, so copied resources can conflict with or be overwritten by
+HiClaw-managed state.
+
+The supported paths are:
+
+- use the Higress instance managed by HiClaw for HiClaw traffic
+- use the external `ai-gateway` provider path where applicable
+
+Connecting to an existing self-managed Higress instance would require a separate
+external-Higress design, including gateway/console URLs, credentials, resource
+naming isolation, and safeguards around existing routes and consumers.
 
 ---
 
@@ -484,6 +568,11 @@ With a `package` reference in the YAML pointing to a marketplace template.
 **Receiving files from you**: Yes. You can upload a file directly in Element Web (the attachment button), and Manager or Worker will receive it as a Matrix media message and can read its content.
 
 **Sending files to you**: Yes. When you ask Manager (or a Worker) to send you a file — such as a task output artifact, a generated report, or any file it has access to — it will upload the file to the Matrix media server and send it to the room as a downloadable attachment. You can then click to download it in Element Web.
+
+Paths printed by Manager or Worker are usually container-internal paths. If you
+cannot access a path directly from the host, ask the agent to send the file as
+an attachment or provide a downloadable link instead of relying on the raw
+container path.
 
 ---
 
@@ -595,7 +684,18 @@ Search the log for the relevant status code. Common causes:
 - **503**: The container can't reach the external LLM service — likely a network issue inside the container.
 - **404**: The model name is probably wrong.
 
-To determine whether the error came from the backend or from a Higress misconfiguration, check the `upstream_host` field in the log entry. If `upstream_host` has a value, the request reached the backend and the error was returned by the upstream service. If it's empty, Higress itself couldn't route the request.
+To determine whether the error came from the backend or from a Higress
+misconfiguration, check the `upstream_host` field in the log entry. If
+`upstream_host` has a real host value, the request reached the backend and the
+error was returned by the upstream service. If it is `-` or empty, Higress did
+not select an upstream cluster; a log entry with `response_code_details:
+cluster_not_found` usually means the model route or service source is
+misconfigured.
+
+For self-hosted OpenAI-compatible services, check whether the Higress provider
+configuration points to a real URL instead of a non-existent service name. Also
+verify from inside the container that the upstream URL is reachable with the
+same base URL and API key.
 
 ### 4. Check model configuration
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -15,6 +15,7 @@
 - [How to switch the Manager's model](#how-to-switch-the-managers-model)
 - [How to switch a Worker's model](#how-to-switch-a-workers-model)
 - [How to switch a Worker's runtime](#how-to-switch-a-workers-runtime)
+- [Can I connect my own agent implementation as a Worker](#can-i-connect-my-own-agent-implementation-as-a-worker)
 - [How to use the Worker Template Marketplace](#how-to-use-the-worker-template-marketplace)
 - [Does HiClaw support sending and receiving files](#does-hiclaw-support-sending-and-receiving-files)
 - [Why does Manager/Worker keep showing "typing"](#why-does-managerworker-keep-showing-typing)
@@ -437,6 +438,23 @@ Tell Manager to switch a Worker's runtime:
 > "Switch alice's runtime to hermes"
 
 Manager will use the worker-management skill to trigger a container recreation. The Worker's Matrix account, room, gateway consumer, MinIO data, and persisted credentials are preserved. Container-local ephemeral state (caches, in-flight task progress) will be lost.
+
+---
+
+## Can I connect my own agent implementation as a Worker
+
+Not by adding an arbitrary new `spec.runtime` value. The Worker CRD currently
+accepts only `openclaw`, `copaw`, or `hermes` as runtimes.
+
+For most custom Worker needs, package your role prompt, skills, dependencies,
+and optional Dockerfile as a Worker package, or set a custom image while keeping
+one of the supported runtimes. See [Importing Existing Workers](import-worker.md)
+and the `spec.package` / `spec.image` fields in
+[Declarative Resource Management](declarative-resource-management.md#worker-resource).
+
+Adding a completely new runtime requires code changes in the controller,
+runtime image defaults, and the corresponding agent template wiring. It is not
+a configuration-only operation.
 
 ---
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -139,8 +139,8 @@ hiclaw create worker --name alice
 # Create a worker with specific model and runtime
 hiclaw create worker --name bob --model claude-sonnet-4-6 --runtime hermes
 
-# Create a worker with skills and MCP servers
-hiclaw create worker --name charlie --skills github-operations --mcp-servers github
+# Create a worker with skills
+hiclaw create worker --name charlie --skills github-operations
 
 # Create a worker with a custom SOUL.md
 hiclaw create worker --name diana --soul-file /path/to/SOUL.md
@@ -169,9 +169,6 @@ hiclaw update worker --name alice --runtime hermes
 
 # Update a worker's skills
 hiclaw update worker --name alice --skills github-operations,code-review
-
-# Add MCP server access
-hiclaw update worker --name alice --mcp-servers github,sentry
 ```
 
 ### Apply YAML definitions
@@ -179,7 +176,26 @@ hiclaw update worker --name alice --mcp-servers github,sentry
 ```bash
 # Apply a single YAML resource
 hiclaw apply -f worker-alice.yaml
+```
 
+Use YAML for fields not exposed by direct CLI flags, such as `spec.mcpServers`:
+
+```yaml
+apiVersion: hiclaw.io/v1beta1
+kind: Worker
+metadata:
+  name: alice
+spec:
+  workerName: alice
+  skills:
+    - github-operations
+  mcpServers:
+    - name: github
+      url: https://gateway.example.com/mcp-servers/github/mcp
+      transport: http
+```
+
+```bash
 # Import a worker from a zip package
 hiclaw apply worker --name alice --zip worker-package.zip
 ```
@@ -230,12 +246,28 @@ HICLAW_GITHUB_TOKEN=ghp_xxx bash <(curl -sSL https://higress.ai/hiclaw/install.s
 ```
 
 When this variable is present, HiClaw configures the GitHub MCP Server and
-generates Manager-side `mcporter` configuration automatically. After that, give
-a Worker the GitHub MCP capability when creating or updating it:
+generates Manager-side `mcporter` configuration automatically. After that,
+declare the GitHub MCP capability in the Worker manifest:
+
+```yaml
+apiVersion: hiclaw.io/v1beta1
+kind: Worker
+metadata:
+  name: alice
+spec:
+  workerName: alice
+  skills:
+    - github-operations
+  mcpServers:
+    - name: github
+      url: https://gateway.example.com/mcp-servers/github/mcp
+      transport: http
+```
+
+Apply it with the supported YAML path:
 
 ```bash
-hiclaw create worker --name alice --skills github-operations --mcp-servers github
-hiclaw update worker --name alice --mcp-servers github
+hiclaw apply -f worker-alice.yaml
 ```
 
 For an existing installation that skipped the token, re-run the installer from

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,6 +5,7 @@
 - [How to check the current HiClaw version](#how-to-check-the-current-hiclaw-version)
 - [Understanding the new architecture (v1.1.0+)](#understanding-the-new-architecture-v110)
 - [How to use the hiclaw CLI to manage resources](#how-to-use-the-hiclaw-cli-to-manage-resources)
+- [How to configure GitHub credentials for Workers](#how-to-configure-github-credentials-for-workers)
 - [How to connect Feishu/DingTalk/WeCom/Discord/Telegram](#how-to-connect-feishudingtalkwecomdiscordtelegram)
 - [Installation script exits immediately on Windows](#installation-script-exits-immediately-on-windows)
 - [Installation fails: "manifest unknown" for embedded image](#installation-fails-manifest-unknown-for-embedded-image)
@@ -12,6 +13,7 @@
 - [Accessing the web UI from other devices on the LAN](#accessing-the-web-ui-from-other-devices-on-the-lan)
 - [Cannot connect to Matrix server locally](#cannot-connect-to-matrix-server-locally)
 - [How to talk to a Worker directly](#how-to-talk-to-a-worker-directly)
+- [How to connect third-party, local, or multi-provider models](#how-to-connect-third-party-local-or-multi-provider-models)
 - [How to switch the Manager's model](#how-to-switch-the-managers-model)
 - [How to switch a Worker's model](#how-to-switch-a-workers-model)
 - [How to configure OpenRouter or another model provider with slashes in model names](#how-to-configure-openrouter-or-another-model-provider-with-slashes-in-model-names)
@@ -37,6 +39,17 @@ Run the following command to see the installed version:
 ```bash
 docker exec hiclaw-manager cat /opt/hiclaw/agent/.builtin-version
 ```
+
+In v1.1.0+ installs, you can also query the controller-side CLI:
+
+```bash
+docker exec hiclaw-controller hiclaw version
+```
+
+Older `latest` images may print a commit hash instead of a semantic version if
+that image was rebuilt before version metadata was standardized. In that case,
+match the hash against the release or commit history, or upgrade with an
+explicit `HICLAW_VERSION`.
 
 To install a specific version, use the `HICLAW_VERSION` environment variable during installation:
 
@@ -203,6 +216,36 @@ For declarative YAML resource definitions, see [Declarative Resource Management]
 
 ---
 
+## How to configure GitHub credentials for Workers
+
+GitHub credentials are configured as an MCP Server credential, not copied into
+Worker containers. Workers call GitHub through `mcporter` and the AI Gateway;
+the real GitHub PAT stays in the gateway-side MCP configuration.
+
+During installation, set or enter `HICLAW_GITHUB_TOKEN` when the installer asks
+for the optional GitHub Personal Access Token:
+
+```bash
+HICLAW_GITHUB_TOKEN=ghp_xxx bash <(curl -sSL https://higress.ai/hiclaw/install.sh)
+```
+
+When this variable is present, HiClaw configures the GitHub MCP Server and
+generates Manager-side `mcporter` configuration automatically. After that, give
+a Worker the GitHub MCP capability when creating or updating it:
+
+```bash
+hiclaw create worker --name alice --skills github-operations --mcp-servers github
+hiclaw update worker --name alice --mcp-servers github
+```
+
+For an existing installation that skipped the token, re-run the installer from
+the original workspace and provide `HICLAW_GITHUB_TOKEN`, or configure the
+GitHub MCP Server in the gateway manually and then authorize the target
+Manager/Worker consumer. Do not paste a PAT into a Worker prompt or
+container-local config.
+
+---
+
 ## Installation script exits immediately on Windows
 
 If the PowerShell installation script closes immediately after launching, first check whether Docker Desktop is installed. If it is installed, make sure it is actually running — Docker Desktop must be started and fully loaded before the script can connect to the Docker daemon.
@@ -311,6 +354,10 @@ If the login page still reports a homeserver error:
 3. Do not use the default `matrix-local.hiclaw.io` address from another device;
    that name resolves to the client machine's loopback address.
 
+For FluffyChat or Element Mobile over Tailscale, use the same rule: set the
+homeserver to `http://<tailscale-ip>:18080` and make sure the phone and the
+HiClaw host can reach each other in the Tailscale network.
+
 ---
 
 ## Cannot connect to Matrix server locally
@@ -328,6 +375,46 @@ After creating a Worker, Manager automatically adds you and the Worker to a shar
 When using Element or similar clients, type `@` followed by the first letter(s) of the Worker's display name to trigger autocomplete and select the right user.
 
 Alternatively, you can click the Worker's avatar and open a **direct message** (DM) conversation. In a DM you don't need to @mention — every message triggers the Worker. Keep in mind that Manager is not in the DM room and won't see any of that conversation.
+
+---
+
+## How to connect third-party, local, or multi-provider models
+
+HiClaw does not read your `~/.openclaw/openclaw.json` provider definitions
+directly. Model traffic goes through the HiClaw AI Gateway. OpenClaw/QwenPaw
+usually sees one provider named `hiclaw-gateway`; Higress then routes each
+requested model name to the real upstream provider.
+
+### Third-party OpenAI-compatible APIs
+
+For an OpenAI-compatible service, create or update a Higress AI route with:
+
+- the provider's base URL, including `/v1` when the provider requires it
+- the provider API key
+- a model matching rule that matches the model id you will ask Manager or a
+  Worker to use
+
+Then ask Manager to switch to that same model id, or create/update a Worker with
+that model. Do not rely on `/model list` alone as the source of available
+Higress providers; it shows the agent-side known model list, not every route
+defined in Higress.
+
+### Local models such as Ollama or LM Studio
+
+Local models are supported when the service exposes an OpenAI-compatible API
+that the HiClaw containers can reach. From inside Docker, `localhost` means the
+container itself, not your Mac or host machine. Use a reachable host address,
+for example `http://host.docker.internal:<port>/v1` on Docker Desktop, or the
+host LAN IP on Linux/Podman when `host.docker.internal` is not available.
+
+### Multiple providers and task-specific models
+
+Configure separate Higress AI routes with prefix or regex model matching rules,
+for example one rule for `qwen*` and another for `claude*`. Then assign the
+desired model explicitly to the Manager or a Worker. HiClaw can use different
+models for different Workers, but automatic model selection by task type is not
+a built-in policy; express that policy through Worker roles or switch the model
+explicitly.
 
 ---
 

--- a/docs/zh-cn/faq.md
+++ b/docs/zh-cn/faq.md
@@ -138,8 +138,8 @@ hiclaw create worker --name alice
 # 指定模型和运行时创建 Worker
 hiclaw create worker --name bob --model claude-sonnet-4-6 --runtime hermes
 
-# 创建带技能和 MCP Server 的 Worker
-hiclaw create worker --name charlie --skills github-operations --mcp-servers github
+# 创建带技能的 Worker
+hiclaw create worker --name charlie --skills github-operations
 
 # 使用自定义 SOUL.md 创建 Worker
 hiclaw create worker --name diana --soul-file /path/to/SOUL.md
@@ -168,9 +168,6 @@ hiclaw update worker --name alice --runtime hermes
 
 # 更新 Worker 技能
 hiclaw update worker --name alice --skills github-operations,code-review
-
-# 添加 MCP Server 访问权限
-hiclaw update worker --name alice --mcp-servers github,sentry
 ```
 
 ### 应用 YAML 定义
@@ -178,7 +175,26 @@ hiclaw update worker --name alice --mcp-servers github,sentry
 ```bash
 # 应用单个 YAML 资源
 hiclaw apply -f worker-alice.yaml
+```
 
+对于直接 CLI 参数未覆盖的字段（例如 `spec.mcpServers`），请使用 YAML：
+
+```yaml
+apiVersion: hiclaw.io/v1beta1
+kind: Worker
+metadata:
+  name: alice
+spec:
+  workerName: alice
+  skills:
+    - github-operations
+  mcpServers:
+    - name: github
+      url: https://gateway.example.com/mcp-servers/github/mcp
+      transport: http
+```
+
+```bash
 # 从 zip 包导入 Worker
 hiclaw apply worker --name alice --zip worker-package.zip
 ```
@@ -228,11 +244,27 @@ HICLAW_GITHUB_TOKEN=ghp_xxx bash <(curl -sSL https://higress.ai/hiclaw/install.s
 ```
 
 该变量存在时，HiClaw 会自动配置 GitHub MCP Server，并生成 Manager 侧
-`mcporter` 配置。之后创建或更新 Worker 时给它 GitHub MCP 能力：
+`mcporter` 配置。之后在 Worker YAML manifest 中声明 GitHub MCP 能力：
+
+```yaml
+apiVersion: hiclaw.io/v1beta1
+kind: Worker
+metadata:
+  name: alice
+spec:
+  workerName: alice
+  skills:
+    - github-operations
+  mcpServers:
+    - name: github
+      url: https://gateway.example.com/mcp-servers/github/mcp
+      transport: http
+```
+
+通过当前支持的 YAML 路径应用：
 
 ```bash
-hiclaw create worker --name alice --skills github-operations --mcp-servers github
-hiclaw update worker --name alice --mcp-servers github
+hiclaw apply -f worker-alice.yaml
 ```
 
 如果已有安装当时跳过了 token，请在原工作目录重新执行安装并提供

--- a/docs/zh-cn/faq.md
+++ b/docs/zh-cn/faq.md
@@ -14,8 +14,11 @@
 - [如何主动指挥 Worker](#如何主动指挥-worker)
 - [如何切换 Manager 的模型](#如何切换-manager-的模型)
 - [如何切换 Worker 的模型](#如何切换-worker-的模型)
+- [如何配置 OpenRouter 或模型名带斜杠的供应商](#如何配置-openrouter-或模型名带斜杠的供应商)
 - [如何切换 Worker 的运行时](#如何切换-worker-的运行时)
+- [为什么 QwenPaw 仍然使用 `copaw` 作为 runtime 值或镜像名](#为什么-qwenpaw-仍然使用-copaw-作为-runtime-值或镜像名)
 - [如何接入自己实现的 agent 作为 Worker](#如何接入自己实现的-agent-作为-worker)
+- [HiClaw 可以连接已有的 Higress 实例吗](#hiclaw-可以连接已有的-higress-实例吗)
 - [如何使用 Worker 模板市场](#如何使用-worker-模板市场)
 - [HiClaw 支持发送和接收文件吗](#hiclaw-支持发送和接收文件吗)
 - [为什么 Manager/Worker 一直显示"输入中"](#为什么-managerworker-一直显示输入中)
@@ -266,6 +269,13 @@ bash <(curl -sSL https://higress.ai/hiclaw/install.sh)
 - **Docker Desktop**：升级到 4.39.0 或更高版本
 - **Podman**：确保 Podman Engine **Server 版本 ≥ 5.7.1**（可通过 `podman version` 查看）
 
+**情况五：Linux 主机 SELinux 拦截挂载目录**
+
+如果详细日志，尤其是 `mc-mirror.log`，在工作目录或共享目录下出现
+`permission denied`，且主机启用了 SELinux，可能是容器没有访问 bind mount 的
+SELinux 标签。请在 Docker/Podman 允许挂载的位置重新执行安装；如果是手动等价挂载，
+需要给工作目录和共享目录的 `-v` 参数加上 `:z`，让容器可以访问挂载路径。
+
 ---
 
 ## 局域网其他电脑如何访问 Web 端
@@ -289,6 +299,12 @@ http://<局域网IP>:18080
 ```
 
 例如局域网 IP 是 `192.168.1.100`，则填写 `http://192.168.1.100:18080`。
+
+如果登录页仍然提示 homeserver 错误：
+
+1. 确认安装时选择了允许外部访问。本机模式只绑定到 `127.0.0.1`，局域网其他设备无法访问。
+2. 确认 Manager 所在机器的防火墙放行 `18080`（Matrix/Higress Gateway）和 `18088`（Element Web）。
+3. 不要在其他设备上使用默认的 `matrix-local.hiclaw.io`；该域名会解析到当前设备自己的 loopback 地址。
 
 ---
 
@@ -335,6 +351,8 @@ HiClaw 支持两种模型切换方式：**切换当前会话模型**（即时生
 OpenClaw 需要在配置中设置模型的上下文窗口大小（`contextWindow`）。HiClaw 默认使用 qwen3.5-plus 的 200K token 窗口。如果切换到窗口不同的模型但没有更新这个设置，当对话接近窗口上限时，OpenClaw 不知道何时压缩上下文，可能导致 session 无法使用。
 
 模型切换技能会根据模型名自动修改 OpenClaw 配置中的 `contextWindow` 和 `maxTokens`。
+
+如果看到 `model_context_window_exceeded`，先用 `/new` 开启新会话，或切换到上下文窗口更大的模型。随后确认目标模型配置里的 `contextWindow` 与供应商实际窗口一致，再继续长上下文对话。
 
 **切换步骤**
 
@@ -404,6 +422,25 @@ Manager 会使用模型切换技能完成配置更新。
 
 ---
 
+## 如何配置 OpenRouter 或模型名带斜杠的供应商
+
+在 Higress AI 路由配置中，**服务名称**是内部名称，不是模型名，不能包含 `/`。
+`openrouter/`、`stepfun/` 这类模型前缀应放在模型匹配规则里。
+
+OpenRouter 示例：
+
+| 字段 | 值 |
+|------|----|
+| 服务名称 | `openrouter` |
+| 模型匹配规则 | regex，例如 `^openrouter/.*$` |
+| 协议 | `openai` |
+| 自定义 URL | `https://openrouter.ai/api/v1` |
+
+配置完成后，告诉 Manager 使用完整模型名，例如
+`openrouter/stepfun-eur-1-70b`。Higress 会根据模型名前缀匹配到对应供应商路由。
+
+---
+
 ## 如何切换 Worker 的运行时
 
 HiClaw v1.1.0+ 支持三种 Worker 运行时：
@@ -445,6 +482,17 @@ Manager 会通过 worker-management 技能触发容器重建。Worker 的 Matrix
 
 ---
 
+## 为什么 QwenPaw 仍然使用 `copaw` 作为 runtime 值或镜像名
+
+`QwenPaw` 是原 `CoPaw` 运行时的对外展示名称。为了兼容已有安装，部分内部名称会继续保留
+`copaw`，包括 Worker CRD 的 runtime 值、`hiclaw-copaw-worker` 这类镜像名，以及
+`HICLAW_MANAGER_RUNTIME=copaw` 这类环境变量值。
+
+除非 chart、controller 和镜像已经明确支持新的值，否则不要把这些内部值改成
+`qwenpaw`。保留 `copaw` 是为了避免破坏已有配置、Helm values、镜像拉取和升级路径。
+
+---
+
 ## 如何接入自己实现的 agent 作为 Worker
 
 不能直接通过新增任意 `spec.runtime` 值来接入。当前 Worker CRD 只接受
@@ -458,6 +506,24 @@ image。具体见 [导入已有 Worker](import-worker.md)，以及
 
 如果要新增一种完全不同的 runtime，需要修改 controller、runtime 默认镜像以及对应
 agent 模板接线，不是纯配置项。
+
+---
+
+## HiClaw 可以连接已有的 Higress 实例吗
+
+当前不能通过 `gateway.provider=higress` 连接已有 Higress。Helm chart 会校验
+`gateway.provider=higress` 必须搭配 `gateway.mode=managed`，也就是由 HiClaw 部署并管理 Higress。
+
+不建议把已有 Higress 配置目录直接复制到 HiClaw 托管的 Higress 中。HiClaw 会调和它需要的
+AI routes、consumers 和网关资源，复制进去的资源可能和 HiClaw 管理的状态冲突，或在安装/调和流程中被覆盖。
+
+当前支持的路径是：
+
+- 使用 HiClaw 托管的 Higress 承载 HiClaw 流量
+- 在适用场景下使用外部 `ai-gateway` provider
+
+如果要支持已有的自管 Higress，需要单独设计 external Higress 模式，包括 Gateway/Console URL、
+访问凭据、资源命名隔离，以及避免影响已有 routes 和 consumers 的保护策略。
 
 ---
 
@@ -487,6 +553,9 @@ hiclaw apply -f my-worker.yaml
 **接收你发送的文件**：支持。在 Element Web 中点击附件按钮上传文件，Manager 或 Worker 会收到 Matrix 媒体消息并可以读取其内容。
 
 **向你发送文件**：支持。当你要求 Manager（或 Worker）发送文件时——例如任务产物、生成的报告或它能访问的任意文件——它会将文件上传到 Matrix 媒体服务器，并以可下载附件的形式发送到房间中，你在 Element Web 里点击即可下载。
+
+Manager 或 Worker 输出的路径通常是容器内部路径。如果你在宿主机上无法直接访问该路径，
+请要求 Agent 把文件作为附件发送，或提供可下载链接，而不是依赖原始容器路径。
 
 ---
 
@@ -598,7 +667,9 @@ docker exec -it hiclaw-controller cat /var/log/hiclaw/higress-gateway.log
 - **503**：容器内网络环境问题，导致外网 LLM 服务不可达。
 - **404**：模型名称填写有误。
 
-要判断是后端服务出错还是 Higress 自身配置问题，查看日志中的 `upstream_host` 字段：如果该字段有值，说明请求已到达后端，异常状态码是由上游服务返回的；如果为空，说明 Higress 本身无法路由该请求。
+要判断是后端服务出错还是 Higress 自身配置问题，查看日志中的 `upstream_host` 字段：如果该字段是真实 host，说明请求已到达后端，异常状态码是由上游服务返回的；如果是 `-` 或为空，说明 Higress 没有选中上游集群；日志里出现 `response_code_details: cluster_not_found` 时，通常表示模型路由或服务来源配置不正确。
+
+自部署 OpenAI 兼容服务时，检查 Higress 的供应商配置是否指向真实 URL，而不是不存在的服务名。同时在容器内用相同 base URL 和 API key 验证上游是否可达。
 
 ### 4. 检查模型配置
 

--- a/docs/zh-cn/faq.md
+++ b/docs/zh-cn/faq.md
@@ -15,6 +15,7 @@
 - [如何切换 Manager 的模型](#如何切换-manager-的模型)
 - [如何切换 Worker 的模型](#如何切换-worker-的模型)
 - [如何切换 Worker 的运行时](#如何切换-worker-的运行时)
+- [如何接入自己实现的 agent 作为 Worker](#如何接入自己实现的-agent-作为-worker)
 - [如何使用 Worker 模板市场](#如何使用-worker-模板市场)
 - [HiClaw 支持发送和接收文件吗](#hiclaw-支持发送和接收文件吗)
 - [为什么 Manager/Worker 一直显示"输入中"](#为什么-managerworker-一直显示输入中)
@@ -441,6 +442,22 @@ spec:
 > "把 alice 的运行时切换为 hermes"
 
 Manager 会通过 worker-management 技能触发容器重建。Worker 的 Matrix 账号、房间、网关 Consumer、MinIO 数据和持久化凭据都会保留。容器本地临时状态（缓存、进行中的任务）会丢失。
+
+---
+
+## 如何接入自己实现的 agent 作为 Worker
+
+不能直接通过新增任意 `spec.runtime` 值来接入。当前 Worker CRD 只接受
+`openclaw`、`copaw` 或 `hermes` 三种运行时。
+
+大多数自定义 Worker 场景应通过 Worker package 或自定义镜像完成：把角色提示词、
+skills、依赖和可选 Dockerfile 打包，或在保留受支持 runtime 的前提下设置自定义
+image。具体见 [导入已有 Worker](import-worker.md)，以及
+[声明式资源管理](declarative-resource-management.md#worker-资源) 中的
+`spec.package` / `spec.image` 字段。
+
+如果要新增一种完全不同的 runtime，需要修改 controller、runtime 默认镜像以及对应
+agent 模板接线，不是纯配置项。
 
 ---
 

--- a/docs/zh-cn/faq.md
+++ b/docs/zh-cn/faq.md
@@ -5,6 +5,7 @@
 - [如何查看当前 HiClaw 版本](#如何查看当前-hiclaw-版本)
 - [新架构说明（v1.1.0+）](#新架构说明v110)
 - [如何使用 hiclaw CLI 管理资源](#如何使用-hiclaw-cli-管理资源)
+- [如何为 Worker 配置 GitHub 凭据](#如何为-worker-配置-github-凭据)
 - [如何对接飞书/钉钉/企业微信/Discord/Telegram](#如何对接飞书钉钉企业微信discordtelegram)
 - [Windows 下执行安装脚本闪退](#windows-下执行安装脚本闪退)
 - [安装失败：embedded 镜像 "manifest unknown"](#安装失败embedded-镜像-manifest-unknown)
@@ -12,6 +13,7 @@
 - [局域网其他电脑如何访问 Web 端](#局域网其他电脑如何访问-web-端)
 - [本地访问 Matrix 服务器不通](#本地访问-matrix-服务器不通)
 - [如何主动指挥 Worker](#如何主动指挥-worker)
+- [如何接入第三方、本地或多供应商模型](#如何接入第三方本地或多供应商模型)
 - [如何切换 Manager 的模型](#如何切换-manager-的模型)
 - [如何切换 Worker 的模型](#如何切换-worker-的模型)
 - [如何配置 OpenRouter 或模型名带斜杠的供应商](#如何配置-openrouter-或模型名带斜杠的供应商)
@@ -37,6 +39,16 @@
 ```bash
 docker exec hiclaw-manager cat /opt/hiclaw/agent/.builtin-version
 ```
+
+v1.1.0+ 架构下，也可以通过 controller 里的 CLI 查询：
+
+```bash
+docker exec hiclaw-controller hiclaw version
+```
+
+早期 `latest` 镜像如果是在版本元数据规范化之前重新构建的，可能会显示 commit hash
+而不是语义化版本号。遇到这种情况，可以用 hash 对照 release 或 commit 历史，或者使用
+明确的 `HICLAW_VERSION` 升级到指定版本。
 
 安装时指定版本：
 
@@ -203,6 +215,32 @@ hiclaw delete human john
 
 ---
 
+## 如何为 Worker 配置 GitHub 凭据
+
+GitHub 凭据应作为 MCP Server 凭据配置，不要复制到 Worker 容器里。Worker 通过
+`mcporter` 和 AI Gateway 调用 GitHub，真实 GitHub PAT 保存在网关侧 MCP 配置中。
+
+安装时，在安装脚本询问可选 GitHub Personal Access Token 时输入，或提前设置
+`HICLAW_GITHUB_TOKEN`：
+
+```bash
+HICLAW_GITHUB_TOKEN=ghp_xxx bash <(curl -sSL https://higress.ai/hiclaw/install.sh)
+```
+
+该变量存在时，HiClaw 会自动配置 GitHub MCP Server，并生成 Manager 侧
+`mcporter` 配置。之后创建或更新 Worker 时给它 GitHub MCP 能力：
+
+```bash
+hiclaw create worker --name alice --skills github-operations --mcp-servers github
+hiclaw update worker --name alice --mcp-servers github
+```
+
+如果已有安装当时跳过了 token，请在原工作目录重新执行安装并提供
+`HICLAW_GITHUB_TOKEN`，或在网关中手动配置 GitHub MCP Server 并授权目标
+Manager/Worker consumer。不要把 PAT 粘贴进 Worker 提示词或容器本地配置。
+
+---
+
 ## Windows 下执行安装脚本闪退
 
 如果在 Windows 下执行 PowerShell 安装脚本后窗口立即关闭，请先确认是否已安装 Docker Desktop。如果已安装，请确认 Docker Desktop 是否已启动并完全加载——脚本需要连接 Docker 守护进程，Docker Desktop 未运行时会直接失败退出。
@@ -306,6 +344,9 @@ http://<局域网IP>:18080
 2. 确认 Manager 所在机器的防火墙放行 `18080`（Matrix/Higress Gateway）和 `18088`（Element Web）。
 3. 不要在其他设备上使用默认的 `matrix-local.hiclaw.io`；该域名会解析到当前设备自己的 loopback 地址。
 
+如果通过 Tailscale 使用 FluffyChat 或 Element Mobile，规则相同：homeserver 填
+`http://<tailscale-ip>:18080`，并确认手机和 HiClaw 所在机器在 Tailscale 网络内互通。
+
 ---
 
 ## 本地访问 Matrix 服务器不通
@@ -323,6 +364,40 @@ http://<局域网IP>:18080
 在 Element 等客户端中，输入 `@` 后再输入 Worker 昵称的首字母，才会出现补全列表，选择对应用户即可。
 
 也可以点击 Worker 的头像，进入**私聊**。私聊中不需要 @，每条消息都会触发 Worker 响应。但注意：私聊对 Manager 不可见，Manager 不会感知到这部分对话内容。
+
+---
+
+## 如何接入第三方、本地或多供应商模型
+
+HiClaw 不会直接读取你的 `~/.openclaw/openclaw.json` 供应商定义。模型流量会经过
+HiClaw AI Gateway。OpenClaw/QwenPaw 通常只看到一个名为 `hiclaw-gateway` 的
+provider；Higress 再根据请求里的模型名路由到真实上游供应商。
+
+### 第三方 OpenAI 兼容 API
+
+对于 OpenAI 兼容服务，在 Higress AI 路由中配置：
+
+- 供应商 base URL；供应商要求 `/v1` 时需要包含 `/v1`
+- 供应商 API Key
+- 能匹配你准备让 Manager 或 Worker 使用的 model id 的模型匹配规则
+
+然后让 Manager 切换到同一个 model id，或创建/更新 Worker 时指定这个模型。不要只把
+`/model list` 当成 Higress 可用供应商列表；它展示的是 Agent 侧已知模型列表，不是
+Higress 里定义的全部路由。
+
+### Ollama、LM Studio 等本地模型
+
+本地模型需要暴露 OpenAI 兼容 API，并且 HiClaw 容器必须能访问该地址。在 Docker 容器内，
+`localhost` 指的是容器自身，不是你的 Mac 或宿主机。请使用容器可达的宿主机地址，例如
+Docker Desktop 下的 `http://host.docker.internal:<port>/v1`，或在 Linux/Podman 下使用
+宿主机局域网 IP。
+
+### 多供应商和按任务使用不同模型
+
+在 Higress 中配置多条 AI 路由，每条路由使用不同的前缀或正则匹配规则，例如一条匹配
+`qwen*`，另一条匹配 `claude*`。然后明确给 Manager 或 Worker 指定目标模型。HiClaw
+可以让不同 Worker 使用不同模型，但不会内置按任务类型自动选择模型的策略；这类策略需要
+通过 Worker 角色设计或显式切换模型表达。
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify supported Worker runtime/custom agent paths and QwenPaw/copaw naming compatibility
- expand FAQ coverage for LAN/FluffyChat homeserver setup, file delivery, GitHub MCP credentials, third-party/local/multi-provider model setup, OpenRouter/model-prefix routing, context-window errors, 503 routing diagnostics, SELinux volume denial, and existing Higress support boundaries
- keep the guidance source-backed from Worker CRD, Helm gateway validation, install/runtime behavior, MCP setup scripts, and existing FAQ sections

## Source of truth checked
- hiclaw-controller/api/v1beta1/types.go: WorkerSpec.Runtime documents openclaw/copaw/hermes and exposes spec.image/spec.package
- hiclaw-controller/config/crd/workers.hiclaw.io.yaml: runtime enum is openclaw/copaw/hermes
- helm/hiclaw/templates/00-validate.yaml and helm/hiclaw/values.yaml: gateway.provider=higress requires managed mode; external mode is for ai-gateway
- install/hiclaw-install.sh and install/hiclaw-install.ps1: HICLAW_GITHUB_TOKEN is the optional GitHub PAT input and is passed to the controller/manager runtime
- manager/scripts/init/start-manager-agent.sh: HICLAW_GITHUB_TOKEN triggers Manager mcporter GitHub MCP config generation
- docs/import-worker.md and docs/declarative-resource-management.md already document Worker packages, custom images, MCP servers, and package import paths
- existing FAQ troubleshooting already covers Matrix access, contextWindow, file transfer, model switching, and gateway logs; this PR adds missing concrete branches from the linked issues

Fixes #612
Fixes #46
Fixes #591
Fixes #37
Fixes #39
Fixes #788
Fixes #806
Fixes #584
Fixes #536
Fixes #31
Fixes #102
Fixes #390
Fixes #515
Fixes #241
Fixes #549
Fixes #239
Fixes #813
Fixes #827

## Verification
- git diff --check