### PR TITLE
fix(controller): add host gateway extra host for docker workers

### DIFF
--- a/hiclaw-controller/internal/controller/member_reconcile.go
+++ b/hiclaw-controller/internal/controller/member_reconcile.go
@@ -24,6 +24,8 @@ const (
 	RoleTeamWorker MemberRole = "worker"
 )
 
+const dockerHostInternalExtraHost = "host.docker.internal:host-gateway"
+
 // String renders the role as stored in annotations / legacy registries.
 func (r MemberRole) String() string { return string(r) }
 
@@ -380,6 +382,7 @@ func createMemberContainer(ctx context.Context, d MemberDeps, m MemberContext, s
 		Runtime:            m.Spec.Runtime,
 		RuntimeFallback:    d.DefaultRuntime,
 		Env:                workerEnv,
+		ExtraHosts:         extraHostsForBackend(wb),
 		ServiceAccountName: saName,
 		Labels:             labels,
 		Owner:              m.Owner,
@@ -399,6 +402,13 @@ func createMemberContainer(ctx context.Context, d MemberDeps, m MemberContext, s
 		return reconcile.Result{}, fmt.Errorf("create container: %w", err)
 	}
 	return reconcile.Result{}, nil
+}
+
+func extraHostsForBackend(wb backend.WorkerBackend) []string {
+	if wb != nil && wb.Name() == "docker" {
+		return []string{dockerHostInternalExtraHost}
+	}
+	return nil
 }
 
 // ReconcileMemberExpose reconciles Higress port exposure for the member.

--- a/hiclaw-controller/internal/controller/member_reconcile_test.go
+++ b/hiclaw-controller/internal/controller/member_reconcile_test.go
@@ -1,0 +1,76 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	"github.com/hiclaw/hiclaw-controller/internal/service"
+	"github.com/hiclaw/hiclaw-controller/test/testutil/mocks"
+)
+
+func TestCreateMemberContainerAddsDockerHostGateway(t *testing.T) {
+	wb := mocks.NewMockWorkerBackend()
+	wb.NameOverride = "docker"
+	state := &MemberState{
+		ProvResult: &service.WorkerProvisionResult{MatrixToken: "token"},
+	}
+
+	_, err := createMemberContainer(context.Background(), MemberDeps{
+		Provisioner: mocks.NewMockProvisioner(),
+		EnvBuilder:  mocks.NewMockEnvBuilder(),
+	}, MemberContext{
+		Name: "alice",
+		Spec: v1beta1.WorkerSpec{Image: "img:latest"},
+	}, state, wb)
+	if err != nil {
+		t.Fatalf("createMemberContainer failed: %v", err)
+	}
+
+	req, ok := wb.LastCreateReq()
+	if !ok {
+		t.Fatal("expected backend Create to be called")
+	}
+	if got, want := req.ExtraHosts, []string{dockerHostInternalExtraHost}; !equalStringSlices(got, want) {
+		t.Fatalf("ExtraHosts=%v, want %v", got, want)
+	}
+}
+
+func TestCreateMemberContainerDoesNotAddDockerHostGatewayForK8s(t *testing.T) {
+	wb := mocks.NewMockWorkerBackend()
+	wb.NameOverride = "k8s"
+	state := &MemberState{
+		ProvResult: &service.WorkerProvisionResult{MatrixToken: "token"},
+	}
+
+	_, err := createMemberContainer(context.Background(), MemberDeps{
+		Provisioner: mocks.NewMockProvisioner(),
+		EnvBuilder:  mocks.NewMockEnvBuilder(),
+	}, MemberContext{
+		Name: "alice",
+		Spec: v1beta1.WorkerSpec{Image: "img:latest"},
+	}, state, wb)
+	if err != nil {
+		t.Fatalf("createMemberContainer failed: %v", err)
+	}
+
+	req, ok := wb.LastCreateReq()
+	if !ok {
+		t.Fatal("expected backend Create to be called")
+	}
+	if len(req.ExtraHosts) != 0 {
+		t.Fatalf("ExtraHosts=%v, want empty for k8s backend", req.ExtraHosts)
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- add `host.docker.internal:host-gateway` to Docker worker create requests
- keep Kubernetes worker create requests unchanged so Docker-specific `host-gateway` is not emitted as a Pod host alias
- add controller regression tests for both Docker and k8s backend paths

Fixes #878

## Tests
- `go test ./internal/controller -run 'TestCreateMemberContainer(AddsDockerHostGateway|DoesNotAddDockerHostGatewayForK8s)$'`\n- `go test ./internal/controller`\n- `git diff --check`