### PR TITLE
fix(copaw): seed worker agent heartbeat

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -10,4 +10,5 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 
 **Bug Fixes**
 
+- **CoPaw Worker heartbeat**: CoPaw worker templates now seed heartbeat at a 10-minute interval so Team Leader agents created from the worker template can run heartbeat turns without requiring an explicit Team CR heartbeat spec.
 - **CoPaw local runtime paths**: CoPaw direct-run defaults now honor `COPAW_INSTALL_DIR` and `COPAW_WORKING_DIR` before falling back to local home-directory paths, while container entrypoints can continue to pass explicit directories.

--- a/copaw/src/copaw_worker/templates/agent.worker.json
+++ b/copaw/src/copaw_worker/templates/agent.worker.json
@@ -8,7 +8,7 @@
     "PROFILE.md"
   ],
   "heartbeat": {
-    "enabled": false,
+    "enabled": true,
     "every": "10m"
   },
   "channels": {

--- a/copaw/tests/test_bridge.py
+++ b/copaw/tests/test_bridge.py
@@ -422,7 +422,7 @@ def test_manager_template_heartbeat_wins_over_openclaw_seed(monkeypatch):
 
 def test_worker_template_seeds_default_heartbeat_when_openclaw_silent():
     agent = _bridge_and_read_agent(_make_openclaw_cfg())
-    assert agent["heartbeat"] == {"enabled": False, "every": "10m"}
+    assert agent["heartbeat"] == {"enabled": True, "every": "10m"}
 
 
 def test_openclaw_heartbeat_seeds_existing_agent_without_heartbeat():


### PR DESCRIPTION
## Summary

- enable the CoPaw worker template heartbeat seed at a 10-minute interval
- add the required unreleased changelog entry for the CoPaw image content change

## Validation

- `git diff --check HEAD~1..HEAD`
- `node -e 'JSON.parse(require("fs").readFileSync("copaw/src/copaw_worker/templates/agent.worker.json", "utf8"))'`
