### PR TITLE
fix(copaw): suppress warning for missing MinIO objects

### DIFF
--- a/copaw/src/copaw_worker/sync.py
+++ b/copaw/src/copaw_worker/sync.py
@@ -192,11 +192,11 @@ def _mc(
         exc.cmd = redacted_cmd
         log = logger.warning if warn_on_error else logger.debug
         log(
-            "mc command failed returncode=%s cmd=%s stdout=%s stderr=%s",
+            "mc command failed returncode=%s cmd=%s stdout=%r stderr=%r",
             exc.returncode,
             " ".join(redacted_cmd),
-            exc.stdout,
-            exc.stderr,
+            _preview_text(exc.stdout),
+            _preview_text(exc.stderr),
         )
         raise
     if log_output:


### PR DESCRIPTION
## Summary
- Treat missing MinIO objects from `mc cat` as debug-only in CoPaw file sync.
- Keep non-missing `mc cat` failures as warnings with redacted/previewed stderr.

## Validation
- `python3 -m py_compile copaw/src/copaw_worker/sync.py`
- `python3 -m pytest copaw/tests/test_sync.py` not run: local environment has no `pytest` module.
