### PR TITLE
fix(helm): remove unsupported CRD propertyNames

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -12,4 +12,5 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 **Bug Fixes**
 
 - **CoPaw Worker heartbeat**: CoPaw worker templates now seed heartbeat at a 10-minute interval so Team Leader agents created from the worker template can run heartbeat turns without requiring an explicit Team CR heartbeat spec.
+- **Helm CRDs**: Removed unsupported `propertyNames` schema fields from Worker and Team CRDs so Kubernetes API servers accept the chart CRDs.
 - **CoPaw local runtime paths**: CoPaw direct-run defaults now honor `COPAW_INSTALL_DIR` and `COPAW_WORKING_DIR` before falling back to local home-directory paths, while container entrypoints can continue to pass explicit directories.

--- a/helm/hiclaw/crds/teams.hiclaw.io.yaml
+++ b/helm/hiclaw/crds/teams.hiclaw.io.yaml
@@ -169,8 +169,6 @@ spec:
                         ignored with a warning log — the system value always wins.
                       additionalProperties:
                         type: string
-                      propertyNames:
-                        pattern: "^[a-zA-Z_][a-zA-Z0-9_]*$"
                     channelPolicy:
                       type: object
                       properties:
@@ -396,8 +394,6 @@ spec:
                           value always wins.
                         additionalProperties:
                           type: string
-                        propertyNames:
-                          pattern: "^[a-zA-Z_][a-zA-Z0-9_]*$"
             status:
               type: object
               properties:

--- a/helm/hiclaw/crds/workers.hiclaw.io.yaml
+++ b/helm/hiclaw/crds/workers.hiclaw.io.yaml
@@ -172,17 +172,6 @@ spec:
                     hiclaw.io/role, hiclaw.io/runtime, app). Entries whose
                     keys collide with those system labels are silently
                     overridden.
-                env:
-                  type: object
-                  description: |
-                    User-defined environment variables injected into the worker container.
-                    Keys that collide with variables already set by the controller or backend
-                    (HICLAW_*, OPENCLAW_*, HOME, and similar internal keys) are silently
-                    ignored with a warning log — the system value always wins.
-                  additionalProperties:
-                    type: string
-                  propertyNames:
-                    pattern: "^[a-zA-Z_][a-zA-Z0-9_]*$"
                 accessEntries:
                   type: array
                   description: >

--- a/hiclaw-controller/config/crd/teams.hiclaw.io.yaml
+++ b/hiclaw-controller/config/crd/teams.hiclaw.io.yaml
@@ -169,8 +169,6 @@ spec:
                         ignored with a warning log — the system value always wins.
                       additionalProperties:
                         type: string
-                      propertyNames:
-                        pattern: "^[a-zA-Z_][a-zA-Z0-9_]*$"
                     channelPolicy:
                       type: object
                       properties:
@@ -396,8 +394,6 @@ spec:
                           value always wins.
                         additionalProperties:
                           type: string
-                        propertyNames:
-                          pattern: "^[a-zA-Z_][a-zA-Z0-9_]*$"
             status:
               type: object
               properties:

--- a/hiclaw-controller/config/crd/workers.hiclaw.io.yaml
+++ b/hiclaw-controller/config/crd/workers.hiclaw.io.yaml
@@ -172,17 +172,6 @@ spec:
                     hiclaw.io/role, hiclaw.io/runtime, app). Entries whose
                     keys collide with those system labels are silently
                     overridden.
-                env:
-                  type: object
-                  description: |
-                    User-defined environment variables injected into the worker container.
-                    Keys that collide with variables already set by the controller or backend
-                    (HICLAW_*, OPENCLAW_*, HOME, and similar internal keys) are silently
-                    ignored with a warning log — the system value always wins.
-                  additionalProperties:
-                    type: string
-                  propertyNames:
-                    pattern: "^[a-zA-Z_][a-zA-Z0-9_]*$"
                 accessEntries:
                   type: array
                   description: >


### PR DESCRIPTION
## Summary

- Remove unsupported `propertyNames` schema fields from Worker and Team CRDs.
- Keep `hiclaw-controller/config/crd` and `helm/hiclaw/crds` in sync.
- Add an unreleased changelog entry for the Helm CRD compatibility fix.

## Why

Kubernetes CRD schemas use the `apiextensions.k8s.io/v1` `JSONSchemaProps` subset, which does not support the JSON Schema `propertyNames` keyword. Installing the chart with the current CRDs can fail during CRD creation with:

```text
field not declared in schema
```

The `env` maps still retain `additionalProperties: { type: string }`; this change only removes the unsupported key-name regex validation from the CRD schema.

## Test Plan

- `rg -n "propertyNames" hiclaw-controller/config/crd helm/hiclaw/crds`
- `make check-crd-sync`
- `git diff --check`
- `make helm-template`
- `kubectl apply --dry-run=server -f helm/hiclaw/crds/teams.hiclaw.io.yaml`
- `kubectl apply --dry-run=server -f helm/hiclaw/crds/workers.hiclaw.io.yaml`
