### PR TITLE
手动构建build-hiclaw-controller 漏掉了 $(REGISTRY_ARG) || Manually building build-hiclaw-controller misses $(REGISTRY_ARG)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ OPENCLAW_BASE_PUSH_ARG  = --build-arg OPENCLAW_BASE_IMAGE=$(OPENCLAW_BASE_IMAGE)
 build-hiclaw-controller: ## Build hiclaw-controller image (prerequisite for Manager)
 	@echo "==> Building hiclaw-controller image: $(LOCAL_CONTROLLER)"
 	@rm -rf ./hiclaw-controller/agent && cp -r ./manager/agent ./hiclaw-controller/agent
-	docker build $(PLATFORM_FLAG) $(DOCKER_BUILD_ARGS) \
+	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(DOCKER_BUILD_ARGS) \
 		-t $(LOCAL_CONTROLLER) \
 		./hiclaw-controller/
 	@rm -rf ./hiclaw-controller/agent


### PR DESCRIPTION
undefined
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
null
