### PR TITLE
fix(taskflow): prevent worker name prefix mismatch in task assignment

### DIFF
--- a/manager/agent/team-leader-agent/skills/project-management/SKILL.md
+++ b/manager/agent/team-leader-agent/skills/project-management/SKILL.md
@@ -134,7 +134,7 @@ Use DAG when `team-coordination` decided the work is finite and dependencies can
       {
         "taskId": "{project-id}-01",
         "title": "Short outcome title",
-        "assignedTo": "worker-runtime-short-name",
+        "assignedTo": "<matrix-localpart>",
         "dependsOn": []
       }
     ]
@@ -149,7 +149,21 @@ Each node uses:
 - `assignedTo`
 - `dependsOn`
 
-For `assignedTo`, use the Worker's runtime short name that matches its Matrix localpart. Do not use deployment-prefixed Worker CR names from CLI output. If organization data shows a name such as `magic-cn-plt4s29va0r-worker-dev-worker`, strip the deployment/resource prefix and use `dev-worker`. If you have a Matrix ID such as `@dev-worker:domain`, use `dev-worker`.
+For `assignedTo`, use the Worker's **Matrix localpart** (the part between `@` and `:` in `matrixUserID`). Extract it mechanically — never guess, strip, or transform.
+
+**Lookup steps (mandatory before every `plan_dag` / `plan_loop` call):**
+1. Run `hiclaw get workers --team "$TEAM_CR" -o json`
+2. For each Worker, extract the localpart from `.matrixUserID`: e.g. `@worker-issue-resolver:domain` → `worker-issue-resolver`
+3. Use that localpart verbatim as `assignedTo`
+
+❌ Do NOT use CLI `.name` field directly (it may include deployment prefixes like `magic-cn-...-worker-issue-resolver`)
+❌ Do NOT strip prefixes yourself — you will incorrectly remove legitimate name components
+❌ Do NOT infer worker names from memory, AGENTS.md, or display names
+
+| CLI `.name` | `matrixUserID` | ✅ `assignedTo` | ❌ Wrong |
+|---|---|---|---|
+| `magic-cn-x0a4t4pr201-worker-issue-resolver` | `@worker-issue-resolver:domain` | `worker-issue-resolver` | `issue-resolver` |
+| `magic-cn-plt4s29va0r-worker-dev-worker` | `@dev-worker:domain` | `dev-worker` | `worker` |
 
 Do not use `worker`, `owner`, `dependencies`, or standalone short IDs.
 
@@ -185,7 +199,7 @@ Use Loop when `team-coordination` decided the work should repeat until a stop co
       {
         "taskId": "{project-id}-i001-01",
         "title": "Short outcome title",
-        "assignedTo": "worker-runtime-short-name",
+        "assignedTo": "<matrix-localpart>",
         "dependsOn": []
       }
     ]
@@ -206,7 +220,7 @@ Optional inputs:
 - `status`
 - `tasks`
 
-For every Loop task, `assignedTo` follows the same rule as DAG tasks: use the runtime short Worker name, not a deployment-prefixed Worker CR name.
+For every Loop task, `assignedTo` follows the same rule as DAG tasks: extract the Matrix localpart from `hiclaw get workers` output. Never strip or transform.
 
 Use `ready_loop_nodes` to find pending nodes in the current iteration whose dependencies are satisfied by accepted `[x]` nodes. Delegate returned nodes with `task-management`.
 

--- a/manager/agent/team-leader-agent/skills/project-management/references/dag-execution.md
+++ b/manager/agent/team-leader-agent/skills/project-management/references/dag-execution.md
@@ -21,13 +21,13 @@ The DAG is the current execution plan. It can be replaced when results, blockers
       {
         "taskId": "{project-id}-01",
         "title": "Short task title",
-        "assignedTo": "worker-runtime-short-name",
+        "assignedTo": "<matrix-localpart>",
         "dependsOn": []
       },
       {
         "taskId": "{project-id}-02",
         "title": "Follow-up task title",
-        "assignedTo": "worker-runtime-short-name",
+        "assignedTo": "<matrix-localpart>",
         "dependsOn": ["{project-id}-01"]
       }
     ]
@@ -39,7 +39,10 @@ Each task node uses:
 
 - `taskId`: stable node ID. Use `{projectId}-{seq}`.
 - `title`: short human-readable work unit.
