### PR TITLE
fix(agent): update file sharing path guidance

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,6 +4,8 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 
 ---
 
+- fix(agent): update file-sharing path guidance for CoPaw and Team Leader agents to use `/root/hiclaw-fs/agents/...` instead of the retired `/root/.hiclaw-worker/...` path.
+
 - **OpenHuman runtime**: OpenHuman added as the fourth Worker runtime with native Matrix support via `channel-matrix` feature flag; includes controller routing (K8s + Docker backends), Dockerfile, entrypoint script, agent template, Helm chart integration, and Makefile build targets.
 
 **Bug Fixes**

--- a/manager/agent/copaw-worker-agent/skills/file-sharing/SKILL.md
+++ b/manager/agent/copaw-worker-agent/skills/file-sharing/SKILL.md
@@ -21,7 +21,7 @@ Do not use in chat, task outputs, or normal reasoning:
 - `hiclaw/hiclaw-storage/...`
 - `teams/{team}/shared/...`
 - `/root/hiclaw-fs/...`
-- `/root/.hiclaw-worker/...`
+- `/root/hiclaw-fs/agents/...`
 
 ## Task Lifecycle Sync
 

--- a/manager/agent/team-leader-agent/skills/file-sharing/SKILL.md
+++ b/manager/agent/team-leader-agent/skills/file-sharing/SKILL.md
@@ -21,7 +21,7 @@ Do not write these in chat or task specs:
 - `hiclaw/hiclaw-storage/...`
 - `teams/{team}/shared/...`
 - `/root/hiclaw-fs/...`
-- `/root/.hiclaw-worker/...`
+- `/root/hiclaw-fs/agents/...`
 
 ## Team Task Files
 


### PR DESCRIPTION
## Summary

- update CoPaw Worker file-sharing guidance to use `/root/hiclaw-fs/agents/...`
- update Team Leader file-sharing guidance to use the same current runtime path
- record the image-affecting prompt change in `changelog/current.md`

## Validation

- `git diff --check`

## Sync Notes

This is a narrow agent-facing content slice from the internal sync baseline. It is independent from PR #914 and only updates path guidance.
