### PR TITLE
fix(install): normalize admin username

### DIFF
--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -2052,6 +2052,7 @@ function Step-Admin {
     Write-Log (Get-Msg "admin.title")
     $script:config.ADMIN_USER = Read-Prompt -VarName "HICLAW_ADMIN_USER" -PromptText (Get-Msg "admin.username_prompt") -Default "admin"
     if ($script:StepResult -eq "back") { return }
+    $script:config.ADMIN_USER = $script:config.ADMIN_USER.ToLowerInvariant()
 
     # Pre-set via env var: validate; non-interactive fails fast,
     # interactive warns and falls through to the retry prompt.

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -2184,6 +2184,7 @@ step_llm() {
 step_admin() {
     log "$(msg admin.title)"
     prompt HICLAW_ADMIN_USER "$(msg admin.username_prompt)" "admin" || return 0
+    HICLAW_ADMIN_USER="$(printf '%s' "${HICLAW_ADMIN_USER}" | tr '[:upper:]' '[:lower:]')"
 
     # Pre-set via env var: validate; in non-interactive mode fail fast,
     # in interactive mode warn and fall through to the retry prompt.


### PR DESCRIPTION
## Summary
- normalize the installer admin username to lowercase after reading it
- apply the same behavior in the shell and PowerShell installers

Fixes #746

## Validation
- bash -n install/hiclaw-install.sh
- pwsh Parser.ParseFile for install/hiclaw-install.ps1