### PR TITLE
fix(helm): default chart images to v1.1.2

### DIFF
--- a/helm/hiclaw/Chart.yaml
+++ b/helm/hiclaw/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: hiclaw
 description: AgentTeams - AI Agent Teams with Matrix-based collaboration and human-in-the-loop oversight
 type: application
-version: 1.1.1
-appVersion: "1.1.1"
+version: 1.1.2
+appVersion: "1.1.2"
 
 keywords:
   - ai-agent


### PR DESCRIPTION
## Summary
- Bump the Helm chart version/appVersion to 1.1.2 so default image tags resolve to v1.1.2.



