### PR TITLE
test: stop Manager asking 4-input confirmation in worker-creation tests

### DIFF
--- a/tests/lib/matrix-client.sh
+++ b/tests/lib/matrix-client.sh
@@ -549,3 +549,26 @@ matrix_find_dm_room() {
 
     return 1
 }
+
+# Dump recent Manager DM messages to stderr.
+#
+# Use when a test fails because Manager didn't perform an expected action
+# (didn't create a Worker, didn't open a project room, etc.). Manager's last
+# few DM replies usually reveal the cause — e.g. it asked for confirmation
+# instead of acting, or it errored out internally. Without this dump, those
+# failures look like silent infrastructure timeouts.
+#
+# Usage: dump_manager_dm_messages <token> <dm_room> [note]
+dump_manager_dm_messages() {
+    local token="$1"
+    local dm_room="$2"
+    local note="${3:-Manager DM dump}"
+    {
+        printf "\n--- %s ---\n" "${note}"
+        matrix_read_messages "${token}" "${dm_room}" 20 2>&1 \
+            | jq -r '.chunk[] | "[\(.sender // "?")] \(.content.body // "<no body>" | tostring | .[0:400])"' 2>&1 \
+            | head -40 || true
+        printf -- "--- end of Manager DM dump ---\n"
+    } >&2
+    return 0
+}

