### PR TITLE
fix(controller): preserve leader coordination context after inline AGENTS

### DIFF
--- a/hiclaw-controller/internal/controller/team_controller.go
+++ b/hiclaw-controller/internal/controller/team_controller.go
@@ -153,10 +153,11 @@ func (r *TeamReconciler) resolveTeamAdminActor(ctx context.Context, t *v1beta1.T
 
 // reconcileTeamNormal drives one convergence pass over a Team CR:
 //  1. Provision team-level infra (rooms, shared storage)
-//  2. Clean up stale members (in Status.Members but no longer desired)
-//  3. Reconcile each desired member (leader + workers) via the shared phases
-//  4. Inject leader coordination context + register with Manager + Legacy
-//  5. Summarise backend readiness and patch Team.Status
+//  2. Write local inline configs
+//  3. Clean up stale members (in Status.Members but no longer desired)
+//  4. Reconcile each desired member (leader + workers) via the shared phases
+//  4.5. Inject leader coordination context + SOUL.md template (after package deploy)
+//  5. Registry updates + summarise backend readiness and patch Team.Status
 func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Team) (reconcile.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -269,26 +270,6 @@ func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Tea
 	}
 	pruneMembers(&t.Status, desiredNames)
 
-	// --- Step 3.5: Leader coordination context + SOUL.md template ---
-	// Must run before member reconciliation so renderAndPushSoulTemplate
-	// pushes the final SOUL.md to MinIO before the leader container starts
-	// and before DeployWorkerConfig would otherwise race with it.
-	if err := r.Deployer.InjectCoordinationContext(ctx, service.CoordinationDeployRequest{
-		LeaderName:         leaderRuntimeName,
-		Role:               RoleTeamLeader.String(),
-		TeamName:           teamRuntimeName,
-		TeamRoomID:         rooms.TeamRoomID,
-		LeaderDMRoomID:     rooms.LeaderDMRoomID,
-		HeartbeatEvery:     leaderHeartbeatEvery(t),
-		WorkerIdleTimeout:  t.Spec.Leader.WorkerIdleTimeout,
-		TeamWorkers:        workerRuntimeNames,
-		TeamAdminID:        teamAdminMatrixID(derivedTeam),
-		TeamCoordinatorIDs: teamCoordinatorIDs(derivedTeam),
-		LeaderSoul:         t.Spec.Leader.Soul,
-	}); err != nil {
-		logger.Error(err, "leader coordination context injection failed (non-fatal)")
-	}
-
 	// --- Step 4: Reconcile each desired member (leader first) ---
 	//
 	// ms.Observed flips to true the moment ReconcileMemberInfra returns nil —
@@ -328,6 +309,28 @@ func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Tea
 		// only after ReconcileMemberExpose succeeded: a fully converged
 		// member is what the Manager-side tooling expects to find there.
 		r.reconcileLegacyMember(ctx, t, m, ms)
+	}
+
+	// --- Step 4.5: Leader coordination context + SOUL.md template ---
+	// Runs AFTER member reconciliation so that package deploy (seed-only)
+	// writes the leader's package AGENTS.md and SOUL.md to OSS first.
+	// InjectCoordinationContext then reads the package content from OSS and
+	// overlays coordination context on top; renderAndPushSoulTemplate is
+	// seed-only and correctly skips when the package already provided SOUL.md.
+	if err := r.Deployer.InjectCoordinationContext(ctx, service.CoordinationDeployRequest{
+		LeaderName:         leaderRuntimeName,
+		Role:               RoleTeamLeader.String(),
+		TeamName:           teamRuntimeName,
+		TeamRoomID:         rooms.TeamRoomID,
+		LeaderDMRoomID:     rooms.LeaderDMRoomID,
+		HeartbeatEvery:     leaderHeartbeatEvery(t),
+		WorkerIdleTimeout:  t.Spec.Leader.WorkerIdleTimeout,
+		TeamWorkers:        workerRuntimeNames,
+		TeamAdminID:        teamAdminMatrixID(derivedTeam),
+		TeamCoordinatorIDs: teamCoordinatorIDs(derivedTeam),
+		LeaderSoul:         t.Spec.Leader.Soul,
+	}); err != nil {
+		logger.Error(err, "leader coordination context injection failed (non-fatal)")
 	}
 
 	// --- Step 5: Registry updates ---

