### PR TITLE
fix(shared): pass cluster id to STS credential refresh

### DIFF
--- a/shared/lib/oss-credentials.sh
+++ b/shared/lib/oss-credentials.sh
@@ -59,9 +59,16 @@ _oss_refresh_sts_via_controller() {
         return 1
     fi
 
-    resp=$(curl -s -w "\n%{http_code}" -X POST "${_controller_url}/api/v1/credentials/sts" \
-        -H "Authorization: Bearer ${bearer}" \
-        --connect-timeout 10 --max-time 30 2>&1)
+    if [ -n "${HICLAW_CLUSTER_ID:-}" ]; then
+        resp=$(curl -s -w "\n%{http_code}" -X POST "${_controller_url}/api/v1/credentials/sts" \
+            -H "Authorization: Bearer ${bearer}" \
+            -H "X-HiClaw-Cluster-ID: ${HICLAW_CLUSTER_ID}" \
+            --connect-timeout 10 --max-time 30 2>&1)
+    else
+        resp=$(curl -s -w "\n%{http_code}" -X POST "${_controller_url}/api/v1/credentials/sts" \
+            -H "Authorization: Bearer ${bearer}" \
+            --connect-timeout 10 --max-time 30 2>&1)
+    fi
 
     http_code=$(echo "${resp}" | tail -1)
     resp=$(echo "${resp}" | sed '$d')

--- a/shared/tests/test-oss-credentials.sh
+++ b/shared/tests/test-oss-credentials.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 TMPDIR_ROOT="$(mktemp -d)"
 trap 'rm -rf "${TMPDIR_ROOT}"' EXIT
 

--- a/tests/test-oss-credentials.sh
+++ b/tests/test-oss-credentials.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Regression tests for shared/lib/oss-credentials.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR_ROOT}"' EXIT
+
+pass() { echo "  PASS: $1"; }
+
+assert_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if printf '%s' "${haystack}" | grep -qF -- "${needle}"; then
+        pass "${desc}"
+    else
+        echo "  FAIL: ${desc}" >&2
+        echo "       expected to contain: ${needle}" >&2
+        echo "       got: ${haystack}" >&2
+        exit 1
+    fi
+}
+
+assert_not_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if ! printf '%s' "${haystack}" | grep -qF -- "${needle}"; then
+        pass "${desc}"
+    else
+        echo "  FAIL: ${desc}" >&2
+        echo "       expected not to contain: ${needle}" >&2
+        echo "       got: ${haystack}" >&2
+        exit 1
+    fi
+}
+
+create_mock_tools() {
+    local mockbin="$1"
+    mkdir -p "${mockbin}"
+
+    cat > "${mockbin}/curl" <<'MOCK_CURL'
+#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${TEST_CURL_LOG:?}"
+cat <<'OUT'
+{"access_key_id":"test-ak","access_key_secret":"test-sk","security_token":"test-token","oss_endpoint":"oss.example.test"}
+200
+OUT
+MOCK_CURL
+    chmod +x "${mockbin}/curl"
+
+    cat > "${mockbin}/jq" <<'MOCK_JQ'
+#!/bin/sh
+set -eu
+if [ "${1:-}" = "-r" ]; then
+    shift
+fi
+cat >/dev/null
+case "${1:-}" in
+    .access_key_id) echo "test-ak" ;;
+    .access_key_secret) echo "test-sk" ;;
+    .security_token) echo "test-token" ;;
+    .oss_endpoint) echo "oss.example.test" ;;
+    *) echo "null" ;;
+esac
+MOCK_JQ
+    chmod +x "${mockbin}/jq"
+}
+
+run_refresh() {
+    local case_name="$1" cluster_id="${2:-}"
+    local mockbin="${TMPDIR_ROOT}/${case_name}-bin"
+    local curl_log="${TMPDIR_ROOT}/${case_name}-curl.log"
+    create_mock_tools "${mockbin}"
+
+    (
+        . "${PROJECT_ROOT}/shared/lib/oss-credentials.sh"
+        _OSS_CRED_FILE="${TMPDIR_ROOT}/${case_name}-mc.env"
+        export PATH="${mockbin}:${PATH}"
+        export TEST_CURL_LOG="${curl_log}"
+        export HICLAW_CONTROLLER_URL="http://controller:8090"
+        export HICLAW_AUTH_TOKEN="controller-token"
+        if [ -n "${cluster_id}" ]; then
+            export HICLAW_CLUSTER_ID="${cluster_id}"
+        else
+            unset HICLAW_CLUSTER_ID
+        fi
+        _oss_refresh_sts_via_controller >/dev/null
+    )
+
+    cat "${curl_log}"
+}
+
+echo ""
+echo "=== oss credentials STS controller request ==="
+
+with_cluster="$(run_refresh with-cluster remote-cluster-a)"
+assert_contains "cluster id should be sent as controller header" "X-HiClaw-Cluster-ID: remote-cluster-a" "${with_cluster}"
+assert_contains "bearer token should still be sent" "Authorization: Bearer controller-token" "${with_cluster}"
+
+without_cluster="$(run_refresh without-cluster)"
+assert_not_contains "cluster header should be omitted when HICLAW_CLUSTER_ID is empty" "X-HiClaw-Cluster-ID:" "${without_cluster}"
+assert_contains "bearer token should be sent without cluster id" "Authorization: Bearer controller-token" "${without_cluster}"
+
+echo "All oss-credentials tests passed"


### PR DESCRIPTION
## Summary
- include `X-HiClaw-Cluster-ID` when shared OSS credential refresh requests controller STS credentials
- keep the existing request shape unchanged when `HICLAW_CLUSTER_ID` is empty
- add a standalone shell regression test with mocked `curl` and `jq`

## Scope
- independent from #933 and #934; this only changes the shared mc/OSS credential helper
- does not include QwenPaw runtime, TeamHarness plugin, install/build, or controller changes

## Tests
- `tests/test-oss-credentials.sh`
- `bash -n shared/lib/oss-credentials.sh`
- `bash -n tests/test-oss-credentials.sh`
- `git diff --check`