--- a/tests/lib/matrix-client.sh
+++ b/tests/lib/matrix-client.sh
@@ -563,11 +563,20 @@ dump_manager_dm_messages() {
     local token="$1"
     local dm_room="$2"
     local note="${3:-Manager DM dump}"
+    local raw formatted
+    raw=$(matrix_read_messages "${token}" "${dm_room}" 20 2>&1 || true)
     {
         printf "\n--- %s ---\n" "${note}"
-        matrix_read_messages "${token}" "${dm_room}" 20 2>&1 \
-            | jq -r '.chunk[] | "[\(.sender // "?")] \(.content.body // "<no body>" | tostring | .[0:400])"' 2>&1 \
-            | head -40 || true
+        # Try to render as one-line-per-message. If matrix_read_messages
+        # returned a curl error instead of JSON, jq will fail — fall back to
+        # the raw response so the dump always shows something useful.
+        if formatted=$(printf '%s' "${raw}" \
+            | jq -r '.chunk[] | "[\(.sender // "?")] \(.content.body // "<no body>" | tostring | .[0:400])"' 2>/dev/null) \
+            && [ -n "${formatted}" ]; then
+            printf '%s\n' "${formatted}" | head -40
+        else
+            printf 'raw response (jq parse failed):\n%s\n' "${raw}" | head -40
+        fi
         printf -- "--- end of Manager DM dump ---\n"
     } >&2
     return 0

--- a/tests/test-06-multi-worker.sh
+++ b/tests/test-06-multi-worker.sh
@@ -38,8 +38,18 @@ wait_for_manager_agent_ready 300 "${DM_ROOM}" "${ADMIN_TOKEN}" || {
 # Alice is running from previous tests; bob will be created below (offset=0 is correct for new workers)
 wait_for_worker_container "alice" 60
 METRICS_BASELINE=$(snapshot_baseline "alice" "bob")
+# Same explicit 4-input prompt pattern as test-02 — see comment there for why.
+# Without all four inputs, Manager (per worker-management/SKILL.md) may reply
+# with a confirmation request instead of calling `hiclaw create worker`, and
+# the consumer/SOUL.md poll below silently times out.
 matrix_send_message "${ADMIN_TOKEN}" "${DM_ROOM}" \
-    "Create a new Worker for backend development. The worker's name (username) must be exactly 'bob'. He should have access to GitHub MCP."
+    "Please create a new Worker now using these exact values — do not ask me to confirm any of them:
+- name: bob
+- runtime: use the install default (do not ask, just pick whatever the env says)
+- SOUL/role: Backend developer specializing in REST APIs, server-side logic, and data persistence
+- skills: github-operations (file-sync / task-progress / project-participation are auto-included, no need to ask)
+
+Proceed immediately and tell me when he is created."
 
 log_info "Waiting for Manager to create Worker Bob..."
 REPLY=$(matrix_wait_for_message_containing "${ADMIN_TOKEN}" "${DM_ROOM}" "@manager" \
@@ -53,6 +63,9 @@ assert_contains_i "${REPLY}" "bob" "Reply mentions worker name 'bob'"
 sleep 30
 higress_login "${TEST_ADMIN_USER}" "${TEST_ADMIN_PASSWORD}" > /dev/null
 CONSUMERS=$(higress_get_consumers)
+if ! echo "${CONSUMERS}" | grep -qi "worker-bob"; then
+    dump_manager_dm_messages "${ADMIN_TOKEN}" "${DM_ROOM}" "worker-bob consumer missing"
+fi
 assert_contains_i "${CONSUMERS}" "worker-bob" "Higress consumer 'worker-bob' exists"
 
 minio_setup

--- a/tests/test-06-multi-worker.sh
+++ b/tests/test-06-multi-worker.sh
@@ -38,10 +38,13 @@ wait_for_manager_agent_ready 300 "${DM_ROOM}" "${ADMIN_TOKEN}" || {
 # Alice is running from previous tests; bob will be created below (offset=0 is correct for new workers)
 wait_for_worker_container "alice" 60
 METRICS_BASELINE=$(snapshot_baseline "alice" "bob")
-# Same explicit 4-input prompt pattern as test-02 — see comment there for why.
-# Without all four inputs, Manager (per worker-management/SKILL.md) may reply
-# with a confirmation request instead of calling `hiclaw create worker`, and
-# the consumer/SOUL.md poll below silently times out.
+# worker-management/SKILL.md tells Manager to ask admin for FOUR inputs
+# (name / runtime / SOUL / skills) before running `hiclaw create worker`
+# and not to invent defaults. A vague prompt that only names the worker is
+# therefore a coin flip — sometimes Manager replies with a confirmation
+# request, never calls the CLI, and the consumer/SOUL.md polls below
+# silently time out. Spell out all four inputs and tell Manager to skip
+# confirmation so this test exercises actual Worker creation.
 matrix_send_message "${ADMIN_TOKEN}" "${DM_ROOM}" \
     "Please create a new Worker now using these exact values — do not ask me to confirm any of them:
 - name: bob

--- a/tests/test-11-github-pr-collab.sh
+++ b/tests/test-11-github-pr-collab.sh
@@ -103,7 +103,14 @@ TASK_DESCRIPTION="I need a collaborative GitHub PR workflow test:
 
 GitHub repo: ${GITHUB_OWNER}/${GITHUB_REPO}
 
-Please create workers alice (developer), bob (reviewer), and charlie (qa-tester) and coordinate this workflow."
+Please create workers alice (developer), bob (reviewer), and charlie (qa-tester) and coordinate this workflow.
+
+For each worker creation, use these exact values — do not ask me to confirm any of them:
+- alice: runtime=install default; SOUL/role='Developer who implements features in JavaScript and pushes commits'; skills='github-operations'
+- bob: runtime=install default; SOUL/role='Code reviewer who inspects PRs for correctness and quality'; skills='github-operations'
+- charlie: runtime=install default; SOUL/role='QA tester who writes unit tests and verifies behavior'; skills='github-operations'
+
+If a worker already exists, reuse it instead of recreating. Proceed immediately."
 
 matrix_send_message "${ADMIN_TOKEN}" "${DM_ROOM}" "${TASK_DESCRIPTION}"
 

--- a/tests/test-13-git-delegation.sh
+++ b/tests/test-13-git-delegation.sh
@@ -45,7 +45,13 @@ wait_for_manager_agent_ready 300 "${DM_ROOM}" "${ADMIN_TOKEN}" || {
 # Ensure Alice worker exists
 METRICS_BASELINE=$(snapshot_baseline "alice")
 matrix_send_message "${ADMIN_TOKEN}" "${DM_ROOM}" \
-    "Create a worker named alice if it doesn't exist yet. Give her the github-operations and git-delegation skills."
+    "Create a worker named alice if she doesn't exist yet. If you do create her, use these exact values — do not ask me to confirm any of them:
+- name: alice
+- runtime: use the install default (do not ask, just pick whatever the env says)
+- SOUL/role: Backend developer who works on shared repos using git-delegation workflows
+- skills: github-operations, git-delegation
+
+If she already exists, reuse her. Proceed immediately."
 
 log_info "Waiting for Worker creation/setup..."
 REPLY=$(matrix_wait_for_reply "${ADMIN_TOKEN}" "${DM_ROOM}" "@manager" 120 \

--- a/tests/test-14-git-collab.sh
+++ b/tests/test-14-git-collab.sh
@@ -99,7 +99,11 @@ DO NOT assign any phase to a different worker. DO NOT give alice phase 2 or phas
 IMPORTANT: You MUST use the EXACT branch names and file paths specified below. Do not rename, substitute, or simplify them. The verification system checks these exact names.
 
 Before starting any phase:
-1. Ensure workers with usernames exactly 'alice', 'bob', and 'charlie' exist with the git-delegation skill. The username (container name) must match exactly — do not use variations like 'alice-dev' or 'bob-backend'. IMPORTANT: Create any missing workers IN PARALLEL (run all create-worker.sh calls concurrently) to save time — do NOT create them one by one sequentially.
+1. Ensure workers with usernames exactly 'alice', 'bob', and 'charlie' exist with the git-delegation skill. The username (container name) must match exactly — do not use variations like 'alice-dev' or 'bob-backend'. IMPORTANT: Create any missing workers IN PARALLEL (run all create-worker.sh calls concurrently) to save time — do NOT create them one by one sequentially. When creating any missing worker, use these exact values — do NOT ask me to confirm any of them:
+   - runtime: install default
+   - skills: github-operations, git-delegation
+   - SOUL/role: 'Developer working on a shared git repo using git-delegation workflows'
+   If a worker already exists, reuse it.
 2. Create a shared project room that includes alice, bob, charlie, and the human admin (use the create-project.sh script). All phase assignments and reports MUST happen in this project room — never in individual worker rooms.
 
 Run the phases strictly in order, waiting for each phase's report before starting the next.


### PR DESCRIPTION
worker-management/SKILL.md tells Manager to ask 4 inputs (name / runtime / SOUL / skills) before running \`hiclaw create worker\` and not to invent defaults. Tests that send only a worker name therefore hit a coin flip: sometimes Manager calls the CLI, sometimes it just replies with a confirmation request, and the consumer / SOUL.md polls silently time out — looks like an infra issue but is just LLM conformance.

test-02 already got this fix in #862. This PR applies the same pattern to test-06 / test-11 / test-13 / test-14: spell out runtime / SOUL / skills inline and tell Manager not to ask.

Also adds a \`dump_manager_dm_messages\` helper and uses it in test-06 when the bob consumer is missing — so future flakes show what Manager actually said instead of a silent timeout.

Not fixing test-02 here to avoid conflicting with #862.