--- a/hiclaw-controller/internal/controller/team_controller_test.go
+++ b/hiclaw-controller/internal/controller/team_controller_test.go
@@ -6,9 +6,13 @@ import (
 	"testing"
 
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	"github.com/hiclaw/hiclaw-controller/internal/backend"
 	"github.com/hiclaw/hiclaw-controller/internal/oss/ossfake"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 	"github.com/hiclaw/hiclaw-controller/test/testutil/mocks"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestLeaderHeartbeatEvery(t *testing.T) {
@@ -376,6 +380,77 @@ func TestHashMemberSourceSpec_EnvChangeFlipsHash(t *testing.T) {
 	}
 }
 
+func TestReconcileTeamNormalInjectsLeaderCoordinationAfterMemberConfig(t *testing.T) {
+	ctx := context.Background()
+	team := &v1beta1.Team{
+		ObjectMeta: metav1.ObjectMeta{Name: "alpha", Namespace: "default"},
+		Spec: v1beta1.TeamSpec{
+			Leader: v1beta1.LeaderSpec{
+				Name:       "alpha-lead",
+				WorkerName: "leader",
+				Model:      "qwen",
+				Agents:     "custom leader AGENTS.md",
+			},
+			Workers: []v1beta1.TeamWorkerSpec{{
+				Name:       "alpha-dev",
+				WorkerName: "dev",
+				Model:      "qwen",
+			}},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("register scheme: %v", err)
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(team.DeepCopy()).
+		WithStatusSubresource(&v1beta1.Team{}).
+		Build()
+
+	var calls []string
+	deployer := mocks.NewMockDeployer()
+	deployer.DeployWorkerConfigFn = func(ctx context.Context, req service.WorkerDeployRequest) error {
+		calls = append(calls, "config:"+req.Name)
+		return nil
+	}
+	deployer.InjectCoordinationContextFn = func(ctx context.Context, req service.CoordinationDeployRequest) error {
+		calls = append(calls, "inject:"+req.LeaderName)
+		if req.LeaderName != "leader" {
+			t.Fatalf("LeaderName=%q, want leader", req.LeaderName)
+		}
+		if len(req.TeamWorkers) != 1 || req.TeamWorkers[0] != "dev" {
+			t.Fatalf("TeamWorkers=%v, want [dev]", req.TeamWorkers)
+		}
+		return nil
+	}
+
+	r := &TeamReconciler{
+		Client:      c,
+		Provisioner: mocks.NewMockProvisioner(),
+		Deployer:    deployer,
+		Backend:     backend.NewRegistry([]backend.WorkerBackend{mocks.NewMockWorkerBackend()}),
+		EnvBuilder:  mocks.NewMockEnvBuilder(),
+		AgentFSDir:  t.TempDir(),
+	}
+	if _, err := r.reconcileTeamNormal(ctx, team); err != nil {
+		t.Fatalf("reconcileTeamNormal: %v", err)
+	}
+
+	leaderConfig := callIndex(calls, "config:leader")
+	inject := callIndex(calls, "inject:leader")
+	if leaderConfig == -1 || inject == -1 {
+		t.Fatalf("calls=%v, want config:leader and inject:leader", calls)
+	}
+	if inject < leaderConfig {
+		t.Fatalf("calls=%v, leader coordination injection must run after leader AGENTS.md config write", calls)
+	}
+	if inject != len(calls)-1 {
+		t.Fatalf("calls=%v, leader coordination injection must run after all member config writes", calls)
+	}
+}
+
 // registryEntry is the minimal subset of service.workersRegistry we need to
 // inspect in tests — duplicated locally because the registry shape (and
 // WorkerRegistryEntry fields we care about) are stable JSON contracts that
@@ -738,4 +813,13 @@ func stringSliceContains(values []string, target string) bool {
 		}
 	}
 	return false
+}
+
+func callIndex(calls []string, target string) int {
+	for i, call := range calls {
+		if call == target {
+			return i
+		}
+	}
+	return -1
 }


### PR DESCRIPTION
## Summary
- move leader InjectCoordinationContext after team member config deployment
- preserve inline/package AGENTS.md before overlaying the controller-managed coordination block
- add a regression test for Teams with inline spec.leader.agents

Fixes #879

## Tests
- go test ./internal/controller
- go test ./...