### PR TITLE
fix(controller): reject team worker name conflicts

### DIFF
--- a/hiclaw-controller/internal/controller/team_controller.go
+++ b/hiclaw-controller/internal/controller/team_controller.go
@@ -1023,11 +1023,15 @@ func (r *TeamReconciler) validateNoStandaloneWorkerRuntimeConflicts(ctx context.
 		return nil
 	}
 
-	desired := map[string]string{
+	desiredNames := map[string]string{
+		t.Spec.Leader.Name: "leader[" + t.Spec.Leader.Name + "]",
+	}
+	desiredRuntimeNames := map[string]string{
 		t.Spec.Leader.EffectiveWorkerName(): "leader[" + t.Spec.Leader.Name + "]",
 	}
 	for _, w := range t.Spec.Workers {
-		desired[w.EffectiveWorkerName()] = "worker[" + w.Name + "]"
+		desiredNames[w.Name] = "worker[" + w.Name + "]"
+		desiredRuntimeNames[w.EffectiveWorkerName()] = "worker[" + w.Name + "]"
 	}
 
 	var workers v1beta1.WorkerList
@@ -1035,8 +1039,11 @@ func (r *TeamReconciler) validateNoStandaloneWorkerRuntimeConflicts(ctx context.
 		return fmt.Errorf("list standalone workers: %w", err)
 	}
 	for _, worker := range workers.Items {
+		if owner, ok := desiredNames[worker.Name]; ok {
+			return fmt.Errorf("team member %s name %q conflicts with existing standalone Worker %s/%s", owner, worker.Name, worker.Namespace, worker.Name)
+		}
 		runtimeName := worker.Spec.EffectiveWorkerName(worker.Name)
-		if owner, ok := desired[runtimeName]; ok {
+		if owner, ok := desiredRuntimeNames[runtimeName]; ok {
 			return fmt.Errorf("team member %s runtime workerName %q conflicts with existing standalone Worker %s/%s", owner, runtimeName, worker.Namespace, worker.Name)
 		}
 	}

--- a/hiclaw-controller/internal/controller/team_controller.go
+++ b/hiclaw-controller/internal/controller/team_controller.go
@@ -178,6 +178,9 @@ func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Tea
 	if err := validateTeamRuntimeNames(t); err != nil {
 		return r.failTeam(ctx, t, patchBase, err.Error())
 	}
+	if err := r.validateNoStandaloneWorkerRuntimeConflicts(ctx, t); err != nil {
+		return r.failTeam(ctx, t, patchBase, err.Error())
+	}
 	teamRuntimeName := t.Spec.EffectiveTeamName(t.Name)
 	leaderRuntimeName := t.Spec.Leader.EffectiveWorkerName()
 	adminActor, err := r.resolveTeamAdminActor(ctx, t)
@@ -1011,6 +1014,31 @@ func validateTeamRuntimeNames(t *v1beta1.Team) error {
 			return fmt.Errorf("duplicate team runtime workerName %q between %s and worker[%s]", runtimeName, owner, w.Name)
 		}
 		seen[runtimeName] = "worker[" + w.Name + "]"
+	}
+	return nil
+}
+
+func (r *TeamReconciler) validateNoStandaloneWorkerRuntimeConflicts(ctx context.Context, t *v1beta1.Team) error {
+	if r.Client == nil {
+		return nil
+	}
+
+	desired := map[string]string{
+		t.Spec.Leader.EffectiveWorkerName(): "leader[" + t.Spec.Leader.Name + "]",
+	}
+	for _, w := range t.Spec.Workers {
+		desired[w.EffectiveWorkerName()] = "worker[" + w.Name + "]"
+	}
+
+	var workers v1beta1.WorkerList
+	if err := r.List(ctx, &workers, client.InNamespace(t.Namespace)); err != nil {
+		return fmt.Errorf("list standalone workers: %w", err)
+	}
+	for _, worker := range workers.Items {
+		runtimeName := worker.Spec.EffectiveWorkerName(worker.Name)
+		if owner, ok := desired[runtimeName]; ok {
+			return fmt.Errorf("team member %s runtime workerName %q conflicts with existing standalone Worker %s/%s", owner, runtimeName, worker.Namespace, worker.Name)
+		}
 	}
 	return nil
 }

--- a/hiclaw-controller/internal/controller/team_controller_test.go
+++ b/hiclaw-controller/internal/controller/team_controller_test.go
@@ -118,6 +118,31 @@ func TestValidateNoStandaloneWorkerRuntimeConflicts(t *testing.T) {
 	}
 }
 
