### PR TITLE
feat(controller): support model provider selection

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -7,6 +7,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 - fix(agent): update file-sharing path guidance for CoPaw and Team Leader agents to use `/root/hiclaw-fs/agents/...` instead of the retired `/root/.hiclaw-worker/...` path.
 
 - **OpenHuman runtime**: OpenHuman added as the fourth Worker runtime with native Matrix support via `channel-matrix` feature flag; includes controller routing (K8s + Docker backends), Dockerfile, entrypoint script, agent template, Helm chart integration, and Makefile build targets.
+- **Multi model providers**: Worker, Team, and Manager specs can now select a Higress model provider via `spec.modelProvider`; the controller resolves the provider, injects the matching gateway URL into runtime config, and authorizes consumers only on the selected AI route.
 
 **Bug Fixes**
 

--- a/helm/hiclaw/crds/managers.hiclaw.io.yaml
+++ b/helm/hiclaw/crds/managers.hiclaw.io.yaml
@@ -19,6 +19,14 @@ spec:
                 model:
                   type: string
                   description: LLM model ID (e.g. qwen3.6-plus, claude-sonnet-4-6)
+                modelProvider:
+                  type: string
+                  description: >
+                    Name of the APIG Model API (HttpApi) to use as the LLM provider.
+                    When set, the controller discovers the Model API's endpoint
+                    (basePath + Intranet subdomain) and authorization target from
+                    the APIG ListHttpApis API. When omitted, the cluster-wide
+                    AI Gateway URL and Model API ID are used.
                 runtime:
                   type: string
                   enum: [openclaw, copaw]

--- a/helm/hiclaw/crds/managers.hiclaw.io.yaml
+++ b/helm/hiclaw/crds/managers.hiclaw.io.yaml
@@ -21,12 +21,7 @@ spec:
                   description: LLM model ID (e.g. qwen3.6-plus, claude-sonnet-4-6)
                 modelProvider:
                   type: string
-                  description: >
-                    Name of the APIG Model API (HttpApi) to use as the LLM provider.
-                    When set, the controller discovers the Model API's endpoint
-                    (basePath + Intranet subdomain) and authorization target from
-                    the APIG ListHttpApis API. When omitted, the cluster-wide
-                    AI Gateway URL and Model API ID are used.
+                  description: Name of the AI gateway Model API to use as the LLM provider.
                 runtime:
                   type: string
                   enum: [openclaw, copaw]

--- a/helm/hiclaw/crds/teams.hiclaw.io.yaml
+++ b/helm/hiclaw/crds/teams.hiclaw.io.yaml
@@ -82,6 +82,14 @@ spec:
                       description: Runtime identity for leader (Matrix localpart, OSS path key). Defaults to leader.name.
                     model:
                       type: string
+                    modelProvider:
+                      type: string
+                      description: >
+                        Name of the APIG Model API (HttpApi) to use as the LLM provider.
+                        When set, the controller discovers the Model API's endpoint
+                        (basePath + Intranet subdomain) and authorization target from
+                        the APIG ListHttpApis API. When omitted, the cluster-wide
+                        AI Gateway URL and Model API ID are used.
                     identity:
                       type: string
                     soul:
@@ -234,6 +242,14 @@ spec:
                         description: Runtime identity for worker (Matrix localpart, OSS path key). Defaults to worker.name.
                       model:
                         type: string
+                      modelProvider:
+                        type: string
+                        description: >
+                          Name of the APIG Model API (HttpApi) to use as the LLM provider.
+                          When set, the controller discovers the Model API's endpoint
+                          (basePath + Intranet subdomain) and authorization target from
+                          the APIG ListHttpApis API. When omitted, the cluster-wide
+                          AI Gateway URL and Model API ID are used.
                       runtime:
                         type: string
                         enum: [openclaw, copaw, hermes, openhuman]

--- a/helm/hiclaw/crds/teams.hiclaw.io.yaml
+++ b/helm/hiclaw/crds/teams.hiclaw.io.yaml
@@ -84,12 +84,7 @@ spec:
                       type: string
                     modelProvider:
                       type: string
-                      description: >
-                        Name of the APIG Model API (HttpApi) to use as the LLM provider.
-                        When set, the controller discovers the Model API's endpoint
-                        (basePath + Intranet subdomain) and authorization target from
-                        the APIG ListHttpApis API. When omitted, the cluster-wide
-                        AI Gateway URL and Model API ID are used.
+                      description: Name of the AI gateway Model API to use as the LLM provider.
                     identity:
                       type: string
                     soul:
@@ -244,12 +239,7 @@ spec:
                         type: string
                       modelProvider:
                         type: string
-                        description: >
-                          Name of the APIG Model API (HttpApi) to use as the LLM provider.
-                          When set, the controller discovers the Model API's endpoint
-                          (basePath + Intranet subdomain) and authorization target from
-                          the APIG ListHttpApis API. When omitted, the cluster-wide
-                          AI Gateway URL and Model API ID are used.
+                        description: Name of the AI gateway Model API to use as the LLM provider.
                       runtime:
                         type: string
                         enum: [openclaw, copaw, hermes, openhuman]

--- a/helm/hiclaw/crds/workers.hiclaw.io.yaml
+++ b/helm/hiclaw/crds/workers.hiclaw.io.yaml
@@ -19,6 +19,14 @@ spec:
                 model:
                   type: string
                   description: LLM model ID (e.g. claude-sonnet-4-6, qwen3.6-plus)
+                modelProvider:
+                  type: string
+                  description: >
+                    Name of the APIG Model API (HttpApi) to use as the LLM provider.
+                    When set, the controller discovers the Model API's endpoint
+                    (basePath + Intranet subdomain) and authorization target from
+                    the APIG ListHttpApis API. When omitted, the cluster-wide
+                    AI Gateway URL and Model API ID are used.
                 runtime:
                   type: string
                   enum: [openclaw, copaw, hermes, openhuman]

--- a/helm/hiclaw/crds/workers.hiclaw.io.yaml
+++ b/helm/hiclaw/crds/workers.hiclaw.io.yaml
@@ -21,12 +21,7 @@ spec:
                   description: LLM model ID (e.g. claude-sonnet-4-6, qwen3.6-plus)
                 modelProvider:
                   type: string
-                  description: >
-                    Name of the APIG Model API (HttpApi) to use as the LLM provider.
-                    When set, the controller discovers the Model API's endpoint
-                    (basePath + Intranet subdomain) and authorization target from
-                    the APIG ListHttpApis API. When omitted, the cluster-wide
-                    AI Gateway URL and Model API ID are used.
+                  description: Name of the AI gateway Model API to use as the LLM provider.
                 runtime:
                   type: string
                   enum: [openclaw, copaw, hermes, openhuman]

