### PR TITLE
feat(plugins): add AgentTeams plugin packaging CLI

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -42,6 +42,11 @@ Plugins are distributed as tarballs whose root is the plugin content itself:
     └── uninstall.sh
 ```
 
+`metadata.name` must use 1-63 lowercase letters, digits, `-`, or `_`, starting
+and ending with a letter or digit. Manifest-controlled paths (`package.include`,
+prompts, skills, MCP args, and adapters) must be relative paths inside the
+plugin root and must not contain `..` segments.
+
 The lifecycle entrypoints are the shared contract:
 
 - `scripts/install.sh`: detects supported local runtimes and dispatches to the

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,70 @@
+# HiClaw Plugins
+
+This directory contains HiClaw runtime plugin packages and the local fallback
+CLI for installing them.
+
+This package contract lets a plugin ship prompts, skills, MCP servers, runtime
+adapters, and lifecycle scripts in one tarball. The package can be installed by
+the HiClaw `agentteams` CLI, and it can also be consumed by local deployment
+systems that unpack a tarball and run the same lifecycle script.
+
+## Default Path: HiClaw CLI
+
+The default installer is the HiClaw-owned `agentteams` CLI:
+
+```bash
+agentteams plugin install <name> --package dist/<name>.tar.gz
+agentteams plugin list
+agentteams plugin update <name> --package dist/<name>.tar.gz
+agentteams plugin uninstall <name>
+```
+
+The CLI stores local state under `.agentteams/`. It does not manage cluster
+worker lifecycle, and it does not hard-code runtime-specific install details.
+It unpacks the plugin tarball, calls the package lifecycle script, and records
+the installed manifest.
+
+## Plugin Package Contract
+
+Plugins are distributed as tarballs whose root is the plugin content itself:
+
+```text
+<name>.tar.gz
+├── plugin.yaml
+├── prompts/
+├── skills/
+├── mcp/
+├── adapters/
+│   ├── runtime-a/
+│   └── runtime-b/
+└── scripts/
+    ├── install.sh
+    └── uninstall.sh
+```
+
+The lifecycle entrypoints are the shared contract:
+
+- `scripts/install.sh`: detects supported local runtimes and dispatches to the
+  matching adapter.
+- `scripts/uninstall.sh`: removes the runtime-specific installation through the
+  matching adapter when available.
+
+The HiClaw CLI calls these lifecycle scripts with `AGENTTEAMS_PLUGIN_NAME`,
+`AGENTTEAMS_PLUGIN_DIR`, `AGENTTEAMS_PROJECT_DIR`, `PILOT_DATA_DIR`, and
+`PILOT_LOG_DIR` set.
+
+## Boundaries
+
+- `desired.agentPackage` in the runtime config contract is a HiClaw AgentSpec
+  package. It is not this plugin package.
+- This directory defines the package, lifecycle, and CLI fallback contract.
+  Plugin-specific business semantics live in each plugin package.
+
+## Validation
+
+```bash
+python3 -m compileall -q plugins/cli/src
+python3 plugins/tests/cli/test_agentteams_plugin_cli.py
+ruby plugins/scripts/validate-plugin.rb path/to/plugin.yaml
+git diff --check
+```

--- a/plugins/cli/pyproject.toml
+++ b/plugins/cli/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agentteams"
+version = "0.1.0"
+description = "AgentTeams plugin CLI fallback"
+requires-python = ">=3.9"
+dependencies = []
+
+[project.scripts]
+agentteams = "agentteams_cli.main:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/plugins/cli/src/agentteams_cli/__init__.py
+++ b/plugins/cli/src/agentteams_cli/__init__.py
@@ -1,0 +1,1 @@
+"""AgentTeams CLI package."""

--- a/plugins/cli/src/agentteams_cli/config_store.py
+++ b/plugins/cli/src/agentteams_cli/config_store.py
@@ -1,0 +1,60 @@
+"""Local `.agentteams/` state store."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+class ConfigStore:
+    """Read and write project-local AgentTeams plugin state."""
+
+    def __init__(self, project_dir: Optional[Path] = None) -> None:
+        self.project_dir = Path(project_dir) if project_dir else Path.cwd()
+        self.root = self.project_dir / ".agentteams"
+
+    def _ensure_parent(self, path: Path) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def _read_json(self, path: Path) -> Dict[str, Any]:
+        if not path.exists():
+            return {}
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def _write_json(self, path: Path, data: Dict[str, Any]) -> None:
+        self._ensure_parent(path)
+        path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    def plugin_dir(self, name: str) -> Path:
+        return self.root / "plugins" / name
+
+    def plugin_content_dir(self, name: str) -> Path:
+        return self.plugin_dir(name) / "content"
+
+    def list_plugins(self) -> List[Dict[str, Any]]:
+        plugins_dir = self.root / "plugins"
+        if not plugins_dir.exists():
+            return []
+        result: List[Dict[str, Any]] = []
+        for path in sorted(plugins_dir.iterdir()):
+            manifest = path / "manifest.json"
+            if manifest.exists():
+                result.append(self._read_json(manifest))
+        return result
+
+    def get_plugin_manifest(self, name: str) -> Optional[Dict[str, Any]]:
+        path = self.plugin_dir(name) / "manifest.json"
+        if not path.exists():
+            return None
+        return self._read_json(path)
+
+    def save_plugin_manifest(self, name: str, manifest: Dict[str, Any]) -> None:
+        self._write_json(self.plugin_dir(name) / "manifest.json", manifest)
+
+    def remove_plugin(self, name: str) -> None:
+        plugin_dir = self.plugin_dir(name)
+        if plugin_dir.exists():
+            shutil.rmtree(plugin_dir)

--- a/plugins/cli/src/agentteams_cli/main.py
+++ b/plugins/cli/src/agentteams_cli/main.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""agentteams — AgentTeams plugin CLI fallback."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from agentteams_cli import plugin_manager
+from agentteams_cli.config_store import ConfigStore
+
+
+def cmd_plugin_install(args: argparse.Namespace) -> int:
+    store = ConfigStore()
+    ok = plugin_manager.install(
+        store,
+        args.name,
+        package=Path(args.package) if args.package else None,
+        source=Path(args.source) if args.source else None,
+    )
+    return 0 if ok else 1
+
+
+def cmd_plugin_list(_args: argparse.Namespace) -> int:
+    plugins = plugin_manager.list_plugins(ConfigStore())
+    if not plugins:
+        print("No plugins installed.")
+        return 0
+    print(f"{'NAME':<20} {'VERSION':<10} {'INSTALLED'}")
+    for plugin in plugins:
+        print(f"{plugin.get('name', '?'):<20} {plugin.get('version', '?'):<10} {plugin.get('installed_at', '?')}")
+    return 0
+
+
+def cmd_plugin_update(args: argparse.Namespace) -> int:
+    store = ConfigStore()
+    ok = plugin_manager.update(
+        store,
+        args.name,
+        package=Path(args.package) if args.package else None,
+        source=Path(args.source) if args.source else None,
+    )
+    return 0 if ok else 1
+
+
+def cmd_plugin_uninstall(args: argparse.Namespace) -> int:
+    ok = plugin_manager.uninstall(ConfigStore(), args.name)
+    return 0 if ok else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="agentteams",
+        description="AgentTeams plugin manager and fallback installer",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    plugin_parser = sub.add_parser("plugin", help="Manage AgentTeams plugins")
+    plugin_sub = plugin_parser.add_subparsers(dest="plugin_action")
+
+    p_install = plugin_sub.add_parser("install", help="Install a plugin package")
+    p_install.add_argument("name", help="Plugin name")
+    p_install.add_argument("--package", help="plugin tarball or directory")
+    p_install.add_argument("--source", help="Raw plugin source directory")
+
+    plugin_sub.add_parser("list", help="List installed plugins")
+
+    p_update = plugin_sub.add_parser("update", help="Update an installed plugin")
+    p_update.add_argument("name", help="Plugin name")
+    p_update.add_argument("--package", help="plugin tarball or directory")
+    p_update.add_argument("--source", help="Raw plugin source directory")
+
+    p_uninstall = plugin_sub.add_parser("uninstall", help="Uninstall a plugin")
+    p_uninstall.add_argument("name", help="Plugin name")
+
+    args = parser.parse_args()
+    if args.command == "plugin":
+        handlers = {
+            "install": cmd_plugin_install,
+            "list": cmd_plugin_list,
+            "update": cmd_plugin_update,
+            "uninstall": cmd_plugin_uninstall,
+        }
+        fn = handlers.get(getattr(args, "plugin_action", None))
+        if fn:
+            return fn(args)
+        plugin_parser.print_help()
+        return 1
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/cli/src/agentteams_cli/plugin_manager.py
+++ b/plugins/cli/src/agentteams_cli/plugin_manager.py
@@ -1,0 +1,240 @@
+"""Plugin package installer used by the `agentteams` CLI fallback."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from agentteams_cli.config_store import ConfigStore
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _load_metadata(manifest_path: Path) -> Tuple[str, str, list[str]]:
+    """Load only the manifest fields the CLI needs.
+
+    The full plugin schema is validated by `plugins/scripts/validate-plugin.rb`.
+    Keeping the CLI parser tiny avoids adding a PyYAML dependency for the fallback
+    installer path.
+    """
+    if not manifest_path.exists():
+        raise ValueError(f"missing plugin.yaml: {manifest_path}")
+
+    metadata: Dict[str, str] = {}
+    dependencies: list[str] = []
+    section: Optional[str] = None
+
+    for raw in manifest_path.read_text(encoding="utf-8").splitlines():
+        line = raw.rstrip()
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if not line.startswith(" ") and stripped.endswith(":"):
+            section = stripped[:-1]
+            continue
+        if section == "metadata" and line.startswith("  ") and ":" in stripped:
+            key, _, value = stripped.partition(":")
+            metadata[key.strip()] = value.strip().strip('"').strip("'")
+            continue
+        if section == "dependencies" and stripped.startswith("- "):
+            dependencies.append(stripped[2:].strip())
+
+    name = metadata.get("name", "")
+    version = metadata.get("version", "")
+    if not name:
+        raise ValueError("metadata.name is required")
+    if not version:
+        raise ValueError("metadata.version is required")
+    return name, version, dependencies
+
+
+def _safe_extract_tar(package: Path, target: Path) -> None:
+    try:
+        with tarfile.open(package, "r:gz") as archive:
+            root = target.resolve()
+            for member in archive.getmembers():
+                member_path = (target / member.name).resolve()
+                if not str(member_path).startswith(str(root) + os.sep) and member_path != root:
+                    raise ValueError(f"unsafe tar member: {member.name}")
+                if member.name.startswith("/") or ".." in Path(member.name).parts:
+                    raise ValueError(f"unsafe tar member: {member.name}")
+            archive.extractall(target)
+    except tarfile.TarError as exc:
+        raise ValueError(f"invalid tar package: {exc}") from exc
+
+
+def _find_plugin_root(search_root: Path) -> Path:
+    if (search_root / "plugin.yaml").is_file():
+        return search_root
+    candidates = [
+        path
+        for path in search_root.iterdir()
+        if path.is_dir() and (path / "plugin.yaml").is_file()
+    ]
+    if len(candidates) == 1:
+        return candidates[0]
+    raise ValueError(f"plugin.yaml not found under {search_root}")
+
+
+def _copytree(src: Path, dst: Path) -> None:
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(
+        src,
+        dst,
+        ignore=shutil.ignore_patterns("__pycache__", ".DS_Store", "*.pyc"),
+    )
+
+
+def _hash_path(path: Path) -> str:
+    digest = hashlib.sha256()
+    if path.is_file():
+        digest.update(path.read_bytes())
+    else:
+        for file_path in sorted(p for p in path.rglob("*") if p.is_file()):
+            digest.update(str(file_path.relative_to(path)).encode("utf-8"))
+            digest.update(b"\0")
+            digest.update(file_path.read_bytes())
+    return "sha256:" + digest.hexdigest()
+
+
+def _script_env(store: ConfigStore, name: str, content_dir: Path) -> dict[str, str]:
+    env = dict(os.environ)
+    env.setdefault("AGENTTEAMS_PROJECT_DIR", str(store.project_dir))
+    env.setdefault("AGENTTEAMS_PLUGIN_NAME", name)
+    env.setdefault("AGENTTEAMS_PLUGIN_DIR", str(content_dir))
+    env.setdefault("PILOT_DATA_DIR", str(store.root))
+    env.setdefault("PILOT_LOG_DIR", str(store.root / "logs" / name))
+    env.setdefault("PILOT_NODE_BIN", shutil.which("node") or "")
+    env.setdefault("PILOT_NPM_BIN", shutil.which("npm") or "")
+    return env
+
+
+def _run_lifecycle(store: ConfigStore, name: str, content_dir: Path, script_name: str) -> bool:
+    script = content_dir / "scripts" / script_name
+    if not script.exists():
+        return script_name == "uninstall.sh"
+    result = subprocess.run(
+        ["bash", str(script)],
+        cwd=store.project_dir,
+        env=_script_env(store, name, content_dir),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        print(f"ERROR: {script_name} failed for {name}: {detail}")
+        return False
+    return True
+
+
+def _prepare_package(package: Path) -> Tuple[Path, Optional[tempfile.TemporaryDirectory[str]]]:
+    if not package.exists():
+        raise ValueError(f"package not found: {package}")
+    if package.is_dir():
+        return _find_plugin_root(package), None
+
+    tmp = tempfile.TemporaryDirectory(prefix="agentteams-plugin-")
+    tmp_root = Path(tmp.name)
+    _safe_extract_tar(package, tmp_root)
+    return _find_plugin_root(tmp_root), tmp
+
+
+def install(
+    store: ConfigStore,
+    name: str,
+    package: Optional[Path] = None,
+    source: Optional[Path] = None,
+) -> bool:
+    if not package and not source:
+        print("ERROR: Use --package or --source.")
+        return False
+
+    tmp: Optional[tempfile.TemporaryDirectory[str]] = None
+    try:
+        plugin_root, tmp = _prepare_package(package) if package else (_find_plugin_root(source), None)  # type: ignore[arg-type]
+        manifest_name, version, dependencies = _load_metadata(plugin_root / "plugin.yaml")
+        if manifest_name != name:
+            print(f"ERROR: Plugin source metadata.name is '{manifest_name}', not requested plugin '{name}'.")
+            return False
+
+        plugin_dir = store.plugin_dir(name)
+        content_dir = store.plugin_content_dir(name)
+        old_content_dir = content_dir if content_dir.exists() else None
+        if old_content_dir:
+            if not _run_lifecycle(store, name, old_content_dir, "uninstall.sh"):
+                return False
+
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        _copytree(plugin_root, content_dir)
+
+        if not _run_lifecycle(store, name, content_dir, "install.sh"):
+            return False
+
+        content_dir_rel = content_dir.relative_to(store.project_dir)
+        manifest: Dict[str, Any] = {
+            "name": name,
+            "version": version,
+            "installed_at": _now(),
+            "content_dir": str(content_dir_rel),
+            "content_hash": _hash_path(content_dir),
+            "dependencies": dependencies,
+        }
+        if package:
+            manifest["package"] = str(package)
+        if source:
+            manifest["source"] = str(source)
+        store.save_plugin_manifest(name, manifest)
+        print(f"Installed {name} v{version}.")
+        return True
+    except Exception as exc:
+        print(f"ERROR: Failed to install {name}: {exc}")
+        return False
+    finally:
+        if tmp:
+            tmp.cleanup()
+
+
+def update(
+    store: ConfigStore,
+    name: str,
+    package: Optional[Path] = None,
+    source: Optional[Path] = None,
+) -> bool:
+    old = store.get_plugin_manifest(name)
+    if not old:
+        print(f"Plugin '{name}' is not installed. Use 'install' first.")
+        return False
+    if install(store, name, package=package, source=source):
+        new = store.get_plugin_manifest(name) or {}
+        print(f"Updated {name}: {old.get('version', '?')} -> {new.get('version', '?')}")
+        return True
+    return False
+
+
+def uninstall(store: ConfigStore, name: str) -> bool:
+    manifest = store.get_plugin_manifest(name)
+    if not manifest:
+        print(f"Plugin '{name}' is not installed.")
+        return False
+    content_dir = store.project_dir / manifest.get("content_dir", store.plugin_content_dir(name))
+    if not _run_lifecycle(store, name, content_dir, "uninstall.sh"):
+        return False
+    store.remove_plugin(name)
+    print(f"Uninstalled {name}.")
+    return True
+
+
+def list_plugins(store: ConfigStore) -> list[Dict[str, Any]]:
+    return store.list_plugins()

--- a/plugins/cli/src/agentteams_cli/plugin_manager.py
+++ b/plugins/cli/src/agentteams_cli/plugin_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 import shutil
 import subprocess
 import tarfile
@@ -14,9 +15,19 @@ from typing import Any, Dict, Optional, Tuple
 
 from agentteams_cli.config_store import ConfigStore
 
+PLUGIN_NAME_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9_-]{0,61}[a-z0-9])?$")
+
 
 def _now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _validate_plugin_name(name: str) -> None:
+    if not PLUGIN_NAME_PATTERN.fullmatch(name):
+        raise ValueError(
+            "invalid plugin name: use 1-63 lowercase letters, digits, '-' or '_', "
+            "starting and ending with a letter or digit"
+        )
 
 
 def _load_metadata(manifest_path: Path) -> Tuple[str, str, list[str]]:
@@ -52,6 +63,7 @@ def _load_metadata(manifest_path: Path) -> Tuple[str, str, list[str]]:
     version = metadata.get("version", "")
     if not name:
         raise ValueError("metadata.name is required")
+    _validate_plugin_name(name)
     if not version:
         raise ValueError("metadata.version is required")
     return name, version, dependencies
@@ -163,6 +175,7 @@ def install(
 
     tmp: Optional[tempfile.TemporaryDirectory[str]] = None
     try:
+        _validate_plugin_name(name)
         plugin_root, tmp = _prepare_package(package) if package else (_find_plugin_root(source), None)  # type: ignore[arg-type]
         manifest_name, version, dependencies = _load_metadata(plugin_root / "plugin.yaml")
         if manifest_name != name:
@@ -212,6 +225,12 @@ def update(
     package: Optional[Path] = None,
     source: Optional[Path] = None,
 ) -> bool:
+    try:
+        _validate_plugin_name(name)
+    except ValueError as exc:
+        print(f"ERROR: Failed to update {name}: {exc}")
+        return False
+
     old = store.get_plugin_manifest(name)
     if not old:
         print(f"Plugin '{name}' is not installed. Use 'install' first.")
@@ -224,6 +243,12 @@ def update(
 
 
 def uninstall(store: ConfigStore, name: str) -> bool:
+    try:
+        _validate_plugin_name(name)
+    except ValueError as exc:
+        print(f"ERROR: Failed to uninstall {name}: {exc}")
+        return False
+
     manifest = store.get_plugin_manifest(name)
     if not manifest:
         print(f"Plugin '{name}' is not installed.")

--- a/plugins/schemas/plugin.schema.json
+++ b/plugins/schemas/plugin.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "HiClaw AgentTeams Plugin",
+  "type": "object",
+  "required": ["apiVersion", "kind", "metadata", "prompts", "skills", "mcp", "adapters", "package"],
+  "properties": {
+    "apiVersion": { "const": "hiclaw.agentteam/v1alpha1" },
+    "kind": { "const": "AgentTeamPlugin" },
+    "metadata": {
+      "type": "object",
+      "required": ["name", "version"],
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" }
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/plugins/scripts/package-plugin.rb
+++ b/plugins/scripts/package-plugin.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "open3"
+require "pathname"
+require "rbconfig"
+require "tmpdir"
+require "yaml"
+
+unless ARGV[0]
+  warn "usage: plugins/scripts/package-plugin.rb <plugin.yaml>"
+  exit 1
+end
+
+manifest_path = Pathname.new(ARGV[0]).expand_path
+plugin_root = manifest_path.dirname
+repo_root = plugin_root.ascend.find { |path| (path / ".git").directory? } || plugin_root
+out_dir = Pathname.new(ENV["OUT_DIR"] || (repo_root / "dist/plugins").to_s).expand_path
+
+validate = Pathname.new(__dir__).expand_path / "validate-plugin.rb"
+system(RbConfig.ruby, validate.to_s, manifest_path.to_s) || abort("plugin validation failed")
+
+manifest = YAML.load_file(manifest_path)
+name = manifest.fetch("metadata").fetch("name")
+out_dir.mkpath
+out_path = out_dir / "#{name}.tar.gz"
+FileUtils.rm_f(out_path)
+
+includes = manifest.fetch("package").fetch("include")
+
+def copy_entry(plugin_root, staging_root, entry)
+  src = plugin_root / entry
+  abort("package include missing: #{src}") unless src.exist?
+
+  dst = staging_root / entry
+  if src.directory?
+    FileUtils.mkdir_p(dst)
+    entries = Dir.glob((src / "*").to_s, File::FNM_DOTMATCH).reject do |path|
+      [".", ".."].include?(File.basename(path))
+    end
+    FileUtils.cp_r(entries, dst)
+  else
+    FileUtils.mkdir_p(dst.dirname)
+    FileUtils.cp(src, dst)
+  end
+end
+
+def prune_generated(path)
+  Dir.glob((path / "**/*").to_s, File::FNM_DOTMATCH).each do |item|
+    base = File.basename(item)
+    FileUtils.rm_rf(item) if base == "__pycache__" || base == ".DS_Store" || base.end_with?(".pyc")
+  end
+end
+
+Dir.mktmpdir("agentteams-plugin-") do |tmp|
+  staging = Pathname.new(tmp) / name
+  staging.mkpath
+  includes.each { |entry| copy_entry(plugin_root, staging, entry) }
+  prune_generated(staging)
+
+  python = <<~PY
+    import os, tarfile
+    root = #{staging.to_s.dump}
+    out = #{out_path.to_s.dump}
+    with tarfile.open(out, "w:gz") as tf:
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in dirnames if d != "__pycache__" and d != ".DS_Store"]
+            for filename in sorted(filenames):
+                if filename == ".DS_Store" or filename.startswith("._") or filename.endswith(".pyc"):
+                    continue
+                path = os.path.join(dirpath, filename)
+                rel = os.path.relpath(path, root)
+                tf.add(path, arcname=rel)
+  PY
+  stdout, stderr, status = Open3.capture3("python3", "-c", python)
+  abort("python tar failed: #{stderr}#{stdout}") unless status.success?
+end
+
+puts out_path

--- a/plugins/scripts/validate-plugin.rb
+++ b/plugins/scripts/validate-plugin.rb
@@ -1,0 +1,104 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "pathname"
+require "yaml"
+
+unless ARGV[0]
+  warn "usage: plugins/scripts/validate-plugin.rb <plugin.yaml>"
+  exit 1
+end
+
+manifest_path = Pathname.new(ARGV[0]).expand_path
+plugin_root = manifest_path.dirname
+plugins_root = plugin_root.parent
+
+def fail!(message)
+  warn "ERROR: #{message}"
+  exit 1
+end
+
+def assert_file(path)
+  fail!("missing file: #{path}") unless path.file?
+end
+
+def assert_dir(path)
+  fail!("missing directory: #{path}") unless path.directory?
+end
+
+def read_yaml(path)
+  YAML.load_file(path)
+rescue Psych::SyntaxError => e
+  fail!("invalid yaml #{path}: #{e.message}")
+end
+
+assert_file(manifest_path)
+manifest = read_yaml(manifest_path)
+
+fail!("apiVersion must be hiclaw.agentteam/v1alpha1") unless manifest["apiVersion"] == "hiclaw.agentteam/v1alpha1"
+fail!("kind must be AgentTeamPlugin") unless manifest["kind"] == "AgentTeamPlugin"
+
+metadata = manifest.fetch("metadata") { fail!("metadata is required") }
+name = metadata["name"].to_s
+version = metadata["version"].to_s
+fail!("metadata.name is required") if name.empty?
+fail!("metadata.version must be semver") unless version.match?(/\A\d+\.\d+\.\d+\z/)
+
+schema_path = plugins_root / "schemas/plugin.schema.json"
+assert_file(schema_path)
+JSON.parse(schema_path.read)
+
+package = manifest.fetch("package") { fail!("package is required") }
+includes = package.fetch("include") { fail!("package.include is required") }
+fail!("package.include must be an array") unless includes.is_a?(Array)
+includes.each { |entry| fail!("package include missing: #{plugin_root / entry}") unless (plugin_root / entry).exist? }
+
+prompts = manifest.fetch("prompts") { fail!("prompts is required") }
+assert_file(plugin_root / prompts.fetch("team") { fail!("prompts.team is required") })
+agent_prompts = prompts.fetch("agent") { fail!("prompts.agent is required") }
+fail!("prompts.agent must be a map") unless agent_prompts.is_a?(Hash)
+agent_prompts.each_value { |path| assert_file(plugin_root / path) }
+manager_prompts = prompts.fetch("manager") { fail!("prompts.manager is required") }
+fail!("prompts.manager must be a map") unless manager_prompts.is_a?(Hash)
+manager_prompts.each_value { |path| assert_file(plugin_root / path) }
+
+skill_ids = []
+skills = manifest.fetch("skills") { fail!("skills is required") }
+fail!("skills must be a map") unless skills.is_a?(Hash)
+skills.each do |group, entries|
+  fail!("skills.#{group} must be an array") unless entries.is_a?(Array)
+  entries.each do |entry|
+    id = entry.fetch("id") { fail!("skill id is required in #{group}") }
+    path = plugin_root / entry.fetch("path") { fail!("skill path is required for #{id}") }
+    assert_dir(path)
+    assert_file(path / "SKILL.md")
+    skill_ids << id
+  end
+end
+duplicates = skill_ids.group_by { |id| id }.select { |_id, values| values.size > 1 }.keys
+fail!("duplicate skill ids: #{duplicates.join(', ')}") unless duplicates.empty?
+
+mcp = manifest.fetch("mcp") { fail!("mcp is required") }
+servers = mcp.fetch("servers") { fail!("mcp.servers is required") }
+fail!("mcp.servers must be an array") unless servers.is_a?(Array)
+servers.each do |server|
+  server_id = server.fetch("id") { fail!("mcp server id is required") }
+  server.fetch("args") { fail!("mcp server #{server_id} args are required") }.each do |arg|
+    assert_file(plugin_root / arg) if arg.end_with?(".py")
+  end
+end
+
+fail!("top-level hooks are not part of the plugin contract; put runtime hooks under adapters") if manifest.key?("hooks")
+
+Array(manifest["adapters"]).each do |adapter|
+  id = adapter.fetch("id") { fail!("adapter id is required") }
+  path = plugin_root / adapter.fetch("path") { fail!("adapter path is required for #{id}") }
+  assert_dir(path)
+  assert_file(path / "README.md")
+end
+
+assert_file(plugin_root / "scripts/install.sh")
+assert_file(plugin_root / "scripts/uninstall.sh")
+
+puts "ok: #{name} #{version}"

--- a/plugins/scripts/validate-plugin.rb
+++ b/plugins/scripts/validate-plugin.rb
@@ -27,6 +27,24 @@ def assert_dir(path)
   fail!("missing directory: #{path}") unless path.directory?
 end
 
+def assert_plugin_name(name)
+  return if name.match?(/\A[a-z0-9](?:[a-z0-9_-]{0,61}[a-z0-9])?\z/)
+
+  fail!("metadata.name must use 1-63 lowercase letters, digits, '-' or '_', starting and ending with a letter or digit")
+end
+
+def safe_relative_path(value, field)
+  path = value.to_s
+  fail!("#{field} must be a non-empty relative path") if path.empty?
+  fail!("#{field} must be a relative path") if Pathname.new(path).absolute?
+  fail!("#{field} must not contain '..' segments") if path.split(/[\/\\]+/).include?("..")
+  path
+end
+
+def plugin_path(plugin_root, value, field)
+  plugin_root / safe_relative_path(value, field)
+end
+
 def read_yaml(path)
   YAML.load_file(path)
 rescue Psych::SyntaxError => e
@@ -43,6 +61,7 @@ metadata = manifest.fetch("metadata") { fail!("metadata is required") }
 name = metadata["name"].to_s
 version = metadata["version"].to_s
 fail!("metadata.name is required") if name.empty?
+assert_plugin_name(name)
 fail!("metadata.version must be semver") unless version.match?(/\A\d+\.\d+\.\d+\z/)
 
 schema_path = plugins_root / "schemas/plugin.schema.json"
@@ -52,16 +71,19 @@ JSON.parse(schema_path.read)
 package = manifest.fetch("package") { fail!("package is required") }
 includes = package.fetch("include") { fail!("package.include is required") }
 fail!("package.include must be an array") unless includes.is_a?(Array)
-includes.each { |entry| fail!("package include missing: #{plugin_root / entry}") unless (plugin_root / entry).exist? }
+includes.each do |entry|
+  path = plugin_path(plugin_root, entry, "package.include")
+  fail!("package include missing: #{path}") unless path.exist?
+end
 
 prompts = manifest.fetch("prompts") { fail!("prompts is required") }
-assert_file(plugin_root / prompts.fetch("team") { fail!("prompts.team is required") })
+assert_file(plugin_path(plugin_root, prompts.fetch("team") { fail!("prompts.team is required") }, "prompts.team"))
 agent_prompts = prompts.fetch("agent") { fail!("prompts.agent is required") }
 fail!("prompts.agent must be a map") unless agent_prompts.is_a?(Hash)
-agent_prompts.each_value { |path| assert_file(plugin_root / path) }
+agent_prompts.each_value { |path| assert_file(plugin_path(plugin_root, path, "prompts.agent")) }
 manager_prompts = prompts.fetch("manager") { fail!("prompts.manager is required") }
 fail!("prompts.manager must be a map") unless manager_prompts.is_a?(Hash)
-manager_prompts.each_value { |path| assert_file(plugin_root / path) }
+manager_prompts.each_value { |path| assert_file(plugin_path(plugin_root, path, "prompts.manager")) }
 
 skill_ids = []
 skills = manifest.fetch("skills") { fail!("skills is required") }
@@ -70,7 +92,7 @@ skills.each do |group, entries|
   fail!("skills.#{group} must be an array") unless entries.is_a?(Array)
   entries.each do |entry|
     id = entry.fetch("id") { fail!("skill id is required in #{group}") }
-    path = plugin_root / entry.fetch("path") { fail!("skill path is required for #{id}") }
+    path = plugin_path(plugin_root, entry.fetch("path") { fail!("skill path is required for #{id}") }, "skills.#{group}.path")
     assert_dir(path)
     assert_file(path / "SKILL.md")
     skill_ids << id
@@ -85,7 +107,8 @@ fail!("mcp.servers must be an array") unless servers.is_a?(Array)
 servers.each do |server|
   server_id = server.fetch("id") { fail!("mcp server id is required") }
   server.fetch("args") { fail!("mcp server #{server_id} args are required") }.each do |arg|
-    assert_file(plugin_root / arg) if arg.end_with?(".py")
+    safe_arg = safe_relative_path(arg, "mcp.servers.#{server_id}.args")
+    assert_file(plugin_root / safe_arg) if safe_arg.end_with?(".py")
   end
 end
 
@@ -93,7 +116,7 @@ fail!("top-level hooks are not part of the plugin contract; put runtime hooks un
 
 Array(manifest["adapters"]).each do |adapter|
   id = adapter.fetch("id") { fail!("adapter id is required") }
-  path = plugin_root / adapter.fetch("path") { fail!("adapter path is required for #{id}") }
+  path = plugin_path(plugin_root, adapter.fetch("path") { fail!("adapter path is required for #{id}") }, "adapters.#{id}.path")
   assert_dir(path)
   assert_file(path / "README.md")
 end

--- a/plugins/tests/cli/test_agentteams_plugin_cli.py
+++ b/plugins/tests/cli/test_agentteams_plugin_cli.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Integration tests for the AgentTeams plugin package and CLI fallback."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CLI_SRC = REPO_ROOT / "plugins" / "cli" / "src"
+PLUGIN_NAME = "demo-plugin"
+
+
+class AgentTeamsPluginCliTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory(prefix="agentteams-cli-")
+        self.project = Path(self.tmp.name)
+        self.out_dir = self.project / "dist"
+        self.out_dir.mkdir()
+        self.plugin_root = self.create_plugin_fixture()
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def create_plugin_fixture(self) -> Path:
+        plugins_root = self.project / "plugins"
+        plugin_root = plugins_root / PLUGIN_NAME
+        schema_dir = plugins_root / "schemas"
+        schema_dir.mkdir(parents=True)
+        shutil.copy(REPO_ROOT / "plugins" / "schemas" / "plugin.schema.json", schema_dir / "plugin.schema.json")
+
+        files = {
+            "plugin.yaml": f"""
+                apiVersion: hiclaw.agentteam/v1alpha1
+                kind: AgentTeamPlugin
+                metadata:
+                  name: {PLUGIN_NAME}
+                  version: 0.1.0
+                dependencies:
+                  - python>=3.9
+                package:
+                  include:
+                    - plugin.yaml
+                    - prompts
+                    - skills
+                    - mcp
+                    - adapters
+                    - scripts
+                prompts:
+                  team: prompts/team.md
+                  agent:
+                    worker: prompts/worker.md
+                  manager:
+                    default: prompts/manager.md
+                skills:
+                  team:
+                    - id: demo-communication
+                      path: skills/team/communication
+                mcp:
+                  servers:
+                    - id: demo
+                      command: python3
+                      args:
+                        - mcp/server.py
+                adapters:
+                  - id: demo
+                    path: adapters/demo
+            """,
+            "prompts/team.md": "team prompt\n",
+            "prompts/worker.md": "worker prompt\n",
+            "prompts/manager.md": "manager prompt\n",
+            "skills/team/communication/SKILL.md": "---\nname: demo-communication\n---\n",
+            "mcp/server.py": "print('demo')\n",
+            "adapters/demo/README.md": "# Demo adapter\n",
+            "scripts/install.sh": """
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [ -n "${AGENTTEAMS_TEST_INSTALL_LOG:-}" ]; then
+                  printf '{"event":"install","name":"%s","dir":"%s"}\\n' "${AGENTTEAMS_PLUGIN_NAME:-}" "${AGENTTEAMS_PLUGIN_DIR:-}" >> "$AGENTTEAMS_TEST_INSTALL_LOG"
+                fi
+            """,
+            "scripts/uninstall.sh": """
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [ -n "${AGENTTEAMS_TEST_INSTALL_LOG:-}" ]; then
+                  printf '{"event":"uninstall","name":"%s","dir":"%s"}\\n' "${AGENTTEAMS_PLUGIN_NAME:-}" "${AGENTTEAMS_PLUGIN_DIR:-}" >> "$AGENTTEAMS_TEST_INSTALL_LOG"
+                fi
+            """,
+        }
+        for relative, content in files.items():
+            path = plugin_root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
+        return plugin_root
+
+    def run_agentteams(
+        self,
+        *args: str,
+        env_extra: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        env = {
+            **os.environ,
+            "PYTHONPATH": str(CLI_SRC),
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "AGENTTEAMS_TEST_INSTALL_LOG": str(self.project / "agentteams-install.jsonl"),
+        }
+        if env_extra:
+            env.update(env_extra)
+        return subprocess.run(
+            [sys.executable, "-m", "agentteams_cli.main", *args],
+            cwd=self.project,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+    def package_demo_plugin(self) -> Path:
+        result = subprocess.run(
+            ["ruby", str(REPO_ROOT / "plugins" / "scripts" / "package-plugin.rb"), str(self.plugin_root / "plugin.yaml")],
+            cwd=REPO_ROOT,
+            env={**os.environ, "OUT_DIR": str(self.out_dir)},
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        package = Path(result.stdout.strip().splitlines()[-1])
+        self.assertTrue(package.is_file(), package)
+        return package
+
+    def test_plugin_tarball_contract(self) -> None:
+        package = self.package_demo_plugin()
+
+        self.assertEqual(package.name, f"{PLUGIN_NAME}.tar.gz")
+        with tarfile.open(package, "r:gz") as archive:
+            names = set(archive.getnames())
+
+        required = {
+            "plugin.yaml",
+            "prompts/team.md",
+            "skills/team/communication/SKILL.md",
+            "mcp/server.py",
+            "adapters/demo/README.md",
+            "scripts/install.sh",
+            "scripts/uninstall.sh",
+        }
+        self.assertTrue(required.issubset(names), sorted(required - names))
+
+    def test_cli_installs_updates_and_uninstalls_same_tarball(self) -> None:
+        package = self.package_demo_plugin()
+
+        listed_empty = self.run_agentteams("plugin", "list")
+        self.assertEqual(listed_empty.returncode, 0, listed_empty.stderr + listed_empty.stdout)
+        self.assertIn("No plugins installed.", listed_empty.stdout)
+
+        installed = self.run_agentteams("plugin", "install", PLUGIN_NAME, "--package", str(package))
+        self.assertEqual(installed.returncode, 0, installed.stderr + installed.stdout)
+
+        manifest_path = self.project / ".agentteams" / "plugins" / PLUGIN_NAME / "manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        self.assertEqual(manifest["name"], PLUGIN_NAME)
+        self.assertEqual(manifest["version"], "0.1.0")
+        self.assertEqual(manifest["package"], str(package))
+        self.assertTrue((self.project / manifest["content_dir"] / "scripts" / "install.sh").is_file())
+
+        listed = self.run_agentteams("plugin", "list")
+        self.assertEqual(listed.returncode, 0, listed.stderr + listed.stdout)
+        self.assertIn(PLUGIN_NAME, listed.stdout)
+
+        updated = self.run_agentteams("plugin", "update", PLUGIN_NAME, "--package", str(package))
+        self.assertEqual(updated.returncode, 0, updated.stderr + updated.stdout)
+        self.assertIn(f"Updated {PLUGIN_NAME}", updated.stdout)
+
+        uninstalled = self.run_agentteams("plugin", "uninstall", PLUGIN_NAME)
+        self.assertEqual(uninstalled.returncode, 0, uninstalled.stderr + uninstalled.stdout)
+        self.assertFalse(manifest_path.exists())
+        self.assertFalse((self.project / ".agentteams" / "plugins" / PLUGIN_NAME).exists())
+
+        log_lines = (self.project / "agentteams-install.jsonl").read_text(encoding="utf-8").splitlines()
+        events = [json.loads(line)["event"] for line in log_lines]
+        self.assertGreaterEqual(events.count("install"), 2)
+        self.assertGreaterEqual(events.count("uninstall"), 2)
+
+    def test_cli_reports_invalid_package_without_traceback(self) -> None:
+        broken = self.project / "broken.tar.gz"
+        broken.write_text("not a tarball", encoding="utf-8")
+
+        result = self.run_agentteams("plugin", "install", PLUGIN_NAME, "--package", str(broken))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("ERROR:", result.stdout + result.stderr)
+        self.assertNotIn("Traceback", result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/plugins/tests/cli/test_agentteams_plugin_cli.py
+++ b/plugins/tests/cli/test_agentteams_plugin_cli.py
@@ -140,6 +140,76 @@ class AgentTeamsPluginCliTest(unittest.TestCase):
         self.assertTrue(package.is_file(), package)
         return package
 
+    def run_validate_plugin(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["ruby", str(REPO_ROOT / "plugins" / "scripts" / "validate-plugin.rb"), str(self.plugin_root / "plugin.yaml")],
+            cwd=REPO_ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+    def test_validate_plugin_rejects_unsafe_names_and_paths(self) -> None:
+        manifest_path = self.plugin_root / "plugin.yaml"
+        original = manifest_path.read_text(encoding="utf-8")
+        cases = [
+            (
+                f"name: {PLUGIN_NAME}",
+                "name: ../escaped-plugin",
+                "metadata.name must use",
+            ),
+            (
+                "- prompts",
+                "- ../prompts",
+                "package.include must not contain '..' segments",
+            ),
+            (
+                "team: prompts/team.md",
+                "team: /tmp/team.md",
+                "prompts.team must be a relative path",
+            ),
+            (
+                "path: skills/team/communication",
+                "path: ../skills/team/communication",
+                "skills.team.path must not contain '..' segments",
+            ),
+            (
+                "- mcp/server.py",
+                "- ../mcp/server.py",
+                "mcp.servers.demo.args must not contain '..' segments",
+            ),
+            (
+                "path: adapters/demo",
+                "path: /tmp/adapters/demo",
+                "adapters.demo.path must be a relative path",
+            ),
+        ]
+
+        for old, new, expected in cases:
+            with self.subTest(expected=expected):
+                self.assertIn(old, original)
+                manifest_path.write_text(original.replace(old, new, 1), encoding="utf-8")
+                result = self.run_validate_plugin()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(expected, result.stderr + result.stdout)
+
+        manifest_path.write_text(original, encoding="utf-8")
+
+    def test_cli_rejects_unsafe_plugin_name_before_installing(self) -> None:
+        manifest_path = self.plugin_root / "plugin.yaml"
+        manifest_path.write_text(
+            manifest_path.read_text(encoding="utf-8").replace(f"name: {PLUGIN_NAME}", "name: ../escaped-plugin", 1),
+            encoding="utf-8",
+        )
+
+        result = self.run_agentteams("plugin", "install", "../escaped-plugin", "--source", str(self.plugin_root))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid plugin name", result.stdout + result.stderr)
+        self.assertFalse((self.project / ".agentteams" / "escaped-plugin").exists())
+        self.assertFalse((self.project / ".agentteams" / "plugins" / PLUGIN_NAME).exists())
+
     def test_plugin_tarball_contract(self) -> None:
         package = self.package_demo_plugin()
 


### PR DESCRIPTION
## Summary
- add a generic AgentTeams plugin package contract under `plugins/`
- add the `agentteams plugin` fallback CLI for install/list/update/uninstall flows
- add plugin validation/package scripts and CLI integration tests using a synthetic demo plugin fixture

## Boundaries
- this PR only introduces the generic plugin package/CLI layer
- it does not include TeamHarness, QwenPaw, Claude, or LoongSuite-specific plugin content; those will be split into follow-up PRs

## Tests
- `python3 -m compileall -q plugins/cli/src`
- `python3 plugins/tests/cli/test_agentteams_plugin_cli.py`
- `git diff --check`