### PR TITLE
feat(manager): support STS auth in skill discovery

### DIFF
--- a/manager/agent/copaw-worker-agent/skills/find-skills/scripts/hiclaw-find-skill.sh
+++ b/manager/agent/copaw-worker-agent/skills/find-skills/scripts/hiclaw-find-skill.sh
@@ -69,6 +69,57 @@ get_skills_api_url() {
     printf '%s\n' "https://skills.sh"
 }
 
+resolve_controller_bearer() {
+    if [ -n "${HICLAW_AUTH_TOKEN:-}" ]; then
+        printf '%s' "${HICLAW_AUTH_TOKEN}"
+        return
+    fi
+    if [ -n "${HICLAW_AUTH_TOKEN_FILE:-}" ] && [ -f "${HICLAW_AUTH_TOKEN_FILE}" ]; then
+        cat "${HICLAW_AUTH_TOKEN_FILE}"
+        return
+    fi
+    if [ -n "${HICLAW_WORKER_API_KEY:-}" ]; then
+        printf '%s' "${HICLAW_WORKER_API_KEY}"
+    fi
+}
+
+ensure_nacos_sts_credentials() {
+    [ -n "${HICLAW_NACOS_STS_ACCESS_KEY:-}" ] && return 0
+
+    controller_url="${HICLAW_CONTROLLER_URL:-}"
+    bearer="$(resolve_controller_bearer)"
+    if [ -z "${controller_url}" ] || [ -z "${bearer}" ]; then
+        echo "error: NACOS_AUTH_TYPE=sts-hiclaw requires HICLAW_CONTROLLER_URL and a controller bearer token" >&2
+        exit 1
+    fi
+
+    if [ -n "${HICLAW_CLUSTER_ID:-}" ]; then
+        resp="$(curl -s -w "\n%{http_code}" -X POST "${controller_url%/}/api/v1/credentials/sts" \
+            -H "Authorization: Bearer ${bearer}" \
+            -H "X-HiClaw-Cluster-ID: ${HICLAW_CLUSTER_ID}" \
+            --connect-timeout 10 --max-time 30 2>&1)"
+    else
+        resp="$(curl -s -w "\n%{http_code}" -X POST "${controller_url%/}/api/v1/credentials/sts" \
+            -H "Authorization: Bearer ${bearer}" \
+            --connect-timeout 10 --max-time 30 2>&1)"
+    fi
+    http_code="$(printf '%s\n' "${resp}" | tail -1)"
+    body="$(printf '%s\n' "${resp}" | sed '$d')"
+    if [ "${http_code}" != "200" ]; then
+        echo "error: controller STS request for AI registry failed (HTTP ${http_code})" >&2
+        printf '%s\n' "${body}" >&2
+        exit 1
+    fi
+
+    HICLAW_NACOS_STS_ACCESS_KEY="$(printf '%s\n' "${body}" | jq -r '.access_key_id')"
+    HICLAW_NACOS_STS_SECRET_KEY="$(printf '%s\n' "${body}" | jq -r '.access_key_secret')"
+    HICLAW_NACOS_STS_SECURITY_TOKEN="$(printf '%s\n' "${body}" | jq -r '.security_token')"
+    if [ -z "${HICLAW_NACOS_STS_ACCESS_KEY}" ] || [ "${HICLAW_NACOS_STS_ACCESS_KEY}" = "null" ]; then
+        echo "error: failed to parse AI registry STS credentials from controller response" >&2
+        exit 1
+    fi
+}
+
 get_registry_label() {
     backend="$1"
     api_url="$(get_skills_api_url)"
@@ -204,9 +255,17 @@ run_nacos_cli() {
     [ -n "${host}" ] && set -- "$@" --host "${host}"
     [ -n "${port}" ] && set -- "$@" --port "${port}"
     [ -n "${namespace}" ] && set -- "$@" --namespace "${namespace}"
-    [ -n "${username}" ] && set -- "$@" --username "${username}"
-    [ -n "${password}" ] && set -- "$@" --password "${password}"
-    [ -n "${token}" ] && set -- "$@" --token "${token}"
+    if [ "${NACOS_AUTH_TYPE:-}" = "sts-hiclaw" ]; then
+        ensure_nacos_sts_credentials
+        set -- "$@" --auth-type sts-hiclaw \
+            --access-key "${HICLAW_NACOS_STS_ACCESS_KEY}" \
+            --secret-key "${HICLAW_NACOS_STS_SECRET_KEY}" \
+            --security-token "${HICLAW_NACOS_STS_SECURITY_TOKEN}"
+    else
+        [ -n "${username}" ] && set -- "$@" --username "${username}"
+        [ -n "${password}" ] && set -- "$@" --password "${password}"
+        [ -n "${token}" ] && set -- "$@" --token "${token}"
+    fi
     "$@"
 }
 

--- a/manager/agent/hermes-worker-agent/skills/find-skills/scripts/hiclaw-find-skill.sh
+++ b/manager/agent/hermes-worker-agent/skills/find-skills/scripts/hiclaw-find-skill.sh
@@ -69,6 +69,57 @@ get_skills_api_url() {
     printf '%s\n' "https://skills.sh"
 }
 
+resolve_controller_bearer() {
+    if [ -n "${HICLAW_AUTH_TOKEN:-}" ]; then
+        printf '%s' "${HICLAW_AUTH_TOKEN}"
+        return
+    fi
+    if [ -n "${HICLAW_AUTH_TOKEN_FILE:-}" ] && [ -f "${HICLAW_AUTH_TOKEN_FILE}" ]; then
+        cat "${HICLAW_AUTH_TOKEN_FILE}"
+        return
+    fi
+    if [ -n "${HICLAW_WORKER_API_KEY:-}" ]; then
+        printf '%s' "${HICLAW_WORKER_API_KEY}"
+    fi
+}
+
+ensure_nacos_sts_credentials() {
+    [ -n "${HICLAW_NACOS_STS_ACCESS_KEY:-}" ] && return 0
+
+    controller_url="${HICLAW_CONTROLLER_URL:-}"
+    bearer="$(resolve_controller_bearer)"
+    if [ -z "${controller_url}" ] || [ -z "${bearer}" ]; then
+        echo "error: NACOS_AUTH_TYPE=sts-hiclaw requires HICLAW_CONTROLLER_URL and a controller bearer token" >&2
+        exit 1
+    fi
+
+    if [ -n "${HICLAW_CLUSTER_ID:-}" ]; then
+        resp="$(curl -s -w "\n%{http_code}" -X POST "${controller_url%/}/api/v1/credentials/sts" \
+            -H "Authorization: Bearer ${bearer}" \
+            -H "X-HiClaw-Cluster-ID: ${HICLAW_CLUSTER_ID}" \
+            --connect-timeout 10 --max-time 30 2>&1)"
+    else
+        resp="$(curl -s -w "\n%{http_code}" -X POST "${controller_url%/}/api/v1/credentials/sts" \
+            -H "Authorization: Bearer ${bearer}" \
+            --connect-timeout 10 --max-time 30 2>&1)"
+    fi
+    http_code="$(printf '%s\n' "${resp}" | tail -1)"
+    body="$(printf '%s\n' "${resp}" | sed '$d')"
+    if [ "${http_code}" != "200" ]; then
+        echo "error: controller STS request for AI registry failed (HTTP ${http_code})" >&2
+        printf '%s\n' "${body}" >&2
+        exit 1
+    fi
+
+    HICLAW_NACOS_STS_ACCESS_KEY="$(printf '%s\n' "${body}" | jq -r '.access_key_id')"
+    HICLAW_NACOS_STS_SECRET_KEY="$(printf '%s\n' "${body}" | jq -r '.access_key_secret')"
+    HICLAW_NACOS_STS_SECURITY_TOKEN="$(printf '%s\n' "${body}" | jq -r '.security_token')"
+    if [ -z "${HICLAW_NACOS_STS_ACCESS_KEY}" ] || [ "${HICLAW_NACOS_STS_ACCESS_KEY}" = "null" ]; then
+        echo "error: failed to parse AI registry STS credentials from controller response" >&2
+        exit 1
+    fi
+}
+
 get_registry_label() {
     backend="$1"
     api_url="$(get_skills_api_url)"
@@ -204,9 +255,17 @@ run_nacos_cli() {
     [ -n "${host}" ] && set -- "$@" --host "${host}"
     [ -n "${port}" ] && set -- "$@" --port "${port}"
     [ -n "${namespace}" ] && set -- "$@" --namespace "${namespace}"
-    [ -n "${username}" ] && set -- "$@" --username "${username}"
-    [ -n "${password}" ] && set -- "$@" --password "${password}"
-    [ -n "${token}" ] && set -- "$@" --token "${token}"
+    if [ "${NACOS_AUTH_TYPE:-}" = "sts-hiclaw" ]; then
+        ensure_nacos_sts_credentials
+        set -- "$@" --auth-type sts-hiclaw \
+            --access-key "${HICLAW_NACOS_STS_ACCESS_KEY}" \
+            --secret-key "${HICLAW_NACOS_STS_SECRET_KEY}" \
+            --security-token "${HICLAW_NACOS_STS_SECURITY_TOKEN}"
+    else
+        [ -n "${username}" ] && set -- "$@" --username "${username}"
+        [ -n "${password}" ] && set -- "$@" --password "${password}"
+        [ -n "${token}" ] && set -- "$@" --token "${token}"
+    fi
     "$@"
 }
 

--- a/manager/agent/worker-agent/skills/find-skills/scripts/hiclaw-find-skill.sh
+++ b/manager/agent/worker-agent/skills/find-skills/scripts/hiclaw-find-skill.sh
@@ -69,6 +69,57 @@ get_skills_api_url() {
     printf '%s\n' "https://skills.sh"
 }
 
+resolve_controller_bearer() {
+    if [ -n "${HICLAW_AUTH_TOKEN:-}" ]; then
+        printf '%s' "${HICLAW_AUTH_TOKEN}"
+        return
+    fi
+    if [ -n "${HICLAW_AUTH_TOKEN_FILE:-}" ] && [ -f "${HICLAW_AUTH_TOKEN_FILE}" ]; then
+        cat "${HICLAW_AUTH_TOKEN_FILE}"
+        return
+    fi
+    if [ -n "${HICLAW_WORKER_API_KEY:-}" ]; then
+        printf '%s' "${HICLAW_WORKER_API_KEY}"
+    fi
+}
+
+ensure_nacos_sts_credentials() {
+    [ -n "${HICLAW_NACOS_STS_ACCESS_KEY:-}" ] && return 0
+
+    controller_url="${HICLAW_CONTROLLER_URL:-}"
+    bearer="$(resolve_controller_bearer)"
+    if [ -z "${controller_url}" ] || [ -z "${bearer}" ]; then
+        echo "error: NACOS_AUTH_TYPE=sts-hiclaw requires HICLAW_CONTROLLER_URL and a controller bearer token" >&2
+        exit 1
+    fi
+
+    if [ -n "${HICLAW_CLUSTER_ID:-}" ]; then
+        resp="$(curl -s -w "\n%{http_code}" -X POST "${controller_url%/}/api/v1/credentials/sts" \
+            -H "Authorization: Bearer ${bearer}" \
+            -H "X-HiClaw-Cluster-ID: ${HICLAW_CLUSTER_ID}" \
+            --connect-timeout 10 --max-time 30 2>&1)"
+    else
+        resp="$(curl -s -w "\n%{http_code}" -X POST "${controller_url%/}/api/v1/credentials/sts" \
+            -H "Authorization: Bearer ${bearer}" \
+            --connect-timeout 10 --max-time 30 2>&1)"
+    fi
+    http_code="$(printf '%s\n' "${resp}" | tail -1)"
+    body="$(printf '%s\n' "${resp}" | sed '$d')"
+    if [ "${http_code}" != "200" ]; then
+        echo "error: controller STS request for AI registry failed (HTTP ${http_code})" >&2
+        printf '%s\n' "${body}" >&2
+        exit 1
+    fi
+
+    HICLAW_NACOS_STS_ACCESS_KEY="$(printf '%s\n' "${body}" | jq -r '.access_key_id')"
+    HICLAW_NACOS_STS_SECRET_KEY="$(printf '%s\n' "${body}" | jq -r '.access_key_secret')"
+    HICLAW_NACOS_STS_SECURITY_TOKEN="$(printf '%s\n' "${body}" | jq -r '.security_token')"
+    if [ -z "${HICLAW_NACOS_STS_ACCESS_KEY}" ] || [ "${HICLAW_NACOS_STS_ACCESS_KEY}" = "null" ]; then
+        echo "error: failed to parse AI registry STS credentials from controller response" >&2
+        exit 1
+    fi
+}
+
 get_registry_label() {
     backend="$1"
     api_url="$(get_skills_api_url)"
@@ -204,9 +255,17 @@ run_nacos_cli() {
     [ -n "${host}" ] && set -- "$@" --host "${host}"
     [ -n "${port}" ] && set -- "$@" --port "${port}"
     [ -n "${namespace}" ] && set -- "$@" --namespace "${namespace}"
-    [ -n "${username}" ] && set -- "$@" --username "${username}"
-    [ -n "${password}" ] && set -- "$@" --password "${password}"
-    [ -n "${token}" ] && set -- "$@" --token "${token}"
+    if [ "${NACOS_AUTH_TYPE:-}" = "sts-hiclaw" ]; then
+        ensure_nacos_sts_credentials
+        set -- "$@" --auth-type sts-hiclaw \
+            --access-key "${HICLAW_NACOS_STS_ACCESS_KEY}" \
+            --secret-key "${HICLAW_NACOS_STS_SECRET_KEY}" \
+            --security-token "${HICLAW_NACOS_STS_SECURITY_TOKEN}"
+    else
+        [ -n "${username}" ] && set -- "$@" --username "${username}"
+        [ -n "${password}" ] && set -- "$@" --password "${password}"
+        [ -n "${token}" ] && set -- "$@" --token "${token}"
+    fi
     "$@"
 }
 

--- a/manager/tests/test-hiclaw-find-skill.sh
+++ b/manager/tests/test-hiclaw-find-skill.sh
@@ -16,6 +16,7 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 WORKER_SCRIPT="${PROJECT_ROOT}/manager/agent/worker-agent/skills/find-skills/scripts/hiclaw-find-skill.sh"
 COPAW_SCRIPT="${PROJECT_ROOT}/manager/agent/copaw-worker-agent/skills/find-skills/scripts/hiclaw-find-skill.sh"
+HERMES_SCRIPT="${PROJECT_ROOT}/manager/agent/hermes-worker-agent/skills/find-skills/scripts/hiclaw-find-skill.sh"
 
 pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL: $1"; echo "       expected: $2"; echo "       got:      $3"; FAIL=$((FAIL + 1)); }
@@ -184,15 +185,33 @@ EOF
     chmod +x "${mockbin}/skills"
 }
 
+create_mock_curl() {
+    local mockbin="$1"
+    cat > "${mockbin}/curl" <<'EOF'
+#!/bin/sh
+set -eu
+
+log_file="${TEST_CURL_LOG:?}"
+printf '%s\n' "$*" >> "${log_file}"
+cat <<'OUT'
+{"access_key_id":"test-ak","access_key_secret":"test-sk","security_token":"test-sts"}
+200
+OUT
+EOF
+    chmod +x "${mockbin}/curl"
+}
+
 run_case() {
     local script_path="$1" query="$2" log_file="$3"
     local mockbin="${TMPDIR_ROOT}/mockbin"
     create_mock_npx "${mockbin}"
     create_mock_skills "${mockbin}"
+    create_mock_curl "${mockbin}"
 
     PATH="${mockbin}:${PATH}" \
     TEST_NPX_LOG="${log_file}" \
     TEST_SKILLS_LOG="${TMPDIR_ROOT}/skills.log" \
+    TEST_CURL_LOG="${TMPDIR_ROOT}/curl.log" \
     SKILLS_API_URL="nacos://registry.local:8848" \
     HICLAW_FIND_SKILL_MAX_RESULTS=3 \
     HICLAW_FIND_SKILL_NACOS_PAGE_SIZE=50 \
@@ -204,10 +223,12 @@ run_case_with_env() {
     local mockbin="${TMPDIR_ROOT}/mockbin"
     create_mock_npx "${mockbin}"
     create_mock_skills "${mockbin}"
+    create_mock_curl "${mockbin}"
 
     PATH="${mockbin}:${PATH}" \
     TEST_NPX_LOG="${log_file}" \
     TEST_SKILLS_LOG="${skills_log_file}" \
+    TEST_CURL_LOG="${TMPDIR_ROOT}/curl.log" \
     SKILLS_API_URL="${skills_api_url}" \
     HICLAW_FIND_SKILL_MAX_RESULTS=3 \
     HICLAW_FIND_SKILL_NACOS_PAGE_SIZE=50 \
@@ -216,7 +237,7 @@ run_case_with_env() {
 
 echo ""
 echo "=== TC1: react performance should still return React skills ==="
-for script_path in "${WORKER_SCRIPT}" "${COPAW_SCRIPT}"; do
+for script_path in "${WORKER_SCRIPT}" "${COPAW_SCRIPT}" "${HERMES_SCRIPT}"; do
     {
         case_name="$(basename "$(dirname "$(dirname "${script_path}")")")"
         log_file="${TMPDIR_ROOT}/${case_name}-react.log"
@@ -236,7 +257,7 @@ done
 
 echo ""
 echo "=== TC2: pr review should rank code-review skills ahead of postgres matches ==="
-for script_path in "${WORKER_SCRIPT}" "${COPAW_SCRIPT}"; do
+for script_path in "${WORKER_SCRIPT}" "${COPAW_SCRIPT}" "${HERMES_SCRIPT}"; do
     {
         case_name="$(basename "$(dirname "$(dirname "${script_path}")")")"
         log_file="${TMPDIR_ROOT}/${case_name}-pr-review.log"
@@ -252,7 +273,7 @@ done
 
 echo ""
 echo "=== TC3: nacos backend should derive host/port from SKILLS_API_URL scheme ==="
-for script_path in "${WORKER_SCRIPT}" "${COPAW_SCRIPT}"; do
+for script_path in "${WORKER_SCRIPT}" "${COPAW_SCRIPT}" "${HERMES_SCRIPT}"; do
     {
         case_name="$(basename "$(dirname "$(dirname "${script_path}")")")"
         log_file="${TMPDIR_ROOT}/${case_name}-nacos-conn.log"
@@ -267,7 +288,7 @@ done
 
 echo ""
 echo "=== TC4: nacos backend should derive namespace from SKILLS_API_URL path ==="
-for script_path in "${WORKER_SCRIPT}" "${COPAW_SCRIPT}"; do
+for script_path in "${WORKER_SCRIPT}" "${COPAW_SCRIPT}" "${HERMES_SCRIPT}"; do
     {
         case_name="$(basename "$(dirname "$(dirname "${script_path}")")")"
         log_file="${TMPDIR_ROOT}/${case_name}-nacos-namespace.log"
@@ -280,7 +301,7 @@ done
 
 echo ""
 echo "=== TC5: https skills api should use skills CLI backend ==="
-for script_path in "${WORKER_SCRIPT}" "${COPAW_SCRIPT}"; do
+for script_path in "${WORKER_SCRIPT}" "${COPAW_SCRIPT}" "${HERMES_SCRIPT}"; do
     {
         case_name="$(basename "$(dirname "$(dirname "${script_path}")")")"
         log_file="${TMPDIR_ROOT}/${case_name}-skills-sh.log"
@@ -290,6 +311,41 @@ for script_path in "${WORKER_SCRIPT}" "${COPAW_SCRIPT}"; do
         assert_contains "${case_name}: should use skills CLI output" "react-performance-toolkit" "${output}"
         assert_contains "${case_name}: should call skills find" "find react performance" "$(cat "${skills_log}")"
         assert_eq "${case_name}: nacos cli should not be used for https registry" "" "$(cat "${log_file}" 2>/dev/null || true)"
+    }
+done
+
+echo ""
+echo "=== TC6: sts-hiclaw nacos backend should request controller STS with cluster header ==="
+for script_path in "${WORKER_SCRIPT}" "${COPAW_SCRIPT}" "${HERMES_SCRIPT}"; do
+    {
+        case_name="$(basename "$(dirname "$(dirname "${script_path}")")")"
+        mockbin="${TMPDIR_ROOT}/${case_name}-sts-mockbin"
+        log_file="${TMPDIR_ROOT}/${case_name}-sts-npx.log"
+        curl_log="${TMPDIR_ROOT}/${case_name}-sts-curl.log"
+        skills_log="${TMPDIR_ROOT}/${case_name}-sts-skills.log"
+        create_mock_npx "${mockbin}"
+        create_mock_skills "${mockbin}"
+        create_mock_curl "${mockbin}"
+
+        output="$(PATH="${mockbin}:${PATH}" \
+            TEST_NPX_LOG="${log_file}" \
+            TEST_SKILLS_LOG="${skills_log}" \
+            TEST_CURL_LOG="${curl_log}" \
+            SKILLS_API_URL="nacos://registry.local:8848/team-a" \
+            NACOS_AUTH_TYPE="sts-hiclaw" \
+            HICLAW_CONTROLLER_URL="http://controller:8090" \
+            HICLAW_AUTH_TOKEN="controller-token" \
+            HICLAW_CLUSTER_ID="remote-cluster-a" \
+            HICLAW_FIND_SKILL_MAX_RESULTS=3 \
+            HICLAW_FIND_SKILL_NACOS_PAGE_SIZE=50 \
+            /bin/sh "${script_path}" find review | strip_ansi)"
+
+        assert_contains "${case_name}: should still return sts-backed results" "requesting-code-review" "${output}"
+        assert_contains "${case_name}: controller STS call should include cluster header" "X-HiClaw-Cluster-ID: remote-cluster-a" "$(cat "${curl_log}")"
+        assert_contains "${case_name}: controller STS call should include bearer" "Authorization: Bearer controller-token" "$(cat "${curl_log}")"
+        assert_contains "${case_name}: nacos cli should use sts auth type" "--auth-type sts-hiclaw" "$(cat "${log_file}")"
+        assert_contains "${case_name}: nacos cli should pass sts access key" "--access-key test-ak" "$(cat "${log_file}")"
+        assert_contains "${case_name}: nacos cli should pass sts token" "--security-token test-sts" "$(cat "${log_file}")"
     }
 done
 


### PR DESCRIPTION
## Summary
- add `NACOS_AUTH_TYPE=sts-hiclaw` support to the manager worker skill discovery wrappers
- request STS credentials from the HiClaw controller and pass them to the Nacos CLI
- extend the find-skill regression tests to cover worker, CoPaw worker, and Hermes worker scripts

## Scope
- independent from #933; this only changes manager skill discovery wrappers and their shell regression test
- does not include TeamHarness plugin, QwenPaw worker runtime, or external CLI harness runtime changes

## Tests
- `bash manager/tests/test-hiclaw-find-skill.sh`
- `bash -n manager/agent/worker-agent/skills/find-skills/scripts/hiclaw-find-skill.sh`
- `bash -n manager/agent/copaw-worker-agent/skills/find-skills/scripts/hiclaw-find-skill.sh`
- `bash -n manager/agent/hermes-worker-agent/skills/find-skills/scripts/hiclaw-find-skill.sh`
- `bash -n manager/tests/test-hiclaw-find-skill.sh`
- `git diff --check`