-- `assignedTo`: Worker runtime short name that matches its Matrix localpart. If organization data shows a deployment-prefixed Worker CR name such as `magic-cn-plt4s29va0r-worker-dev-worker`, strip the deployment/resource prefix and use `dev-worker`. If you have a Matrix ID such as `@dev-worker:domain`, use `dev-worker`.
+- `assignedTo`: Worker's **Matrix localpart** (the part between `@` and `:` in `matrixUserID`). Extract mechanically from `hiclaw get workers --team "$TEAM_CR" -o json` output. Never strip, guess, or transform.
+  - ❌ Do NOT use CLI `.name` field directly (may include deployment prefixes)
+  - ❌ Do NOT strip prefixes yourself
+  - Example: `@worker-issue-resolver:domain` → `worker-issue-resolver`
 - `dependsOn`: list of task IDs that must produce accepted upstream results first.
 
 Do not use `worker`, `owner`, `dependencies`, or short standalone IDs like `st-01`.

--- a/manager/agent/team-leader-agent/skills/task-management/SKILL.md
+++ b/manager/agent/team-leader-agent/skills/task-management/SKILL.md
@@ -101,6 +101,38 @@ Keep machine-facing identifiers and protocol tokens unchanged:
 - `BLOCKED`
 - `INTERRUPTED`
 
+## Worker Name Canonicality
+
+`assigned_to`, Matrix @mention, and all task tracking fields must use the Worker's **Matrix localpart** (the part between `@` and `:` in `matrixUserID`). Extract it mechanically — never guess, strip, or transform.
+
+### Lookup (mandatory before assigning any task)
+
+```bash
+# 1. Resolve team CR name
+TEAM_CR="$(hiclaw get workers "${HICLAW_WORKER_CR_NAME:-$HICLAW_WORKER_NAME}" -o json | jq -r '.team')"
+
+# 2. Get all team workers
+hiclaw get workers --team "$TEAM_CR" -o json
+
+# 3. Extract localpart from matrixUserID for each worker
+#    @worker-issue-resolver:domain → worker-issue-resolver
+```
+
+Use the extracted localpart verbatim everywhere:
+
+- `manage-team-state.sh --assigned-to <localpart>`
+- Matrix @mention: `@<localpart>:<domain>`
+- `meta.json` `assigned_to` field
+
+### Common mistake
+
+CLI `.name` may include a deployment prefix (e.g. `magic-cn-x0a4t4pr201-worker-issue-resolver`). **Do NOT use `.name` directly and do NOT manually strip prefixes.** Always extract the localpart from `.matrixUserID` instead.
+
+| CLI `.name` | `matrixUserID` | ✅ `assigned_to` | ❌ Wrong |
+|---|---|---|---|
+| `magic-cn-...-worker-issue-resolver` | `@worker-issue-resolver:domain` | `worker-issue-resolver` | `issue-resolver` |
+| `magic-cn-...-dev-worker` | `@dev-worker:domain` | `dev-worker` | `worker` |
+
 ## Delegate A Ready Node
 
 Delegate only nodes returned by:


### PR DESCRIPTION
## Problem

The Leader LLM may incorrectly use the CLI `.name` field, which can include deployment prefixes such as `magic-cn-...-worker-issue-resolver`, or attempt to strip prefixes manually when assigning tasks. This can make `assignedTo` / `assigned_to` differ from the Worker's actual Matrix localpart and break task routing.

## Solution

Clarify the Leader skill guidance so task assignment uses the Worker's Matrix localpart from `matrixUserID` as the source of truth. The updated guidance tells the Leader to extract the localpart mechanically and not infer, strip, or transform worker names manually.

## Changes

| File | Change |
|------|--------|
| `manager/agent/team-leader-agent/skills/project-management/SKILL.md` | Updates DAG/Loop `assignedTo` guidance to use the Matrix localpart from `matrixUserID`, with lookup steps and examples |
| `manager/agent/team-leader-agent/skills/project-management/references/dag-execution.md` | Aligns DAG reference docs with the Matrix localpart rule |
| `manager/agent/team-leader-agent/skills/task-management/SKILL.md` | Adds Worker name canonicality guidance for `assigned_to`, task metadata, and Matrix mentions |

## Test plan

- [x] Leader uses Matrix localpart for `assignedTo` when creating DAG plans
- [x] Leader uses Matrix localpart for `assignedTo` when creating Loop plans
- [x] Leader uses Matrix localpart for `assigned_to` and @mentions when delegating tasks