--- a/hiclaw-controller/api/v1beta1/types.go
+++ b/hiclaw-controller/api/v1beta1/types.go
@@ -89,9 +89,10 @@ type Worker struct {
 
 type WorkerSpec struct {
 	Model         string              `json:"model"`
-	Runtime       string              `json:"runtime,omitempty"`    // openclaw | copaw | hermes | openhuman (default: openclaw)
-	Image         string              `json:"image,omitempty"`      // custom Docker image
-	WorkerName    string              `json:"workerName,omitempty"` // business/runtime identity (Matrix localpart, OSS path key)
+	ModelProvider string              `json:"modelProvider,omitempty"` // APIG Model API name for per-worker LLM provider
+	Runtime       string              `json:"runtime,omitempty"`       // openclaw | copaw | hermes | openhuman (default: openclaw)
+	Image         string              `json:"image,omitempty"`         // custom Docker image
+	WorkerName    string              `json:"workerName,omitempty"`    // business/runtime identity (Matrix localpart, OSS path key)
 	Identity      string              `json:"identity,omitempty"`
 	Soul          string              `json:"soul,omitempty"`
 	Agents        string              `json:"agents,omitempty"`
@@ -248,6 +249,7 @@ type LeaderSpec struct {
 	Name              string                   `json:"name"`
 	WorkerName        string                   `json:"workerName,omitempty"`
 	Model             string                   `json:"model,omitempty"`
+	ModelProvider     string                   `json:"modelProvider,omitempty"` // APIG Model API name for per-leader LLM provider
 	Identity          string                   `json:"identity,omitempty"`
 	Soul              string                   `json:"soul,omitempty"`
 	Agents            string                   `json:"agents,omitempty"`
@@ -286,6 +288,7 @@ type TeamWorkerSpec struct {
 	Name          string              `json:"name"`
 	WorkerName    string              `json:"workerName,omitempty"`
 	Model         string              `json:"model,omitempty"`
+	ModelProvider string              `json:"modelProvider,omitempty"` // APIG Model API name for per-worker LLM provider
 	Runtime       string              `json:"runtime,omitempty"`
 	Image         string              `json:"image,omitempty"`
 	Identity      string              `json:"identity,omitempty"`
@@ -488,15 +491,16 @@ type Manager struct {
 }
 
 type ManagerSpec struct {
-	Model      string        `json:"model"`
-	Runtime    string        `json:"runtime,omitempty"`    // openclaw | copaw | hermes | openhuman (default: openclaw)
-	Image      string        `json:"image,omitempty"`      // custom Docker image
-	Soul       string        `json:"soul,omitempty"`       // custom SOUL.md content
-	Agents     string        `json:"agents,omitempty"`     // custom AGENTS.md content
-	Skills     []string      `json:"skills,omitempty"`     // on-demand skills to enable
-	McpServers []MCPServer   `json:"mcpServers,omitempty"` // MCP servers callable by the Manager via mcporter
-	Package    string        `json:"package,omitempty"`    // file://, http(s)://, or nacos://; optional ?authType= for Nacos
-	Config     ManagerConfig `json:"config,omitempty"`
+	Model         string        `json:"model"`
+	ModelProvider string        `json:"modelProvider,omitempty"` // APIG Model API name for per-manager LLM provider
+	Runtime       string        `json:"runtime,omitempty"`       // openclaw | copaw | hermes | openhuman (default: openclaw)
+	Image         string        `json:"image,omitempty"`         // custom Docker image
+	Soul          string        `json:"soul,omitempty"`          // custom SOUL.md content
+	Agents        string        `json:"agents,omitempty"`        // custom AGENTS.md content
+	Skills        []string      `json:"skills,omitempty"`        // on-demand skills to enable
+	McpServers    []MCPServer   `json:"mcpServers,omitempty"`    // MCP servers callable by the Manager via mcporter
+	Package       string        `json:"package,omitempty"`       // file://, http(s)://, or nacos://; optional ?authType= for Nacos
+	Config        ManagerConfig `json:"config,omitempty"`
 
 	// State is the desired lifecycle state of the manager.
 	// Valid values: "Running" (default), "Sleeping", "Stopped".

--- a/hiclaw-controller/config/crd/managers.hiclaw.io.yaml
+++ b/hiclaw-controller/config/crd/managers.hiclaw.io.yaml
@@ -19,6 +19,9 @@ spec:
                 model:
                   type: string
                   description: LLM model ID (e.g. qwen3.6-plus, claude-sonnet-4-6)
+                modelProvider:
+                  type: string
+                  description: Name of the AI gateway Model API to use as the LLM provider.
                 runtime:
                   type: string
                   enum: [openclaw, copaw]

--- a/hiclaw-controller/config/crd/teams.hiclaw.io.yaml
+++ b/hiclaw-controller/config/crd/teams.hiclaw.io.yaml
@@ -82,6 +82,9 @@ spec:
                       description: Runtime identity for leader (Matrix localpart, OSS path key). Defaults to leader.name.
                     model:
                       type: string
+                    modelProvider:
+                      type: string
+                      description: Name of the AI gateway Model API to use as the LLM provider.
                     identity:
                       type: string
                     soul:
@@ -234,6 +237,9 @@ spec:
                         description: Runtime identity for worker (Matrix localpart, OSS path key). Defaults to worker.name.
                       model:
                         type: string
+                      modelProvider:
+                        type: string
+                        description: Name of the AI gateway Model API to use as the LLM provider.
                       runtime:
                         type: string
                         enum: [openclaw, copaw, hermes, openhuman]

--- a/hiclaw-controller/config/crd/workers.hiclaw.io.yaml
+++ b/hiclaw-controller/config/crd/workers.hiclaw.io.yaml
@@ -19,6 +19,9 @@ spec:
                 model:
                   type: string
                   description: LLM model ID (e.g. claude-sonnet-4-6, qwen3.6-plus)
+                modelProvider:
+                  type: string
+                  description: Name of the AI gateway Model API to use as the LLM provider.
                 runtime:
                   type: string
                   enum: [openclaw, copaw, hermes, openhuman]

--- a/hiclaw-controller/internal/agentconfig/generator.go
+++ b/hiclaw-controller/internal/agentconfig/generator.go
@@ -38,8 +38,10 @@ func (g *Generator) GenerateOpenClawConfig(req WorkerConfigRequest) ([]byte, err
 	}
 
 	aiGatewayURL := g.config.AIGatewayURL
+	if req.AIGatewayURL != "" {
+		aiGatewayURL = req.AIGatewayURL
+	}
 	if aiGatewayURL == "" {
-		// K8s deployments must set HICLAW_AI_GATEWAY_URL (Helm injects it automatically).
 		aiGatewayURL = "http://aigw-local.hiclaw.io:8080"
 	}
 
@@ -138,7 +140,7 @@ func (g *Generator) GenerateOpenClawConfig(req WorkerConfigRequest) ([]byte, err
 				"model": map[string]interface{}{
 					"primary": "hiclaw-gateway/" + modelName,
 				},
-				"models":       g.allModelAliases(modelName),
+				"models":        g.allModelAliases(modelName),
 				"maxConcurrent": 4,
 				"subagents": map[string]interface{}{
 					"maxConcurrent": 8,
@@ -378,21 +380,21 @@ func defaultModelSpec(modelName string) ModelSpec {
 	}
 
 	presets := map[string]preset{
-		"gpt-5.3-codex":     {400000, 128000, true, true},
-		"gpt-5-mini":        {400000, 128000, true, true},
-		"gpt-5-nano":        {400000, 128000, true, true},
-		"claude-opus-4-6":   {1000000, 128000, true, true},
-		"claude-sonnet-4-6": {1000000, 64000, true, true},
-		"claude-haiku-4-5":  {200000, 64000, true, true},
-		"qwen3.6-plus":      {200000, 64000, true, true},
-		"qwen3.5-plus":      {200000, 64000, true, true},
-		"deepseek-chat":     {256000, 128000, false, true},
-		"deepseek-reasoner": {256000, 128000, false, true},
-		"kimi-k2.5":         {256000, 128000, true, true},
-		"glm-5":             {200000, 128000, false, true},
-		"MiniMax-M2.7":          {200000, 128000, false, true},
+		"gpt-5.3-codex":          {400000, 128000, true, true},
+		"gpt-5-mini":             {400000, 128000, true, true},
+		"gpt-5-nano":             {400000, 128000, true, true},
+		"claude-opus-4-6":        {1000000, 128000, true, true},
+		"claude-sonnet-4-6":      {1000000, 64000, true, true},
+		"claude-haiku-4-5":       {200000, 64000, true, true},
+		"qwen3.6-plus":           {200000, 64000, true, true},
+		"qwen3.5-plus":           {200000, 64000, true, true},
+		"deepseek-chat":          {256000, 128000, false, true},
+		"deepseek-reasoner":      {256000, 128000, false, true},
+		"kimi-k2.5":              {256000, 128000, true, true},
+		"glm-5":                  {200000, 128000, false, true},
+		"MiniMax-M2.7":           {200000, 128000, false, true},
 		"MiniMax-M2.7-highspeed": {200000, 128000, false, true},
-		"MiniMax-M2.5":          {200000, 128000, false, true},
+		"MiniMax-M2.5":           {200000, 128000, false, true},
 	}
 
 	p, found := presets[modelName]

--- a/hiclaw-controller/internal/agentconfig/types.go
+++ b/hiclaw-controller/internal/agentconfig/types.go
@@ -2,14 +2,14 @@ package agentconfig
 
 // Config holds parameters for generating agent runtime configurations.
 type Config struct {
-	MatrixDomain     string // Matrix domain for user IDs, e.g. "matrix-local.hiclaw.io:8080"
-	MatrixServerURL  string // Matrix CS API URL for agent connections
-	AIGatewayURL     string // AI gateway URL for model API calls
-	AdminUser        string // admin username
-	DefaultModel     string // default model name
-	EmbeddingModel   string // embedding model for memory search (optional)
-	Runtime          string // "docker", "k8s", "aliyun"
-	E2EEEnabled      bool   // enable Matrix E2EE
+	MatrixDomain    string // Matrix domain for user IDs, e.g. "matrix-local.hiclaw.io:8080"
+	MatrixServerURL string // Matrix CS API URL for agent connections
+	AIGatewayURL    string // AI gateway URL for model API calls
+	AdminUser       string // admin username
+	DefaultModel    string // default model name
+	EmbeddingModel  string // embedding model for memory search (optional)
+	Runtime         string // "docker", "k8s", "aliyun"
+	E2EEEnabled     bool   // enable Matrix E2EE
 
 	// Model parameter overrides (empty = use defaults from model table)
 	ModelContextWindow int
@@ -35,12 +35,13 @@ type HeartbeatConfig struct {
 
 // WorkerConfigRequest describes everything needed to generate a worker's config files.
 type WorkerConfigRequest struct {
-	WorkerName     string // e.g. "worker-alice"
-	MatrixToken    string // worker's Matrix access token
-	GatewayKey     string // worker's gateway API key
-	ModelName      string // optional: override default model
-	TeamLeaderName string // if non-empty, this is a team worker
-	ChannelPolicy  *ChannelPolicy // optional communication policy overrides
+	WorkerName     string           // e.g. "worker-alice"
+	MatrixToken    string           // worker's Matrix access token
+	GatewayKey     string           // worker's gateway API key
+	ModelName      string           // optional: override default model
+	AIGatewayURL   string           // per-worker AI Gateway URL override (from modelProvider)
+	TeamLeaderName string           // if non-empty, this is a team worker
+	ChannelPolicy  *ChannelPolicy   // optional communication policy overrides
 	Heartbeat      *HeartbeatConfig // optional: team leader heartbeat settings
 }
 

--- a/hiclaw-controller/internal/app/app.go
+++ b/hiclaw-controller/internal/app/app.go
@@ -490,6 +490,7 @@ func (a *App) initReconcilers(_ context.Context) error {
 		Legacy:         a.legacy,
 		DefaultRuntime: a.cfg.DefaultWorkerRuntime,
 		ControllerName: a.cfg.ControllerName,
+		GatewayClient:  a.gateway,
 	}).SetupWithManager(a.mgr); err != nil {
 		return fmt.Errorf("setup WorkerReconciler: %w", err)
 	}
@@ -505,6 +506,7 @@ func (a *App) initReconcilers(_ context.Context) error {
 		AgentFSDir:     a.cfg.AgentFSDir(),
 		ControllerName: a.cfg.ControllerName,
 		ResourcePrefix: resourcePrefix,
+		GatewayClient:  a.gateway,
 	}).SetupWithManager(a.mgr); err != nil {
 		return fmt.Errorf("setup TeamReconciler: %w", err)
 	}
@@ -529,6 +531,7 @@ func (a *App) initReconcilers(_ context.Context) error {
 		ControllerName:   a.cfg.ControllerName,
 		UserLanguage:     a.cfg.UserLanguage,
 		UserTimezone:     a.cfg.UserTimezone,
+		GatewayClient:    a.gateway,
 	}
 	if a.cfg.KubeMode == "embedded" {
 		mgrReconciler.EmbeddedConfig = &controller.ManagerEmbeddedConfig{

--- a/hiclaw-controller/internal/config/config.go
+++ b/hiclaw-controller/internal/config/config.go
@@ -616,6 +616,7 @@ func (c *Config) GatewayConfig() gateway.Config {
 		AdminUser:                 c.HigressAdminUser,
 		AdminPassword:             c.HigressAdminPassword,
 		AllowDefaultAdminFallback: c.KubeMode == "embedded",
+		DataPlaneURL:              c.WorkerEnv.AIGatewayURL,
 	}
 }
 

--- a/hiclaw-controller/internal/controller/manager_container_test.go
+++ b/hiclaw-controller/internal/controller/manager_container_test.go
@@ -8,6 +8,7 @@ import (
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
 	"github.com/hiclaw/hiclaw-controller/internal/auth"
 	"github.com/hiclaw/hiclaw-controller/internal/backend"
+	"github.com/hiclaw/hiclaw-controller/internal/gateway"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 	"github.com/hiclaw/hiclaw-controller/test/testutil/mocks"
 )
@@ -80,12 +81,12 @@ func TestCreateManagerContainer_MergesMetadataAndSpecLabels(t *testing.T) {
 	labels := captureManagerCreateLabels(t, m)
 
 	cases := map[string]string{
-		"owner":                 "alice",       // metadata.labels propagated
-		"env":                   "prod",        // spec.labels propagated
-		"tier":                  "spec-tier",   // spec beats metadata
-		"hiclaw.io/manager":     "default",     // system label
-		"hiclaw.io/role":        "manager",     // system label
-		"hiclaw.io/runtime":     "copaw",       // system label
+		"owner":                 "alice",     // metadata.labels propagated
+		"env":                   "prod",      // spec.labels propagated
+		"tier":                  "spec-tier", // spec beats metadata
+		"hiclaw.io/manager":     "default",   // system label
+		"hiclaw.io/role":        "manager",   // system label
+		"hiclaw.io/runtime":     "copaw",     // system label
 		"app":                   "hiclaw-manager",
 		v1beta1.LabelController: "real-ctl",
 	}
@@ -153,5 +154,54 @@ func TestCreateManagerContainer_NilLabelsSafe(t *testing.T) {
 		if _, ok := labels[k]; !ok {
 			t.Errorf("missing system label %q on labelless Manager (full=%v)", k, labels)
 		}
+	}
+}
+
+func TestReconcileManagerInfrastructurePassesModelProviderToProvision(t *testing.T) {
+	prov := mocks.NewMockManagerProvisioner()
+	r := &ManagerReconciler{Provisioner: prov}
+	m := &v1beta1.Manager{}
+	m.Name = "default"
+
+	scope := &managerScope{
+		manager:           m,
+		modelProviderInfo: &gateway.ModelProviderInfo{HttpApiID: "qwen-http-api"},
+	}
+
+	if _, err := r.reconcileManagerInfrastructure(context.Background(), scope); err != nil {
+		t.Fatalf("reconcileManagerInfrastructure: %v", err)
+	}
+	if len(prov.Calls.ProvisionManager) != 1 {
+		t.Fatalf("ProvisionManager calls=%d, want 1", len(prov.Calls.ProvisionManager))
+	}
+	if got := prov.Calls.ProvisionManager[0].ModelProviderID; got != "qwen-http-api" {
+		t.Fatalf("ProvisionManager ModelProviderID=%q, want qwen-http-api", got)
+	}
+}
+
+func TestReconcileManagerInfrastructureRestoresModelProviderAuth(t *testing.T) {
+	prov := mocks.NewMockManagerProvisioner()
+	r := &ManagerReconciler{Provisioner: prov}
+	m := &v1beta1.Manager{}
+	m.Name = "default"
+	m.Status.MatrixUserID = "@manager:localhost"
+
+	scope := &managerScope{
+		manager:           m,
+		modelProviderInfo: &gateway.ModelProviderInfo{HttpApiID: "openai-http-api"},
+	}
+
+	if _, err := r.reconcileManagerInfrastructure(context.Background(), scope); err != nil {
+		t.Fatalf("reconcileManagerInfrastructure: %v", err)
+	}
+	if len(prov.Calls.EnsureManagerGatewayAuth) != 1 {
+		t.Fatalf("EnsureManagerGatewayAuth calls=%d, want 1", len(prov.Calls.EnsureManagerGatewayAuth))
+	}
+	call := prov.Calls.EnsureManagerGatewayAuth[0]
+	if call.Name != "default" {
+		t.Fatalf("EnsureManagerGatewayAuth name=%q, want default", call.Name)
+	}
+	if call.ModelProviderID != "openai-http-api" {
+		t.Fatalf("EnsureManagerGatewayAuth ModelProviderID=%q, want openai-http-api", call.ModelProviderID)
 	}
 }

--- a/hiclaw-controller/internal/controller/manager_controller.go
+++ b/hiclaw-controller/internal/controller/manager_controller.go
@@ -8,6 +8,7 @@ import (
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
 	"github.com/hiclaw/hiclaw-controller/internal/auth"
 	"github.com/hiclaw/hiclaw-controller/internal/backend"
+	"github.com/hiclaw/hiclaw-controller/internal/gateway"
 	"github.com/hiclaw/hiclaw-controller/internal/metrics"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 	corev1 "k8s.io/api/core/v1"
@@ -41,6 +42,7 @@ type ManagerReconciler struct {
 	ManagerResources *backend.ResourceRequirements
 	ResourcePrefix   auth.ResourcePrefix    // tenant prefix used to derive Pod names and labels
 	EmbeddedConfig   *ManagerEmbeddedConfig // non-nil in embedded mode only
+	GatewayClient    gateway.Client         // gateway client for modelProvider resolution
 
 	// DefaultRuntime is the value passed to backend.CreateRequest.RuntimeFallback
 	// when a Manager CR omits spec.runtime. Sourced from HICLAW_MANAGER_RUNTIME
@@ -131,8 +133,22 @@ func (r *ManagerReconciler) Reconcile(ctx context.Context, req reconcile.Request
 // reconcileManagerNormal runs the declarative convergence loop: infrastructure,
 // config, container. Critical-path phases are serial with early return on error.
 func (r *ManagerReconciler) reconcileManagerNormal(ctx context.Context, s *managerScope) (reconcile.Result, error) {
+	if s.manager.Spec.ModelProvider != "" && r.GatewayClient != nil {
+		info, err := r.GatewayClient.ResolveModelProvider(ctx, s.manager.Spec.ModelProvider)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("resolve model provider %q: %w", s.manager.Spec.ModelProvider, err)
+		}
+		s.modelProviderInfo = info
+	}
+
 	if res, err := r.reconcileManagerInfrastructure(ctx, s); err != nil || res.RequeueAfter > 0 {
 		return res, err
+	}
+	if s.modelProviderInfo != nil && r.GatewayClient != nil && s.provResult != nil {
+		consumerName := "manager"
+		if err := r.GatewayClient.AuthorizeAIRoutes(ctx, consumerName, s.modelProviderInfo.HttpApiID); err != nil {
+			return reconcile.Result{}, fmt.Errorf("authorize model provider %s for manager: %w", s.modelProviderInfo.HttpApiID, err)
+		}
 	}
 	if err := r.Provisioner.EnsureManagerServiceAccount(ctx, s.manager.Name); err != nil {
 		return reconcile.Result{}, fmt.Errorf("ServiceAccount: %w", err)

--- a/hiclaw-controller/internal/controller/manager_reconcile_config.go
+++ b/hiclaw-controller/internal/controller/manager_reconcile_config.go
@@ -25,6 +25,10 @@ func (r *ManagerReconciler) reconcileManagerConfig(ctx context.Context, s *manag
 		return reconcile.Result{}, fmt.Errorf("deploy package: %w", err)
 	}
 
+	var aiGatewayURL string
+	if s.modelProviderInfo != nil {
+		aiGatewayURL = s.modelProviderInfo.IntranetURL
+	}
 	if err := r.Deployer.DeployManagerConfig(ctx, service.ManagerDeployRequest{
 		Name:           m.Name,
 		Spec:           m.Spec,
@@ -32,6 +36,7 @@ func (r *ManagerReconciler) reconcileManagerConfig(ctx context.Context, s *manag
 		GatewayKey:     s.provResult.GatewayKey,
 		MatrixPassword: s.provResult.MatrixPassword,
 		McpServers:     m.Spec.McpServers,
+		AIGatewayURL:   aiGatewayURL,
 		IsUpdate:       isUpdate,
 	}); err != nil {
 		return reconcile.Result{}, fmt.Errorf("deploy manager config: %w", err)

--- a/hiclaw-controller/internal/controller/manager_reconcile_container.go
+++ b/hiclaw-controller/internal/controller/manager_reconcile_container.go
@@ -146,6 +146,9 @@ func (r *ManagerReconciler) createManagerContainer(ctx context.Context, s *manag
 	}
 
 	managerEnv := r.EnvBuilder.BuildManager(m.Name, prov, m.Spec)
+	if s.modelProviderInfo != nil && s.modelProviderInfo.IntranetURL != "" {
+		managerEnv["HICLAW_AI_GATEWAY_URL"] = s.modelProviderInfo.IntranetURL
+	}
 	mergeUserEnv(managerEnv, m.Spec.Env, logger, "manager/"+m.Name)
 	containerName := r.managerContainerName(m.Name)
 	saName := r.ResourcePrefix.SAName(authpkg.RoleManager, m.Name)

--- a/hiclaw-controller/internal/controller/manager_reconcile_infra.go
+++ b/hiclaw-controller/internal/controller/manager_reconcile_infra.go
@@ -14,6 +14,10 @@ import (
 // provisioned (MatrixUserID set), it refreshes credentials and restores gateway auth.
 func (r *ManagerReconciler) reconcileManagerInfrastructure(ctx context.Context, s *managerScope) (reconcile.Result, error) {
 	m := s.manager
+	modelProviderID := ""
+	if s.modelProviderInfo != nil {
+		modelProviderID = s.modelProviderInfo.HttpApiID
+	}
 
 	if m.Status.MatrixUserID != "" {
 		refreshResult, err := r.Provisioner.RefreshManagerCredentials(ctx, m.Name)
@@ -26,7 +30,7 @@ func (r *ManagerReconciler) reconcileManagerInfrastructure(ctx context.Context, 
 		// "non-fatal", which masked real failures (e.g. Higress Console PUT
 		// returning non-200) and left the data plane stuck with an empty
 		// allowedConsumers list until a subsequent event happened to retry.
-		if err := r.Provisioner.EnsureManagerGatewayAuth(ctx, m.Name, refreshResult.GatewayKey); err != nil {
+		if err := r.Provisioner.EnsureManagerGatewayAuth(ctx, m.Name, refreshResult.GatewayKey, modelProviderID); err != nil {
 			return reconcile.Result{}, fmt.Errorf("restore manager gateway auth: %w", err)
 		}
 
@@ -45,7 +49,8 @@ func (r *ManagerReconciler) reconcileManagerInfrastructure(ctx context.Context, 
 	logger.Info("provisioning manager infrastructure", "name", m.Name)
 
 	provResult, err := r.Provisioner.ProvisionManager(ctx, service.ManagerProvisionRequest{
-		Name: m.Name,
+		Name:            m.Name,
+		ModelProviderID: modelProviderID,
 	})
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("provision manager: %w", err)

--- a/hiclaw-controller/internal/controller/manager_scope.go
+++ b/hiclaw-controller/internal/controller/manager_scope.go
@@ -2,14 +2,16 @@ package controller
 
 import (
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	"github.com/hiclaw/hiclaw-controller/internal/gateway"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type managerScope struct {
-	manager    *v1beta1.Manager
-	provResult *service.ManagerProvisionResult
-	patchBase  client.Patch
+	manager           *v1beta1.Manager
+	provResult        *service.ManagerProvisionResult
+	patchBase         client.Patch
+	modelProviderInfo *gateway.ModelProviderInfo
 }
 
 // computeManagerPhase determines the Manager status phase based on reconcile outcome.

--- a/hiclaw-controller/internal/controller/member_reconcile.go
+++ b/hiclaw-controller/internal/controller/member_reconcile.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hiclaw/hiclaw-controller/internal/agentconfig"
 	authpkg "github.com/hiclaw/hiclaw-controller/internal/auth"
 	"github.com/hiclaw/hiclaw-controller/internal/backend"
+	"github.com/hiclaw/hiclaw-controller/internal/gateway"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -99,6 +100,10 @@ type MemberContext struct {
 	// Workers this is the Worker CR; for Team members (leader or worker)
 	// this is the Team CR.
 	Owner metav1.Object
+
+	// ModelProviderInfo is the resolved APIG Model API info when
+	// spec.modelProvider is set. Nil when not set or on non-ai-gateway.
+	ModelProviderInfo *gateway.ModelProviderInfo
 }
 
 // MemberState captures reconcile outputs that the caller writes back to the
@@ -117,10 +122,11 @@ type MemberState struct {
 // invoke. Both WorkerReconciler and TeamReconciler build a MemberDeps once
 // and pass it through each phase.
 type MemberDeps struct {
-	Provisioner service.WorkerProvisioner
-	Deployer    service.WorkerDeployer
-	Backend     *backend.Registry
-	EnvBuilder  service.WorkerEnvBuilderI
+	Provisioner   service.WorkerProvisioner
+	Deployer      service.WorkerDeployer
+	Backend       *backend.Registry
+	EnvBuilder    service.WorkerEnvBuilderI
+	GatewayClient gateway.Client
 
 	// ResourcePrefix is the tenant-level prefix that scopes ServiceAccount
 	// (and Pod) names for every member this reconciler provisions. Empty
@@ -185,6 +191,22 @@ func ReconcileMemberInfra(ctx context.Context, d MemberDeps, m MemberContext, st
 	return reconcile.Result{}, nil
 }
 
+// EnsureModelProviderAuth authorizes the member's gateway consumer on the
+// model provider's HttpApi. No-op when modelProvider is not set.
+func EnsureModelProviderAuth(ctx context.Context, d MemberDeps, m MemberContext, state *MemberState) error {
+	if m.ModelProviderInfo == nil || d.GatewayClient == nil {
+		return nil
+	}
+	if state.ProvResult == nil || state.ProvResult.GatewayKey == "" {
+		return nil
+	}
+	consumerName := "worker-" + m.RuntimeName
+	if err := d.GatewayClient.AuthorizeAIRoutes(ctx, consumerName, m.ModelProviderInfo.HttpApiID); err != nil {
+		return fmt.Errorf("authorize model provider %s: %w", m.ModelProviderInfo.HttpApiID, err)
+	}
+	return nil
+}
+
 // EnsureMemberServiceAccount ensures the Kubernetes ServiceAccount used by the
 // member pod exists. Separated from Infra because SA creation can race with
 // the K8s API after namespace setup and benefits from independent retry.
@@ -210,6 +232,10 @@ func ReconcileMemberConfig(ctx context.Context, d MemberDeps, m MemberContext, s
 		return fmt.Errorf("write inline configs: %w", err)
 	}
 
+	var aiGatewayURL string
+	if m.ModelProviderInfo != nil {
+		aiGatewayURL = m.ModelProviderInfo.IntranetURL
+	}
 	if err := d.Deployer.DeployWorkerConfig(ctx, service.WorkerDeployRequest{
 		Name:              m.RuntimeName,
 		Spec:              m.Spec,
@@ -223,6 +249,7 @@ func ReconcileMemberConfig(ctx context.Context, d MemberDeps, m MemberContext, s
 		TeamAdminMatrixID: m.TeamAdminMatrixID,
 		Heartbeat:         m.Heartbeat,
 		IsUpdate:          m.IsUpdate,
+		AIGatewayURL:      aiGatewayURL,
 	}); err != nil {
 		return fmt.Errorf("deploy worker config: %w", err)
 	}
@@ -364,6 +391,9 @@ func createMemberContainer(ctx context.Context, d MemberDeps, m MemberContext, s
 
 	workerEnv := d.EnvBuilder.Build(m.RuntimeName, prov)
 	workerEnv["HICLAW_WORKER_CR_NAME"] = m.Name
+	if m.ModelProviderInfo != nil && m.ModelProviderInfo.IntranetURL != "" {
+		workerEnv["HICLAW_AI_GATEWAY_URL"] = m.ModelProviderInfo.IntranetURL
+	}
 	mergeUserEnv(workerEnv, m.Spec.Env, logger, string(m.Role)+"/"+m.Name)
 	saName := d.ResourcePrefix.SAName(authpkg.RoleWorker, m.Name)
 

--- a/hiclaw-controller/internal/controller/member_reconcile.go
+++ b/hiclaw-controller/internal/controller/member_reconcile.go
@@ -174,12 +174,17 @@ func ReconcileMemberInfra(ctx context.Context, d MemberDeps, m MemberContext, st
 
 	log.FromContext(ctx).Info("provisioning member infrastructure", "name", m.Name, "runtimeName", m.RuntimeName, "role", m.Role)
 
+	modelProviderID := ""
+	if m.ModelProviderInfo != nil {
+		modelProviderID = m.ModelProviderInfo.HttpApiID
+	}
 	provResult, err := d.Provisioner.ProvisionWorker(ctx, service.WorkerProvisionRequest{
-		Name:           m.RuntimeName,
-		CredentialName: m.Name,
-		Role:           m.Role.String(),
-		TeamName:       m.TeamName,
-		TeamLeaderName: m.TeamLeaderName,
+		Name:            m.RuntimeName,
+		CredentialName:  m.Name,
+		ModelProviderID: modelProviderID,
+		Role:            m.Role.String(),
+		TeamName:        m.TeamName,
+		TeamLeaderName:  m.TeamLeaderName,
 	})
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("provision worker: %w", err)

--- a/hiclaw-controller/internal/controller/team_controller.go
+++ b/hiclaw-controller/internal/controller/team_controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hiclaw/hiclaw-controller/internal/auth"
 	"github.com/hiclaw/hiclaw-controller/internal/backend"
 	"github.com/hiclaw/hiclaw-controller/internal/executor"
+	"github.com/hiclaw/hiclaw-controller/internal/gateway"
 	"github.com/hiclaw/hiclaw-controller/internal/metrics"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 	corev1 "k8s.io/api/core/v1"
@@ -72,6 +73,7 @@ type TeamReconciler struct {
 	// createMemberContainer uses it when computing saName. Empty collapses
 	// to DefaultResourcePrefix ("hiclaw-").
 	ResourcePrefix auth.ResourcePrefix
+	GatewayClient  gateway.Client // gateway client for modelProvider resolution
 }
 
 type teamAdminActor struct {
@@ -156,7 +158,7 @@ func (r *TeamReconciler) resolveTeamAdminActor(ctx context.Context, t *v1beta1.T
 //  2. Write local inline configs
 //  3. Clean up stale members (in Status.Members but no longer desired)
 //  4. Reconcile each desired member (leader + workers) via the shared phases
-//  4.5. Inject leader coordination context + SOUL.md template (after package deploy)
+//     4.5. Inject leader coordination context + SOUL.md template (after package deploy)
 //  5. Registry updates + summarise backend readiness and patch Team.Status
 func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Team) (reconcile.Result, error) {
 	logger := log.FromContext(ctx)
@@ -225,6 +227,19 @@ func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Tea
 
 	// --- Step 3: Stale cleanup ---
 	desiredMembers := buildDesiredMembers(derivedTeam, r.ControllerName)
+	if r.GatewayClient != nil {
+		for i := range desiredMembers {
+			mp := desiredMembers[i].Spec.ModelProvider
+			if mp == "" {
+				continue
+			}
+			info, err := r.GatewayClient.ResolveModelProvider(ctx, mp)
+			if err != nil {
+				return r.failTeam(ctx, t, patchBase, fmt.Sprintf("resolve model provider %q for %s: %v", mp, desiredMembers[i].Name, err))
+			}
+			desiredMembers[i].ModelProviderInfo = info
+		}
+	}
 	desiredNames := make(map[string]struct{}, len(desiredMembers))
 	for _, m := range desiredMembers {
 		desiredNames[m.Name] = struct{}{}
@@ -236,6 +251,7 @@ func (r *TeamReconciler) reconcileTeamNormal(ctx context.Context, t *v1beta1.Tea
 		EnvBuilder:     r.EnvBuilder,
 		ResourcePrefix: r.ResourcePrefix,
 		DefaultRuntime: r.DefaultRuntime,
+		GatewayClient:  r.GatewayClient,
 	}
 	// staleCtx.Spec is intentionally left zero. The original TeamWorkerSpec
 	// has already been removed from t.Spec.Workers, and we never persisted a
@@ -411,6 +427,9 @@ func (r *TeamReconciler) reconcileMember(ctx context.Context, deps MemberDeps, m
 	if _, err := ReconcileMemberInfra(ctx, deps, m, state); err != nil {
 		return err
 	}
+	if err := EnsureModelProviderAuth(ctx, deps, m, state); err != nil {
+		return err
+	}
 	ms.Observed = true
 	if state.RoomID != "" {
 		ms.RoomID = state.RoomID
@@ -511,6 +530,7 @@ func (r *TeamReconciler) handleDelete(ctx context.Context, t *v1beta1.Team) erro
 		EnvBuilder:     r.EnvBuilder,
 		ResourcePrefix: r.ResourcePrefix,
 		DefaultRuntime: r.DefaultRuntime,
+		GatewayClient:  r.GatewayClient,
 	}
 
 	// Union of Status.Members and desired members to guarantee cleanup even
@@ -948,6 +968,7 @@ func leaderWorkerSpec(t *v1beta1.Team) v1beta1.WorkerSpec {
 	}
 	return v1beta1.WorkerSpec{
 		Model:         t.Spec.Leader.Model,
+		ModelProvider: t.Spec.Leader.ModelProvider,
 		Runtime:       "copaw",
 		WorkerName:    t.Spec.Leader.WorkerName,
 		Identity:      t.Spec.Leader.Identity,
@@ -990,6 +1011,7 @@ func teamWorkerSpecToWorkerSpec(t *v1beta1.Team, w v1beta1.TeamWorkerSpec) v1bet
 	}
 	return v1beta1.WorkerSpec{
 		Model:         w.Model,
+		ModelProvider: w.ModelProvider,
 		Runtime:       w.Runtime,
 		WorkerName:    w.WorkerName,
 		Image:         w.Image,

--- a/hiclaw-controller/internal/controller/team_controller_test.go
+++ b/hiclaw-controller/internal/controller/team_controller_test.go
@@ -12,6 +12,7 @@ import (
 
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
 	"github.com/hiclaw/hiclaw-controller/internal/backend"
+	"github.com/hiclaw/hiclaw-controller/internal/gateway"
 	"github.com/hiclaw/hiclaw-controller/internal/oss/ossfake"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 	"github.com/hiclaw/hiclaw-controller/test/testutil/mocks"
@@ -265,9 +266,10 @@ func TestReconcileMemberInfraUsesCRNameForCredentialKey(t *testing.T) {
 	prov := mocks.NewMockProvisioner()
 	state := &MemberState{}
 	member := MemberContext{
-		Name:        "alpha-worker-lead",
-		RuntimeName: "leader",
-		Role:        RoleTeamLeader,
+		Name:              "alpha-worker-lead",
+		RuntimeName:       "leader",
+		Role:              RoleTeamLeader,
+		ModelProviderInfo: &gateway.ModelProviderInfo{HttpApiID: "qwen-http-api"},
 	}
 
 	if _, err := ReconcileMemberInfra(context.Background(), MemberDeps{Provisioner: prov}, member, state); err != nil {
@@ -283,6 +285,9 @@ func TestReconcileMemberInfraUsesCRNameForCredentialKey(t *testing.T) {
 	}
 	if req.CredentialName != "alpha-worker-lead" {
 		t.Fatalf("ProvisionWorker CredentialName=%q, want CR name alpha-worker-lead", req.CredentialName)
+	}
+	if req.ModelProviderID != "qwen-http-api" {
+		t.Fatalf("ProvisionWorker ModelProviderID=%q, want qwen-http-api", req.ModelProviderID)
 	}
 }
 

--- a/hiclaw-controller/internal/controller/worker_controller.go
+++ b/hiclaw-controller/internal/controller/worker_controller.go
@@ -7,6 +7,7 @@ import (
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
 	"github.com/hiclaw/hiclaw-controller/internal/auth"
 	"github.com/hiclaw/hiclaw-controller/internal/backend"
+	"github.com/hiclaw/hiclaw-controller/internal/gateway"
 	"github.com/hiclaw/hiclaw-controller/internal/metrics"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
 	corev1 "k8s.io/api/core/v1"
@@ -40,6 +41,7 @@ type WorkerReconciler struct {
 	EnvBuilder     service.WorkerEnvBuilderI
 	ResourcePrefix auth.ResourcePrefix   // tenant prefix used to derive SA names
 	Legacy         *service.LegacyCompat // nil in incluster mode
+	GatewayClient  gateway.Client        // gateway client for modelProvider resolution
 
 	// DefaultRuntime is the value passed to backend.CreateRequest.RuntimeFallback
 	// when a Worker CR omits spec.runtime. Sourced from
@@ -119,13 +121,27 @@ func (r *WorkerReconciler) reconcileNormal(ctx context.Context, w *v1beta1.Worke
 		EnvBuilder:     r.EnvBuilder,
 		ResourcePrefix: r.ResourcePrefix,
 		DefaultRuntime: r.DefaultRuntime,
+		GatewayClient:  r.GatewayClient,
 	}
 	mctx := r.workerMemberContext(w)
+
+	if w.Spec.ModelProvider != "" && r.GatewayClient != nil {
+		info, err := r.GatewayClient.ResolveModelProvider(ctx, w.Spec.ModelProvider)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("resolve model provider %q: %w", w.Spec.ModelProvider, err)
+		}
+		mctx.ModelProviderInfo = info
+	}
+
 	state := &MemberState{}
 
 	if res, err := ReconcileMemberInfra(ctx, deps, mctx, state); err != nil || res.RequeueAfter > 0 {
 		applyMemberStateToWorker(w, state)
 		return res, err
+	}
+	if err := EnsureModelProviderAuth(ctx, deps, mctx, state); err != nil {
+		applyMemberStateToWorker(w, state)
+		return reconcile.Result{}, err
 	}
 	if err := EnsureMemberServiceAccount(ctx, deps, mctx); err != nil {
 		applyMemberStateToWorker(w, state)
@@ -168,6 +184,7 @@ func (r *WorkerReconciler) reconcileDelete(ctx context.Context, w *v1beta1.Worke
 		EnvBuilder:     r.EnvBuilder,
 		ResourcePrefix: r.ResourcePrefix,
 		DefaultRuntime: r.DefaultRuntime,
+		GatewayClient:  r.GatewayClient,
 	}
 	mctx := r.workerMemberContext(w)
 

--- a/hiclaw-controller/internal/controller/worker_controller.go
+++ b/hiclaw-controller/internal/controller/worker_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"

--- a/hiclaw-controller/internal/gateway/aigateway.go
+++ b/hiclaw-controller/internal/gateway/aigateway.go
@@ -41,6 +41,7 @@ type apigClient interface {
 	CreateConsumerAuthorizationRules(req *apig.CreateConsumerAuthorizationRulesRequest) (*apig.CreateConsumerAuthorizationRulesResponse, error)
 	QueryConsumerAuthorizationRules(req *apig.QueryConsumerAuthorizationRulesRequest) (*apig.QueryConsumerAuthorizationRulesResponse, error)
 	DeleteConsumerAuthorizationRule(consumerAuthorizationRuleID *string, consumerID *string) (*apig.DeleteConsumerAuthorizationRuleResponse, error)
+	ListHttpApis(req *apig.ListHttpApisRequest) (*apig.ListHttpApisResponse, error)
 }
 
 // AIGatewayClient implements gateway.Client against Alibaba Cloud APIG.
@@ -167,8 +168,12 @@ func (a *AIGatewayClient) DeleteConsumer(_ context.Context, name string) error {
 	return nil
 }
 
-func (a *AIGatewayClient) AuthorizeAIRoutes(_ context.Context, consumerName string) error {
-	if a.config.ModelAPIID == "" || a.config.EnvID == "" {
+func (a *AIGatewayClient) AuthorizeAIRoutes(_ context.Context, consumerName string, modelAPIID string) error {
+	effectiveModelAPIID := a.config.ModelAPIID
+	if modelAPIID != "" {
+		effectiveModelAPIID = modelAPIID
+	}
+	if effectiveModelAPIID == "" || a.config.EnvID == "" {
 		return fmt.Errorf("ai-gateway: ModelAPIID and EnvID must be configured to authorize consumers")
 	}
 	full := a.consumerName(consumerName)
@@ -182,7 +187,7 @@ func (a *AIGatewayClient) AuthorizeAIRoutes(_ context.Context, consumerName stri
 
 	query := (&apig.QueryConsumerAuthorizationRulesRequest{}).
 		SetConsumerId(id).
-		SetResourceId(a.config.ModelAPIID).
+		SetResourceId(effectiveModelAPIID).
 		SetEnvironmentId(a.config.EnvID).
 		SetResourceType("LLM").
 		SetPageNumber(1).
@@ -190,7 +195,6 @@ func (a *AIGatewayClient) AuthorizeAIRoutes(_ context.Context, consumerName stri
 	if qresp, qerr := a.client.QueryConsumerAuthorizationRules(query); qerr == nil &&
 		qresp != nil && qresp.Body != nil && qresp.Body.Data != nil &&
 		len(qresp.Body.Data.Items) > 0 {
-		// Already authorized.
 		return nil
 	}
 
@@ -200,19 +204,23 @@ func (a *AIGatewayClient) AuthorizeAIRoutes(_ context.Context, consumerName stri
 		ResourceType: tea.String("LLM"),
 		ExpireMode:   tea.String("LongTerm"),
 		ResourceIdentifier: &apig.CreateConsumerAuthorizationRulesRequestAuthorizationRulesResourceIdentifier{
-			ResourceId:    tea.String(a.config.ModelAPIID),
+			ResourceId:    tea.String(effectiveModelAPIID),
 			EnvironmentId: tea.String(a.config.EnvID),
 		},
 	}})
 	if _, err := a.client.CreateConsumerAuthorizationRules(create); err != nil {
 		return fmt.Errorf("ai-gateway: CreateConsumerAuthorizationRules: %w", err)
 	}
-	log.Printf("[ai-gateway] authorized consumer %s on model %s", full, a.config.ModelAPIID)
+	log.Printf("[ai-gateway] authorized consumer %s on model %s", full, effectiveModelAPIID)
 	return nil
 }
 
-func (a *AIGatewayClient) DeauthorizeAIRoutes(_ context.Context, consumerName string) error {
-	if a.config.ModelAPIID == "" || a.config.EnvID == "" {
+func (a *AIGatewayClient) DeauthorizeAIRoutes(_ context.Context, consumerName string, modelAPIID string) error {
+	effectiveModelAPIID := a.config.ModelAPIID
+	if modelAPIID != "" {
+		effectiveModelAPIID = modelAPIID
+	}
+	if effectiveModelAPIID == "" || a.config.EnvID == "" {
 		return nil // nothing to revoke
 	}
 	full := a.consumerName(consumerName)
@@ -225,7 +233,7 @@ func (a *AIGatewayClient) DeauthorizeAIRoutes(_ context.Context, consumerName st
 	}
 	query := (&apig.QueryConsumerAuthorizationRulesRequest{}).
 		SetConsumerId(id).
-		SetResourceId(a.config.ModelAPIID).
+		SetResourceId(effectiveModelAPIID).
 		SetEnvironmentId(a.config.EnvID).
 		SetResourceType("LLM").
 		SetPageNumber(1).
@@ -304,6 +312,81 @@ func (a *AIGatewayClient) Healthy(_ context.Context) error {
 		return fmt.Errorf("ai-gateway: list consumers: %w", err)
 	}
 	return nil
+}
+
+// ResolveModelProvider looks up a named APIG Model API (HttpApi of type LLM)
+// and returns its basePath, Intranet subdomain URL, and httpApiId.
+func (a *AIGatewayClient) ResolveModelProvider(_ context.Context, name string) (*ModelProviderInfo, error) {
+	if a.config.GatewayID == "" {
+		return nil, fmt.Errorf("ai-gateway: gateway ID is required to resolve model provider")
+	}
+
+	page := int32(1)
+	for {
+		req := (&apig.ListHttpApisRequest{}).
+			SetGatewayId(a.config.GatewayID).
+			SetGatewayType("AI").
+			SetTypes("LLM").
+			SetName(name).
+			SetPageNumber(page).
+			SetPageSize(100)
+		resp, err := a.client.ListHttpApis(req)
+		if err != nil {
+			return nil, fmt.Errorf("ai-gateway: ListHttpApis: %w", err)
+		}
+		if resp == nil || resp.Body == nil || resp.Body.Data == nil {
+			return nil, fmt.Errorf("ai-gateway: model provider %q not found", name)
+		}
+		for _, item := range resp.Body.Data.Items {
+			if item == nil {
+				continue
+			}
+			for _, api := range item.VersionedHttpApis {
+				if api == nil || api.Name == nil || *api.Name != name {
+					continue
+				}
+				info := &ModelProviderInfo{
+					HttpApiID: tea.StringValue(api.HttpApiId),
+					BasePath:  tea.StringValue(api.BasePath),
+				}
+				info.IntranetURL = resolveIntranetURL(api.DeployConfigs, info.BasePath)
+				if info.IntranetURL == "" {
+					return nil, fmt.Errorf("ai-gateway: model provider %q has no Intranet subdomain", name)
+				}
+				return info, nil
+			}
+		}
+		if len(resp.Body.Data.Items) < 100 {
+			break
+		}
+		page++
+	}
+	return nil, fmt.Errorf("ai-gateway: model provider %q not found", name)
+}
+
+// resolveIntranetURL finds the Intranet subdomain in deploy configs and
+// constructs the full URL with basePath.
+func resolveIntranetURL(deployConfigs []*apig.HttpApiDeployConfig, basePath string) string {
+	for _, dc := range deployConfigs {
+		if dc == nil {
+			continue
+		}
+		for _, sd := range dc.SubDomains {
+			if sd == nil || sd.NetworkType == nil || *sd.NetworkType != "Intranet" {
+				continue
+			}
+			domain := tea.StringValue(sd.Name)
+			if domain == "" {
+				continue
+			}
+			protocol := "http"
+			if sd.Protocol != nil && strings.EqualFold(*sd.Protocol, "HTTPS") {
+				protocol = "https"
+			}
+			return protocol + "://" + domain + basePath
+		}
+	}
+	return ""
 }
 
 // TriggerPush is a no-op on APIG: configuration propagates

--- a/hiclaw-controller/internal/gateway/client.go
+++ b/hiclaw-controller/internal/gateway/client.go
@@ -13,11 +13,13 @@ type Client interface {
 	DeleteConsumer(ctx context.Context, name string) error
 
 	// AuthorizeAIRoutes adds the consumer to all AI routes' allowedConsumers.
-	// Handles 409 conflict with retry logic.
-	AuthorizeAIRoutes(ctx context.Context, consumerName string) error
+	// Handles 409 conflict with retry logic. When modelAPIID is non-empty,
+	// it overrides the default Model API ID for consumer authorization.
+	AuthorizeAIRoutes(ctx context.Context, consumerName string, modelAPIID string) error
 
 	// DeauthorizeAIRoutes removes the consumer from all AI routes' allowedConsumers.
-	DeauthorizeAIRoutes(ctx context.Context, consumerName string) error
+	// When modelAPIID is non-empty, it overrides the default Model API ID.
+	DeauthorizeAIRoutes(ctx context.Context, consumerName string, modelAPIID string) error
 
 	// ExposePort creates gateway resources to expose a worker port.
 	ExposePort(ctx context.Context, req PortExposeRequest) error
@@ -49,6 +51,11 @@ type Client interface {
 
 	// EnsureAIRoute creates an AI route with consumer auth.
 	EnsureAIRoute(ctx context.Context, req AIRouteRequest) error
+
+	// ResolveModelProvider looks up a named APIG Model API (HttpApi) and returns
+	// its basePath, Intranet subdomain URL, and httpApiId. Only meaningful for
+	// the ai-gateway provider; Higress returns ErrUnsupportedOp.
+	ResolveModelProvider(ctx context.Context, name string) (*ModelProviderInfo, error)
 
 	// Healthy returns nil if the gateway console is reachable and authenticated.
 	Healthy(ctx context.Context) error

--- a/hiclaw-controller/internal/gateway/client.go
+++ b/hiclaw-controller/internal/gateway/client.go
@@ -12,13 +12,14 @@ type Client interface {
 	// DeleteConsumer removes a consumer by name. No-op if not found.
 	DeleteConsumer(ctx context.Context, name string) error
 
-	// AuthorizeAIRoutes adds the consumer to all AI routes' allowedConsumers.
+	// AuthorizeAIRoutes adds the consumer to AI routes' allowedConsumers.
 	// Handles 409 conflict with retry logic. When modelAPIID is non-empty,
-	// it overrides the default Model API ID for consumer authorization.
+	// the consumer is authorized only on that provider route and removed
+	// from other AI routes.
 	AuthorizeAIRoutes(ctx context.Context, consumerName string, modelAPIID string) error
 
-	// DeauthorizeAIRoutes removes the consumer from all AI routes' allowedConsumers.
-	// When modelAPIID is non-empty, it overrides the default Model API ID.
+	// DeauthorizeAIRoutes removes the consumer from AI routes' allowedConsumers.
+	// When modelAPIID is non-empty, only that provider route is modified.
 	DeauthorizeAIRoutes(ctx context.Context, consumerName string, modelAPIID string) error
 
 	// ExposePort creates gateway resources to expose a worker port.

--- a/hiclaw-controller/internal/gateway/client_test.go
+++ b/hiclaw-controller/internal/gateway/client_test.go
@@ -190,7 +190,7 @@ func TestAuthorizeAIRoutesSerializesRouteUpdates(t *testing.T) {
 		wg.Add(1)
 		go func(consumer string) {
 			defer wg.Done()
-			errs <- c.AuthorizeAIRoutes(context.Background(), consumer)
+			errs <- c.AuthorizeAIRoutes(context.Background(), consumer, "")
 		}(consumer)
 	}
 	wg.Wait()

--- a/hiclaw-controller/internal/gateway/client_test.go
+++ b/hiclaw-controller/internal/gateway/client_test.go
@@ -529,7 +529,7 @@ func TestEnsureAIRoute_MissingCreatesSkeletonWithoutAllowedConsumers(t *testing.
 }
 
 func TestAuthorizeAIRoutes_ProviderFilter(t *testing.T) {
-	var putRoutes []string
+	putRoutes := map[string]map[string]interface{}{}
 	client := newGatewayTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/system/init":
@@ -560,13 +560,17 @@ func TestAuthorizeAIRoutes_ProviderFilter(t *testing.T) {
 					"name":      "openai-route",
 					"upstreams": []interface{}{map[string]interface{}{"provider": "openai"}},
 					"authConfig": map[string]interface{}{
-						"allowedConsumers": []string{"manager"},
+						"allowedConsumers": []string{"manager", "worker-alice"},
 					},
 				},
 			})
 		case strings.HasPrefix(r.URL.Path, "/v1/ai/routes/") && r.Method == "PUT":
 			routeName := strings.TrimPrefix(r.URL.Path, "/v1/ai/routes/")
-			putRoutes = append(putRoutes, routeName)
+			var body map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode PUT body: %v", err)
+			}
+			putRoutes[routeName] = body
 			w.WriteHeader(http.StatusOK)
 		default:
 			t.Logf("unexpected: %s %s", r.Method, r.URL.Path)
@@ -576,16 +580,25 @@ func TestAuthorizeAIRoutes_ProviderFilter(t *testing.T) {
 
 	c := NewHigressClient(Config{ConsoleURL: "http://higress.test"}, client)
 
-	// With provider filter "qwen", only qwen-route should be PUT
+	// With provider filter "qwen", qwen-route is authorized and stale
+	// worker-alice authorization is removed from non-matching openai-route.
 	if err := c.AuthorizeAIRoutes(context.Background(), "worker-alice", "qwen"); err != nil {
 		t.Fatalf("AuthorizeAIRoutes: %v", err)
 	}
-	if len(putRoutes) != 1 || putRoutes[0] != "qwen-route" {
-		t.Errorf("expected PUT only on qwen-route, got %v", putRoutes)
+	if len(putRoutes) != 2 {
+		t.Fatalf("expected PUT on qwen-route and stale openai-route, got %v", putRoutes)
+	}
+	qwenConsumers := toStringSlice(putRoutes["qwen-route"]["authConfig"].(map[string]interface{})["allowedConsumers"])
+	if !containsString(qwenConsumers, "worker-alice") {
+		t.Fatalf("qwen-route allowedConsumers=%v, want worker-alice", qwenConsumers)
+	}
+	openAIConsumers := toStringSlice(putRoutes["openai-route"]["authConfig"].(map[string]interface{})["allowedConsumers"])
+	if containsString(openAIConsumers, "worker-alice") {
+		t.Fatalf("openai-route allowedConsumers=%v, want worker-alice removed", openAIConsumers)
 	}
 
 	// Without provider filter, both routes should be PUT
-	putRoutes = nil
+	putRoutes = map[string]map[string]interface{}{}
 	if err := c.AuthorizeAIRoutes(context.Background(), "worker-bob", ""); err != nil {
 		t.Fatalf("AuthorizeAIRoutes (no filter): %v", err)
 	}

--- a/hiclaw-controller/internal/gateway/client_test.go
+++ b/hiclaw-controller/internal/gateway/client_test.go
@@ -528,6 +528,72 @@ func TestEnsureAIRoute_MissingCreatesSkeletonWithoutAllowedConsumers(t *testing.
 	}
 }
 
+func TestAuthorizeAIRoutes_ProviderFilter(t *testing.T) {
+	var putRoutes []string
+	client := newGatewayTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/system/init":
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/session/login":
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "test"})
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/v1/ai/routes" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": []map[string]interface{}{
+					{"name": "qwen-route"},
+					{"name": "openai-route"},
+				},
+			})
+		case r.URL.Path == "/v1/ai/routes/qwen-route" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"name":      "qwen-route",
+					"upstreams": []interface{}{map[string]interface{}{"provider": "qwen"}},
+					"authConfig": map[string]interface{}{
+						"allowedConsumers": []string{"manager"},
+					},
+				},
+			})
+		case r.URL.Path == "/v1/ai/routes/openai-route" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"name":      "openai-route",
+					"upstreams": []interface{}{map[string]interface{}{"provider": "openai"}},
+					"authConfig": map[string]interface{}{
+						"allowedConsumers": []string{"manager"},
+					},
+				},
+			})
+		case strings.HasPrefix(r.URL.Path, "/v1/ai/routes/") && r.Method == "PUT":
+			routeName := strings.TrimPrefix(r.URL.Path, "/v1/ai/routes/")
+			putRoutes = append(putRoutes, routeName)
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Logf("unexpected: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+
+	c := NewHigressClient(Config{ConsoleURL: "http://higress.test"}, client)
+
+	// With provider filter "qwen", only qwen-route should be PUT
+	if err := c.AuthorizeAIRoutes(context.Background(), "worker-alice", "qwen"); err != nil {
+		t.Fatalf("AuthorizeAIRoutes: %v", err)
+	}
+	if len(putRoutes) != 1 || putRoutes[0] != "qwen-route" {
+		t.Errorf("expected PUT only on qwen-route, got %v", putRoutes)
+	}
+
+	// Without provider filter, both routes should be PUT
+	putRoutes = nil
+	if err := c.AuthorizeAIRoutes(context.Background(), "worker-bob", ""); err != nil {
+		t.Fatalf("AuthorizeAIRoutes (no filter): %v", err)
+	}
+	if len(putRoutes) != 2 {
+		t.Errorf("expected PUT on 2 routes, got %v", putRoutes)
+	}
+}
+
 func TestResolveModelProvider_Higress(t *testing.T) {
 	client := newGatewayTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {

--- a/hiclaw-controller/internal/gateway/client_test.go
+++ b/hiclaw-controller/internal/gateway/client_test.go
@@ -131,7 +131,7 @@ func TestAuthorizeAIRoutes(t *testing.T) {
 	}))
 
 	c := NewHigressClient(Config{ConsoleURL: "http://higress.test"}, client)
-	if err := c.AuthorizeAIRoutes(context.Background(), "worker-alice"); err != nil {
+	if err := c.AuthorizeAIRoutes(context.Background(), "worker-alice", ""); err != nil {
 		t.Fatalf("AuthorizeAIRoutes: %v", err)
 	}
 }
@@ -384,7 +384,7 @@ func TestAuthorizeAIRoutes_PUTFailsPropagatesError(t *testing.T) {
 	}))
 
 	c := NewHigressClient(Config{ConsoleURL: "http://higress.test"}, client)
-	if err := c.AuthorizeAIRoutes(context.Background(), "worker-alice"); err == nil {
+	if err := c.AuthorizeAIRoutes(context.Background(), "worker-alice", ""); err == nil {
 		t.Fatalf("AuthorizeAIRoutes: expected error from 500 PUT, got nil")
 	}
 }
@@ -525,5 +525,104 @@ func TestEnsureAIRoute_MissingCreatesSkeletonWithoutAllowedConsumers(t *testing.
 	}
 	if _, present := authConfig["allowedConsumers"]; present {
 		t.Fatalf("authConfig.allowedConsumers must NOT be written by EnsureAIRoute; got %v", authConfig["allowedConsumers"])
+	}
+}
+
+func TestResolveModelProvider_Higress(t *testing.T) {
+	client := newGatewayTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/system/init":
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/session/login":
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "test"})
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/v1/ai/providers/qwen" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{"name": "qwen", "type": "qwen"},
+			})
+		case r.URL.Path == "/v1/ai/routes" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": []map[string]interface{}{
+					{"name": "qwen-route"},
+					{"name": "openai-route"},
+				},
+			})
+		case r.URL.Path == "/v1/ai/routes/qwen-route" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"name": "qwen-route",
+					"pathPredicate": map[string]interface{}{
+						"matchValue": "/v1/qwen",
+					},
+					"upstreams": []interface{}{
+						map[string]interface{}{"provider": "qwen", "weight": 100},
+					},
+				},
+			})
+		case r.URL.Path == "/v1/ai/routes/openai-route" && r.Method == "GET":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"name": "openai-route",
+					"pathPredicate": map[string]interface{}{
+						"matchValue": "/v1",
+					},
+					"upstreams": []interface{}{
+						map[string]interface{}{"provider": "openai", "weight": 100},
+					},
+				},
+			})
+		default:
+			t.Logf("unexpected: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+
+	c := NewHigressClient(Config{
+		ConsoleURL:   "http://higress.test",
+		DataPlaneURL: "http://aigw-local.hiclaw.io:8080",
+	}, client)
+
+	info, err := c.ResolveModelProvider(context.Background(), "qwen")
+	if err != nil {
+		t.Fatalf("ResolveModelProvider: %v", err)
+	}
+	if info.HttpApiID != "qwen" {
+		t.Errorf("HttpApiID = %q, want qwen", info.HttpApiID)
+	}
+	if info.BasePath != "/v1/qwen" {
+		t.Errorf("BasePath = %q, want /v1/qwen", info.BasePath)
+	}
+	if info.IntranetURL != "http://aigw-local.hiclaw.io:8080/v1/qwen" {
+		t.Errorf("IntranetURL = %q, want http://aigw-local.hiclaw.io:8080/v1/qwen", info.IntranetURL)
+	}
+}
+
+func TestResolveModelProvider_Higress_NotFound(t *testing.T) {
+	client := newGatewayTestClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/system/init":
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/session/login":
+			http.SetCookie(w, &http.Cookie{Name: "session", Value: "test"})
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/v1/ai/providers/nonexist" && r.Method == "GET":
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Logf("unexpected: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+
+	c := NewHigressClient(Config{
+		ConsoleURL:   "http://higress.test",
+		DataPlaneURL: "http://aigw-local.hiclaw.io:8080",
+	}, client)
+
+	_, err := c.ResolveModelProvider(context.Background(), "nonexist")
+	if err == nil {
+		t.Fatal("expected error for nonexistent provider, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error = %q, want it to contain 'not found'", err.Error())
 	}
 }

--- a/hiclaw-controller/internal/gateway/higress.go
+++ b/hiclaw-controller/internal/gateway/higress.go
@@ -178,15 +178,18 @@ func (c *HigressClient) DeleteConsumer(ctx context.Context, name string) error {
 	return nil
 }
 
-func (c *HigressClient) AuthorizeAIRoutes(ctx context.Context, consumerName string, _ string) error {
-	return c.modifyAIRoutes(ctx, consumerName, true)
+func (c *HigressClient) AuthorizeAIRoutes(ctx context.Context, consumerName string, modelAPIID string) error {
+	return c.modifyAIRoutes(ctx, consumerName, modelAPIID, true)
 }
 
-func (c *HigressClient) DeauthorizeAIRoutes(ctx context.Context, consumerName string, _ string) error {
-	return c.modifyAIRoutes(ctx, consumerName, false)
+func (c *HigressClient) DeauthorizeAIRoutes(ctx context.Context, consumerName string, modelAPIID string) error {
+	return c.modifyAIRoutes(ctx, consumerName, modelAPIID, false)
 }
 
-func (c *HigressClient) modifyAIRoutes(ctx context.Context, consumerName string, add bool) error {
+// modifyAIRoutes adds or removes the consumer from AI routes' allowedConsumers.
+// When providerFilter is non-empty, only routes whose upstreams reference that
+// provider are modified; when empty, all routes are modified (legacy behavior).
+func (c *HigressClient) modifyAIRoutes(ctx context.Context, consumerName string, providerFilter string, add bool) error {
 	c.aiRouteMu.Lock()
 	defer c.aiRouteMu.Unlock()
 
@@ -257,6 +260,11 @@ func (c *HigressClient) modifyAIRoutes(ctx context.Context, consumerName string,
 				break
 			}
 
+			// When providerFilter is set, skip routes that don't match the provider.
+			if providerFilter != "" && !routeMatchesProvider(route, providerFilter) {
+				break
+			}
+
 			authConfig, _ := route["authConfig"].(map[string]interface{})
 			if authConfig == nil {
 				authConfig = make(map[string]interface{})
@@ -303,6 +311,24 @@ func (c *HigressClient) modifyAIRoutes(ctx context.Context, consumerName string,
 	}
 
 	return firstErr
+}
+
+// routeMatchesProvider checks if any upstream in the route references the given provider.
+func routeMatchesProvider(route map[string]interface{}, provider string) bool {
+	upstreams, ok := route["upstreams"].([]interface{})
+	if !ok {
+		return false
+	}
+	for _, u := range upstreams {
+		ups, ok := u.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if p, _ := ups["provider"].(string); p == provider {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *HigressClient) ExposePort(ctx context.Context, req PortExposeRequest) error {

--- a/hiclaw-controller/internal/gateway/higress.go
+++ b/hiclaw-controller/internal/gateway/higress.go
@@ -178,11 +178,11 @@ func (c *HigressClient) DeleteConsumer(ctx context.Context, name string) error {
 	return nil
 }
 
-func (c *HigressClient) AuthorizeAIRoutes(ctx context.Context, consumerName string) error {
+func (c *HigressClient) AuthorizeAIRoutes(ctx context.Context, consumerName string, _ string) error {
 	return c.modifyAIRoutes(ctx, consumerName, true)
 }
 
-func (c *HigressClient) DeauthorizeAIRoutes(ctx context.Context, consumerName string) error {
+func (c *HigressClient) DeauthorizeAIRoutes(ctx context.Context, consumerName string, _ string) error {
 	return c.modifyAIRoutes(ctx, consumerName, false)
 }
 
@@ -524,6 +524,87 @@ func (c *HigressClient) EnsureAIRoute(ctx context.Context, req AIRouteRequest) e
 	default:
 		return fmt.Errorf("ensure AI route %s: check existence: HTTP %d", req.Name, sc)
 	}
+}
+
+func (c *HigressClient) ResolveModelProvider(ctx context.Context, name string) (*ModelProviderInfo, error) {
+	// Verify the provider exists.
+	_, sc, err := c.doJSON(ctx, http.MethodGet, "/v1/ai/providers/"+name, nil)
+	if err != nil {
+		return nil, fmt.Errorf("higress: get AI provider %q: %w", name, err)
+	}
+	if sc == http.StatusNotFound {
+		return nil, fmt.Errorf("higress: model provider %q not found", name)
+	}
+	if sc != http.StatusOK {
+		return nil, fmt.Errorf("higress: get AI provider %q: HTTP %d", name, sc)
+	}
+
+	// Find the AI route that uses this provider.
+	routesBody, sc, err := c.doJSON(ctx, http.MethodGet, "/v1/ai/routes", nil)
+	if err != nil {
+		return nil, fmt.Errorf("higress: list AI routes: %w", err)
+	}
+	if sc != http.StatusOK {
+		return nil, fmt.Errorf("higress: list AI routes: HTTP %d", sc)
+	}
+
+	var listResp struct {
+		Data []json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(routesBody, &listResp); err != nil {
+		return nil, fmt.Errorf("higress: decode AI routes list: %w", err)
+	}
+
+	for _, raw := range listResp.Data {
+		var routeInfo struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(raw, &routeInfo); err != nil || routeInfo.Name == "" {
+			continue
+		}
+
+		routeBody, sc, err := c.doJSON(ctx, http.MethodGet, "/v1/ai/routes/"+routeInfo.Name, nil)
+		if err != nil || sc != http.StatusOK {
+			continue
+		}
+
+		var routeResp struct {
+			Data json.RawMessage `json:"data"`
+		}
+		if err := json.Unmarshal(routeBody, &routeResp); err != nil {
+			continue
+		}
+		routeData := routeResp.Data
+		if routeData == nil {
+			routeData = routeBody
+		}
+
+		var route struct {
+			PathPredicate struct {
+				MatchValue string `json:"matchValue"`
+			} `json:"pathPredicate"`
+			Upstreams []struct {
+				Provider string `json:"provider"`
+			} `json:"upstreams"`
+		}
+		if err := json.Unmarshal(routeData, &route); err != nil {
+			continue
+		}
+
+		for _, ups := range route.Upstreams {
+			if ups.Provider == name {
+				basePath := route.PathPredicate.MatchValue
+				intranetURL := strings.TrimRight(c.config.DataPlaneURL, "/") + basePath
+				return &ModelProviderInfo{
+					HttpApiID:   name,
+					BasePath:    basePath,
+					IntranetURL: intranetURL,
+				}, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("higress: no AI route found for model provider %q", name)
 }
 
 func (c *HigressClient) Healthy(ctx context.Context) error {

--- a/hiclaw-controller/internal/gateway/higress.go
+++ b/hiclaw-controller/internal/gateway/higress.go
@@ -187,8 +187,10 @@ func (c *HigressClient) DeauthorizeAIRoutes(ctx context.Context, consumerName st
 }
 
 // modifyAIRoutes adds or removes the consumer from AI routes' allowedConsumers.
-// When providerFilter is non-empty, only routes whose upstreams reference that
-// provider are modified; when empty, all routes are modified (legacy behavior).
+// When providerFilter is non-empty, AuthorizeAIRoutes keeps the consumer only
+// on matching routes and removes it from non-matching routes; DeauthorizeAIRoutes
+// removes it only from matching routes. Empty providerFilter keeps the legacy
+// all-route behavior.
 func (c *HigressClient) modifyAIRoutes(ctx context.Context, consumerName string, providerFilter string, add bool) error {
 	c.aiRouteMu.Lock()
 	defer c.aiRouteMu.Unlock()
@@ -260,8 +262,8 @@ func (c *HigressClient) modifyAIRoutes(ctx context.Context, consumerName string,
 				break
 			}
 
-			// When providerFilter is set, skip routes that don't match the provider.
-			if providerFilter != "" && !routeMatchesProvider(route, providerFilter) {
+			matchesProvider := providerFilter == "" || routeMatchesProvider(route, providerFilter)
+			if providerFilter != "" && !add && !matchesProvider {
 				break
 			}
 
@@ -272,7 +274,8 @@ func (c *HigressClient) modifyAIRoutes(ctx context.Context, consumerName string,
 
 			consumers := toStringSlice(authConfig["allowedConsumers"])
 
-			if add {
+			changed := true
+			if add && matchesProvider {
 				if !containsString(consumers, consumerName) {
 					consumers = append(consumers, consumerName)
 				}
@@ -281,7 +284,13 @@ func (c *HigressClient) modifyAIRoutes(ctx context.Context, consumerName string,
 				// so WASM needs to reload credentials even if the name was
 				// already in allowedConsumers.
 			} else {
+				before := len(consumers)
 				consumers = removeString(consumers, consumerName)
+				changed = before != len(consumers)
+			}
+
+			if !changed {
+				break
 			}
 
 			authConfig["allowedConsumers"] = consumers

--- a/hiclaw-controller/internal/gateway/types.go
+++ b/hiclaw-controller/internal/gateway/types.go
@@ -6,6 +6,7 @@ type Config struct {
 	AdminUser                 string // console login username
 	AdminPassword             string // console login password
 	AllowDefaultAdminFallback bool   // embedded bootstrap only: recover from all-in-one default admin/admin
+	DataPlaneURL              string // gateway data plane URL, e.g. http://aigw-local.hiclaw.io:8080
 }
 
 // ConsumerRequest describes a gateway consumer to create.
@@ -43,6 +44,14 @@ type AIProviderRequest struct {
 	Tokens   []string
 	Protocol string                 // e.g. "openai/v1"
 	Raw      map[string]interface{} // provider-specific raw config
+}
+
+// ModelProviderInfo holds the resolved endpoint info for a named model provider
+// discovered via the APIG ListHttpApis API.
+type ModelProviderInfo struct {
+	HttpApiID   string // APIG httpApiId for consumer authorization
+	BasePath    string // e.g. "/v1"
+	IntranetURL string // full Intranet URL including protocol and domain (e.g. "http://xxx.internal.xxx.com")
 }
 
 // AIRouteRequest describes an AI route skeleton to create.

--- a/hiclaw-controller/internal/server/gateway_handler.go
+++ b/hiclaw-controller/internal/server/gateway_handler.go
@@ -64,7 +64,7 @@ func (h *GatewayHandler) BindConsumer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.gw.AuthorizeAIRoutes(r.Context(), consumerName); err != nil {
+	if err := h.gw.AuthorizeAIRoutes(r.Context(), consumerName, ""); err != nil {
 		log.Printf("[ERROR] bind consumer %s: %v", consumerName, err)
 		httputil.WriteError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/hiclaw-controller/internal/server/resource_handler.go
+++ b/hiclaw-controller/internal/server/resource_handler.go
@@ -104,6 +104,7 @@ func (h *ResourceHandler) CreateWorker(w http.ResponseWriter, r *http.Request) {
 		},
 		Spec: v1beta1.WorkerSpec{
 			Model:            req.Model,
+			ModelProvider:    req.ModelProvider,
 			WorkerName:       req.WorkerName,
 			Runtime:          req.Runtime,
 			Image:            req.Image,
@@ -263,6 +264,9 @@ func (h *ResourceHandler) UpdateWorker(w http.ResponseWriter, r *http.Request) {
 
 		if req.Model != "" {
 			worker.Spec.Model = req.Model
+		}
+		if req.ModelProvider != "" {
+			worker.Spec.ModelProvider = req.ModelProvider
 		}
 		if req.WorkerName != "" {
 			worker.Spec.WorkerName = req.WorkerName

--- a/hiclaw-controller/internal/server/resource_handler.go
+++ b/hiclaw-controller/internal/server/resource_handler.go
@@ -382,6 +382,7 @@ func (h *ResourceHandler) CreateTeam(w http.ResponseWriter, r *http.Request) {
 				Name:              req.Leader.Name,
 				WorkerName:        req.Leader.WorkerName,
 				Model:             req.Leader.Model,
+				ModelProvider:     req.Leader.ModelProvider,
 				Identity:          req.Leader.Identity,
 				Soul:              req.Leader.Soul,
 				Agents:            req.Leader.Agents,
@@ -400,6 +401,7 @@ func (h *ResourceHandler) CreateTeam(w http.ResponseWriter, r *http.Request) {
 			Name:          tw.Name,
 			WorkerName:    tw.WorkerName,
 			Model:         tw.Model,
+			ModelProvider: tw.ModelProvider,
 			Runtime:       tw.Runtime,
 			Image:         tw.Image,
 			Identity:      tw.Identity,
@@ -498,6 +500,9 @@ func (h *ResourceHandler) UpdateTeam(w http.ResponseWriter, r *http.Request) {
 			if req.Leader.Model != "" {
 				team.Spec.Leader.Model = req.Leader.Model
 			}
+			if req.Leader.ModelProvider != "" {
+				team.Spec.Leader.ModelProvider = req.Leader.ModelProvider
+			}
 			if req.Leader.Identity != "" {
 				team.Spec.Leader.Identity = req.Leader.Identity
 			}
@@ -533,6 +538,7 @@ func (h *ResourceHandler) UpdateTeam(w http.ResponseWriter, r *http.Request) {
 					Name:          tw.Name,
 					WorkerName:    tw.WorkerName,
 					Model:         tw.Model,
+					ModelProvider: tw.ModelProvider,
 					Runtime:       tw.Runtime,
 					Image:         tw.Image,
 					Identity:      tw.Identity,
@@ -689,15 +695,16 @@ func (h *ResourceHandler) CreateManager(w http.ResponseWriter, r *http.Request) 
 			Namespace: h.namespace,
 		},
 		Spec: v1beta1.ManagerSpec{
-			Model:      req.Model,
-			Runtime:    req.Runtime,
-			Image:      req.Image,
-			Soul:       req.Soul,
-			Agents:     req.Agents,
-			Skills:     req.Skills,
-			McpServers: req.McpServers,
-			Package:    req.Package,
-			State:      req.State,
+			Model:         req.Model,
+			ModelProvider: req.ModelProvider,
+			Runtime:       req.Runtime,
+			Image:         req.Image,
+			Soul:          req.Soul,
+			Agents:        req.Agents,
+			Skills:        req.Skills,
+			McpServers:    req.McpServers,
+			Package:       req.Package,
+			State:         req.State,
 		},
 	}
 	if req.Config != nil {
@@ -768,6 +775,9 @@ func (h *ResourceHandler) UpdateManager(w http.ResponseWriter, r *http.Request) 
 
 		if req.Model != "" {
 			mgr.Spec.Model = req.Model
+		}
+		if req.ModelProvider != "" {
+			mgr.Spec.ModelProvider = req.ModelProvider
 		}
 		if req.Runtime != "" {
 			mgr.Spec.Runtime = req.Runtime

--- a/hiclaw-controller/internal/server/resource_handler_test.go
+++ b/hiclaw-controller/internal/server/resource_handler_test.go
@@ -210,10 +210,11 @@ func TestCreateAndUpdateTeamLeaderRuntimeConfig(t *testing.T) {
 		"name":"alpha-team",
 		"leader":{
 			"name":"alpha-lead",
+			"modelProvider":"qwen",
 			"heartbeat":{"enabled":true,"every":"30m"},
 			"workerIdleTimeout":"12h"
 		},
-		"workers":[]
+		"workers":[{"name":"alpha-dev","modelProvider":"openai"}]
 	}`)
 	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/teams", bytes.NewReader(createBody))
 	createRec := httptest.NewRecorder()
@@ -232,12 +233,20 @@ func TestCreateAndUpdateTeamLeaderRuntimeConfig(t *testing.T) {
 	if created.Spec.Leader.WorkerIdleTimeout != "12h" {
 		t.Fatalf("expected worker idle timeout 12h, got %q", created.Spec.Leader.WorkerIdleTimeout)
 	}
+	if created.Spec.Leader.ModelProvider != "qwen" {
+		t.Fatalf("leader.modelProvider=%q, want qwen", created.Spec.Leader.ModelProvider)
+	}
+	if len(created.Spec.Workers) != 1 || created.Spec.Workers[0].ModelProvider != "openai" {
+		t.Fatalf("workers modelProvider not persisted: %#v", created.Spec.Workers)
+	}
 
 	updateBody := []byte(`{
 		"leader":{
+			"modelProvider":"dashscope",
 			"heartbeat":{"enabled":true,"every":"45m"},
 			"workerIdleTimeout":"24h"
-		}
+		},
+		"workers":[{"name":"alpha-qa","modelProvider":"qwen"}]
 	}`)
 	updateReq := httptest.NewRequest(http.MethodPut, "/api/v1/teams/alpha-team", bytes.NewReader(updateBody))
 	updateReq.SetPathValue("name", "alpha-team")
@@ -256,6 +265,12 @@ func TestCreateAndUpdateTeamLeaderRuntimeConfig(t *testing.T) {
 	}
 	if updated.Spec.Leader.WorkerIdleTimeout != "24h" {
 		t.Fatalf("expected worker idle timeout 24h, got %q", updated.Spec.Leader.WorkerIdleTimeout)
+	}
+	if updated.Spec.Leader.ModelProvider != "dashscope" {
+		t.Fatalf("leader.modelProvider=%q, want dashscope", updated.Spec.Leader.ModelProvider)
+	}
+	if len(updated.Spec.Workers) != 1 || updated.Spec.Workers[0].Name != "alpha-qa" || updated.Spec.Workers[0].ModelProvider != "qwen" {
+		t.Fatalf("workers after update=%#v, want alpha-qa with qwen modelProvider", updated.Spec.Workers)
 	}
 
 	var resp TeamResponse
@@ -300,6 +315,45 @@ func TestCreateTeamPersistsRuntimeWorkerNames(t *testing.T) {
 	}
 	if got := stored.Spec.Workers[0].WorkerName; got != "dev-runtime" {
 		t.Fatalf("workers[0].workerName = %q, want dev-runtime", got)
+	}
+}
+
+func TestCreateAndUpdateManagerPersistsModelProvider(t *testing.T) {
+	scheme := newServerTestScheme(t)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	handler := NewResourceHandler(k8sClient, "default", nil, "")
+
+	createBody := []byte(`{"name":"default","model":"qwen-plus","modelProvider":"qwen"}`)
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/managers", bytes.NewReader(createBody))
+	createRec := httptest.NewRecorder()
+	handler.CreateManager(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("expected create status %d, got %d: %s", http.StatusCreated, createRec.Code, createRec.Body.String())
+	}
+
+	var created v1beta1.Manager
+	if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "default", Namespace: "default"}, &created); err != nil {
+		t.Fatalf("get created manager: %v", err)
+	}
+	if created.Spec.ModelProvider != "qwen" {
+		t.Fatalf("created manager modelProvider=%q, want qwen", created.Spec.ModelProvider)
+	}
+
+	updateBody := []byte(`{"modelProvider":"openai"}`)
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/v1/managers/default", bytes.NewReader(updateBody))
+	updateReq.SetPathValue("name", "default")
+	updateRec := httptest.NewRecorder()
+	handler.UpdateManager(updateRec, updateReq)
+	if updateRec.Code != http.StatusOK {
+		t.Fatalf("expected update status %d, got %d: %s", http.StatusOK, updateRec.Code, updateRec.Body.String())
+	}
+
+	var updated v1beta1.Manager
+	if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "default", Namespace: "default"}, &updated); err != nil {
+		t.Fatalf("get updated manager: %v", err)
+	}
+	if updated.Spec.ModelProvider != "openai" {
+		t.Fatalf("updated manager modelProvider=%q, want openai", updated.Spec.ModelProvider)
 	}
 }
 

--- a/hiclaw-controller/internal/server/types.go
+++ b/hiclaw-controller/internal/server/types.go
@@ -101,6 +101,7 @@ type TeamLeaderRequest struct {
 	Name              string                      `json:"name"`
 	WorkerName        string                      `json:"workerName,omitempty"`
 	Model             string                      `json:"model,omitempty"`
+	ModelProvider     string                      `json:"modelProvider,omitempty"`
 	Identity          string                      `json:"identity,omitempty"`
 	Soul              string                      `json:"soul,omitempty"`
 	Agents            string                      `json:"agents,omitempty"`
@@ -121,6 +122,7 @@ type TeamWorkerRequest struct {
 	Name          string                     `json:"name"`
 	WorkerName    string                     `json:"workerName,omitempty"`
 	Model         string                     `json:"model,omitempty"`
+	ModelProvider string                     `json:"modelProvider,omitempty"`
 	Runtime       string                     `json:"runtime,omitempty"`
 	Image         string                     `json:"image,omitempty"`
 	Identity      string                     `json:"identity,omitempty"`
@@ -200,30 +202,32 @@ type HumanListResponse struct {
 // --- Manager API types ---
 
 type CreateManagerRequest struct {
-	Name       string                 `json:"name"`
-	Model      string                 `json:"model"`
-	Runtime    string                 `json:"runtime,omitempty"`
-	Image      string                 `json:"image,omitempty"`
-	Soul       string                 `json:"soul,omitempty"`
-	Agents     string                 `json:"agents,omitempty"`
-	Skills     []string               `json:"skills,omitempty"`
-	McpServers []v1beta1.MCPServer    `json:"mcpServers,omitempty"`
-	Package    string                 `json:"package,omitempty"`
-	Config     *v1beta1.ManagerConfig `json:"config,omitempty"`
-	State      *string                `json:"state,omitempty"` // desired lifecycle state: Running, Sleeping, Stopped
+	Name          string                 `json:"name"`
+	Model         string                 `json:"model"`
+	ModelProvider string                 `json:"modelProvider,omitempty"`
+	Runtime       string                 `json:"runtime,omitempty"`
+	Image         string                 `json:"image,omitempty"`
+	Soul          string                 `json:"soul,omitempty"`
+	Agents        string                 `json:"agents,omitempty"`
+	Skills        []string               `json:"skills,omitempty"`
+	McpServers    []v1beta1.MCPServer    `json:"mcpServers,omitempty"`
+	Package       string                 `json:"package,omitempty"`
+	Config        *v1beta1.ManagerConfig `json:"config,omitempty"`
+	State         *string                `json:"state,omitempty"` // desired lifecycle state: Running, Sleeping, Stopped
 }
 
 type UpdateManagerRequest struct {
-	Model      string                 `json:"model,omitempty"`
-	Runtime    string                 `json:"runtime,omitempty"`
-	Image      string                 `json:"image,omitempty"`
-	Soul       string                 `json:"soul,omitempty"`
-	Agents     string                 `json:"agents,omitempty"`
-	Skills     []string               `json:"skills,omitempty"`
-	McpServers []v1beta1.MCPServer    `json:"mcpServers,omitempty"`
-	Package    string                 `json:"package,omitempty"`
-	Config     *v1beta1.ManagerConfig `json:"config,omitempty"`
-	State      *string                `json:"state,omitempty"` // desired lifecycle state: Running, Sleeping, Stopped
+	Model         string                 `json:"model,omitempty"`
+	ModelProvider string                 `json:"modelProvider,omitempty"`
+	Runtime       string                 `json:"runtime,omitempty"`
+	Image         string                 `json:"image,omitempty"`
+	Soul          string                 `json:"soul,omitempty"`
+	Agents        string                 `json:"agents,omitempty"`
+	Skills        []string               `json:"skills,omitempty"`
+	McpServers    []v1beta1.MCPServer    `json:"mcpServers,omitempty"`
+	Package       string                 `json:"package,omitempty"`
+	Config        *v1beta1.ManagerConfig `json:"config,omitempty"`
+	State         *string                `json:"state,omitempty"` // desired lifecycle state: Running, Sleeping, Stopped
 }
 
 type ManagerResponse struct {

--- a/hiclaw-controller/internal/server/types.go
+++ b/hiclaw-controller/internal/server/types.go
@@ -8,6 +8,7 @@ type CreateWorkerRequest struct {
 	Name          string                     `json:"name"`
 	WorkerName    string                     `json:"workerName,omitempty"`
 	Model         string                     `json:"model,omitempty"`
+	ModelProvider string                     `json:"modelProvider,omitempty"`
 	Runtime       string                     `json:"runtime,omitempty"`
 	Image         string                     `json:"image,omitempty"`
 	Identity      string                     `json:"identity,omitempty"`
@@ -35,6 +36,7 @@ type CreateWorkerRequest struct {
 type UpdateWorkerRequest struct {
 	WorkerName    string                     `json:"workerName,omitempty"`
 	Model         string                     `json:"model,omitempty"`
+	ModelProvider string                     `json:"modelProvider,omitempty"`
 	Runtime       string                     `json:"runtime,omitempty"`
 	Image         string                     `json:"image,omitempty"`
 	Identity      string                     `json:"identity,omitempty"`

--- a/hiclaw-controller/internal/service/deployer.go
+++ b/hiclaw-controller/internal/service/deployer.go
@@ -34,6 +34,9 @@ type WorkerDeployRequest struct {
 	GatewayKey     string
 	MatrixPassword string
 
+	// AIGatewayURL overrides the cluster-wide AI Gateway URL when modelProvider is set.
+	AIGatewayURL string
+
 	// MCP servers declared in spec.mcpServers. The deployer translates this into
 	// mcporter-servers.json and injects Authorization: Bearer <GatewayKey>.
 	McpServers []v1beta1.MCPServer
@@ -201,6 +204,7 @@ func (d *Deployer) DeployWorkerConfig(ctx context.Context, req WorkerDeployReque
 		MatrixToken:    req.MatrixToken,
 		GatewayKey:     req.GatewayKey,
 		ModelName:      req.Spec.Model,
+		AIGatewayURL:   req.AIGatewayURL,
 		TeamLeaderName: req.TeamLeaderName,
 		ChannelPolicy:  channelPolicy,
 		Heartbeat:      req.Heartbeat,
@@ -644,6 +648,9 @@ type ManagerDeployRequest struct {
 	// mcporter-servers.json and injects Authorization: Bearer <GatewayKey>.
 	McpServers []v1beta1.MCPServer
 
+	// AIGatewayURL overrides the cluster-wide AI Gateway URL when modelProvider is set.
+	AIGatewayURL string
+
 	IsUpdate bool
 }
 
@@ -662,10 +669,11 @@ func (d *Deployer) DeployManagerConfig(ctx context.Context, req ManagerDeployReq
 	// silently never sees admin messages. See commit 3f8f84b which fixed this
 	// originally before the controller refactor accidentally reverted it.
 	configJSON, err := d.agentConfig.GenerateOpenClawConfig(agentconfig.WorkerConfigRequest{
-		WorkerName:  "manager",
-		MatrixToken: req.MatrixToken,
-		GatewayKey:  req.GatewayKey,
-		ModelName:   req.Spec.Model,
+		WorkerName:   "manager",
+		MatrixToken:  req.MatrixToken,
+		GatewayKey:   req.GatewayKey,
+		ModelName:    req.Spec.Model,
+		AIGatewayURL: req.AIGatewayURL,
 	})
 	if err != nil {
 		return fmt.Errorf("config generation failed: %w", err)

--- a/hiclaw-controller/internal/service/interfaces.go
+++ b/hiclaw-controller/internal/service/interfaces.go
@@ -13,7 +13,7 @@ type WorkerProvisioner interface {
 	DeprovisionWorker(ctx context.Context, req WorkerDeprovisionRequest) error
 	RefreshCredentials(ctx context.Context, workerName string) (*RefreshResult, error)
 	RefreshWorkerCredentials(ctx context.Context, credentialName, workerName string) (*RefreshResult, error)
-	EnsureWorkerGatewayAuth(ctx context.Context, workerName, gatewayKey string) error
+	EnsureWorkerGatewayAuth(ctx context.Context, workerName, gatewayKey, modelProviderID string) error
 	ReconcileExpose(ctx context.Context, workerName string, desired []v1beta1.ExposePort, current []v1beta1.ExposedPortStatus) ([]v1beta1.ExposedPortStatus, error)
 	EnsureServiceAccount(ctx context.Context, workerName string) error
 	DeleteServiceAccount(ctx context.Context, workerName string) error
@@ -64,7 +64,7 @@ type ManagerProvisioner interface {
 	DeprovisionManager(ctx context.Context, name string) error
 	RefreshCredentials(ctx context.Context, name string) (*RefreshResult, error)
 	RefreshManagerCredentials(ctx context.Context, managerName string) (*RefreshResult, error)
-	EnsureManagerGatewayAuth(ctx context.Context, managerName, gatewayKey string) error
+	EnsureManagerGatewayAuth(ctx context.Context, managerName, gatewayKey, modelProviderID string) error
 	EnsureManagerServiceAccount(ctx context.Context, managerName string) error
 	DeleteManagerServiceAccount(ctx context.Context, managerName string) error
 	DeleteCredentials(ctx context.Context, name string) error

--- a/hiclaw-controller/internal/service/provisioner.go
+++ b/hiclaw-controller/internal/service/provisioner.go
@@ -20,11 +20,12 @@ import (
 
 // WorkerProvisionRequest describes the infrastructure to provision for a worker.
 type WorkerProvisionRequest struct {
-	Name           string
-	CredentialName string
-	Role           string // "standalone" | "team_leader" | "worker"
-	TeamName       string
-	TeamLeaderName string
+	Name            string
+	CredentialName  string
+	ModelProviderID string
+	Role            string // "standalone" | "team_leader" | "worker"
+	TeamName        string
+	TeamLeaderName  string
 }
 
 // WorkerProvisionResult contains all outputs from a successful provision.
@@ -447,7 +448,7 @@ func (p *Provisioner) ProvisionWorker(ctx context.Context, req WorkerProvisionRe
 		_ = p.creds.Save(ctx, credentialName, creds)
 	}
 
-	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, ""); err != nil {
+	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, req.ModelProviderID); err != nil {
 		return nil, fmt.Errorf("AI route authorization failed: %w", err)
 	}
 	// Higress WASM key-auth plugin needs ~1-2s to sync after route update.
@@ -611,7 +612,7 @@ func (p *Provisioner) RefreshManagerCredentials(ctx context.Context, managerName
 // EnsureManagerGatewayAuth ensures the Manager's gateway consumer exists and is
 // authorized on AI routes. Called during container recreation to restore auth
 // that may have been lost (e.g. after upgrade with fresh Higress state).
-func (p *Provisioner) EnsureManagerGatewayAuth(ctx context.Context, managerName, gatewayKey string) error {
+func (p *Provisioner) EnsureManagerGatewayAuth(ctx context.Context, managerName, gatewayKey, modelProviderID string) error {
 	consumerName := "manager"
 	_, err := p.gateway.EnsureConsumer(ctx, gateway.ConsumerRequest{
 		Name:          consumerName,
@@ -620,7 +621,7 @@ func (p *Provisioner) EnsureManagerGatewayAuth(ctx context.Context, managerName,
 	if err != nil {
 		return fmt.Errorf("ensure consumer: %w", err)
 	}
-	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, ""); err != nil {
+	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, modelProviderID); err != nil {
 		return fmt.Errorf("authorize AI routes: %w", err)
 	}
 	return nil
@@ -631,7 +632,7 @@ func (p *Provisioner) EnsureManagerGatewayAuth(ctx context.Context, managerName,
 // to defensively restore auth that may have been lost (e.g. if the Higress
 // route was rewritten, or after upgrade with fresh Higress state). Mirrors
 // EnsureManagerGatewayAuth but uses the worker-scoped consumer name.
-func (p *Provisioner) EnsureWorkerGatewayAuth(ctx context.Context, workerName, gatewayKey string) error {
+func (p *Provisioner) EnsureWorkerGatewayAuth(ctx context.Context, workerName, gatewayKey, modelProviderID string) error {
 	consumerName := "worker-" + workerName
 	_, err := p.gateway.EnsureConsumer(ctx, gateway.ConsumerRequest{
 		Name:          consumerName,
@@ -640,7 +641,7 @@ func (p *Provisioner) EnsureWorkerGatewayAuth(ctx context.Context, workerName, g
 	if err != nil {
 		return fmt.Errorf("ensure consumer: %w", err)
 	}
-	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, ""); err != nil {
+	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, modelProviderID); err != nil {
 		return fmt.Errorf("authorize AI routes: %w", err)
 	}
 	return nil
@@ -1165,7 +1166,8 @@ func (p *Provisioner) DeleteManagerRoomAlias(ctx context.Context, managerName st
 
 // ManagerProvisionRequest describes the infrastructure to provision for a Manager.
 type ManagerProvisionRequest struct {
-	Name string
+	Name            string
+	ModelProviderID string
 }
 
 // ManagerProvisionResult contains all outputs from a successful Manager provision.
@@ -1280,7 +1282,7 @@ func (p *Provisioner) ProvisionManager(ctx context.Context, req ManagerProvision
 		_ = p.creds.Save(ctx, managerName, creds)
 	}
 
-	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, ""); err != nil {
+	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, req.ModelProviderID); err != nil {
 		return nil, fmt.Errorf("AI route authorization failed: %w", err)
 	}
 	// Higress WASM key-auth plugin needs ~1-2s to sync after route update.

--- a/hiclaw-controller/internal/service/provisioner.go
+++ b/hiclaw-controller/internal/service/provisioner.go
@@ -447,7 +447,7 @@ func (p *Provisioner) ProvisionWorker(ctx context.Context, req WorkerProvisionRe
 		_ = p.creds.Save(ctx, credentialName, creds)
 	}
 
-	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName); err != nil {
+	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, ""); err != nil {
 		return nil, fmt.Errorf("AI route authorization failed: %w", err)
 	}
 	// Higress WASM key-auth plugin needs ~1-2s to sync after route update.
@@ -488,7 +488,7 @@ func (p *Provisioner) DeprovisionWorker(ctx context.Context, req WorkerDeprovisi
 	}
 
 	// Deauthorize gateway
-	if err := p.gateway.DeauthorizeAIRoutes(ctx, consumerName); err != nil {
+	if err := p.gateway.DeauthorizeAIRoutes(ctx, consumerName, ""); err != nil {
 		logger.Error(err, "failed to deauthorize AI routes (non-fatal)")
 	}
 	if err := p.gateway.DeleteConsumer(ctx, consumerName); err != nil {
@@ -620,7 +620,7 @@ func (p *Provisioner) EnsureManagerGatewayAuth(ctx context.Context, managerName,
 	if err != nil {
 		return fmt.Errorf("ensure consumer: %w", err)
 	}
-	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName); err != nil {
+	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, ""); err != nil {
 		return fmt.Errorf("authorize AI routes: %w", err)
 	}
 	return nil
@@ -640,7 +640,7 @@ func (p *Provisioner) EnsureWorkerGatewayAuth(ctx context.Context, workerName, g
 	if err != nil {
 		return fmt.Errorf("ensure consumer: %w", err)
 	}
-	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName); err != nil {
+	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, ""); err != nil {
 		return fmt.Errorf("authorize AI routes: %w", err)
 	}
 	return nil
@@ -1280,7 +1280,7 @@ func (p *Provisioner) ProvisionManager(ctx context.Context, req ManagerProvision
 		_ = p.creds.Save(ctx, managerName, creds)
 	}
 
-	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName); err != nil {
+	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, ""); err != nil {
 		return nil, fmt.Errorf("AI route authorization failed: %w", err)
 	}
 	// Higress WASM key-auth plugin needs ~1-2s to sync after route update.
@@ -1497,7 +1497,7 @@ func (p *Provisioner) DeprovisionManager(ctx context.Context, name string) error
 	logger := log.FromContext(ctx)
 	consumerName := "manager"
 
-	if err := p.gateway.DeauthorizeAIRoutes(ctx, consumerName); err != nil {
+	if err := p.gateway.DeauthorizeAIRoutes(ctx, consumerName, ""); err != nil {
 		logger.Error(err, "failed to deauthorize AI routes (non-fatal)")
 	}
 	if err := p.gateway.DeleteConsumer(ctx, consumerName); err != nil {

--- a/hiclaw-controller/test/testutil/mocks/manager_provisioner.go
+++ b/hiclaw-controller/test/testutil/mocks/manager_provisioner.go
@@ -15,7 +15,7 @@ type MockManagerProvisioner struct {
 	DeprovisionManagerFn          func(ctx context.Context, name string) error
 	RefreshCredentialsFn          func(ctx context.Context, name string) (*service.RefreshResult, error)
 	RefreshManagerCredentialsFn   func(ctx context.Context, managerName string) (*service.RefreshResult, error)
-	EnsureManagerGatewayAuthFn    func(ctx context.Context, managerName, gatewayKey string) error
+	EnsureManagerGatewayAuthFn    func(ctx context.Context, managerName, gatewayKey, modelProviderID string) error
 	EnsureManagerServiceAccountFn func(ctx context.Context, managerName string) error
 	DeleteManagerServiceAccountFn func(ctx context.Context, managerName string) error
 	DeleteCredentialsFn           func(ctx context.Context, name string) error
@@ -32,7 +32,7 @@ type MockManagerProvisioner struct {
 		DeprovisionManager          []string
 		RefreshCredentials          []string
 		RefreshManagerCredentials   []string
-		EnsureManagerGatewayAuth    []string
+		EnsureManagerGatewayAuth    []managerGatewayAuthCall
 		EnsureManagerServiceAccount []string
 		DeleteManagerServiceAccount []string
 		DeleteCredentials           []string
@@ -48,6 +48,12 @@ type MockManagerProvisioner struct {
 
 func NewMockManagerProvisioner() *MockManagerProvisioner {
 	return &MockManagerProvisioner{}
+}
+
+type managerGatewayAuthCall struct {
+	Name            string
+	GatewayKey      string
+	ModelProviderID string
 }
 
 func (m *MockManagerProvisioner) Reset() {
@@ -83,7 +89,7 @@ func (m *MockManagerProvisioner) clearCallsLocked() {
 		DeprovisionManager          []string
 		RefreshCredentials          []string
 		RefreshManagerCredentials   []string
-		EnsureManagerGatewayAuth    []string
+		EnsureManagerGatewayAuth    []managerGatewayAuthCall
 		EnsureManagerServiceAccount []string
 		DeleteManagerServiceAccount []string
 		DeleteCredentials           []string
@@ -158,13 +164,17 @@ func (m *MockManagerProvisioner) RefreshManagerCredentials(ctx context.Context, 
 	}, nil
 }
 
-func (m *MockManagerProvisioner) EnsureManagerGatewayAuth(ctx context.Context, managerName, gatewayKey string) error {
+func (m *MockManagerProvisioner) EnsureManagerGatewayAuth(ctx context.Context, managerName, gatewayKey, modelProviderID string) error {
 	m.mu.Lock()
-	m.Calls.EnsureManagerGatewayAuth = append(m.Calls.EnsureManagerGatewayAuth, managerName)
+	m.Calls.EnsureManagerGatewayAuth = append(m.Calls.EnsureManagerGatewayAuth, managerGatewayAuthCall{
+		Name:            managerName,
+		GatewayKey:      gatewayKey,
+		ModelProviderID: modelProviderID,
+	})
 	fn := m.EnsureManagerGatewayAuthFn
 	m.mu.Unlock()
 	if fn != nil {
-		return fn(ctx, managerName, gatewayKey)
+		return fn(ctx, managerName, gatewayKey, modelProviderID)
 	}
 	return nil
 }

--- a/hiclaw-controller/test/testutil/mocks/provisioner.go
+++ b/hiclaw-controller/test/testutil/mocks/provisioner.go
@@ -16,7 +16,7 @@ type MockProvisioner struct {
 	DeprovisionWorkerFn        func(ctx context.Context, req service.WorkerDeprovisionRequest) error
 	RefreshCredentialsFn       func(ctx context.Context, workerName string) (*service.RefreshResult, error)
 	RefreshWorkerCredentialsFn func(ctx context.Context, credentialName, workerName string) (*service.RefreshResult, error)
-	EnsureWorkerGatewayAuthFn  func(ctx context.Context, workerName, gatewayKey string) error
+	EnsureWorkerGatewayAuthFn  func(ctx context.Context, workerName, gatewayKey, modelProviderID string) error
 	ReconcileExposeFn          func(ctx context.Context, workerName string, desired []v1beta1.ExposePort, current []v1beta1.ExposedPortStatus) ([]v1beta1.ExposedPortStatus, error)
 	EnsureServiceAccountFn     func(ctx context.Context, workerName string) error
 	DeleteServiceAccountFn     func(ctx context.Context, workerName string) error
@@ -36,7 +36,7 @@ type MockProvisioner struct {
 		DeprovisionWorker        []service.WorkerDeprovisionRequest
 		RefreshCredentials       []string
 		RefreshWorkerCredentials []workerCredentialCall
-		EnsureWorkerGatewayAuth  []string
+		EnsureWorkerGatewayAuth  []gatewayAuthCall
 		ReconcileExpose          []string
 		EnsureServiceAccount     []string
 		DeleteServiceAccount     []string
@@ -55,6 +55,12 @@ type MockProvisioner struct {
 type workerCredentialCall struct {
 	CredentialName string
 	WorkerName     string
+}
+
+type gatewayAuthCall struct {
+	Name            string
+	GatewayKey      string
+	ModelProviderID string
 }
 
 type humanLoginCall struct {
@@ -104,7 +110,7 @@ func (m *MockProvisioner) clearCallsLocked() {
 		DeprovisionWorker        []service.WorkerDeprovisionRequest
 		RefreshCredentials       []string
 		RefreshWorkerCredentials []workerCredentialCall
-		EnsureWorkerGatewayAuth  []string
+		EnsureWorkerGatewayAuth  []gatewayAuthCall
 		ReconcileExpose          []string
 		EnsureServiceAccount     []string
 		DeleteServiceAccount     []string
@@ -184,13 +190,17 @@ func (m *MockProvisioner) RefreshWorkerCredentials(ctx context.Context, credenti
 	}, nil
 }
 
-func (m *MockProvisioner) EnsureWorkerGatewayAuth(ctx context.Context, workerName, gatewayKey string) error {
+func (m *MockProvisioner) EnsureWorkerGatewayAuth(ctx context.Context, workerName, gatewayKey, modelProviderID string) error {
 	m.mu.Lock()
-	m.Calls.EnsureWorkerGatewayAuth = append(m.Calls.EnsureWorkerGatewayAuth, workerName)
+	m.Calls.EnsureWorkerGatewayAuth = append(m.Calls.EnsureWorkerGatewayAuth, gatewayAuthCall{
+		Name:            workerName,
+		GatewayKey:      gatewayKey,
+		ModelProviderID: modelProviderID,
+	})
 	fn := m.EnsureWorkerGatewayAuthFn
 	m.mu.Unlock()
 	if fn != nil {
-		return fn(ctx, workerName, gatewayKey)
+		return fn(ctx, workerName, gatewayKey, modelProviderID)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- add spec.modelProvider to Worker, Team leader/member, and Manager CRDs
- resolve Higress model providers and inject the selected gateway URL into runtime config
- authorize AI gateway consumers only on the selected provider route while preserving legacy all-route behavior

## Tests
- go test ./internal/gateway ./internal/agentconfig ./api/v1beta1 ./internal/controller