+func TestValidateNoStandaloneWorkerRuntimeConflictsRejectsCRNameConflict(t *testing.T) {
+	team := &v1beta1.Team{
+		ObjectMeta: metav1.ObjectMeta{Name: "alpha", Namespace: "default"},
+		Spec: v1beta1.TeamSpec{
+			Leader: v1beta1.LeaderSpec{Name: "alpha-lead", WorkerName: "team-lead"},
+			Workers: []v1beta1.TeamWorkerSpec{
+				{Name: "alpha-dev", WorkerName: "team-dev"},
+			},
+		},
+	}
+	standalone := &v1beta1.Worker{
+		ObjectMeta: metav1.ObjectMeta{Name: "alpha-dev", Namespace: "default"},
+		Spec:       v1beta1.WorkerSpec{WorkerName: "standalone-dev"},
+	}
+	r := &TeamReconciler{Client: newTeamTestClient(t, standalone)}
+
+	err := r.validateNoStandaloneWorkerRuntimeConflicts(context.Background(), team)
+	if err == nil {
+		t.Fatalf("expected CR name conflict with standalone Worker")
+	}
+	if got := err.Error(); got != `team member worker[alpha-dev] name "alpha-dev" conflicts with existing standalone Worker default/alpha-dev` {
+		t.Fatalf("unexpected error: %s", got)
+	}
+}
+
 func TestValidateNoStandaloneWorkerRuntimeConflictsAllowsDifferentNamespace(t *testing.T) {
 	team := &v1beta1.Team{
 		ObjectMeta: metav1.ObjectMeta{Name: "alpha", Namespace: "default"},

--- a/hiclaw-controller/internal/controller/team_controller_test.go
+++ b/hiclaw-controller/internal/controller/team_controller_test.go
@@ -5,11 +5,25 @@ import (
 	"encoding/json"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
 	"github.com/hiclaw/hiclaw-controller/internal/oss/ossfake"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 	"github.com/hiclaw/hiclaw-controller/test/testutil/mocks"
 )
+
+func newTeamTestClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("register scheme: %v", err)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
 
 func TestLeaderHeartbeatEvery(t *testing.T) {
 	team := &v1beta1.Team{}
@@ -76,6 +90,52 @@ func TestBuildDesiredMembers_LeaderAndWorkers(t *testing.T) {
 				t.Errorf("worker %s runtime=%q, want \"\" (pass-through from TeamWorkerSpec)", m.Name, m.Spec.Runtime)
 			}
 		}
+	}
+}
+
+func TestValidateNoStandaloneWorkerRuntimeConflicts(t *testing.T) {
+	team := &v1beta1.Team{
+		ObjectMeta: metav1.ObjectMeta{Name: "alpha", Namespace: "default"},
+		Spec: v1beta1.TeamSpec{
+			Leader: v1beta1.LeaderSpec{Name: "alpha-lead"},
+			Workers: []v1beta1.TeamWorkerSpec{
+				{Name: "alpha-dev", WorkerName: "shared-dev"},
+			},
+		},
+	}
+	standalone := &v1beta1.Worker{
+		ObjectMeta: metav1.ObjectMeta{Name: "existing-worker", Namespace: "default"},
+		Spec:       v1beta1.WorkerSpec{WorkerName: "shared-dev"},
+	}
+	r := &TeamReconciler{Client: newTeamTestClient(t, standalone)}
+
+	err := r.validateNoStandaloneWorkerRuntimeConflicts(context.Background(), team)
+	if err == nil {
+		t.Fatalf("expected runtime name conflict with standalone Worker")
+	}
+	if got := err.Error(); got != `team member worker[alpha-dev] runtime workerName "shared-dev" conflicts with existing standalone Worker default/existing-worker` {
+		t.Fatalf("unexpected error: %s", got)
+	}
+}
+
+func TestValidateNoStandaloneWorkerRuntimeConflictsAllowsDifferentNamespace(t *testing.T) {
+	team := &v1beta1.Team{
+		ObjectMeta: metav1.ObjectMeta{Name: "alpha", Namespace: "default"},
+		Spec: v1beta1.TeamSpec{
+			Leader: v1beta1.LeaderSpec{Name: "alpha-lead"},
+			Workers: []v1beta1.TeamWorkerSpec{
+				{Name: "alpha-dev", WorkerName: "shared-dev"},
+			},
+		},
+	}
+	standalone := &v1beta1.Worker{
+		ObjectMeta: metav1.ObjectMeta{Name: "existing-worker", Namespace: "other"},
+		Spec:       v1beta1.WorkerSpec{WorkerName: "shared-dev"},
+	}
+	r := &TeamReconciler{Client: newTeamTestClient(t, standalone)}
+
+	if err := r.validateNoStandaloneWorkerRuntimeConflicts(context.Background(), team); err != nil {
+		t.Fatalf("validateNoStandaloneWorkerRuntimeConflicts: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- reject Team members whose runtime workerName collides with an existing standalone Worker in the same namespace
- add regression coverage for same-namespace conflict and different-namespace non-conflict

Fixes #799

## Validation
- go test ./internal/controller -run 'TestValidateNoStandaloneWorkerRuntimeConflicts|TestBuildDesiredMembers'