### PR TITLE
fix(controller): pass default worker runtime to manager

### DIFF
--- a/hiclaw-controller/internal/config/config.go
+++ b/hiclaw-controller/internal/config/config.go
@@ -167,20 +167,21 @@ type Config struct {
 	WorkerEnv WorkerEnvDefaults
 }
 
-// WorkerEnvDefaults holds environment variable defaults injected into worker containers.
+// WorkerEnvDefaults holds environment variable defaults injected into worker and manager containers.
 // All values are resolved once at config load time from the controller's own environment.
 type WorkerEnvDefaults struct {
-	MatrixDomain  string
-	FSEndpoint    string
-	FSBucket      string
-	StoragePrefix string
-	ControllerURL string
-	AIGatewayURL  string
-	MatrixURL     string
-	AdminUser     string
-	Runtime       string // "docker" for embedded, "k8s" for incluster
-	YoloMode      bool   // HICLAW_YOLO=1 — propagated to managers and workers
-	MatrixDebug   bool   // HICLAW_MATRIX_DEBUG=1 — propagated to managers and workers,
+	MatrixDomain         string
+	FSEndpoint           string
+	FSBucket             string
+	StoragePrefix        string
+	ControllerURL        string
+	AIGatewayURL         string
+	MatrixURL            string
+	AdminUser            string
+	Runtime              string // "docker" for embedded, "k8s" for incluster
+	DefaultWorkerRuntime string
+	YoloMode             bool // HICLAW_YOLO=1 — propagated to managers and workers
+	MatrixDebug          bool // HICLAW_MATRIX_DEBUG=1 — propagated to managers and workers,
 	// translated to OPENCLAW_MATRIX_DEBUG=1 by the container entrypoints to
 	// enable structured INFO-level traces in the openclaw matrix plugin.
 
@@ -335,16 +336,17 @@ func LoadConfig() *Config {
 		CMSServiceName:    envOrDefault("HICLAW_CMS_SERVICE_NAME", "hiclaw-manager"),
 
 		WorkerEnv: WorkerEnvDefaults{
-			MatrixDomain:  envOrDefault("HICLAW_MATRIX_DOMAIN", "matrix-local.hiclaw.io:8080"),
-			FSEndpoint:    os.Getenv("HICLAW_FS_ENDPOINT"),
-			FSBucket:      envOrDefault("HICLAW_FS_BUCKET", "hiclaw-storage"),
-			StoragePrefix: envOrDefault("HICLAW_STORAGE_PREFIX", "hiclaw/hiclaw-storage"),
-			ControllerURL: os.Getenv("HICLAW_CONTROLLER_URL"),
-			AIGatewayURL:  envOrDefault("HICLAW_AI_GATEWAY_URL", "http://aigw-local.hiclaw.io:8080"),
-			MatrixURL:     envOrDefault("HICLAW_MATRIX_URL", "http://matrix-local.hiclaw.io:8080"),
-			AdminUser:     os.Getenv("HICLAW_ADMIN_USER"),
-			YoloMode:      envBool("HICLAW_YOLO"),
-			MatrixDebug:   envBool("HICLAW_MATRIX_DEBUG"),
+			MatrixDomain:         envOrDefault("HICLAW_MATRIX_DOMAIN", "matrix-local.hiclaw.io:8080"),
+			FSEndpoint:           os.Getenv("HICLAW_FS_ENDPOINT"),
+			FSBucket:             envOrDefault("HICLAW_FS_BUCKET", "hiclaw-storage"),
+			StoragePrefix:        envOrDefault("HICLAW_STORAGE_PREFIX", "hiclaw/hiclaw-storage"),
+			ControllerURL:        os.Getenv("HICLAW_CONTROLLER_URL"),
+			AIGatewayURL:         envOrDefault("HICLAW_AI_GATEWAY_URL", "http://aigw-local.hiclaw.io:8080"),
+			MatrixURL:            envOrDefault("HICLAW_MATRIX_URL", "http://matrix-local.hiclaw.io:8080"),
+			AdminUser:            os.Getenv("HICLAW_ADMIN_USER"),
+			DefaultWorkerRuntime: os.Getenv("HICLAW_DEFAULT_WORKER_RUNTIME"),
+			YoloMode:             envBool("HICLAW_YOLO"),
+			MatrixDebug:          envBool("HICLAW_MATRIX_DEBUG"),
 
 			// CMS observability (propagated from controller env to all workers/managers)
 			CMSTracesEnabled:  envBool("HICLAW_CMS_TRACES_ENABLED"),

--- a/hiclaw-controller/internal/service/worker_env.go
+++ b/hiclaw-controller/internal/service/worker_env.go
@@ -64,6 +64,9 @@ func (b *WorkerEnvBuilder) BuildManager(managerName string, prov *ManagerProvisi
 	if b.defaults.AdminUser != "" {
 		env["HICLAW_ADMIN_USER"] = b.defaults.AdminUser
 	}
+	if b.defaults.DefaultWorkerRuntime != "" {
+		env["HICLAW_DEFAULT_WORKER_RUNTIME"] = b.defaults.DefaultWorkerRuntime
+	}
 
 	cfg := spec.Config
 	if cfg.HeartbeatInterval != "" {

--- a/hiclaw-controller/internal/service/worker_env_test.go
+++ b/hiclaw-controller/internal/service/worker_env_test.go
@@ -61,16 +61,17 @@ func TestWorkerEnvBuilderBuildIncludesFinalRuntimeEnv(t *testing.T) {
 
 func TestWorkerEnvBuilderBuildManagerUsesConfiguredRuntimeAndBucket(t *testing.T) {
 	builder := NewWorkerEnvBuilder(config.WorkerEnvDefaults{
-		MatrixDomain:  "matrix.example.com",
-		FSEndpoint:    "http://fs.example.com:9000",
-		FSBucket:      "hiclaw-fs",
-		StoragePrefix: "teams/demo",
-		ControllerURL: "http://controller.example.com:8090",
-		AIGatewayURL:  "http://aigw.example.com:8080",
-		MatrixURL:     "http://matrix.example.com:8080",
-		AdminUser:     "admin",
-		Runtime:       "docker",
-		SkillsAPIURL:  "nacos://skills.example.com:8848/public",
+		MatrixDomain:         "matrix.example.com",
+		FSEndpoint:           "http://fs.example.com:9000",
+		FSBucket:             "hiclaw-fs",
+		StoragePrefix:        "teams/demo",
+		ControllerURL:        "http://controller.example.com:8090",
+		AIGatewayURL:         "http://aigw.example.com:8080",
+		MatrixURL:            "http://matrix.example.com:8080",
+		AdminUser:            "admin",
+		Runtime:              "docker",
+		DefaultWorkerRuntime: "copaw",
+		SkillsAPIURL:         "nacos://skills.example.com:8848/public",
 	})
 
 	env := builder.BuildManager("manager", &ManagerProvisionResult{
@@ -80,15 +81,16 @@ func TestWorkerEnvBuilderBuildManagerUsesConfiguredRuntimeAndBucket(t *testing.T
 	}, v1beta1.ManagerSpec{})
 
 	for key, want := range map[string]string{
-		"HICLAW_MANAGER_NAME":        "manager",
-		"HICLAW_MANAGER_GATEWAY_KEY": "gateway-key",
-		"HICLAW_MANAGER_PASSWORD":    "matrix-password",
-		"HICLAW_FS_ACCESS_KEY":       "manager",
-		"HICLAW_FS_SECRET_KEY":       "secret",
-		"HICLAW_FS_BUCKET":           "hiclaw-fs",
-		"HICLAW_RUNTIME":             "docker",
-		"HICLAW_ADMIN_USER":          "admin",
-		"SKILLS_API_URL":             "nacos://skills.example.com:8848/public",
+		"HICLAW_MANAGER_NAME":           "manager",
+		"HICLAW_MANAGER_GATEWAY_KEY":    "gateway-key",
+		"HICLAW_MANAGER_PASSWORD":       "matrix-password",
+		"HICLAW_FS_ACCESS_KEY":          "manager",
+		"HICLAW_FS_SECRET_KEY":          "secret",
+		"HICLAW_FS_BUCKET":              "hiclaw-fs",
+		"HICLAW_RUNTIME":                "docker",
+		"HICLAW_DEFAULT_WORKER_RUNTIME": "copaw",
+		"HICLAW_ADMIN_USER":             "admin",
+		"SKILLS_API_URL":                "nacos://skills.example.com:8848/public",
 	} {
 		if got := env[key]; got != want {
 			t.Fatalf("%s = %q, want %q", key, got, want)


### PR DESCRIPTION
## Summary
- propagate HICLAW_DEFAULT_WORKER_RUNTIME from the controller config into Manager container env
- keep Worker env unchanged; backend runtime fallback still decides the actual Worker runtime
- add coverage for Manager env construction

## Tests
- go test ./internal/service ./internal/config
- go test ./internal/...

Fixes #892