### PR TITLE
feat(teamharness): add TeamHarness plugin core

### DIFF
--- a/docs/teamharness-boundary-and-contracts.md
+++ b/docs/teamharness-boundary-and-contracts.md
@@ -1,0 +1,98 @@
+# TeamHarness v0.1 Boundary And Contracts
+
+This document defines the functional boundary for the current TeamHarness
+plugin package.
+
+TeamHarness v0.1 is the runtime-neutral team collaboration base. It packages
+stable prompts, team skills, MCP tools, lifecycle scripts, and runtime adapter
+entrypoints. It does not own worker lifecycle, controller reconciliation,
+worker desired-state apply loop, runtime hook behavior, or
+periodic workspace persistence.
+
+## Responsibilities
+
+TeamHarness owns:
+
+- Stable team collaboration prompts and role prompts.
+- Team collaboration skills for organization, communication, shared files,
+  projects, task delegation, and task execution.
+- Explicit MCP tools for team messages, shared files, project flow, task flow,
+  and plugin health.
+- A single plugin tarball installed through the HiClaw `agentteams` CLI by
+  default and compatible with LoongSuite `plugin-probe` for local runtimes.
+
+TeamHarness does not own:
+
+- Controller generation of `shared/runtime/members/{runtimeName}/runtime.yaml`.
+- Worker process lifecycle, pod restart, or runtime process supervision.
+- Worker desired-state parsing, polling, apply, or diagnostics.
+- Runtime-neutral top-level hooks.
+- Runtime hook trigger contracts, payload formats, and enforcement behavior.
+- Credential access enforcement that depends on runtime-specific file or tool
+  guard support.
+- AgentSpec package download, apply, rollback, or update inside the worker desired-state apply loop.
+- Periodic workspace push/pull loops.
+- Direct QwenPaw or Claude Code runtime mutation in the base package.
+- Secret value storage.
+
+## Contract Relationships
+
+Controller to runtime:
+
+- The controller writes non-secret desired state and team facts to
+  `shared/runtime/members/{runtimeName}/runtime.yaml`.
+- Secrets stay in environment variables, mounted files, or service account
+  tokens.
+
+Runtime worker to TeamHarness:
+
+- The worker installs or exposes TeamHarness assets for the selected runtime.
+- The worker owns the desired-state apply loop, including runtime config polling and AgentSpec package application.
+- The worker may call TeamHarness MCP tools, but TeamHarness does not poll CR
+  state or object storage by itself.
+
+Runtime adapter to TeamHarness:
+
+- The adapter maps TeamHarness prompts, skills, and MCP into a concrete runtime.
+- Runtime-specific hooks live under the adapter implementation, for example
+  `adapters/qwenpaw/hooks/` or `adapters/claude-code/hooks/`, when that runtime
+  integration phase defines them.
+- Runtime config consumption belongs to the worker/runtime adapter layer, not to
+  the TeamHarness plugin package.
+- The adapter should consume controller-written runtime config facts instead of
+  querying `hiclaw` CLI for team or member identity.
+
+TeamHarness plugin package to AgentSpec package:
+
+- The TeamHarness plugin package is runtime infrastructure.
+- `desired.agentPackage` in `runtime.yaml` is a HiClaw AgentSpec package and
+  belongs to the worker desired-state apply path.
+- Updating an AgentSpec package must not be modeled as updating the TeamHarness
+  plugin package.
+
+## Standard Asset Set
+
+Prompts:
+
+- `prompts/team/TEAMS.md`
+- `prompts/agent/leader.md`
+- `prompts/agent/worker.md`
+- `prompts/agent/remote-member.md`
+- `prompts/manager/AGENTS.md`
+- `prompts/manager/TOOLS.md`
+- `prompts/manager/HEARTBEAT.md`
+
+Skills:
+
+- Agent skills: `mcporter`, `find-skills`.
+- Team skills: `organization`, `communication`, `file-sharing`,
+  `team-coordination`, `project-management`, `task-delegation`,
+  `task-execution`.
+
+MCP tools:
+
+- `health`
+- `message`
+- `filesync`
+- `projectflow`
+- `taskflow`

--- a/plugins/teamharness/adapters/claude-code/README.md
+++ b/plugins/teamharness/adapters/claude-code/README.md
@@ -1,0 +1,8 @@
+# TeamHarness Claude Code Adapter
+
+This adapter owns Claude Code-specific installation and hook integration.
+
+The TeamHarness base package does not define runtime-neutral top-level hooks.
+Claude Code hooks should live under this adapter when the Claude Code integration
+phase defines the concrete local runtime trigger points, payload format, and
+enforcement behavior.

--- a/plugins/teamharness/adapters/claude-code/install.sh
+++ b/plugins/teamharness/adapters/claude-code/install.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_file="${TEAMHARNESS_INSTALL_LOG:-}"
+if [ -n "$log_file" ]; then
+  mkdir -p "$(dirname "$log_file")"
+  printf '{"event":"install","runtime":"claude-code","pluginDir":"%s"}\n' "${AGENTTEAMS_PLUGIN_DIR:-${PWD}}" >> "$log_file"
+fi

--- a/plugins/teamharness/adapters/claude-code/uninstall.sh
+++ b/plugins/teamharness/adapters/claude-code/uninstall.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_file="${TEAMHARNESS_INSTALL_LOG:-}"
+if [ -n "$log_file" ]; then
+  mkdir -p "$(dirname "$log_file")"
+  printf '{"event":"uninstall","runtime":"claude-code","pluginDir":"%s"}\n' "${AGENTTEAMS_PLUGIN_DIR:-${PWD}}" >> "$log_file"
+fi

--- a/plugins/teamharness/adapters/qwenpaw/README.md
+++ b/plugins/teamharness/adapters/qwenpaw/README.md
@@ -1,0 +1,40 @@
+# TeamHarness QwenPaw Adapter
+
+This adapter turns the runtime-neutral TeamHarness package into a QwenPaw-native
+plugin package. The Dockerfile and worker image do not need to understand the
+TeamHarness source tree.
+
+Build the QwenPaw package:
+
+```bash
+plugins/teamharness/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb plugins/teamharness/plugin.yaml
+```
+
+The generated zip contains:
+
+```text
+teamharness-qwenpaw-{version}/
+├── plugin.json
+├── plugin.py
+└── teamharness/
+    ├── plugin.yaml
+    ├── prompts/
+    ├── skills/
+    └── mcp/
+```
+
+Install the adapter into the current QwenPaw working directory:
+
+```bash
+plugins/teamharness/adapters/qwenpaw/install.sh
+```
+
+`install.sh` builds the package, unpacks it, and runs:
+
+```bash
+qwenpaw plugin install <generated-package-dir> --force
+```
+
+QwenPaw writes the installed plugin under `${QWENPAW_WORKING_DIR}/plugins`.
+Set `QWENPAW_WORKING_DIR` before installation when running inside a managed
+worker.

--- a/plugins/teamharness/adapters/qwenpaw/install.sh
+++ b/plugins/teamharness/adapters/qwenpaw/install.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEAMHARNESS_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BUILD_SCRIPT="${SCRIPT_DIR}/scripts/build-qwenpaw-plugin.rb"
+
+if ! command -v qwenpaw >/dev/null 2>&1; then
+  echo "ERROR: qwenpaw command not found" >&2
+  exit 1
+fi
+
+if ! command -v ruby >/dev/null 2>&1; then
+  echo "ERROR: ruby is required to build the QwenPaw plugin package" >&2
+  exit 1
+fi
+
+stage_dir="$(mktemp -d "${TMPDIR:-/tmp}/teamharness-qwenpaw-install.XXXXXX")"
+cleanup() {
+  rm -rf "$stage_dir"
+}
+trap cleanup EXIT
+
+package_zip="$(OUT_DIR="${stage_dir}/dist" ruby "${BUILD_SCRIPT}" "${TEAMHARNESS_DIR}/plugin.yaml" | tail -n 1)"
+unpack_dir="${stage_dir}/unpacked"
+mkdir -p "$unpack_dir"
+
+python3 - "$package_zip" "$unpack_dir" <<'PY'
+import sys
+import zipfile
+
+with zipfile.ZipFile(sys.argv[1]) as archive:
+    archive.extractall(sys.argv[2])
+PY
+
+package_dir="$(find "$unpack_dir" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+if [ -z "$package_dir" ] || [ ! -f "$package_dir/plugin.json" ]; then
+  echo "ERROR: generated QwenPaw plugin package is invalid" >&2
+  exit 1
+fi
+
+qwenpaw plugin install "$package_dir" --force
+
+log_file="${TEAMHARNESS_INSTALL_LOG:-}"
+if [ -n "$log_file" ]; then
+  mkdir -p "$(dirname "$log_file")"
+  printf '{"event":"install","runtime":"qwenpaw","pluginDir":"%s"}\n' "${AGENTTEAMS_PLUGIN_DIR:-${PWD}}" >> "$log_file"
+fi

--- a/plugins/teamharness/adapters/qwenpaw/plugin.json
+++ b/plugins/teamharness/adapters/qwenpaw/plugin.json
@@ -1,0 +1,13 @@
+{
+  "id": "teamharness",
+  "name": "TeamHarness",
+  "version": "0.1.0",
+  "type": "general",
+  "description": "HiClaw TeamHarness runtime plugin for QwenPaw.",
+  "author": "HiClaw",
+  "entry": {
+    "backend": "plugin.py"
+  },
+  "dependencies": [],
+  "min_version": "1.1.7"
+}

--- a/plugins/teamharness/adapters/qwenpaw/plugin.py
+++ b/plugins/teamharness/adapters/qwenpaw/plugin.py
@@ -1,0 +1,784 @@
+#!/usr/bin/env python3
+"""QwenPaw adapter for TeamHarness.
+
+The adapter owns QwenPaw-specific install/reconcile behavior. It does not poll
+storage or runtime config by itself; the qwenpaw-worker triggers those loops.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+import re
+import shutil
+import sys
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_DIR = Path(__file__).resolve().parent
+ASSET_DIR = PLUGIN_DIR / "teamharness"
+if not (ASSET_DIR / "plugin.yaml").exists():
+    ASSET_DIR = PLUGIN_DIR.parent.parent
+
+TEAMS_PROMPT_FILE = "TEAMS.md"
+MCP_CLIENT_ID = "teamharness"
+REDACTION = "[REDACTED]"
+SENSITIVE_FILE_AUTO_DENY_RULE = "SENSITIVE_FILE_BLOCK"
+TEAMS_CONTEXT_START = "<!-- BEGIN HICLAW RUNTIME TEAM CONTEXT -->"
+TEAMS_CONTEXT_END = "<!-- END HICLAW RUNTIME TEAM CONTEXT -->"
+
+_BUILTIN_SANITIZER_PATTERNS: List[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\b(LTAI)[A-Za-z0-9]{12,}"), r"\1****"),
+    (re.compile(r"\b(AKIA)[A-Za-z0-9]{12,}"), r"\1****"),
+    (re.compile(r"\b(AKID)[A-Za-z0-9]{12,}"), r"\1****"),
+    (
+        re.compile(
+            r"(?i)((?:access_?key_?secret|secret_?access_?key|accesskeysecret"
+            r"|TENCENTCLOUD_SECRET_KEY|aws_secret_access_key"
+            r"|credentials\.secret)"
+            r"""["']?[\s]*[=:]\s*["']?)([A-Za-z0-9/+=]{16,})"""
+        ),
+        r"\1********",
+    ),
+    (
+        re.compile(
+            r"(?i)((?:security_?token|session_?token|sts_?token)"
+            r"""["']?[\s]*[=:]\s*["']?)([A-Za-z0-9/+=]{100,})"""
+        ),
+        r"\1********",
+    ),
+    (
+        re.compile(
+            r"(?i)((?:secret|token|password|passwd|key_secret)"
+            r"""["']?[\s]*[=:]\s*["']?)([A-Za-z0-9/+=]{30,})"""
+        ),
+        r"\1********",
+    ),
+]
+
+
+def _read_yaml(path: Path) -> Dict[str, Any]:
+    try:
+        import yaml
+
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except FileNotFoundError:
+        return {}
+    except ImportError:
+        logger.warning("PyYAML unavailable; TeamHarness adapter cannot parse %s", path)
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _runtime_config_path() -> Optional[Path]:
+    raw = os.getenv("TEAMHARNESS_RUNTIME_CONFIG", "").strip()
+    return Path(raw) if raw else None
+
+
+def load_runtime_config() -> Dict[str, Any]:
+    path = _runtime_config_path()
+    return _read_yaml(path) if path else {}
+
+
+def _section(data: Dict[str, Any], name: str) -> Dict[str, Any]:
+    value = data.get(name) or {}
+    return value if isinstance(value, dict) else {}
+
+
+def _string(value: Any) -> str:
+    return str(value).strip() if value is not None else ""
+
+
+def _string_list(value: Any) -> List[str]:
+    if not isinstance(value, list):
+        return []
+    return [_string(item) for item in value if _string(item)]
+
+
+def _string_fields(value: Any, keys: List[str]) -> Dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    result: Dict[str, str] = {}
+    for key in keys:
+        text = _string(value.get(key))
+        if text:
+            result[key] = text
+    return result
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_json_atomic(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.tmp")
+    tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _shared_dir() -> Path:
+    raw = os.getenv("TEAMHARNESS_SHARED_DIR", "").strip() or os.getenv("HICLAW_SHARED_DIR", "").strip()
+    if raw:
+        return Path(raw)
+    qwenpaw_dir = os.getenv("QWENPAW_WORKING_DIR", "").strip()
+    if qwenpaw_dir:
+        qwenpaw_path = Path(qwenpaw_dir)
+        if qwenpaw_path.name == ".qwenpaw":
+            return qwenpaw_path.parent.parent.parent / "shared"
+    return Path.cwd() / "shared"
+
+
+def _role_prompt(role: str) -> Optional[Path]:
+    mapping = {
+        "leader": ASSET_DIR / "prompts" / "agent" / "leader.md",
+        "team_leader": ASSET_DIR / "prompts" / "agent" / "leader.md",
+        "worker": ASSET_DIR / "prompts" / "agent" / "worker.md",
+        "remote-member": ASSET_DIR / "prompts" / "agent" / "remote-member.md",
+        "manager": ASSET_DIR / "prompts" / "manager" / "AGENTS.md",
+    }
+    return mapping.get(role)
+
+
+def render_team_context(config: Dict[str, Any]) -> str:
+    team = _section(config, "team")
+    member = _section(config, "member")
+    desired = _section(config, "desired")
+    package = _section(desired, "agentPackage")
+    channel_policy = _section(desired, "channelPolicy")
+    base_prompt = ASSET_DIR / "prompts" / "team" / "TEAMS.md"
+    base = base_prompt.read_text(encoding="utf-8").strip() if base_prompt.exists() else ""
+    role = _string(member.get("role") or os.getenv("HICLAW_AGENT_ROLE") or "worker")
+    role_prompt = _role_prompt(role)
+    role_text = role_prompt.read_text(encoding="utf-8").strip() if role_prompt and role_prompt.exists() else ""
+
+    lines = []
+    if base:
+        lines.append(base)
+    else:
+        lines.append("# Team Contract")
+    if role_text:
+        lines.extend(["", role_text])
+    lines.extend(["", TEAMS_CONTEXT_START, "## Runtime Team Context", ""])
+
+    facts = [
+        ("team.name", team.get("name")),
+        ("team.teamRoomId", team.get("teamRoomId")),
+        ("team.leaderName", team.get("leaderName")),
+        ("team.leaderRuntimeName", team.get("leaderRuntimeName")),
+        ("team.admin.name", _section(team, "admin").get("name")),
+        ("team.admin.matrixUserId", _section(team, "admin").get("matrixUserId")),
+        ("member.name", member.get("name")),
+        ("member.runtimeName", member.get("runtimeName")),
+        ("member.role", member.get("role")),
+        ("member.runtime", member.get("runtime")),
+        ("member.matrixUserId", member.get("matrixUserId")),
+        ("member.personalRoomId", member.get("personalRoomId")),
+        ("desired.agentPackage.name", package.get("name")),
+        ("desired.agentPackage.version", package.get("version")),
+    ]
+    for key, value in facts:
+        text = _string(value)
+        if text:
+            lines.append(f"- {key}: {text}")
+    members = team.get("members")
+    if isinstance(members, list) and members:
+        lines.extend(["", "### Team Members"])
+        for item in members:
+            entry = _string_fields(item, ["name", "runtimeName", "role", "matrixUserId", "personalRoomId"])
+            if entry:
+                lines.append("- " + ", ".join(f"{key}: {value}" for key, value in entry.items()))
+
+    if channel_policy:
+        lines.append("- desired.channelPolicy: configured")
+    lines.append("")
+    lines.append("Do not write secrets, credentials, or live task status into this file.")
+    lines.append(TEAMS_CONTEXT_END)
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _write_team_context(workspace_dir: Path, config: Dict[str, Any]) -> Dict[str, Any]:
+    target = workspace_dir / TEAMS_PROMPT_FILE
+    text = render_team_context(config)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    existing = target.read_text(encoding="utf-8") if target.exists() else None
+    target.write_text(text, encoding="utf-8")
+    return {
+        "ok": True,
+        "asset": "team-context",
+        "path": str(target),
+        "action": "created" if existing is None else ("unchanged" if existing == text else "updated"),
+    }
+
+
+def apply_team_context() -> Dict[str, Any]:
+    config = load_runtime_config()
+    targets = [
+        {"agent": agent_id, **_write_team_context(workspace_dir, config)}
+        for agent_id, workspace_dir in _iter_qwenpaw_agents()
+    ]
+    return {"ok": True, "asset": "team-context", "targets": targets}
+
+
+def _sanitizer_rules() -> List[str]:
+    config = load_runtime_config()
+    desired = _section(config, "desired")
+    policy = _section(desired, "outputSanitize")
+    rules = _string_list(policy.get("keywords"))
+    credentials = _section(config, "credentials")
+    env_refs = _string_list(policy.get("envRefs"))
+    for key in ("matrixTokenEnv", "gatewayKeyEnv", "storageAccessKeyEnv", "storageSecretKeyEnv"):
+        value = _string(credentials.get(key))
+        if value:
+            env_refs.append(value)
+    for env_name in env_refs:
+        value = os.getenv(env_name, "")
+        if len(value) >= 4:
+            rules.append(value)
+    deduped = []
+    seen = set()
+    for rule in rules:
+        if rule and rule not in seen:
+            seen.add(rule)
+            deduped.append(rule)
+    return deduped
+
+
+def _qwenpaw_working_dir() -> Optional[Path]:
+    raw = os.getenv("QWENPAW_WORKING_DIR", "").strip() or os.getenv("COPAW_WORKING_DIR", "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    home = os.getenv("HOME", "").strip()
+    return Path(home).expanduser() / ".qwenpaw" if home else None
+
+
+def _credagent_paths() -> List[Path]:
+    paths: List[Path] = []
+    for _agent_id, workspace_dir in _iter_qwenpaw_agents():
+        paths.append(workspace_dir / "config" / "credagent.json")
+    for env_name in ("HICLAW_AGENT_HOME", "HICLAW_WORKER_HOME"):
+        raw = os.getenv(env_name, "").strip()
+        if raw:
+            paths.append(Path(raw).expanduser() / "config" / "credagent.json")
+    working_dir = _qwenpaw_working_dir()
+    if working_dir is not None:
+        paths.append(working_dir / "workspaces" / "default" / "config" / "credagent.json")
+        paths.append(working_dir.parent / "config" / "credagent.json")
+
+    deduped: List[Path] = []
+    seen = set()
+    for path in paths:
+        key = str(path)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(path)
+    return deduped
+
+
+def _credagent_specs() -> List[Dict[str, Any]]:
+    specs = []
+    for path in _credagent_paths():
+        if not path.exists():
+            continue
+        spec = _read_json(path)
+        if spec:
+            specs.append(spec)
+    return specs
+
+
+def _normalize_credentials(specs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    normalized: List[Dict[str, Any]] = []
+    for spec in specs:
+        credentials = spec.get("credentials", [])
+        if not isinstance(credentials, list):
+            continue
+        for entry in credentials:
+            if not isinstance(entry, dict):
+                continue
+            raw = _string(entry.get("path"))
+            if not raw:
+                continue
+            expanded = str(Path(raw).expanduser())
+            if raw.endswith("/") and not expanded.endswith("/"):
+                expanded += "/"
+            permit = entry.get("programPermit", [])
+            if isinstance(permit, str):
+                permit = [permit]
+            elif not isinstance(permit, list):
+                permit = []
+            normalized.append(
+                {
+                    "path": expanded,
+                    "programPermit": [str(item) for item in permit],
+                    "writable": bool(entry.get("writable", False)),
+                }
+            )
+    return normalized
+
+
+def _credagent_output_sanitize_rules(specs: Optional[List[Dict[str, Any]]] = None) -> List[Dict[str, Any]]:
+    rules: List[Dict[str, Any]] = []
+    for spec in specs if specs is not None else _credagent_specs():
+        raw_rules = spec.get("output_sanitize", [])
+        if not isinstance(raw_rules, list):
+            continue
+        rules.extend(rule for rule in raw_rules if isinstance(rule, dict))
+    return rules
+
+
+def _sanitizer_patterns() -> List[tuple[re.Pattern[str], str]]:
+    patterns = list(_BUILTIN_SANITIZER_PATTERNS)
+    for rule in _credagent_output_sanitize_rules():
+        try:
+            rule_type = rule.get("type", "")
+            if rule_type == "prefix":
+                prefix = str(rule["prefix"])
+                min_length = int(rule.get("min_length", 16))
+                suffix_len = max(min_length - len(prefix), 1)
+                escaped = re.escape(prefix)
+                patterns.append((re.compile(rf"\b({escaped})[A-Za-z0-9]{{{suffix_len},}}"), r"\1****"))
+            elif rule_type == "keyword":
+                keywords = rule.get("keywords", [])
+                if not isinstance(keywords, list) or not keywords:
+                    continue
+                kw_alt = "|".join(re.escape(str(keyword)) for keyword in keywords)
+                patterns.append(
+                    (
+                        re.compile(rf"""(?i)({kw_alt})(["']?[\s]*[=:]\s*["']?)([A-Za-z0-9/+=]{{16,}})"""),
+                        r"\1\2********",
+                    )
+                )
+            elif rule_type == "regex":
+                patterns.append((re.compile(str(rule["pattern"])), str(rule.get("replacement", "********"))))
+        except (KeyError, TypeError, ValueError, re.error):
+            continue
+    return patterns
+
+
+def _sanitize_text_with_rules(
+    text: str,
+    exact_rules: List[str],
+    patterns: List[tuple[re.Pattern[str], str]],
+) -> str:
+    sanitized = text
+    for rule in sorted(exact_rules, key=len, reverse=True):
+        sanitized = re.sub(re.escape(rule), REDACTION, sanitized)
+    for pattern, replacement in patterns:
+        sanitized = pattern.sub(replacement, sanitized)
+    return sanitized
+
+
+def sanitize_text(text: str) -> str:
+    return _sanitize_text_with_rules(text, _sanitizer_rules(), _sanitizer_patterns())
+
+
+def _qwenpaw_config_path() -> Optional[Path]:
+    try:
+        from qwenpaw.config import get_config_path
+
+        return Path(get_config_path())
+    except Exception:
+        working_dir = _qwenpaw_working_dir()
+        return working_dir / "config.json" if working_dir is not None else None
+
+
+def _reload_qwenpaw_file_guard() -> None:
+    try:
+        from qwenpaw.security.tool_guard.engine import get_guard_engine
+
+        get_guard_engine().reload_rules()
+    except Exception:
+        return
+
+
+def apply_credential_guard() -> Dict[str, Any]:
+    specs = _credagent_specs()
+    if not specs:
+        return {
+            "ok": True,
+            "hook": "credential-guard",
+            "applied": False,
+            "credentials": 0,
+            "outputSanitizeRules": 0,
+            "reason": "credagent.json not found",
+        }
+
+    credentials = _normalize_credentials(specs)
+    paths = {entry["path"] for entry in credentials}
+    rules_count = len(_credagent_output_sanitize_rules(specs))
+    config_path = _qwenpaw_config_path()
+    if config_path is None:
+        return {
+            "ok": True,
+            "hook": "credential-guard",
+            "applied": False,
+            "credentials": len(credentials),
+            "outputSanitizeRules": rules_count,
+            "reason": "qwenpaw config path unavailable",
+        }
+
+    config = _read_json(config_path)
+    security = config.setdefault("security", {})
+    plugins = config.setdefault("plugins", {})
+    teamharness = plugins.setdefault("teamharness", {})
+    guard_state = teamharness.setdefault("credentialGuard", {})
+    previous_paths = {
+        str(path)
+        for path in (guard_state.get("paths", []) or [])
+        if str(path)
+    }
+
+    file_guard = security.setdefault("file_guard", {})
+    file_guard["enabled"] = True
+    existing = {
+        str(path)
+        for path in (file_guard.get("sensitive_files", []) or [])
+        if str(path)
+    } - previous_paths
+    existing.update(paths)
+    file_guard["sensitive_files"] = sorted(existing)
+
+    tool_guard = security.setdefault("tool_guard", {})
+    tool_guard["enabled"] = True
+    auto_rules = [
+        str(rule)
+        for rule in (tool_guard.get("auto_denied_rules", []) or [])
+        if str(rule)
+    ]
+    if SENSITIVE_FILE_AUTO_DENY_RULE not in auto_rules:
+        auto_rules.append(SENSITIVE_FILE_AUTO_DENY_RULE)
+    tool_guard["auto_denied_rules"] = auto_rules
+
+    guard_state["paths"] = sorted(paths)
+    guard_state["source"] = "credagent.json"
+    _write_json_atomic(config_path, config)
+    _reload_qwenpaw_file_guard()
+    return {
+        "ok": True,
+        "hook": "credential-guard",
+        "applied": True,
+        "credentials": len(credentials),
+        "outputSanitizeRules": rules_count,
+        "runtimeConfig": str(config_path),
+        "reason": None,
+    }
+
+
+def sanitize_tool_result(result: Any) -> Dict[str, Any]:
+    summary = {"ok": True, "hook": "output-sanitizer", "redacted": False, "blocks": 0}
+    exact_rules = _sanitizer_rules()
+    patterns = _sanitizer_patterns()
+    if isinstance(result, dict):
+        content = result.get("content") or result.get("output")
+    else:
+        content = getattr(result, "content", None) or getattr(result, "output", None)
+    if isinstance(content, str):
+        sanitized = _sanitize_text_with_rules(content, exact_rules, patterns)
+        if sanitized != content:
+            if isinstance(result, dict):
+                result["content"] = sanitized
+            else:
+                setattr(result, "content", sanitized)
+            summary["redacted"] = True
+        summary["blocks"] = 1
+        return summary
+    if not isinstance(content, list):
+        return summary
+
+    for block in content:
+        if isinstance(block, dict):
+            text = block.get("text")
+        else:
+            text = getattr(block, "text", None)
+        if not isinstance(text, str):
+            continue
+        summary["blocks"] += 1
+        sanitized = _sanitize_text_with_rules(text, exact_rules, patterns)
+        if sanitized != text:
+            if isinstance(block, dict):
+                block["text"] = sanitized
+            else:
+                setattr(block, "text", sanitized)
+            summary["redacted"] = True
+    return summary
+
+
+def _iter_qwenpaw_agents() -> List[tuple[str, Path]]:
+    try:
+        from qwenpaw.config.utils import load_config
+    except ImportError:
+        workspace = os.getenv("QWENPAW_WORKSPACE_DIR", "").strip()
+        if not workspace:
+            qwenpaw_dir = os.getenv("QWENPAW_WORKING_DIR", "").strip()
+            workspace = str(Path(qwenpaw_dir) / "workspaces" / "default") if qwenpaw_dir else ""
+        return [("default", Path(workspace))] if workspace else []
+
+    root = load_config()
+    profiles = getattr(getattr(root, "agents", None), "profiles", {}) or {}
+    agents = []
+    for agent_id, ref in profiles.items():
+        if getattr(ref, "enabled", True) is False:
+            continue
+        workspace_dir = Path(getattr(ref, "workspace_dir", "")).expanduser()
+        if str(workspace_dir):
+            agents.append((str(agent_id), workspace_dir))
+    return agents
+
+
+def _copytree_replace(source: Path, target: Path) -> None:
+    if target.exists():
+        shutil.rmtree(target)
+    shutil.copytree(source, target, ignore=shutil.ignore_patterns("__pycache__", ".DS_Store", "*.pyc"))
+
+
+def _skill_entries() -> List[Dict[str, Any]]:
+    manifest = _read_yaml(ASSET_DIR / "plugin.yaml")
+    skills = _section(manifest, "skills")
+    entries = []
+    for group in ("agent", "team"):
+        for entry in skills.get(group) or []:
+            if isinstance(entry, dict):
+                entries.append(entry)
+    return entries
+
+
+def _role_aliases(role: str) -> set[str]:
+    normalized = _string(role) or "worker"
+    aliases = {normalized}
+    if normalized == "team_leader":
+        aliases.add("leader")
+    if normalized == "remote_member":
+        aliases.add("remote-member")
+    return aliases
+
+
+def _skill_names_for_role(role: str) -> List[str]:
+    role_aliases = _role_aliases(role)
+    names = []
+    for entry in _skill_entries():
+        skill_id = _string(entry.get("id"))
+        if not skill_id:
+            continue
+        roles = _string_list(entry.get("roles"))
+        if roles and not role_aliases.intersection(roles):
+            continue
+        names.append(f"teamharness-{skill_id}")
+    return names
+
+
+def _enable_workspace_skills(workspace_dir: Path, role: str) -> Dict[str, Any]:
+    installed = []
+    failed = []
+    try:
+        from qwenpaw.agents.skill_system.pool_service import SkillPoolService
+    except ImportError:
+        return {"installed": installed, "skipped": "qwenpaw skill pool API unavailable"}
+
+    service = SkillPoolService()
+    for skill_name in _skill_names_for_role(role):
+        result = service.download_to_workspace(skill_name, workspace_dir, overwrite=True)
+        if result.get("success"):
+            installed.append(skill_name)
+        else:
+            failed.append({"name": skill_name, "reason": result.get("reason") or "unknown"})
+    return {"installed": installed, "failed": failed}
+
+
+def _install_workspace_assets(agent_id: str, workspace_dir: Path, config: Dict[str, Any]) -> Dict[str, Any]:
+    member = _section(config, "member")
+    role = _string(member.get("role") or os.getenv("HICLAW_AGENT_ROLE") or "worker")
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    team_context = _write_team_context(workspace_dir, config)
+    prompts = _ensure_prompt_files(agent_id, [TEAMS_PROMPT_FILE])
+    skills = _enable_workspace_skills(workspace_dir, role)
+    return {
+        "agent": agent_id,
+        "workspace": str(workspace_dir),
+        "role": role,
+        "teamContext": team_context,
+        "prompts": prompts,
+        "skills": skills,
+    }
+
+
+def _ensure_prompt_files(agent_id: str, prompt_files: List[str]) -> Dict[str, Any]:
+    try:
+        from qwenpaw.config.config import load_agent_config, save_agent_config
+    except ImportError:
+        return {"agent": agent_id, "skipped": "qwenpaw config API unavailable"}
+
+    agent_config = load_agent_config(agent_id)
+    existing = list(agent_config.system_prompt_files or [])
+    changed = False
+    for prompt_file in prompt_files:
+        if prompt_file not in existing:
+            existing.append(prompt_file)
+            changed = True
+    if changed:
+        agent_config.system_prompt_files = existing
+        save_agent_config(agent_id, agent_config)
+    return {"agent": agent_id, "files": existing, "action": "updated" if changed else "unchanged"}
+
+
+def _install_skills() -> Dict[str, Any]:
+    installed = []
+    try:
+        from qwenpaw.agents.skill_system.registry import ensure_skill_pool_initialized, reconcile_pool_manifest
+        from qwenpaw.agents.skill_system.store import get_skill_pool_dir
+    except ImportError:
+        return {"installed": installed, "skipped": "qwenpaw skill API unavailable"}
+
+    ensure_skill_pool_initialized()
+    pool_dir = get_skill_pool_dir()
+    pool_dir.mkdir(parents=True, exist_ok=True)
+    for entry in _skill_entries():
+        source = ASSET_DIR / str(entry.get("path") or "")
+        skill_id = _string(entry.get("id"))
+        if not skill_id or not source.exists():
+            continue
+        target = pool_dir / f"teamharness-{skill_id}"
+        _copytree_replace(source, target)
+        installed.append(target.name)
+    reconcile_pool_manifest()
+    return {"installed": installed}
+
+
+def _mcp_client_env() -> Dict[str, str]:
+    env = {"TEAMHARNESS_SHARED_DIR": str(_shared_dir())}
+    for name in (
+        "TEAMHARNESS_RUNTIME_CONFIG",
+        "HICLAW_MATRIX_URL",
+        "HICLAW_WORKER_MATRIX_TOKEN",
+        "HICLAW_MATRIX_USER_ID",
+        "HICLAW_WORKER_ROLE",
+        "HICLAW_AGENT_ROLE",
+        "HICLAW_WORKER_NAME",
+        "HICLAW_STORAGE_PREFIX",
+        "HICLAW_SHARED_STORAGE_PREFIX",
+        "HICLAW_FS_BUCKET",
+        "HICLAW_CONTROLLER_URL",
+        "HICLAW_AUTH_TOKEN_FILE",
+        "HICLAW_CLUSTER_ID",
+        "HICLAW_FS_ENDPOINT",
+        "QWENPAW_WORKING_DIR",
+        "COPAW_WORKING_DIR",
+    ):
+        value = os.getenv(name, "").strip()
+        if value:
+            env[name] = value
+    return env
+
+
+def _ensure_mcp_client(agent_id: str, workspace_dir: Path) -> Dict[str, Any]:
+    try:
+        from qwenpaw.config.config import MCPClientConfig, MCPConfig, load_agent_config, save_agent_config
+    except ImportError:
+        marker = workspace_dir / ".teamharness" / "mcp-client.json"
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(json.dumps({"id": MCP_CLIENT_ID}, indent=2), encoding="utf-8")
+        return {"agent": agent_id, "action": "marker", "path": str(marker)}
+
+    agent_config = load_agent_config(agent_id)
+    if agent_config.mcp is None:
+        agent_config.mcp = MCPConfig()
+    server_path = ASSET_DIR / "mcp" / "server.py"
+    client = MCPClientConfig(
+        name=MCP_CLIENT_ID,
+        description="TeamHarness collaboration MCP server",
+        enabled=True,
+        transport="stdio",
+        command=sys.executable,
+        args=[str(server_path)],
+        cwd=str(ASSET_DIR),
+        env=_mcp_client_env(),
+    )
+    agent_config.mcp.clients[MCP_CLIENT_ID] = client
+    save_agent_config(agent_id, agent_config)
+    return {"agent": agent_id, "action": "configured"}
+
+
+def apply_teamharness() -> Dict[str, Any]:
+    config = load_runtime_config()
+    credential_guard = apply_credential_guard()
+    skills = _install_skills()
+    agents = []
+    mcp = []
+    for agent_id, workspace_dir in _iter_qwenpaw_agents():
+        agents.append(_install_workspace_assets(agent_id, workspace_dir, config))
+        mcp.append(_ensure_mcp_client(agent_id, workspace_dir))
+    return {"ok": True, "agents": agents, "skills": skills, "mcp": mcp, "credentialGuard": credential_guard}
+
+
+def install_output_sanitizer_wrapper() -> Dict[str, Any]:
+    try:
+        from qwenpaw.agents.react_agent import QwenPawAgent
+    except ImportError:
+        return {"ok": True, "installed": False, "reason": "qwenpaw agent API unavailable"}
+    if getattr(QwenPawAgent, "_teamharness_sanitizer_installed", False):
+        return {"ok": True, "installed": True, "action": "unchanged"}
+
+    original = QwenPawAgent._acting
+
+    async def _acting_with_sanitizer(self, tool_call):
+        result = await original(self, tool_call)
+        sanitize_tool_result(result)
+        return result
+
+    QwenPawAgent._acting = _acting_with_sanitizer
+    QwenPawAgent._teamharness_sanitizer_installed = True
+    return {"ok": True, "installed": True, "action": "created"}
+
+
+class TeamHarnessPlugin:
+    def __init__(self) -> None:
+        self.last_apply_result: Dict[str, Any] = {}
+        self.sanitizer_result: Dict[str, Any] = {}
+
+    def register(self, api: Any) -> None:
+        def sync() -> Dict[str, Any]:
+            self.last_apply_result = apply_teamharness()
+            self.sanitizer_result = install_output_sanitizer_wrapper()
+            return self.last_apply_result
+
+        def shutdown() -> None:
+            return None
+
+        api.register_startup_hook("teamharness_sync", sync, priority=40)
+        api.register_shutdown_hook("teamharness_shutdown", shutdown, priority=100)
+        self._register_http(api)
+
+    def _register_http(self, api: Any) -> None:
+        try:
+            from fastapi import APIRouter
+        except Exception:
+            return
+        router = APIRouter()
+
+        @router.get("/health")
+        def health() -> Dict[str, Any]:
+            return {"ok": True, "plugin": "teamharness", "adapter": "qwenpaw"}
+
+        @router.get("/status")
+        def status() -> Dict[str, Any]:
+            return {
+                "ok": True,
+                "lastApply": self.last_apply_result,
+                "sanitizer": self.sanitizer_result,
+            }
+
+        @router.post("/sync")
+        def sync_endpoint() -> Dict[str, Any]:
+            self.last_apply_result = apply_teamharness()
+            return self.last_apply_result
+
+        api.register_http_router(router, prefix="/teamharness", tags=["teamharness"])
+
+
+plugin = TeamHarnessPlugin()

--- a/plugins/teamharness/adapters/qwenpaw/plugin.py
+++ b/plugins/teamharness/adapters/qwenpaw/plugin.py
@@ -667,6 +667,9 @@ def _mcp_client_env() -> Dict[str, str]:
         "HICLAW_AUTH_TOKEN_FILE",
         "HICLAW_CLUSTER_ID",
         "HICLAW_FS_ENDPOINT",
+        "HICLAW_FS_ACCESS_KEY",
+        "HICLAW_FS_SECRET_KEY",
+        "MC_HOST_hiclaw",
         "QWENPAW_WORKING_DIR",
         "COPAW_WORKING_DIR",
     ):
@@ -724,7 +727,9 @@ def install_output_sanitizer_wrapper() -> Dict[str, Any]:
     if getattr(QwenPawAgent, "_teamharness_sanitizer_installed", False):
         return {"ok": True, "installed": True, "action": "unchanged"}
 
-    original = QwenPawAgent._acting
+    original = getattr(QwenPawAgent, "_acting", None)
+    if not callable(original):
+        return {"ok": True, "installed": False, "reason": "qwenpaw agent _acting hook unavailable"}
 
     async def _acting_with_sanitizer(self, tool_call):
         result = await original(self, tool_call)

--- a/plugins/teamharness/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb
+++ b/plugins/teamharness/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb
@@ -1,0 +1,134 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "open3"
+require "pathname"
+require "tmpdir"
+require "yaml"
+
+manifest_path = Pathname.new(ARGV[0] || "plugins/teamharness/plugin.yaml").expand_path
+plugin_root = manifest_path.dirname
+repo_root = plugin_root.ascend.find { |path| (path / ".git").directory? } || plugin_root
+adapter_root = plugin_root / "adapters/qwenpaw"
+out_dir = Pathname.new(ENV["OUT_DIR"] || (repo_root / "dist/adapters/qwenpaw").to_s).expand_path
+
+abort("missing manifest: #{manifest_path}") unless manifest_path.file?
+abort("missing qwenpaw adapter: #{adapter_root}") unless adapter_root.directory?
+
+manifest = YAML.load_file(manifest_path)
+name = manifest.fetch("metadata").fetch("name")
+version = manifest.fetch("metadata").fetch("version")
+package_name = "#{name}-qwenpaw-#{version}"
+
+def copy_entry(source_root, target_root, entry)
+  src = source_root / entry
+  abort("missing qwenpaw package source: #{src}") unless src.exist?
+
+  dst = target_root / entry
+  if src.directory?
+    FileUtils.mkdir_p(dst)
+    entries = Dir.glob((src / "*").to_s, File::FNM_DOTMATCH).reject do |path|
+      [".", ".."].include?(File.basename(path))
+    end
+    FileUtils.cp_r(entries, dst)
+  else
+    FileUtils.mkdir_p(dst.dirname)
+    FileUtils.cp(src, dst)
+  end
+end
+
+def prune_generated(path)
+  Dir.glob((path / "**/*").to_s, File::FNM_DOTMATCH).each do |item|
+    base = File.basename(item)
+    FileUtils.rm_rf(item) if base == "__pycache__" || base == ".DS_Store" || base.end_with?(".pyc")
+  end
+end
+
+def zip_dir(root, package_name, out_path)
+  FileUtils.rm_f(out_path)
+  if system("zip", "-v", out: File::NULL, err: File::NULL)
+    Dir.chdir(root) do
+      system("zip", "-qry", out_path.to_s, package_name) || abort("zip failed")
+    end
+    return
+  end
+
+  python = <<~PY
+    import os, zipfile
+    root = #{root.to_s.dump}
+    package = #{package_name.dump}
+    out = #{out_path.to_s.dump}
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as zf:
+        base = os.path.join(root, package)
+        for dirpath, _, filenames in os.walk(base):
+            for filename in filenames:
+                path = os.path.join(dirpath, filename)
+                rel = os.path.relpath(path, root)
+                zf.write(path, rel)
+  PY
+  stdout, stderr, status = Open3.capture3("python3", "-c", python)
+  abort("python zip failed: #{stderr}#{stdout}") unless status.success?
+end
+
+out_dir.mkpath
+out_zip = out_dir / "#{package_name}.zip"
+stable_zip = out_dir / "teamharness-qwenpaw.zip"
+
+Dir.mktmpdir("teamharness-qwenpaw-") do |tmp|
+  tmp_root = Pathname.new(tmp)
+  staging = tmp_root / package_name
+  asset_dir = staging / "teamharness"
+  staging.mkpath
+  asset_dir.mkpath
+
+  %w[
+    plugin.yaml
+    prompts
+    skills
+    mcp
+  ].each do |entry|
+    copy_entry(plugin_root, asset_dir, entry)
+  end
+
+  copy_entry(adapter_root, staging, "plugin.py")
+
+  qwenpaw_manifest = {
+    "id" => "teamharness",
+    "name" => "TeamHarness",
+    "version" => version,
+    "type" => "general",
+    "description" => "HiClaw TeamHarness runtime plugin for QwenPaw.",
+    "author" => "HiClaw",
+    "entry" => {
+      "backend" => "plugin.py"
+    },
+    "dependencies" => [],
+    "min_version" => "1.1.7",
+    "meta" => {
+      "category" => "teamharness",
+      "features" => [
+        "team-context",
+        "tool-output-sanitizer",
+        "teamharness-skills",
+        "teamharness-mcp"
+      ]
+    }
+  }
+  (staging / "plugin.json").write(
+    JSON.pretty_generate(qwenpaw_manifest) + "\n",
+    mode: "w",
+    encoding: "UTF-8"
+  )
+
+  prune_generated(staging)
+
+  validate = adapter_root / "scripts/validate-qwenpaw-plugin.rb"
+  system("ruby", validate.to_s, staging.to_s) || abort("qwenpaw plugin validation failed")
+
+  zip_dir(tmp_root, package_name, out_zip)
+  FileUtils.cp(out_zip, stable_zip)
+end
+
+puts out_zip

--- a/plugins/teamharness/adapters/qwenpaw/scripts/validate-qwenpaw-plugin.rb
+++ b/plugins/teamharness/adapters/qwenpaw/scripts/validate-qwenpaw-plugin.rb
@@ -1,0 +1,61 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "pathname"
+require "yaml"
+
+abort("usage: validate-qwenpaw-plugin.rb <generated-plugin-dir>") if ARGV.empty?
+
+package_dir = Pathname.new(ARGV[0]).expand_path
+
+def fail!(message)
+  warn "ERROR: #{message}"
+  exit 1
+end
+
+def assert_file(path)
+  fail!("missing file: #{path}") unless path.file?
+end
+
+def assert_dir(path)
+  fail!("missing directory: #{path}") unless path.directory?
+end
+
+assert_dir(package_dir)
+plugin_json = package_dir / "plugin.json"
+plugin_py = package_dir / "plugin.py"
+asset_dir = package_dir / "teamharness"
+
+assert_file(plugin_json)
+assert_file(plugin_py)
+assert_dir(asset_dir)
+
+manifest = JSON.parse(plugin_json.read)
+fail!("plugin id must be teamharness") unless manifest["id"] == "teamharness"
+fail!("plugin type must be general") unless manifest["type"] == "general"
+fail!("backend entry must be plugin.py") unless manifest.dig("entry", "backend") == "plugin.py"
+
+features = manifest.dig("meta", "features") || []
+fail!("qwenpaw plugin must not declare periodic-sync") if features.include?("periodic-sync")
+
+assert_file(asset_dir / "plugin.yaml")
+source_manifest = YAML.load_file(asset_dir / "plugin.yaml")
+version = source_manifest.fetch("metadata").fetch("version")
+fail!("plugin version mismatch") unless manifest["version"] == version
+
+assert_file(asset_dir / "prompts/team/TEAMS.md")
+assert_file(asset_dir / "prompts/agent/worker.md")
+assert_file(asset_dir / "prompts/manager/AGENTS.md")
+assert_file(asset_dir / "skills/team/communication/SKILL.md")
+assert_file(asset_dir / "mcp/server.py")
+fail!("top-level hooks must not be packaged for qwenpaw") if (asset_dir / "hooks").exist?
+
+stdout, stderr, status = Open3.capture3("python3", "-m", "py_compile", plugin_py.to_s)
+fail!("plugin.py syntax check failed: #{stderr}#{stdout}") unless status.success?
+
+stdout, stderr, status = Open3.capture3("python3", "-m", "py_compile", (asset_dir / "mcp/server.py").to_s)
+fail!("teamharness mcp syntax check failed: #{stderr}#{stdout}") unless status.success?
+
+puts "ok: qwenpaw teamharness #{version}"

--- a/plugins/teamharness/adapters/qwenpaw/uninstall.sh
+++ b/plugins/teamharness/adapters/qwenpaw/uninstall.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v qwenpaw >/dev/null 2>&1; then
+  printf 'y\n' | qwenpaw plugin uninstall teamharness >/dev/null 2>&1 || true
+fi
+
+log_file="${TEAMHARNESS_INSTALL_LOG:-}"
+if [ -n "$log_file" ]; then
+  mkdir -p "$(dirname "$log_file")"
+  printf '{"event":"uninstall","runtime":"qwenpaw","pluginDir":"%s"}\n' "${AGENTTEAMS_PLUGIN_DIR:-${PWD}}" >> "$log_file"
+fi

--- a/plugins/teamharness/loongsuite/agents.d/teamharness.json
+++ b/plugins/teamharness/loongsuite/agents.d/teamharness.json
@@ -1,0 +1,17 @@
+{
+  "id": "teamharness",
+  "displayName": "TeamHarness",
+  "deployMode": "plugin-probe",
+  "detection": {
+    "paths": ["~/.qwenpaw", "~/.claude"],
+    "commands": ["qwenpaw", "claude"]
+  },
+  "pluginProbe": {
+    "source": {
+      "type": "tar",
+      "tarball": "$PILOT_DIR/plugins/teamharness.tar.gz",
+      "destDir": "$PILOT_DATA/plugins/teamharness"
+    },
+    "mountType": "wrapper"
+  }
+}

--- a/plugins/teamharness/mcp/server.py
+++ b/plugins/teamharness/mcp/server.py
@@ -1,0 +1,2717 @@
+#!/usr/bin/env python3
+"""TeamHarness MCP stdio server entry point."""
+
+from __future__ import annotations
+
+import html
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import threading
+import time
+from typing import Any
+import urllib.parse
+import urllib.request
+import uuid
+
+
+TOOL_NAMES = ["health", "message", "roomflow", "filesync", "projectflow", "taskflow"]
+MESSAGE_TOOL_BLOCKED_ROLES = {"worker", "remote-member"}
+MATRIX_USER_RE = re.compile(r"@[a-zA-Z0-9._=+/\-]+:[a-zA-Z0-9.\-]+(?::\d+)?")
+MENTION_LOCAL_CHARS = r"a-zA-Z0-9._=+/\-"
+SHORT_MATRIX_MENTION_RE = re.compile(
+    rf"(?<![{MENTION_LOCAL_CHARS}])@([{MENTION_LOCAL_CHARS}]+)(?![{MENTION_LOCAL_CHARS}])(?!:[a-zA-Z0-9.\-])"
+)
+MATRIX_ROOM_RE = re.compile(r"^![^:\s]+:[^\s]+$")
+LOW_INFORMATION_ACKS = {"ack", "acknowledged", "ok", "okay", "done", "received", "收到", "好的", "好"}
+MC_ALIAS = "hiclaw"
+UNSAFE_SESSION_FILENAME_RE = re.compile(r'[\\/:*?"<>|]')
+SESSION_WRITE_LOCKS: dict[str, threading.Lock] = {}
+
+TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
+    "health": {
+        "description": (
+            "Check TeamHarness MCP server availability and basic tool wiring. "
+            "This is not runtime worker health, QwenPaw process health, storage "
+            "status, or controller readiness."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": True,
+        },
+    },
+    "message": {
+        "description": (
+            "Send a TeamHarness message only when the output must leave the "
+            "current runtime conversation: Matrix cross-room sends, external "
+            "cross-channel sends, or requester replyRoute/cross-session reports. "
+            "Do not use this tool for normal replies in the current room/session; "
+            "answer directly instead."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["send"],
+                    "description": "Only send is supported.",
+                },
+                "channel": {
+                    "type": "string",
+                    "description": "matrix for Matrix room sends, or an external channel such as dingtalk.",
+                },
+                "target": {
+                    "type": "string",
+                    "description": "Matrix room target for cross-room sends, for example room:!room:domain.",
+                },
+                "replyRoute": {
+                    "type": "object",
+                    "description": "Preferred requester route for cross-session reports.",
+                    "additionalProperties": True,
+                    "properties": {
+                        "channel": {"type": "string"},
+                        "targetUser": {"type": "string"},
+                        "targetSession": {"type": "string"},
+                    },
+                },
+                "targetUser": {
+                    "type": "string",
+                    "description": "External-channel recipient user id; required for non-Matrix sends.",
+                },
+                "targetSession": {
+                    "type": "string",
+                    "description": "External-channel session id; required for non-Matrix sends.",
+                },
+                "text": {
+                    "type": "string",
+                    "description": "Message text. message and body aliases are also accepted.",
+                },
+                "dryRun": {
+                    "type": "boolean",
+                    "description": "Return the resolved payload without sending.",
+                },
+            },
+            "additionalProperties": True,
+        },
+    },
+    "roomflow": {
+        "description": (
+            "Manage Matrix task rooms for TeamHarness execution-channel "
+            "isolation: create a dedicated room for a project or quick task, "
+            "list joined rooms, or archive a task room. Task rooms are internal "
+            "Leader/Worker execution channels, not requester reply channels."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["create_task_room", "list_rooms", "archive_room"],
+                    "description": "Room operation to perform.",
+                },
+                "taskId": {
+                    "type": "string",
+                    "description": "Safe task or project id used in the room topic.",
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Human-readable Matrix room name for create_task_room.",
+                },
+                "source": {
+                    "type": "string",
+                    "description": "Optional requester/source label such as matrix, dingtalk, or wechat. Non-Matrix sources require sourceRoomId.",
+                },
+                "sourceRoomId": {
+                    "type": "string",
+                    "description": "Stable external requester room/conversation id. Required for non-Matrix sources; the same source+sourceRoomId reuses the same task room.",
+                },
+                "topic": {
+                    "type": "string",
+                    "description": "Optional Matrix room topic. Defaults to a task-room topic.",
+                },
+                "invite": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Matrix user ids to invite. A comma-separated string is also accepted.",
+                },
+                "admin": {
+                    "type": "string",
+                    "description": "Optional Team Admin Matrix user id to invite and grant power level 100.",
+                },
+                "roomId": {
+                    "type": "string",
+                    "description": "Matrix room id for archive_room, with or without room: prefix.",
+                },
+                "payload": {
+                    "type": "object",
+                    "description": "Room payload; flat arguments are also accepted.",
+                    "additionalProperties": True,
+                },
+                "dryRun": {
+                    "type": "boolean",
+                    "description": "Return the resolved room operation without calling Matrix.",
+                },
+            },
+            "additionalProperties": True,
+        },
+    },
+    "filesync": {
+        "description": (
+            "Explicitly list, stat, pull, or push TeamHarness shared artifacts "
+            "under shared/projects, shared/tasks, or read-only global-shared. "
+            "Use this for deliberate shared file operations, not periodic "
+            "workspace sync or runtime package updates."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["list", "stat", "pull", "push"],
+                    "description": "Shared artifact operation to perform.",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Relative path beginning with shared/projects/, shared/tasks/, or global-shared/.",
+                },
+                "workspaceDir": {
+                    "type": "string",
+                    "description": "Runtime workspace containing the shared/ tree; usually inferred.",
+                },
+                "storage": {
+                    "type": "object",
+                    "description": "Optional storage prefixes such as sharedPrefix or globalSharedPrefix.",
+                    "additionalProperties": True,
+                },
+                "exclude": {
+                    "type": "array",
+                    "description": "Optional patterns excluded during push.",
+                    "items": {"type": "string"},
+                },
+                "dryRun": {
+                    "type": "boolean",
+                    "description": "Return the mc command without executing it.",
+                },
+            },
+            "additionalProperties": True,
+        },
+    },
+    "projectflow": {
+        "description": (
+            "Manage durable TeamHarness project state only after Project Work "
+            "mode is selected: create projects, plan or update DAG and Loop "
+            "work, query ready nodes, and record loop iterations. Do not use "
+            "for ordinary direct replies or one-off checks."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "create_project",
+                        "create_quick_project",
+                        "resolve_project",
+                        "plan_dag",
+                        "plan_loop",
+                        "ready_nodes",
+                        "ready_loop_nodes",
+                        "record_loop_iteration",
+                        "accept_task_result",
+                        "mark_requester_report_sent",
+                        "pause_project",
+                        "resume_project",
+                        "complete_project",
+                    ],
+                    "description": "Project operation to perform.",
+                },
+                "projectId": {
+                    "type": "string",
+                    "description": "Safe project id used under shared/projects/{projectId}.",
+                },
+                "payload": {
+                    "type": "object",
+                    "description": "Project payload; flat arguments are also accepted.",
+                    "additionalProperties": True,
+                },
+                "tasks": {
+                    "type": "array",
+                    "description": "DAG or Loop task nodes for planning actions.",
+                    "items": {"type": "object", "additionalProperties": True},
+                },
+                "replyRoute": {
+                    "type": "object",
+                    "description": "Requester route for accepted outcome reports from external or cross-session requests.",
+                    "additionalProperties": True,
+                },
+                "sourceRoomId": {
+                    "type": "string",
+                    "description": "Stable external requester room/conversation id to persist with external project and task state.",
+                },
+                "accepted": {
+                    "type": "boolean",
+                    "description": "For accept_task_result, false records a revision state instead of accepting the result.",
+                },
+                "workspaceDir": {
+                    "type": "string",
+                    "description": "Runtime workspace containing shared/projects.",
+                },
+            },
+            "additionalProperties": True,
+        },
+    },
+    "taskflow": {
+        "description": (
+            "Coordinate bounded TeamHarness tasks after a project node is ready: "
+            "leader delegates and checks tasks; worker or remote-member "
+            "acknowledges and submits results. Do not use for direct questions, "
+            "readiness checks, or ordinary conversation."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "role": {
+                    "type": "string",
+                    "enum": ["leader", "worker", "remote-member"],
+                    "description": "Caller TeamHarness role; inferred from runtime config when omitted.",
+                },
+                "action": {
+                    "type": "string",
+                    "enum": ["delegate_task", "ack_task", "submit_task", "check_task"],
+                    "description": "Task lifecycle operation.",
+                },
+                "projectId": {
+                    "type": "string",
+                    "description": "Safe project id associated with a delegated task.",
+                },
+                "taskId": {
+                    "type": "string",
+                    "description": "Safe task id used under shared/tasks/{taskId}.",
+                },
+                "payload": {
+                    "type": "object",
+                    "description": "Task payload; flat arguments are also accepted.",
+                    "additionalProperties": True,
+                },
+                "spec": {
+                    "type": "string",
+                    "description": "Task execution contract for delegate_task.",
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "Worker result summary for submit_task.",
+                },
+                "deliverables": {
+                    "type": "array",
+                    "description": "Shared deliverable paths included in submit_task.",
+                    "items": {"type": "string"},
+                },
+                "workspaceDir": {
+                    "type": "string",
+                    "description": "Runtime workspace containing shared/tasks.",
+                },
+            },
+            "additionalProperties": True,
+        },
+    },
+}
+
+
+def _tool_schema(name: str) -> dict[str, Any]:
+    schema = TOOL_SCHEMAS[name]
+    return {
+        "name": name,
+        "description": schema["description"],
+        "inputSchema": schema["inputSchema"],
+    }
+
+
+def list_tools() -> list[dict[str, Any]]:
+    return [_tool_schema(name) for name in _visible_tool_names()]
+
+
+def call_tool(name: str, arguments: dict[str, Any] | None = None) -> dict[str, Any]:
+    args = arguments or {}
+    if name not in TOOL_NAMES:
+        payload = {"ok": False, "error": "unknown_tool", "tool": name}
+    elif name == "message" and _message_tool_blocked_for_runtime_role():
+        payload = {
+            "ok": False,
+            "error": "forbidden_tool",
+            "tool": name,
+            "message": "message tool is not available to worker roles",
+        }
+    elif name == "health":
+        payload = {"ok": True, "tool": name, "status": "ok"}
+    elif name == "message":
+        payload = _message(args)
+    elif name == "roomflow":
+        payload = _roomflow(args)
+    elif name == "filesync":
+        payload = _filesync(args)
+    elif name == "projectflow":
+        payload = _projectflow(args)
+    elif name == "taskflow":
+        payload = _taskflow(args)
+    else:
+        payload = {
+            "ok": True,
+            "tool": name,
+            "implemented": False,
+            "reason": "tool behavior is defined by later TeamHarness behavior slices",
+            "arguments": args,
+        }
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(payload, ensure_ascii=False),
+            }
+        ]
+    }
+
+
+def _matrix_target(target: str) -> tuple[str, str]:
+    raw = (target or "").strip()
+    if raw.startswith("matrix:"):
+        raw = raw[len("matrix:") :]
+    if raw.startswith("room:"):
+        room_id = raw[len("room:") :].strip()
+        if MATRIX_ROOM_RE.match(room_id):
+            return ("room", room_id)
+    if raw.startswith("!") and MATRIX_ROOM_RE.match(raw):
+        return ("room", raw)
+    if raw.startswith("user:") or raw.startswith("@"):
+        return ("user", raw[len("user:") :] if raw.startswith("user:") else raw)
+    raise ValueError("target must be a Matrix room target such as room:!room:domain")
+
+
+def _matrix_room_domain(room_id: str) -> str:
+    return room_id.split(":", 1)[1] if ":" in room_id else ""
+
+
+def _mentions(text: str, room_id: str = "") -> list[str]:
+    mentions = list(MATRIX_USER_RE.findall(text or ""))
+    domain = _matrix_room_domain(room_id)
+    if domain:
+        for local in SHORT_MATRIX_MENTION_RE.findall(text or ""):
+            mentions.append(f"@{local}:{domain}")
+    return list(dict.fromkeys(mentions))
+
+
+def _compact_without_mentions(text: str, mentions: list[str]) -> str:
+    without_mentions = MATRIX_USER_RE.sub("", text or "")
+    for mxid in mentions:
+        local = mxid.split(":", 1)[0]
+        without_mentions = re.sub(
+            rf"(?<![{MENTION_LOCAL_CHARS}]){re.escape(local)}(?![{MENTION_LOCAL_CHARS}])(?!:[a-zA-Z0-9.\-])",
+            "",
+            without_mentions,
+        )
+    return "".join(re.findall(r"[0-9A-Za-z\u4e00-\u9fff]+", without_mentions)).lower()
+
+
+def _ping_pong_error(text: str, mentions: list[str]) -> str | None:
+    if not mentions:
+        return None
+    compact = _compact_without_mentions(text, mentions)
+    if not compact or compact in LOW_INFORMATION_ACKS:
+        return "message blocked: low-information mention acknowledgements can create ping-pong loops"
+    return None
+
+
+def _render_inline_matrix_html(text: str) -> str:
+    parts = re.split(r"(`[^`\n]+`)", text)
+    rendered: list[str] = []
+    for part in parts:
+        if len(part) >= 2 and part.startswith("`") and part.endswith("`"):
+            rendered.append(f"<code>{html.escape(part[1:-1])}</code>")
+            continue
+        escaped = html.escape(part)
+        escaped = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", escaped)
+        rendered.append(escaped)
+    return "".join(rendered)
+
+
+def _table_cells(line: str) -> list[str]:
+    return [cell.strip() for cell in line.strip().strip("|").split("|")]
+
+
+def _is_table_separator(line: str) -> bool:
+    cells = _table_cells(line)
+    return bool(cells) and all(re.fullmatch(r":?-{3,}:?", cell or "") for cell in cells)
+
+
+def _render_fallback_table(lines: list[str]) -> str:
+    header = _table_cells(lines[0])
+    rows = [_table_cells(line) for line in lines[2:]]
+    parts = ["<table>", "<thead><tr>"]
+    parts.extend(f"<th>{_render_inline_matrix_html(cell)}</th>" for cell in header)
+    parts.append("</tr></thead>")
+    if rows:
+        parts.append("<tbody>")
+        for row in rows:
+            parts.append("<tr>")
+            parts.extend(f"<td>{_render_inline_matrix_html(cell)}</td>" for cell in row)
+            parts.append("</tr>")
+        parts.append("</tbody>")
+    parts.append("</table>")
+    return "".join(parts)
+
+
+def _md_to_html(text: str) -> str:
+    try:
+        from markdown_it import MarkdownIt
+
+        md = MarkdownIt(
+            "commonmark",
+            {
+                "html": False,
+                "linkify": True,
+                "breaks": True,
+                "typographer": False,
+            },
+        )
+        md.enable("strikethrough")
+        md.enable("table")
+        try:
+            from linkify_it import LinkifyIt
+
+            md.linkify = LinkifyIt()
+        except ImportError:
+            pass
+        return md.render(text).rstrip("\n")
+    except ImportError:
+        pass
+
+    lines = (text or "").splitlines()
+    if not lines:
+        return ""
+
+    blocks: list[str] = []
+    in_code_block = False
+    code_lines: list[str] = []
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        if line.strip().startswith("```"):
+            if in_code_block:
+                code = html.escape("\n".join(code_lines))
+                blocks.append(f"<pre><code>{code}</code></pre>")
+                code_lines = []
+                in_code_block = False
+            else:
+                in_code_block = True
+                code_lines = []
+            index += 1
+            continue
+        if in_code_block:
+            code_lines.append(line)
+            index += 1
+            continue
+
+        if index + 1 < len(lines) and "|" in line and _is_table_separator(lines[index + 1]):
+            table_lines = [line, lines[index + 1]]
+            index += 2
+            while index < len(lines) and "|" in lines[index] and lines[index].strip():
+                table_lines.append(lines[index])
+                index += 1
+            blocks.append(_render_fallback_table(table_lines))
+            continue
+
+        heading = re.match(r"^(#{1,6})\s+(.+?)\s*$", line)
+        if heading:
+            level = len(heading.group(1))
+            blocks.append(f"<h{level}>{_render_inline_matrix_html(heading.group(2))}</h{level}>")
+            index += 1
+            continue
+
+        if re.match(r"^\s*[-*]\s+\S", line):
+            items: list[str] = []
+            while index < len(lines):
+                item = re.match(r"^\s*[-*]\s+(.+?)\s*$", lines[index])
+                if not item:
+                    break
+                items.append(item.group(1))
+                index += 1
+            blocks.append("<ul>" + "".join(f"<li>{_render_inline_matrix_html(item)}</li>" for item in items) + "</ul>")
+            continue
+
+        if line.strip():
+            blocks.append(_render_inline_matrix_html(line))
+        else:
+            blocks.append("")
+        index += 1
+
+    if in_code_block:
+        code = html.escape("\n".join(code_lines))
+        blocks.append(f"<pre><code>{code}</code></pre>")
+
+    return "<br>\n".join(blocks)
+
+
+def _formatted_body(text: str, mentions: list[str]) -> str:
+    body = _md_to_html(text or "")
+    for mxid in mentions:
+        encoded = urllib.parse.quote(mxid, safe="")
+        local = mxid.split(":", 1)[0]
+        display = html.escape(local.lstrip("@") or mxid)
+        anchor = f'<a href="https://matrix.to/#/{encoded}">{display}</a>'
+        if mxid in body:
+            body = body.replace(mxid, anchor, 1)
+        else:
+            escaped = html.escape(mxid)
+            if escaped in body:
+                body = body.replace(escaped, anchor, 1)
+            else:
+                body = re.sub(
+                    rf"(?<![{MENTION_LOCAL_CHARS}]){re.escape(html.escape(local))}(?![{MENTION_LOCAL_CHARS}])(?!:[a-zA-Z0-9.\-])",
+                    anchor,
+                    body,
+                    count=1,
+                )
+    return body
+
+
+def _matrix_content(text: str, mentions: list[str]) -> dict[str, Any]:
+    content: dict[str, Any] = {
+        "msgtype": "m.text",
+        "body": text,
+        "format": "org.matrix.custom.html",
+        "formatted_body": _formatted_body(text, mentions),
+    }
+    if mentions:
+        content["m.mentions"] = {"user_ids": mentions}
+    return content
+
+
+def _reply_route(arguments: dict[str, Any]) -> dict[str, Any]:
+    route = arguments.get("replyRoute") or arguments.get("reply_route")
+    return route if isinstance(route, dict) else {}
+
+
+def _route_value(arguments: dict[str, Any], route: dict[str, Any], *names: str) -> str:
+    for name in names:
+        value = route.get(name)
+        if value is None:
+            value = arguments.get(name)
+        if value is not None:
+            return str(value).strip()
+    return ""
+
+
+def _qwenpaw_message(arguments: dict[str, Any], route: dict[str, Any], channel: str, message: str) -> dict[str, Any]:
+    target_user = _route_value(arguments, route, "targetUser", "target_user", "userId", "user_id")
+    target_session = _route_value(arguments, route, "targetSession", "target_session", "sessionId", "session_id")
+    agent_id = str(arguments.get("agentId") or arguments.get("agent_id") or arguments.get("accountId") or "default").strip()
+    base: dict[str, Any] = {
+        "ok": True,
+        "tool": "message",
+        "action": "send",
+        "channel": channel,
+        "targetUser": target_user,
+        "targetSession": target_session,
+        "agentId": agent_id or "default",
+    }
+    if message:
+        base["message"] = message
+    if not target_user:
+        return {"ok": False, "tool": "message", "channel": channel, "error": "targetUser is required for non-Matrix channel sends"}
+    if not target_session:
+        return {"ok": False, "tool": "message", "channel": channel, "error": "targetSession is required for non-Matrix channel sends"}
+    if not message:
+        return {"ok": False, "tool": "message", "channel": channel, "error": "message text is required"}
+    if arguments.get("dryRun"):
+        base["dryRun"] = True
+        return base
+
+    api_base = (os.getenv("QWENPAW_API_BASE") or os.getenv("COPAW_API_BASE") or "http://127.0.0.1:8088").rstrip("/")
+    api_path = "/messages/send" if api_base.endswith("/api") else "/api/messages/send"
+    body = {
+        "channel": channel,
+        "target_user": target_user,
+        "target_session": target_session,
+        "text": message,
+    }
+    request = urllib.request.Request(
+        f"{api_base}{api_path}",
+        data=json.dumps(body).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "X-Agent-Id": agent_id or "default",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8") or "{}")
+        base["response"] = data
+    except urllib.error.HTTPError as exc:
+        body_text = exc.read().decode("utf-8", errors="replace")[:200]
+        return {"ok": False, "tool": "message", "channel": channel, "error": f"QwenPaw message API error: HTTP {exc.code}: {body_text}"}
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return {"ok": False, "tool": "message", "channel": channel, "error": f"QwenPaw message API error: {exc}"}
+    try:
+        base["sessionRecorded"] = _record_outbound_to_session(
+            channel=channel,
+            user_id=target_user,
+            session_id=target_session,
+            text=message,
+            message_id=None,
+            account_id=agent_id or "default",
+        )
+    except Exception:
+        base["sessionRecorded"] = False
+        base["warning"] = "message sent, but local session record failed"
+    return base
+
+
+def _session_safe(name: str) -> str:
+    return UNSAFE_SESSION_FILENAME_RE.sub("--", name)
+
+
+def _qwenpaw_working_dir() -> Path | None:
+    for name in ("QWENPAW_WORKING_DIR", "COPAW_WORKING_DIR"):
+        raw = os.getenv(name, "").strip()
+        if raw:
+            return Path(raw).expanduser()
+    for name in ("HICLAW_AGENT_HOME", "HICLAW_WORKER_HOME", "HOME"):
+        raw = os.getenv(name, "").strip()
+        if raw:
+            home = Path(raw).expanduser()
+            return home / ".qwenpaw"
+    return None
+
+
+def _channel_session_path(channel: str, user_id: str, session_id: str, account_id: str) -> Path | None:
+    working_dir = _qwenpaw_working_dir()
+    if working_dir is None:
+        return None
+
+    workspace_name = account_id or "default"
+    workspace_dir = working_dir / "workspaces" / workspace_name
+    if not workspace_dir.exists() and workspace_name != "default":
+        default_workspace = working_dir / "workspaces" / "default"
+        if default_workspace.exists():
+            workspace_dir = default_workspace
+
+    filename = f"{_session_safe(user_id)}_{_session_safe(session_id)}.json" if user_id else f"{_session_safe(session_id)}.json"
+    channel_dir = _session_safe(channel.strip().lower() or "default")
+    current_path = workspace_dir / "sessions" / channel_dir / filename
+    legacy_path = workspace_dir / "sessions" / filename
+    if not current_path.exists() and legacy_path.exists():
+        current_path.parent.mkdir(parents=True, exist_ok=True)
+        current_path.write_bytes(legacy_path.read_bytes())
+    return current_path
+
+
+def _outbound_message_dict(channel: str, text: str, message_id: str | None, account_id: str, metadata: dict[str, Any]) -> dict[str, Any]:
+    now = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+    millis = int((time.time() % 1) * 1000)
+    msg_metadata = {
+        "channel": channel,
+        "message_id": message_id or "",
+        "source": "message_tool_outbound",
+    }
+    msg_metadata.update(metadata)
+    return {
+        "id": uuid.uuid4().hex,
+        "name": account_id or "default",
+        "role": "assistant",
+        "content": [{"type": "text", "text": text}],
+        "metadata": msg_metadata,
+        "timestamp": f"{now}.{millis:03d}",
+    }
+
+
+def _record_outbound_to_session(
+    *,
+    channel: str,
+    user_id: str,
+    session_id: str,
+    text: str,
+    message_id: str | None,
+    account_id: str,
+    metadata: dict[str, Any] | None = None,
+) -> bool:
+    channel_key = channel.strip().lower() or "default"
+    path = _channel_session_path(channel_key, user_id, session_id, account_id)
+    if path is None:
+        return False
+
+    lock = SESSION_WRITE_LOCKS.setdefault(str(path), threading.Lock())
+    with lock:
+        states: dict[str, Any] = {}
+        if path.exists():
+            try:
+                loaded = json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                return False
+            if not isinstance(loaded, dict):
+                return False
+            states = loaded
+
+        agent_state = states.setdefault("agent", {})
+        if not isinstance(agent_state, dict):
+            return False
+        memory_state = agent_state.setdefault("memory", {})
+        if not isinstance(memory_state, dict):
+            return False
+        content = memory_state.setdefault("content", [])
+        if not isinstance(content, list):
+            return False
+
+        content.append([
+            _outbound_message_dict(
+                channel_key,
+                text,
+                message_id,
+                account_id,
+                metadata or {
+                    "user_id": user_id,
+                    "session_id": session_id,
+                },
+            ),
+            [],
+        ])
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(f".{path.name}.tmp")
+        tmp.write_text(json.dumps(states, ensure_ascii=False), encoding="utf-8")
+        tmp.replace(path)
+    return True
+
+
+def _record_matrix_outbound_to_session(room_id: str, text: str, message_id: str | None, account_id: str) -> bool:
+    return _record_outbound_to_session(
+        channel="matrix",
+        user_id=room_id,
+        session_id=f"matrix:{room_id}",
+        text=text,
+        message_id=message_id,
+        account_id=account_id,
+        metadata={"room_id": room_id},
+    )
+
+
+def _message(arguments: dict[str, Any]) -> dict[str, Any]:
+    action = arguments.get("action") or "send"
+    route = _reply_route(arguments)
+    channel = str(route.get("channel") or arguments.get("channel") or "matrix")
+    if action != "send":
+        return {"ok": False, "tool": "message", "error": f"unsupported action: {action}"}
+    if channel != "matrix":
+        message = str(arguments.get("message") or arguments.get("text") or arguments.get("body") or "")
+        return _qwenpaw_message(arguments, route, channel, message)
+
+    message = str(arguments.get("message") or arguments.get("text") or arguments.get("body") or "")
+    try:
+        target = arguments.get("target") or arguments.get("room_id") or arguments.get("roomId") or ""
+        target_kind, target_id = _matrix_target(str(target))
+    except ValueError as exc:
+        return {"ok": False, "tool": "message", "error": str(exc)}
+    if target_kind == "user":
+        return {"ok": False, "tool": "message", "error": "Matrix user targets are not supported yet"}
+
+    mentions = _mentions(message, target_id)
+    blocked = _ping_pong_error(message, mentions)
+    if blocked:
+        return {"ok": False, "tool": "message", "error": blocked}
+
+    content = _matrix_content(message, mentions)
+    base: dict[str, Any] = {
+        "ok": True,
+        "tool": "message",
+        "action": "send",
+        "channel": "matrix",
+        "target": f"room:{target_id}",
+        "targetKind": "room",
+        "mentions": mentions,
+        "content": content,
+    }
+    if arguments.get("dryRun"):
+        base["dryRun"] = True
+        return base
+
+    homeserver = os.getenv("HICLAW_MATRIX_URL", "").rstrip("/")
+    token = os.getenv("HICLAW_WORKER_MATRIX_TOKEN", "")
+    if not homeserver or not token:
+        return {"ok": False, "tool": "message", "error": "HICLAW_MATRIX_URL and HICLAW_WORKER_MATRIX_TOKEN are required"}
+
+    room_id = urllib.parse.quote(target_id, safe="")
+    txn_id = f"teamharness-{os.getpid()}-{int(time.time() * 1000)}"
+    url = f"{homeserver}/_matrix/client/v3/rooms/{room_id}/send/m.room.message/{txn_id}"
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(content).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="PUT",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8") or "{}")
+        base["messageId"] = data.get("event_id")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")[:200]
+        return {"ok": False, "tool": "message", "error": f"Matrix API error: HTTP {exc.code}: {body}"}
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return {"ok": False, "tool": "message", "error": f"Matrix API error: {exc}"}
+    account_id = str(arguments.get("agentId") or arguments.get("agent_id") or arguments.get("accountId") or arguments.get("account_id") or "default").strip() or "default"
+    try:
+        base["sessionRecorded"] = _record_matrix_outbound_to_session(
+            target_id,
+            message,
+            base.get("messageId"),
+            account_id,
+        )
+    except Exception:
+        base["sessionRecorded"] = False
+        base["warning"] = "message sent, but local session record failed"
+    return base
+
+
+def _matrix_env(tool: str) -> tuple[str, str]:
+    homeserver = os.getenv("HICLAW_MATRIX_URL", "").rstrip("/")
+    token = os.getenv("HICLAW_WORKER_MATRIX_TOKEN", "")
+    if not homeserver or not token:
+        raise ValueError("HICLAW_MATRIX_URL and HICLAW_WORKER_MATRIX_TOKEN are required")
+    return homeserver, token
+
+
+def _matrix_user_id() -> str:
+    explicit = os.getenv("HICLAW_MATRIX_USER_ID", "").strip()
+    if explicit:
+        return explicit
+    member = _section(_load_runtime_config(), "member")
+    matrix_user_id = str(member.get("matrixUserId") or member.get("matrix_user_id") or "").strip()
+    if matrix_user_id:
+        return matrix_user_id
+    name = os.getenv("HICLAW_WORKER_NAME", "").strip()
+    domain = os.getenv("HICLAW_MATRIX_DOMAIN", "").strip()
+    if name and domain:
+        return f"@{name}:{domain}"
+    return ""
+
+
+def _string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        try:
+            decoded = json.loads(text)
+        except json.JSONDecodeError:
+            return [item.strip() for item in text.split(",") if item.strip()]
+        return _string_list(decoded)
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return []
+
+
+def _roomflow(arguments: dict[str, Any]) -> dict[str, Any]:
+    action = str(arguments.get("action") or "create_task_room")
+    payload = _payload(arguments)
+    if action == "create_task_room":
+        return _create_task_room(arguments, payload)
+    if action == "list_rooms":
+        return _list_rooms(arguments)
+    if action == "archive_room":
+        return _archive_room(arguments, payload)
+    return {"ok": False, "tool": "roomflow", "action": action, "error": f"unsupported action: {action}"}
+
+
+def _create_task_room(arguments: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    try:
+        task_id = _safe_id(payload.get("taskId") or payload.get("projectId"), "taskId")
+    except ValueError as exc:
+        return {"ok": False, "tool": "roomflow", "action": "create_task_room", "error": str(exc)}
+    name = str(payload.get("name") or payload.get("title") or "").strip()
+    if not name:
+        return {"ok": False, "tool": "roomflow", "action": "create_task_room", "error": "name is required"}
+    source = str(payload.get("source") or "").strip()
+    topic = str(payload.get("topic") or "").strip()
+    if not topic:
+        suffix = f" [source: {source}]" if source else ""
+        topic = f"Task room for {task_id}{suffix}"
+    invite = _string_list(payload.get("invite") if "invite" in payload else arguments.get("invite"))
+    admin = str(payload.get("admin") or payload.get("adminUser") or payload.get("admin_user") or _runtime_team_admin_user_id()).strip()
+    if admin and admin not in invite:
+        invite.append(admin)
+
+    creator = _matrix_user_id()
+    power_users: dict[str, int] = {}
+    if creator:
+        power_users[creator] = 100
+    if admin:
+        power_users[admin] = 100
+
+    body: dict[str, Any] = {
+        "name": name,
+        "topic": topic,
+        "invite": invite,
+        "preset": "trusted_private_chat",
+    }
+    if power_users:
+        body["power_level_content_override"] = {"users": power_users}
+    binding = _roomflow_source_room_binding(arguments, payload)
+    if binding.get("error"):
+        return {"ok": False, "tool": "roomflow", "action": "create_task_room", "error": binding["error"]}
+
+    base: dict[str, Any] = {
+        "ok": True,
+        "tool": "roomflow",
+        "action": "create_task_room",
+        "taskId": task_id,
+        "name": name,
+        "source": source,
+        "topic": topic,
+        "invite": invite,
+        "content": body,
+    }
+    if binding.get("sourceRoomKey"):
+        base["sourceRoomKey"] = binding["sourceRoomKey"]
+    if binding.get("sourceRoomId"):
+        base["sourceRoomId"] = binding["sourceRoomId"]
+    existing_room_id = _bound_room_id(binding)
+    if existing_room_id:
+        base["roomId"] = existing_room_id
+        base["target"] = f"room:{existing_room_id}"
+        base["reused"] = True
+        if arguments.get("dryRun"):
+            base["dryRun"] = True
+            return base
+        try:
+            _ensure_matrix_room_members(existing_room_id, invite)
+        except ValueError as exc:
+            return {"ok": False, "tool": "roomflow", "action": "create_task_room", "error": str(exc)}
+        except urllib.error.HTTPError as exc:
+            error = exc.read().decode("utf-8", errors="replace")[:200]
+            return {"ok": False, "tool": "roomflow", "action": "create_task_room", "error": f"Matrix API error: HTTP {exc.code}: {error}"}
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            return {"ok": False, "tool": "roomflow", "action": "create_task_room", "error": f"Matrix API error: {exc}"}
+        return base
+
+    if arguments.get("dryRun"):
+        base["dryRun"] = True
+        return base
+
+    try:
+        homeserver, token = _matrix_env("roomflow")
+    except ValueError as exc:
+        return {"ok": False, "tool": "roomflow", "action": "create_task_room", "error": str(exc)}
+    request = urllib.request.Request(
+        f"{homeserver}/_matrix/client/v3/createRoom",
+        data=json.dumps(body).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8") or "{}")
+    except urllib.error.HTTPError as exc:
+        error = exc.read().decode("utf-8", errors="replace")[:200]
+        return {"ok": False, "tool": "roomflow", "action": "create_task_room", "error": f"Matrix API error: HTTP {exc.code}: {error}"}
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return {"ok": False, "tool": "roomflow", "action": "create_task_room", "error": f"Matrix API error: {exc}"}
+    room_id = str(data.get("room_id") or "")
+    if not room_id:
+        return {"ok": False, "tool": "roomflow", "action": "create_task_room", "error": "Matrix createRoom response missing room_id", "response": data}
+    base["roomId"] = room_id
+    base["target"] = f"room:{room_id}"
+    _write_roomflow_source_room_binding(binding, room_id, base)
+    return base
+
+
+def _roomflow_source_room_binding(arguments: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    source, source_room_id = _external_source_room_ref(payload)
+    if not source:
+        return {}
+    if not source_room_id:
+        return {"error": "sourceRoomId is required for non-Matrix source task rooms"}
+    source_room_key = f"{source}:{source_room_id}"
+    binding: dict[str, Any] = {
+        "source": source,
+        "sourceRoomId": source_room_id,
+        "sourceRoomKey": source_room_key,
+    }
+    workspace_dir = _optional_workspace_dir(arguments)
+    if not workspace_dir:
+        return {"error": "workspaceDir is required to persist external source task room bindings"}
+    digest = hashlib.sha256(source_room_key.encode("utf-8")).hexdigest()[:16]
+    path = workspace_dir / "shared" / "roomflow" / "source-rooms" / f"{source}-{digest}.json"
+    record = _read_json(path)
+    binding["path"] = path
+    binding["record"] = record
+    return binding
+
+
+def _external_source_room_ref(payload: dict[str, Any]) -> tuple[str, str]:
+    source = str(payload.get("source") or "").strip().lower()
+    if not source or source == "matrix":
+        return "", ""
+    return source, str(payload.get("sourceRoomId") or payload.get("source_room_id") or "").strip()
+
+
+def _bound_room_id(binding: dict[str, Any]) -> str:
+    record = binding.get("record")
+    if not isinstance(record, dict):
+        return ""
+    return str(record.get("roomId") or record.get("room_id") or "").strip()
+
+
+def _write_roomflow_source_room_binding(binding: dict[str, Any], room_id: str, base: dict[str, Any]) -> None:
+    path = binding.get("path")
+    if not isinstance(path, Path):
+        return
+    record = dict(binding.get("record") if isinstance(binding.get("record"), dict) else {})
+    record.update(
+        {
+            "source": binding.get("source"),
+            "sourceRoomId": binding.get("sourceRoomId"),
+            "sourceRoomKey": binding.get("sourceRoomKey"),
+            "roomId": room_id,
+            "target": f"room:{room_id}",
+            "updatedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "taskId": base.get("taskId"),
+            "name": base.get("name"),
+        }
+    )
+    if "createdAt" not in record:
+        record["createdAt"] = record["updatedAt"]
+    _write_json(path, record)
+
+
+def _ensure_matrix_room_members(room_id: str, invite: list[str]) -> None:
+    current = set(_matrix_room_member_user_ids(room_id))
+    for user_id in invite:
+        if user_id and user_id not in current:
+            _matrix_invite_to_room(room_id, user_id)
+
+
+def _matrix_invite_to_room(room_id: str, user_id: str) -> None:
+    homeserver, token = _matrix_env("roomflow")
+    encoded_room = urllib.parse.quote(room_id, safe="")
+    request = urllib.request.Request(
+        f"{homeserver}/_matrix/client/v3/rooms/{encoded_room}/invite",
+        data=json.dumps({"user_id": user_id}).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        response.read()
+
+
+def _list_rooms(arguments: dict[str, Any]) -> dict[str, Any]:
+    if arguments.get("dryRun"):
+        return {"ok": True, "tool": "roomflow", "action": "list_rooms", "dryRun": True}
+    try:
+        homeserver, token = _matrix_env("roomflow")
+    except ValueError as exc:
+        return {"ok": False, "tool": "roomflow", "action": "list_rooms", "error": str(exc)}
+    request = urllib.request.Request(
+        f"{homeserver}/_matrix/client/v3/joined_rooms",
+        headers={"Authorization": f"Bearer {token}"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8") or "{}")
+    except urllib.error.HTTPError as exc:
+        error = exc.read().decode("utf-8", errors="replace")[:200]
+        return {"ok": False, "tool": "roomflow", "action": "list_rooms", "error": f"Matrix API error: HTTP {exc.code}: {error}"}
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return {"ok": False, "tool": "roomflow", "action": "list_rooms", "error": f"Matrix API error: {exc}"}
+    rooms = data.get("joined_rooms") if isinstance(data.get("joined_rooms"), list) else []
+    return {"ok": True, "tool": "roomflow", "action": "list_rooms", "rooms": rooms, "count": len(rooms)}
+
+
+def _archive_room(arguments: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    target = str(payload.get("roomId") or payload.get("room_id") or arguments.get("target") or "").strip()
+    try:
+        target_kind, room_id = _matrix_target(target)
+    except ValueError as exc:
+        return {"ok": False, "tool": "roomflow", "action": "archive_room", "error": str(exc)}
+    if target_kind != "room":
+        return {"ok": False, "tool": "roomflow", "action": "archive_room", "error": "archive_room requires a Matrix room target"}
+    base = {"ok": True, "tool": "roomflow", "action": "archive_room", "roomId": room_id, "target": f"room:{room_id}"}
+    if arguments.get("dryRun"):
+        base["dryRun"] = True
+        return base
+    try:
+        homeserver, token = _matrix_env("roomflow")
+    except ValueError as exc:
+        return {"ok": False, "tool": "roomflow", "action": "archive_room", "error": str(exc)}
+    encoded_room = urllib.parse.quote(room_id, safe="")
+    request = urllib.request.Request(
+        f"{homeserver}/_matrix/client/v3/rooms/{encoded_room}/leave",
+        data=b"{}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10):
+            pass
+    except urllib.error.HTTPError as exc:
+        error = exc.read().decode("utf-8", errors="replace")[:200]
+        if "M_NOT_FOUND" in error:
+            base["note"] = "already left"
+            return base
+        return {"ok": False, "tool": "roomflow", "action": "archive_room", "error": f"Matrix API error: HTTP {exc.code}: {error}"}
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return {"ok": False, "tool": "roomflow", "action": "archive_room", "error": f"Matrix API error: {exc}"}
+    base["archived"] = True
+    return base
+
+
+def _remote_root(value: str) -> str:
+    text = (value or "").strip()
+    if not text:
+        raise ValueError("storage sharedPrefix is required")
+    return text.rstrip("/") + "/"
+
+
+def _load_runtime_config() -> dict[str, Any]:
+    runtime_config = os.getenv("TEAMHARNESS_RUNTIME_CONFIG", "").strip()
+    if not runtime_config:
+        return {}
+    path = Path(runtime_config)
+    if not path.exists():
+        return {}
+    text = path.read_text(encoding="utf-8")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        data = None
+    if isinstance(data, dict):
+        return data
+    try:
+        import yaml
+
+        data = yaml.safe_load(text) or {}
+    except Exception:
+        data = _simple_yaml_sections(text)
+    return data if isinstance(data, dict) else {}
+
+
+def _simple_yaml_sections(text: str) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    section: str | None = None
+    nested_section: str | None = None
+    for line in text.splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        top = re.match(r"^([A-Za-z0-9_]+):\s*(.*)$", line)
+        if top:
+            key, value = top.group(1), top.group(2).strip()
+            if value:
+                data[key] = _yaml_scalar(value)
+                section = None
+                nested_section = None
+            else:
+                data[key] = {}
+                section = key
+                nested_section = None
+            continue
+        nested = re.match(r"^\s{2}([A-Za-z0-9_]+):\s*(.*)$", line)
+        if nested and section and isinstance(data.get(section), dict):
+            key, value = nested.group(1), nested.group(2).strip()
+            if value:
+                data[section][key] = _yaml_scalar(value)
+                nested_section = None
+            else:
+                data[section][key] = {}
+                nested_section = key
+            continue
+        deep = re.match(r"^\s{4}([A-Za-z0-9_]+):\s*(.*)$", line)
+        if deep and section and nested_section and isinstance(data.get(section), dict):
+            parent = data[section].get(nested_section)
+            if isinstance(parent, dict):
+                parent[deep.group(1)] = _yaml_scalar(deep.group(2).strip())
+    return data
+
+
+def _yaml_scalar(value: str) -> Any:
+    if value in {"", "null", "Null", "NULL", "~"}:
+        return ""
+    if value in {"true", "True", "TRUE"}:
+        return True
+    if value in {"false", "False", "FALSE"}:
+        return False
+    if (value.startswith("'") and value.endswith("'")) or (value.startswith('"') and value.endswith('"')):
+        return value[1:-1]
+    return value
+
+
+def _section(data: dict[str, Any], name: str) -> dict[str, Any]:
+    value = data.get(name)
+    return value if isinstance(value, dict) else {}
+
+
+def _runtime_team_admin_user_id() -> str:
+    config = _load_runtime_config()
+    team = _section(config, "team")
+    admin = _section(team, "admin")
+    matrix_user_id = str(admin.get("matrixUserId") or admin.get("matrix_user_id") or "").strip()
+    if matrix_user_id:
+        return matrix_user_id
+    return _runtime_leader_dm_admin_user_id(config)
+
+
+def _runtime_leader_dm_admin_user_id(config: dict[str, Any]) -> str:
+    team = _section(config, "team")
+    room_id = str(team.get("leaderDmRoomId") or team.get("leader_dm_room_id") or "").strip()
+    if not room_id:
+        return ""
+    leader_id = str(_section(config, "member").get("matrixUserId") or _matrix_user_id()).strip()
+    try:
+        members = _matrix_room_member_user_ids(room_id)
+    except (ValueError, urllib.error.HTTPError, urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError):
+        return ""
+    for user_id in members:
+        if user_id and user_id != leader_id:
+            return user_id
+    return ""
+
+
+def _matrix_room_member_user_ids(room_id: str) -> list[str]:
+    homeserver, token = _matrix_env("roomflow")
+    encoded_room = urllib.parse.quote(room_id, safe="")
+    request = urllib.request.Request(
+        f"{homeserver}/_matrix/client/v3/rooms/{encoded_room}/members",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        data = json.loads(response.read().decode("utf-8") or "{}")
+    members: list[str] = []
+    for event in data.get("chunk", []):
+        if not isinstance(event, dict):
+            continue
+        user_id = str(event.get("state_key") or "").strip()
+        content = event.get("content") if isinstance(event.get("content"), dict) else {}
+        membership = str(content.get("membership") or "").strip()
+        if user_id and membership in {"join", "invite"}:
+            members.append(user_id)
+    return members
+
+
+def _runtime_team_room_id() -> str:
+    team = _section(_load_runtime_config(), "team")
+    return str(team.get("teamRoomId") or team.get("team_room_id") or "").strip()
+
+
+def _storage_root_prefix() -> str:
+    return os.getenv("HICLAW_STORAGE_PREFIX", "").strip().strip("/")
+
+
+def _mc_host_url(endpoint: str, access_key: str, secret_key: str) -> str:
+    url = endpoint.strip().rstrip("/")
+    if not url.startswith(("http://", "https://")):
+        url = f"http://{url}"
+    parsed = urllib.parse.urlsplit(url)
+    if "@" in parsed.netloc:
+        return url
+    user = urllib.parse.quote(access_key, safe="")
+    password = urllib.parse.quote(secret_key, safe="")
+    netloc = f"{user}:{password}@{parsed.netloc}"
+    return urllib.parse.urlunsplit(
+        (parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment)
+    )
+
+
+def _remote_uses_mc_alias(remote: str) -> bool:
+    return remote.strip().startswith(f"{MC_ALIAS}/")
+
+
+def _mc_alias_configured(env: dict[str, str]) -> bool:
+    try:
+        completed = subprocess.run(
+            ["mc", "alias", "list", MC_ALIAS],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=20,
+            env=env,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    output = f"{completed.stdout}\n{completed.stderr}"
+    return completed.returncode == 0 and f"{MC_ALIAS}" in output
+
+
+def _filesync_mc_env(remote: str) -> tuple[dict[str, str], str | None]:
+    env = dict(os.environ)
+    if not _remote_uses_mc_alias(remote):
+        return env, None
+
+    alias_env = f"MC_HOST_{MC_ALIAS}"
+    if env.get(alias_env):
+        return env, None
+
+    endpoint = env.get("HICLAW_FS_ENDPOINT", "").strip()
+    access_key = env.get("HICLAW_FS_ACCESS_KEY", "").strip()
+    secret_key = env.get("HICLAW_FS_SECRET_KEY", "").strip()
+    if endpoint and access_key and secret_key:
+        env[alias_env] = _mc_host_url(endpoint, access_key, secret_key)
+        return env, None
+
+    if _mc_alias_configured(env):
+        return env, None
+    return env, (
+        f"storage alias {MC_ALIAS} is not configured; missing "
+        "HICLAW_FS_ENDPOINT/HICLAW_FS_ACCESS_KEY/HICLAW_FS_SECRET_KEY"
+    )
+
+
+def _with_storage_root(prefix: str) -> str:
+    clean = (prefix or "").strip().strip("/")
+    root = _storage_root_prefix()
+    if not root:
+        return clean
+    if not clean:
+        return root
+    if clean == root or clean.startswith(f"{root}/"):
+        return clean
+    return f"{root}/{clean}"
+
+
+def _default_workspace_dir() -> str:
+    """Derive workspace dir from environment (set by qwenpaw-worker / copaw-worker)."""
+    for env_key in ("QWENPAW_WORKING_DIR", "COPAW_WORKING_DIR"):
+        working_dir = os.getenv(env_key, "").strip()
+        if working_dir:
+            return str(Path(working_dir) / "workspaces" / "default")
+    shared_dir = os.getenv("TEAMHARNESS_SHARED_DIR", "").strip() or os.getenv("HICLAW_SHARED_DIR", "").strip()
+    if shared_dir:
+        return str(Path(shared_dir).parent)
+    return ""
+
+
+def _default_shared_prefix() -> str:
+    """Derive storage shared prefix from environment or runtime.yaml."""
+    configured = os.getenv("HICLAW_SHARED_STORAGE_PREFIX", "").strip()
+    if configured:
+        return _with_storage_root(configured)
+    storage = _section(_load_runtime_config(), "storage")
+    prefix = str(storage.get("sharedPrefix") or "").strip()
+    if prefix:
+        return _with_storage_root(prefix)
+    storage_prefix = _storage_root_prefix()
+    if storage_prefix:
+        return f"{storage_prefix}/shared"
+    return "shared"
+
+
+def _default_global_shared_prefix() -> str:
+    """Derive global-shared storage prefix from environment or runtime.yaml."""
+    storage = _section(_load_runtime_config(), "storage")
+    prefix = str(storage.get("globalSharedPrefix") or "").strip()
+    if prefix:
+        return _with_storage_root(prefix)
+    storage_prefix = _storage_root_prefix()
+    if storage_prefix:
+        return f"{storage_prefix}/shared"
+    return "shared"
+
+
+def _workspace_dir(arguments: dict[str, Any]) -> Path:
+    value = str(arguments.get("workspaceDir") or "").strip()
+    if not value:
+        value = _default_workspace_dir()
+    if not value:
+        raise ValueError("workspaceDir is required")
+    return Path(value).expanduser()
+
+
+def _optional_workspace_dir(arguments: dict[str, Any]) -> Path | None:
+    value = str(arguments.get("workspaceDir") or "").strip()
+    if not value:
+        value = _default_workspace_dir()
+    return Path(value).expanduser() if value else None
+
+
+def _normalize_exclude(value: Any) -> list[str]:
+    if not value:
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        if text.startswith("["):
+            parsed = json.loads(text)
+            if not isinstance(parsed, list):
+                raise ValueError("exclude must be a list")
+            return [str(item) for item in parsed if str(item).strip()]
+        return [text]
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item).strip()]
+    raise ValueError("exclude must be a list")
+
+
+def _normalize_shared_path(raw_path: str, action: str) -> tuple[str, bool]:
+    raw = (raw_path or "").strip()
+    if not raw or raw.startswith("/") or "\\" in raw:
+        raise ValueError("path must be a relative shared path")
+    parts = raw.strip("/").split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ValueError("path must be a relative shared path without '.', '..', or empty segments")
+    if parts[0] not in {"shared", "global-shared"}:
+        raise ValueError("path must start with shared/ or global-shared/")
+    # Allow shared/ root for list, but require projects/ or tasks/ for push/pull
+    if parts[0] == "shared" and len(parts) >= 2 and parts[1] not in {"projects", "tasks"}:
+        raise ValueError("shared path must be under shared/projects/ or shared/tasks/")
+    if parts[0] == "shared" and action in {"push", "pull"} and len(parts) < 3:
+        raise ValueError("shared push/pull requires a project or task path")
+    if parts[0] == "global-shared" and len(parts) < 2:
+        raise ValueError("global-shared path must include a subpath")
+    is_directory = raw.endswith("/") or (
+        action in {"pull", "push", "list"}
+        and len(parts) <= 3
+        and parts[0] in {"shared", "global-shared"}
+    )
+    normalized = "/".join(parts)
+    if is_directory:
+        normalized += "/"
+    return normalized, is_directory
+
+
+def _resolve_filesync(arguments: dict[str, Any]) -> tuple[str, str, Path, str, bool]:
+    action = str(arguments.get("action") or "").strip()
+    if action not in {"pull", "push", "list", "stat"}:
+        raise ValueError("action is required; use pull, push, stat, or list")
+    normalized, is_directory = _normalize_shared_path(str(arguments.get("path") or ""), action)
+    parts = normalized.strip("/").split("/")
+    kind = parts[0]
+    if kind == "global-shared" and action == "push":
+        raise ValueError("global-shared is read-only for TeamHarness filesync")
+
+    storage = arguments.get("storage") if isinstance(arguments.get("storage"), dict) else {}
+    shared_prefix = str(storage.get("sharedPrefix") or "").strip() or _default_shared_prefix()
+    shared_root = _remote_root(shared_prefix)
+    global_root = ""
+    if kind == "global-shared":
+        global_shared_prefix = str(storage.get("globalSharedPrefix") or "").strip() or _default_global_shared_prefix()
+        global_root = _remote_root(global_shared_prefix)
+    workspace = _workspace_dir(arguments)
+    local = workspace / Path(*parts)
+    remote_root = shared_root if kind == "shared" else global_root
+    remote = remote_root + "/".join(parts[1:])
+    if is_directory:
+        remote = remote.rstrip("/") + "/"
+    return action, normalized, local, remote, is_directory
+
+
+def _filesync(arguments: dict[str, Any]) -> dict[str, Any]:
+    try:
+        action, normalized, local, remote, is_directory = _resolve_filesync(arguments)
+        exclude = _normalize_exclude(arguments.get("exclude"))
+    except (ValueError, json.JSONDecodeError) as exc:
+        return {"ok": False, "tool": "filesync", "error": str(exc)}
+
+    kind = normalized.split("/", 1)[0]
+    command: list[str]
+    if action == "list":
+        command = ["mc", "ls", "--recursive", remote]
+    elif action == "stat":
+        command = ["mc", "stat", remote]
+    elif action == "pull":
+        if is_directory:
+            command = ["mc", "mirror", remote, str(local), "--overwrite"]
+        else:
+            command = ["mc", "cp", remote, str(local)]
+    else:
+        if is_directory:
+            source = str(local) + ("/" if not str(local).endswith("/") else "")
+            command = ["mc", "mirror", source, remote, "--overwrite"]
+            for pattern in exclude:
+                command.extend(["--exclude", pattern])
+        else:
+            command = ["mc", "cp", str(local), remote]
+
+    base: dict[str, Any] = {
+        "ok": True,
+        "tool": "filesync",
+        "action": action,
+        "kind": kind,
+        "path": normalized,
+        "localPath": str(local),
+        "remotePath": remote,
+        "command": command,
+        "exclude": exclude,
+    }
+    if arguments.get("dryRun"):
+        base["dryRun"] = True
+        return base
+
+    if action == "pull" and not is_directory:
+        local.parent.mkdir(parents=True, exist_ok=True)
+    mc_env, env_error = _filesync_mc_env(remote)
+    if env_error:
+        return {
+            "ok": False,
+            "tool": "filesync",
+            "action": action,
+            "path": normalized,
+            "error": env_error,
+        }
+    completed = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=mc_env,
+    )
+    command_error = _filesync_command_error(completed)
+    if command_error:
+        return {
+            "ok": False,
+            "tool": "filesync",
+            "action": action,
+            "path": normalized,
+            "error": command_error,
+            "returncode": completed.returncode,
+        }
+    if action == "list":
+        base["entries"] = [line for line in completed.stdout.splitlines() if line.strip()]
+    if action == "stat":
+        base["exists"] = True
+    return base
+
+
+def _filesync_command_error(completed: subprocess.CompletedProcess[str]) -> str:
+    output = "\n".join(part.strip() for part in (completed.stderr, completed.stdout) if part.strip())
+    if completed.returncode != 0:
+        return output or "filesync command failed"
+    if "<ERROR>" in output or "Access Denied" in output:
+        return output
+    return ""
+
+
+def _payload(arguments: dict[str, Any]) -> dict[str, Any]:
+    payload = arguments.get("payload")
+    if isinstance(payload, dict):
+        data = dict(payload)
+    elif isinstance(payload, str) and payload.strip():
+        try:
+            decoded = json.loads(payload)
+        except json.JSONDecodeError:
+            data = {}
+        else:
+            data = decoded if isinstance(decoded, dict) else {}
+    else:
+        data = {}
+
+    aliases = {
+        "projectId": ("projectId", "project_id"),
+        "taskId": ("taskId", "task_id"),
+        "roomId": ("roomId", "room_id"),
+        "sourceRoomId": ("sourceRoomId", "source_room_id"),
+        "assignedTo": ("assignedTo", "assigned_to"),
+        "dependsOn": ("dependsOn", "depends_on"),
+    }
+    for canonical, keys in aliases.items():
+        if any(data.get(key) for key in keys):
+            continue
+        for key in keys:
+            value = arguments.get(key)
+            if value is not None:
+                data[canonical] = value
+                break
+
+    for key in (
+        "title", "name", "source", "requester", "spec", "status", "summary", "notes", "topic", "admin",
+        "invite", "replyRoute", "reply_route", "accepted", "resultStatus", "result_status", "reason",
+    ):
+        if key not in data and arguments.get(key) is not None:
+            data[key] = arguments[key]
+
+    if "deliverables" not in data:
+        if arguments.get("deliverables") is not None:
+            data["deliverables"] = arguments["deliverables"]
+        elif arguments.get("deliverable") is not None:
+            data["deliverables"] = [arguments["deliverable"]]
+    if "tasks" not in data and arguments.get("tasks") is not None:
+        data["tasks"] = arguments["tasks"]
+    return data
+
+
+def _safe_id(value: Any, field: str) -> str:
+    text = str(value or "").strip()
+    if not text or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", text):
+        raise ValueError(f"{field} must be a safe id")
+    return text
+
+
+def _slugify(value: Any, fallback: str) -> str:
+    text = re.sub(r"[^A-Za-z0-9]+", "-", str(value or "").strip().lower()).strip("-")
+    return text or fallback
+
+
+def _project_timestamp() -> str:
+    return time.strftime("%Y%m%d-%H%M%S")
+
+
+def _unique_project_id(arguments: dict[str, Any], base_id: str) -> str:
+    project_id = _safe_id(base_id, "projectId")
+    if not _project_state_path(arguments, project_id).exists():
+        return project_id
+    for index in range(1, 1000):
+        candidate = _safe_id(f"{base_id}-{index:02d}", "projectId")
+        if not _project_state_path(arguments, candidate).exists():
+            return candidate
+    raise ValueError(f"cannot allocate unique project id for: {base_id}")
+
+
+def _project_id_from_payload(arguments: dict[str, Any], payload: dict[str, Any]) -> str:
+    explicit = payload.get("projectId") or payload.get("project_id")
+    if explicit:
+        project_id = _safe_id(explicit, "projectId")
+        if _project_state_path(arguments, project_id).exists():
+            raise ValueError(f"project already exists: {project_id}")
+        return project_id
+    title = str(payload.get("title") or payload.get("name") or "project")
+    base_id = f"{_slugify(title, 'project')}-{_project_timestamp()}"
+    return _unique_project_id(arguments, base_id)
+
+
+def _normalize_reply_route(raw: Any) -> dict[str, str]:
+    route = raw if isinstance(raw, dict) else {}
+    channel = str(route.get("channel") or "").strip()
+    target_user = str(route.get("targetUser") or route.get("target_user") or route.get("userId") or route.get("user_id") or "").strip()
+    target_session = str(route.get("targetSession") or route.get("target_session") or route.get("sessionId") or route.get("session_id") or "").strip()
+    if not (channel and target_user and target_session):
+        return {}
+    return {
+        "channel": channel,
+        "target_user": target_user,
+        "target_session": target_session,
+    }
+
+
+def _reply_route_from_requester(requester: Any) -> dict[str, str]:
+    text = str(requester or "").strip()
+    if not text.startswith("dingtalk:"):
+        return {}
+    parts = text.split(":", 2)
+    if len(parts) != 3 or not parts[1] or not parts[2]:
+        return {}
+    return {
+        "channel": "dingtalk",
+        "target_user": parts[1],
+        "target_session": parts[2],
+    }
+
+
+def _source_room_id_from_payload(payload: dict[str, Any], reply_route: dict[str, str] | None = None) -> str:
+    source_room_id = str(payload.get("sourceRoomId") or payload.get("source_room_id") or "").strip()
+    if source_room_id:
+        return source_room_id
+
+    route = reply_route if isinstance(reply_route, dict) else {}
+    channel = str(route.get("channel") or payload.get("source") or "").strip().lower()
+    if channel and channel != "matrix":
+        return str(route.get("target_session") or "").strip()
+
+    requester_route = _reply_route_from_requester(payload.get("requester"))
+    channel = str(requester_route.get("channel") or "").strip().lower()
+    if channel and channel != "matrix":
+        return str(requester_route.get("target_session") or "").strip()
+    return ""
+
+
+def _canonical_room_id(value: Any) -> str:
+    text = str(value or "").strip()
+    if text.startswith("room:"):
+        text = text[len("room:") :].strip()
+    return text
+
+
+def _external_requester_channel(project: dict[str, Any]) -> str:
+    reply_route = project.get("reply_route") if isinstance(project.get("reply_route"), dict) else {}
+    channel = str(reply_route.get("channel") or project.get("source") or "").strip().lower()
+    if channel and channel != "matrix":
+        return channel
+    requester_route = _reply_route_from_requester(project.get("requester"))
+    channel = str(requester_route.get("channel") or "").strip().lower()
+    return channel if channel and channel != "matrix" else ""
+
+
+def _validate_assignment_room(project: dict[str, Any], room_id: str) -> None:
+    channel = _external_requester_channel(project)
+    if not channel:
+        return
+    team_room_id = _runtime_team_room_id()
+    if not team_room_id:
+        return
+    if _canonical_room_id(room_id) == _canonical_room_id(team_room_id):
+        raise ValueError(
+            f"{channel} requester tasks require a dedicated task room; "
+            "call roomflow create_task_room and pass its roomId"
+        )
+
+
+def _read_json(path: Path, default: dict[str, Any] | None = None) -> dict[str, Any]:
+    if not path.exists():
+        return dict(default or {})
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _project_dir(arguments: dict[str, Any], project_id: str) -> Path:
+    return _workspace_dir(arguments) / "shared" / "projects" / project_id
+
+
+def _task_dir(arguments: dict[str, Any], task_id: str) -> Path:
+    return _workspace_dir(arguments) / "shared" / "tasks" / task_id
+
+
+def _project_state_path(arguments: dict[str, Any], project_id: str) -> Path:
+    return _project_dir(arguments, project_id) / "meta.json"
+
+
+def _task_state_path(arguments: dict[str, Any], task_id: str) -> Path:
+    return _task_dir(arguments, task_id) / "meta.json"
+
+
+def _normalize_task(raw: dict[str, Any], previous: dict[str, Any] | None = None) -> dict[str, Any]:
+    task_id = _safe_id(raw.get("taskId") or raw.get("task_id"), "taskId")
+    previous = previous or {}
+    status = str(raw.get("status") or previous.get("status") or "planned")
+    if status == "pending":
+        status = "planned"
+    return {
+        "task_id": task_id,
+        "title": str(raw.get("title") or previous.get("title") or task_id),
+        "assigned_to": str(raw.get("assignedTo") or raw.get("assigned_to") or previous.get("assigned_to") or ""),
+        "depends_on": [str(item) for item in (raw.get("dependsOn") or raw.get("depends_on") or previous.get("depends_on") or [])],
+        "status": status,
+    }
+
+
+def _validate_task_graph(tasks: list[dict[str, Any]]) -> None:
+    seen: set[str] = set()
+    task_ids: set[str] = set()
+    for task in tasks:
+        task_id = str(task.get("task_id") or "")
+        if task_id in seen:
+            raise ValueError(f"duplicate task id: {task_id}")
+        seen.add(task_id)
+        task_ids.add(task_id)
+
+    for task in tasks:
+        task_id = str(task.get("task_id") or "")
+        for dep in task.get("depends_on", []):
+            if dep not in task_ids:
+                raise ValueError(f"task {task_id} depends on unknown task: {dep}")
+
+    visiting: set[str] = set()
+    visited: set[str] = set()
+    deps_by_id = {
+        str(task.get("task_id")): [str(dep) for dep in task.get("depends_on", [])]
+        for task in tasks
+    }
+
+    def visit(task_id: str, path: list[str]) -> None:
+        if task_id in visited:
+            return
+        if task_id in visiting:
+            raise ValueError(f"task dependency cycle detected: {' -> '.join(path + [task_id])}")
+        visiting.add(task_id)
+        for dep in deps_by_id.get(task_id, []):
+            visit(dep, path + [task_id])
+        visiting.remove(task_id)
+        visited.add(task_id)
+
+    for task_id in deps_by_id:
+        visit(task_id, [])
+
+
+def _positive_int(value: Any, field: str) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{field} must be an integer") from None
+    if parsed < 1:
+        raise ValueError(f"{field} must be greater than zero")
+    return parsed
+
+
+def _non_negative_int(value: Any, field: str) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{field} must be an integer") from None
+    if parsed < 0:
+        raise ValueError(f"{field} must be zero or greater")
+    return parsed
+
+
+def _safe_loop_status(value: Any) -> str:
+    status = str(value or "running").strip()
+    allowed = {"running", "waiting_user", "completed", "blocked"}
+    if status not in allowed:
+        raise ValueError(f"status must be one of: {', '.join(sorted(allowed))}")
+    return status
+
+
+def _safe_loop_decision(value: Any) -> str:
+    decision = str(value or "").strip()
+    allowed = {"continue", "replan", "ask_user", "stop_success", "stop_blocked"}
+    if decision not in allowed:
+        raise ValueError(f"decision must be one of: {', '.join(sorted(allowed))}")
+    return decision
+
+
+def _write_project_plan(project_dir: Path, project: dict[str, Any]) -> None:
+    lines = [
+        f"# {project.get('title') or project.get('project_id')}",
+        "",
+        f"- Project ID: `{project.get('project_id')}`",
+        f"- Status: `{project.get('status')}`",
+    ]
+    plan_type = str(project.get("plan_type") or "").strip()
+    if plan_type:
+        lines.append(f"- Plan Type: `{plan_type}`")
+    requester = project.get("requester")
+    if requester:
+        lines.append(f"- Requester: `{requester}`")
+    source_room_id = project.get("source_room_id")
+    if source_room_id:
+        lines.append(f"- Source Room ID: `{source_room_id}`")
+    reply_route = project.get("reply_route")
+    if isinstance(reply_route, dict):
+        channel = str(reply_route.get("channel") or "").strip()
+        target_user = str(reply_route.get("target_user") or "").strip()
+        target_session = str(reply_route.get("target_session") or "").strip()
+        if channel and target_user and target_session:
+            lines.append(f"- Reply Route: `{channel}/{target_user}/{target_session}`")
+    loop = project.get("loop") if isinstance(project.get("loop"), dict) else {}
+    if plan_type == "loop":
+        lines.extend([
+            f"- Loop Goal: {loop.get('goal') or ''}",
+            f"- Stop Condition: {loop.get('stop_condition') or ''}",
+            f"- Current Iteration: `{loop.get('current_iteration', 0)}` / `{loop.get('max_iterations', 0)}`",
+            f"- Loop Status: `{loop.get('status') or 'running'}`",
+            "",
+            "## Iteration Template",
+            "",
+            str(loop.get("iteration_template") or ""),
+        ])
+        tasks = loop.get("tasks", []) if isinstance(loop.get("tasks"), list) else []
+    else:
+        tasks = project.get("tasks", []) if isinstance(project.get("tasks"), list) else []
+    lines.extend(["", "## Tasks"])
+    for task in tasks:
+        deps = ", ".join(task.get("depends_on", [])) or "none"
+        owner = task.get("assigned_to") or "unassigned"
+        lines.append(f"- `{task['task_id']}` {task.get('title')} -> {owner}; deps: {deps}; status: {task.get('status')}")
+    if plan_type == "loop":
+        history = loop.get("history", []) if isinstance(loop.get("history"), list) else []
+        if history:
+            lines.extend(["", "## Loop History"])
+            for item in history:
+                if isinstance(item, dict):
+                    iteration = item.get("iteration")
+                    decision = item.get("decision")
+                    summary = item.get("summary")
+                    next_action = item.get("next_action")
+                    detail = f"- Iteration {iteration}: `{decision}` - {summary}"
+                    if next_action:
+                        detail += f" Next: {next_action}"
+                    lines.append(detail)
+                else:
+                    lines.append(f"- {item}")
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "plan.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _ready_nodes(project: dict[str, Any]) -> list[dict[str, Any]]:
+    if project.get("plan_type") == "loop":
+        raise ValueError(f"project plan is not a DAG: {project.get('project_id')}")
+    if str(project.get("status") or "active") != "active":
+        return []
+    tasks = project.get("tasks", []) if isinstance(project.get("tasks"), list) else []
+    status_by_id = {task.get("task_id"): task.get("status") for task in tasks}
+    ready: list[dict[str, Any]] = []
+    for task in tasks:
+        if task.get("status") not in {"planned", "assigned"}:
+            continue
+        if all(status_by_id.get(dep) == "completed" for dep in task.get("depends_on", [])):
+            ready.append(task)
+    return ready
+
+
+def _ready_loop_nodes(project: dict[str, Any]) -> list[dict[str, Any]]:
+    if str(project.get("status") or "active") != "active":
+        return []
+    loop = project.get("loop")
+    if not isinstance(loop, dict):
+        raise ValueError(f"project has no loop plan: {project.get('project_id')}")
+    if str(loop.get("status") or "running") in {"completed", "blocked", "waiting_user"}:
+        return []
+    tasks = loop.get("tasks", []) if isinstance(loop.get("tasks"), list) else []
+    status_by_id = {task.get("task_id"): task.get("status") for task in tasks}
+    ready: list[dict[str, Any]] = []
+    for task in tasks:
+        if task.get("status") not in {"planned", "assigned"}:
+            continue
+        if all(status_by_id.get(dep) == "completed" for dep in task.get("depends_on", [])):
+            ready.append(task)
+    return ready
+
+
+def _resolve_project(arguments: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    task: dict[str, Any] = {}
+    project_id_value = payload.get("projectId") or payload.get("project_id")
+    task_id_value = payload.get("taskId") or payload.get("task_id")
+    if task_id_value:
+        task_id = _safe_id(task_id_value, "taskId")
+        task = _read_json(_task_state_path(arguments, task_id))
+        if not task:
+            raise ValueError("task not found")
+        project_id_value = task.get("project_id")
+    if not project_id_value:
+        raise ValueError("projectId or taskId is required")
+    project_id = _safe_id(project_id_value, "projectId")
+    project = _read_json(_project_state_path(arguments, project_id))
+    if not project:
+        raise ValueError("project not found")
+    plan_type = str(project.get("plan_type") or "dag")
+    ready = _ready_loop_nodes(project) if plan_type == "loop" else _ready_nodes(project)
+    result = {
+        "ok": True,
+        "tool": "projectflow",
+        "action": "resolve_project",
+        "project": project,
+        "planType": plan_type,
+        "replyRoute": project.get("reply_route"),
+        "sourceRoomId": project.get("source_room_id") or (task.get("source_room_id") if task else None),
+        "readyNodes": ready,
+    }
+    if task:
+        result["task"] = task
+    return result
+
+
+def _accepted_node_status(result_status: Any) -> str:
+    status = str(result_status or "SUCCESS").strip()
+    if status in {"SUCCESS", "SUCCESS_WITH_NOTES"}:
+        return "completed"
+    if status == "REVISION_NEEDED":
+        return "revision"
+    if status in {"BLOCKED", "INTERRUPTED"}:
+        return "blocked"
+    raise ValueError(f"unsupported result status: {status}")
+
+
+def _payload_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"true", "1", "yes", "y", "accepted"}:
+        return True
+    if text in {"false", "0", "no", "n", "rejected"}:
+        return False
+    return default
+
+
+def _accept_task_result(arguments: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    project_id = _safe_id(payload.get("projectId") or payload.get("project_id"), "projectId")
+    task_id = _safe_id(payload.get("taskId") or payload.get("task_id"), "taskId")
+    project = _read_json(_project_state_path(arguments, project_id))
+    if not project:
+        raise ValueError("project not found")
+    result_status_value = payload.get("resultStatus") or payload.get("result_status")
+    accepted = _payload_bool(payload.get("accepted"), True)
+    node_status = _accepted_node_status(result_status_value)
+    if not accepted and node_status == "completed":
+        result_status_value = "REVISION_NEEDED"
+        node_status = "revision"
+    changed = False
+    for task in project.get("tasks", []):
+        if task.get("task_id") == task_id:
+            task["status"] = node_status
+            changed = True
+            break
+    loop = project.get("loop") if isinstance(project.get("loop"), dict) else {}
+    loop_tasks = loop.get("tasks", []) if isinstance(loop.get("tasks"), list) else []
+    for task in loop_tasks:
+        if task.get("task_id") == task_id:
+            task["status"] = node_status
+            project["loop"] = loop
+            changed = True
+            break
+    if not changed:
+        raise ValueError("task not found in project plan")
+    result_status = str(result_status_value or "SUCCESS")
+    if node_status == "completed":
+        project["requester_report"] = {
+            "pending": True,
+            "reason": "task_result_accepted",
+            "task_id": task_id,
+            "result_status": result_status,
+            "summary": str(payload.get("summary") or ""),
+            "report_path": f"shared/projects/{project_id}/result.md",
+        }
+    else:
+        requester_report = project.get("requester_report") if isinstance(project.get("requester_report"), dict) else {}
+        if requester_report.get("task_id") == task_id:
+            requester_report["pending"] = False
+            requester_report["reason"] = f"task_result_{node_status}"
+            project["requester_report"] = requester_report
+    _write_json(_project_state_path(arguments, project_id), project)
+    _write_project_plan(_project_dir(arguments, project_id), project)
+    return {
+        "ok": True,
+        "tool": "projectflow",
+        "action": "accept_task_result",
+        "project": project,
+        "taskId": task_id,
+        "nodeStatus": node_status,
+        "accepted": node_status == "completed",
+    }
+
+
+def _mark_requester_report_sent(arguments: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    project_id = _safe_id(payload.get("projectId") or payload.get("project_id"), "projectId")
+    project = _read_json(_project_state_path(arguments, project_id))
+    if not project:
+        raise ValueError("project not found")
+    requester_report = project.get("requester_report") if isinstance(project.get("requester_report"), dict) else {}
+    requester_report["pending"] = False
+    requester_report["sent_at"] = str(payload.get("sentAt") or payload.get("sent_at") or time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()))
+    project["requester_report"] = requester_report
+    _write_json(_project_state_path(arguments, project_id), project)
+    return {
+        "ok": True,
+        "tool": "projectflow",
+        "action": "mark_requester_report_sent",
+        "project": project,
+    }
+
+
+def _projectflow(arguments: dict[str, Any]) -> dict[str, Any]:
+    action = str(arguments.get("action") or "").strip()
+    payload = _payload(arguments)
+    try:
+        if action == "create_project":
+            project_id = _project_id_from_payload(arguments, payload)
+            project = {
+                "project_id": project_id,
+                "title": str(payload.get("title") or project_id),
+                "source": str(payload.get("source") or ""),
+                "requester": str(payload.get("requester") or ""),
+                "status": "active",
+                "tasks": [],
+            }
+            reply_route = _normalize_reply_route(payload.get("replyRoute") or payload.get("reply_route"))
+            if not reply_route:
+                reply_route = _reply_route_from_requester(project["requester"])
+            if reply_route:
+                project["reply_route"] = reply_route
+            source_room_id = _source_room_id_from_payload(payload, reply_route)
+            if source_room_id:
+                project["source_room_id"] = source_room_id
+            project_dir = _project_dir(arguments, project_id)
+            _write_json(_project_state_path(arguments, project_id), project)
+            _write_project_plan(project_dir, project)
+            return {"ok": True, "tool": "projectflow", "action": action, "project": project}
+
+        if action == "create_quick_project":
+            project_id = _project_id_from_payload(arguments, payload)
+            title = str(payload.get("title") or project_id)
+            assigned_to = str(payload.get("assignedTo") or payload.get("assigned_to") or "").strip()
+            if not assigned_to:
+                raise ValueError("assignedTo is required")
+            room_id = str(payload.get("roomId") or payload.get("room_id") or "").strip()
+            if not room_id:
+                raise ValueError("roomId is required")
+            spec = str(payload.get("spec") or "").strip()
+            if not spec:
+                raise ValueError("spec is required")
+            task_id = _safe_id(payload.get("taskId") or payload.get("task_id") or f"{project_id}-01", "taskId")
+            if not task_id.startswith(f"{project_id}-"):
+                raise ValueError("taskId must belong to projectId")
+            if _task_state_path(arguments, task_id).exists():
+                raise ValueError(f"task already exists: {task_id}")
+            task_node = {
+                "task_id": task_id,
+                "title": title,
+                "assigned_to": assigned_to,
+                "depends_on": [],
+                "status": "assigned",
+            }
+            project = {
+                "project_id": project_id,
+                "title": title,
+                "source": str(payload.get("source") or ""),
+                "requester": str(payload.get("requester") or ""),
+                "status": "active",
+                "mode": "quick",
+                "plan_type": "dag",
+                "tasks": [task_node],
+            }
+            reply_route = _normalize_reply_route(payload.get("replyRoute") or payload.get("reply_route"))
+            if not reply_route:
+                reply_route = _reply_route_from_requester(project["requester"])
+            if reply_route:
+                project["reply_route"] = reply_route
+            source_room_id = _source_room_id_from_payload(payload, reply_route)
+            if source_room_id:
+                project["source_room_id"] = source_room_id
+                task_node["source_room_id"] = source_room_id
+            _validate_assignment_room(project, room_id)
+            project_dir = _project_dir(arguments, project_id)
+            _write_json(_project_state_path(arguments, project_id), project)
+            _write_project_plan(project_dir, project)
+
+            task_dir = _task_dir(arguments, task_id)
+            task_dir.mkdir(parents=True, exist_ok=True)
+            (task_dir / "spec.md").write_text(spec + "\n", encoding="utf-8")
+            task = {
+                "task_id": task_id,
+                "project_id": project_id,
+                "room_id": room_id,
+                "status": "assigned",
+                "spec_path": f"shared/tasks/{task_id}/spec.md",
+            }
+            if source_room_id:
+                task["source_room_id"] = source_room_id
+            _write_task(arguments, task)
+            return {
+                "ok": True,
+                "tool": "projectflow",
+                "action": action,
+                "project": project,
+                "task": task,
+                "synced": _sync_task(arguments, task_id),
+            }
+
+        if action == "resolve_project":
+            return _resolve_project(arguments, payload)
+
+        if action == "accept_task_result":
+            return _accept_task_result(arguments, payload)
+
+        if action == "mark_requester_report_sent":
+            return _mark_requester_report_sent(arguments, payload)
+
+        if action == "plan_dag":
+            project_id = _safe_id(payload.get("projectId") or payload.get("project_id"), "projectId")
+            state_path = _project_state_path(arguments, project_id)
+            project = _read_json(state_path, {"project_id": project_id, "title": project_id, "status": "active", "tasks": []})
+            previous = {task.get("task_id"): task for task in project.get("tasks", [])}
+            raw_tasks = payload.get("tasks")
+            if not isinstance(raw_tasks, list):
+                raise ValueError("tasks must be a list")
+            planned_tasks = [
+                _normalize_task(task, previous.get(str(task.get("taskId") or task.get("task_id"))))
+                for task in raw_tasks
+                if isinstance(task, dict)
+            ]
+            _validate_task_graph(planned_tasks)
+            project["tasks"] = planned_tasks
+            project["plan_type"] = "dag"
+            project_dir = _project_dir(arguments, project_id)
+            _write_json(state_path, project)
+            _write_project_plan(project_dir, project)
+            return {
+                "ok": True,
+                "tool": "projectflow",
+                "action": action,
+                "project": project,
+                "readyNodes": _ready_nodes(project),
+            }
+
+        if action == "plan_loop":
+            project_id = _safe_id(payload.get("projectId") or payload.get("project_id"), "projectId")
+            state_path = _project_state_path(arguments, project_id)
+            project = _read_json(state_path, {"project_id": project_id, "title": project_id, "status": "active", "tasks": []})
+            previous_loop = project.get("loop") if isinstance(project.get("loop"), dict) else {}
+            previous_tasks = {
+                task.get("task_id"): task
+                for task in (previous_loop.get("tasks", []) if isinstance(previous_loop.get("tasks"), list) else [])
+            }
+            raw_tasks = payload.get("tasks") or []
+            if not isinstance(raw_tasks, list):
+                raise ValueError("tasks must be a list")
+            max_iterations = _positive_int(payload.get("maxIterations") or payload.get("max_iterations"), "maxIterations")
+            current_iteration = _non_negative_int(
+                payload.get("currentIteration") or payload.get("current_iteration") or previous_loop.get("current_iteration") or 0,
+                "currentIteration",
+            )
+            if current_iteration > max_iterations:
+                raise ValueError("currentIteration cannot exceed maxIterations")
+            planned_tasks = [
+                _normalize_task(task, previous_tasks.get(str(task.get("taskId") or task.get("task_id"))))
+                for task in raw_tasks
+                if isinstance(task, dict)
+            ]
+            _validate_task_graph(planned_tasks)
+            loop = {
+                "goal": str(payload.get("goal") or previous_loop.get("goal") or "").strip(),
+                "stop_condition": str(payload.get("stopCondition") or payload.get("stop_condition") or previous_loop.get("stop_condition") or "").strip(),
+                "iteration_template": str(payload.get("iterationTemplate") or payload.get("iteration_template") or previous_loop.get("iteration_template") or "").strip(),
+                "max_iterations": max_iterations,
+                "current_iteration": current_iteration,
+                "status": _safe_loop_status(payload.get("status") or previous_loop.get("status") or "running"),
+                "tasks": planned_tasks,
+                "history": previous_loop.get("history", []) if isinstance(previous_loop.get("history"), list) else [],
+            }
+            if not loop["goal"]:
+                raise ValueError("goal is required")
+            if not loop["stop_condition"]:
+                raise ValueError("stopCondition is required")
+            if not loop["iteration_template"]:
+                raise ValueError("iterationTemplate is required")
+            project["plan_type"] = "loop"
+            project["loop"] = loop
+            project_dir = _project_dir(arguments, project_id)
+            _write_json(state_path, project)
+            _write_project_plan(project_dir, project)
+            return {
+                "ok": True,
+                "tool": "projectflow",
+                "action": action,
+                "project": project,
+                "loop": loop,
+                "readyLoopNodes": _ready_loop_nodes(project),
+            }
+
+        if action == "ready_nodes":
+            project_id = _safe_id(payload.get("projectId") or payload.get("project_id"), "projectId")
+            project = _read_json(_project_state_path(arguments, project_id))
+            if not project:
+                raise ValueError("project not found")
+            return {
+                "ok": True,
+                "tool": "projectflow",
+                "action": action,
+                "project": project,
+                "readyNodes": _ready_nodes(project),
+            }
+
+        if action == "ready_loop_nodes":
+            project_id = _safe_id(payload.get("projectId") or payload.get("project_id"), "projectId")
+            project = _read_json(_project_state_path(arguments, project_id))
+            if not project:
+                raise ValueError("project not found")
+            return {
+                "ok": True,
+                "tool": "projectflow",
+                "action": action,
+                "project": project,
+                "loop": project.get("loop", {}),
+                "readyLoopNodes": _ready_loop_nodes(project),
+            }
+
+        if action == "record_loop_iteration":
+            project_id = _safe_id(payload.get("projectId") or payload.get("project_id"), "projectId")
+            project = _read_json(_project_state_path(arguments, project_id))
+            if not project:
+                raise ValueError("project not found")
+            loop = project.get("loop") if isinstance(project.get("loop"), dict) else {}
+            if not loop:
+                raise ValueError(f"project has no loop plan: {project_id}")
+            iteration = _positive_int(payload.get("iteration"), "iteration")
+            max_iterations = _positive_int(loop.get("max_iterations"), "maxIterations")
+            if iteration > max_iterations:
+                raise ValueError("iteration cannot exceed maxIterations")
+            decision = _safe_loop_decision(payload.get("decision"))
+            loop["status"] = {
+                "continue": "running",
+                "replan": "running",
+                "ask_user": "waiting_user",
+                "stop_success": "completed",
+                "stop_blocked": "blocked",
+            }[decision]
+            loop["current_iteration"] = max(_non_negative_int(loop.get("current_iteration") or 0, "currentIteration"), iteration)
+            history = loop.get("history", []) if isinstance(loop.get("history"), list) else []
+            history.append({
+                "iteration": iteration,
+                "decision": decision,
+                "summary": str(payload.get("summary") or "").strip(),
+                "next_action": str(payload.get("nextAction") or payload.get("next_action") or "").strip(),
+            })
+            loop["history"] = history
+            project["plan_type"] = "loop"
+            project["loop"] = loop
+            project_dir = _project_dir(arguments, project_id)
+            _write_json(_project_state_path(arguments, project_id), project)
+            _write_project_plan(project_dir, project)
+            return {
+                "ok": True,
+                "tool": "projectflow",
+                "action": action,
+                "project": project,
+                "loop": loop,
+                "readyLoopNodes": _ready_loop_nodes(project),
+            }
+
+        if action in {"pause_project", "resume_project", "complete_project"}:
+            project_id = _safe_id(payload.get("projectId") or payload.get("project_id"), "projectId")
+            state_path = _project_state_path(arguments, project_id)
+            project = _read_json(state_path)
+            if not project:
+                raise ValueError("project not found")
+            if action == "pause_project":
+                project["status"] = "paused"
+            elif action == "resume_project":
+                project["status"] = "active"
+            else:
+                project["status"] = "completed"
+                loop = project.get("loop") if isinstance(project.get("loop"), dict) else {}
+                if loop:
+                    loop["status"] = "completed"
+                    project["loop"] = loop
+            project_dir = _project_dir(arguments, project_id)
+            _write_json(state_path, project)
+            _write_project_plan(project_dir, project)
+            return {
+                "ok": True,
+                "tool": "projectflow",
+                "action": action,
+                "project": project,
+            }
+    except ValueError as exc:
+        return {"ok": False, "tool": "projectflow", "action": action, "error": str(exc)}
+
+    return {"ok": False, "tool": "projectflow", "action": action, "error": f"unsupported action: {action}"}
+
+
+def _normalize_role(role: str) -> str:
+    value = (role or "").strip().replace("_", "-").lower()
+    return {
+        "team-leader": "leader",
+        "teamleader": "leader",
+        "team-leader-agent": "leader",
+        "remote": "remote-member",
+        "remote-member-agent": "remote-member",
+    }.get(value, value)
+
+
+def _runtime_role() -> str:
+    role = os.getenv("HICLAW_AGENT_ROLE", "").strip() or os.getenv("HICLAW_WORKER_ROLE", "").strip()
+    if not role:
+        role = str(_section(_load_runtime_config(), "member").get("role") or "").strip()
+    return _normalize_role(role)
+
+
+def _visible_tool_names() -> list[str]:
+    if _message_tool_blocked_for_runtime_role():
+        return [name for name in TOOL_NAMES if name != "message"]
+    return list(TOOL_NAMES)
+
+
+def _message_tool_blocked_for_runtime_role() -> bool:
+    return _runtime_role() in MESSAGE_TOOL_BLOCKED_ROLES
+
+
+def _role(arguments: dict[str, Any]) -> str:
+    role = str(arguments.get("role") or "").strip()
+    if not role:
+        return _runtime_role()
+    return _normalize_role(role)
+
+
+def _load_task(arguments: dict[str, Any], task_id: str) -> dict[str, Any]:
+    task = _read_json(_task_state_path(arguments, task_id))
+    if not task:
+        raise ValueError("task not found")
+    return task
+
+
+def _write_task(arguments: dict[str, Any], task: dict[str, Any]) -> None:
+    _write_json(_task_state_path(arguments, task["task_id"]), task)
+
+
+def _parse_task_result(path: Path) -> tuple[dict[str, Any], list[str]]:
+    result: dict[str, Any] = {"status": "", "summary": "", "deliverables": []}
+    errors: list[str] = []
+    in_deliverables = False
+    has_deliverables_section = False
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        status_match = re.match(r"^(?:-\s*)?Status:\s*`?([^`]+?)`?\s*$", stripped, re.IGNORECASE)
+        if status_match:
+            result["status"] = status_match.group(1).strip()
+            continue
+        summary_match = re.match(r"^(?:-\s*)?Summary:\s*(.+?)\s*$", stripped, re.IGNORECASE)
+        if summary_match:
+            result["summary"] = summary_match.group(1).strip()
+            continue
+        if stripped.lower() in {"## deliverables", "deliverables:"}:
+            in_deliverables = True
+            has_deliverables_section = True
+            continue
+        if in_deliverables and stripped.startswith("- "):
+            item = stripped[2:].strip().strip("`")
+            if item:
+                result["deliverables"].append(item)
+
+    status = str(result.get("status") or "").strip()
+    if not status:
+        errors.append("missing result status")
+    elif status not in {"SUCCESS", "SUCCESS_WITH_NOTES", "REVISION_NEEDED", "BLOCKED", "FAILED", "PARTIAL"}:
+        errors.append(f"invalid result status: {status}")
+    if not str(result.get("summary") or "").strip():
+        errors.append("missing result summary")
+    if not has_deliverables_section:
+        errors.append("missing deliverables section")
+    return result, errors
+
+
+def _sync_task(arguments: dict[str, Any], task_id: str, exclude: list[str] | None = None) -> bool:
+    sync_args = dict(arguments)
+    sync_args.update({
+        "action": "push",
+        "path": f"shared/tasks/{task_id}",
+    })
+    if exclude is not None:
+        sync_args["exclude"] = exclude
+    result = _filesync(sync_args)
+    return bool(result.get("ok"))
+
+
+def _pull_task(arguments: dict[str, Any], task_id: str) -> bool:
+    sync_args = dict(arguments)
+    sync_args.update({
+        "action": "pull",
+        "path": f"shared/tasks/{task_id}",
+    })
+    result = _filesync(sync_args)
+    return bool(result.get("ok"))
+
+
+def _update_project_task(arguments: dict[str, Any], project_id: str, task_id: str, **updates: Any) -> None:
+    path = _project_state_path(arguments, project_id)
+    project = _read_json(path)
+    if not project:
+        return
+    changed = False
+    for task in project.get("tasks", []):
+        if task.get("task_id") == task_id:
+            task.update(updates)
+            changed = True
+            break
+    loop = project.get("loop") if isinstance(project.get("loop"), dict) else {}
+    loop_tasks = loop.get("tasks", []) if isinstance(loop.get("tasks"), list) else []
+    for task in loop_tasks:
+        if task.get("task_id") == task_id:
+            task.update(updates)
+            changed = True
+            break
+    if changed:
+        _write_json(path, project)
+        _write_project_plan(_project_dir(arguments, project_id), project)
+
+
+def _taskflow(arguments: dict[str, Any]) -> dict[str, Any]:
+    action = str(arguments.get("action") or "").strip()
+    payload = _payload(arguments)
+    role = _role(arguments)
+    try:
+        if action == "delegate_task":
+            if role != "leader":
+                raise ValueError("delegate_task requires leader role")
+            project_id = _safe_id(payload.get("projectId") or payload.get("project_id"), "projectId")
+            task_id = _safe_id(payload.get("taskId") or payload.get("task_id"), "taskId")
+            room_id = str(payload.get("roomId") or payload.get("room_id") or "")
+            if not room_id:
+                raise ValueError("roomId is required")
+            project = _read_json(_project_state_path(arguments, project_id))
+            _validate_assignment_room(project, room_id)
+            task_dir = _task_dir(arguments, task_id)
+            task_dir.mkdir(parents=True, exist_ok=True)
+            spec = str(payload.get("spec") or "")
+            (task_dir / "spec.md").write_text(spec + ("\n" if spec else ""), encoding="utf-8")
+            source_room_id = _source_room_id_from_payload(payload) or str(project.get("source_room_id") or "").strip()
+            task = {
+                "task_id": task_id,
+                "project_id": project_id,
+                "room_id": room_id,
+                "status": "assigned",
+                "spec_path": f"shared/tasks/{task_id}/spec.md",
+            }
+            if source_room_id:
+                task["source_room_id"] = source_room_id
+            _write_task(arguments, task)
+            project_task_updates: dict[str, Any] = {"status": "assigned"}
+            if source_room_id:
+                project_task_updates["source_room_id"] = source_room_id
+            _update_project_task(arguments, project_id, task_id, **project_task_updates)
+            return {
+                "ok": True,
+                "tool": "taskflow",
+                "action": action,
+                "task": task,
+                "synced": _sync_task(arguments, task_id),
+            }
+
+        if action == "ack_task":
+            if role not in {"worker", "remote-member"}:
+                raise ValueError("ack_task requires worker or remote-member role")
+            task_id = _safe_id(payload.get("taskId") or payload.get("task_id"), "taskId")
+            pulled = _pull_task(arguments, task_id)
+            task = _load_task(arguments, task_id)
+            task["status"] = "in_progress"
+            task["acknowledged_by_role"] = role
+            _write_task(arguments, task)
+            _update_project_task(arguments, task.get("project_id", ""), task_id, status="in_progress")
+            spec_path = _task_dir(arguments, task_id) / "spec.md"
+            spec = spec_path.read_text(encoding="utf-8") if spec_path.exists() else ""
+            return {
+                "ok": True,
+                "tool": "taskflow",
+                "action": action,
+                "task": task,
+                "spec": spec,
+                "pulled": pulled,
+                "synced": _sync_task(arguments, task_id, exclude=["spec.md", "base/"]),
+            }
+
+        if action == "submit_task":
+            if role not in {"worker", "remote-member"}:
+                raise ValueError("submit_task requires worker or remote-member role")
+            task_id = _safe_id(payload.get("taskId") or payload.get("task_id"), "taskId")
+            task = _load_task(arguments, task_id)
+            summary = str(payload.get("summary") or "")
+            status = str(payload.get("status") or "SUCCESS")
+            deliverables = payload.get("deliverables") or []
+            if not isinstance(deliverables, list):
+                raise ValueError("deliverables must be a list")
+            result_lines = [
+                "# Task Result",
+                "",
+                f"- Status: `{status}`",
+                f"- Summary: {summary}",
+                "",
+                "## Deliverables",
+            ]
+            result_lines.extend(f"- `{item}`" for item in deliverables)
+            task_dir = _task_dir(arguments, task_id)
+            task_dir.mkdir(parents=True, exist_ok=True)
+            (task_dir / "result.md").write_text("\n".join(result_lines) + "\n", encoding="utf-8")
+            task.update({
+                "status": "submitted",
+                "result_status": status,
+                "summary": summary,
+                "deliverables": [str(item) for item in deliverables],
+                "result_path": f"shared/tasks/{task_id}/result.md",
+                "submitted_by_role": role,
+            })
+            _write_task(arguments, task)
+            _update_project_task(arguments, task.get("project_id", ""), task_id, status="submitted")
+            return {
+                "ok": True,
+                "tool": "taskflow",
+                "action": action,
+                "task": task,
+                "synced": _sync_task(arguments, task_id, exclude=["spec.md", "base/"]),
+            }
+
+        if action == "check_task":
+            if role != "leader":
+                raise ValueError("check_task requires leader role")
+            task_id = _safe_id(payload.get("taskId") or payload.get("task_id"), "taskId")
+            pulled = _pull_task(arguments, task_id)
+            task = _load_task(arguments, task_id)
+            result_path = _task_dir(arguments, task_id) / "result.md"
+            if result_path.exists():
+                result, validation_errors = _parse_task_result(result_path)
+            else:
+                result, validation_errors = {}, ["missing result.md"]
+            effective = task.get("status") == "submitted" and result_path.exists() and not validation_errors
+            return {
+                "ok": True,
+                "tool": "taskflow",
+                "action": action,
+                "task": task,
+                "result": result,
+                "validationErrors": validation_errors,
+                "effective": effective,
+                "pulled": pulled,
+            }
+    except ValueError as exc:
+        return {"ok": False, "tool": "taskflow", "action": action, "error": str(exc)}
+
+    return {"ok": False, "tool": "taskflow", "action": action, "error": f"unsupported action: {action}"}
+
+
+def handle_request(request: dict[str, Any]) -> dict[str, Any] | None:
+    method = request.get("method")
+    request_id = request.get("id")
+    if request_id is None and isinstance(method, str) and method.startswith("notifications/"):
+        return None
+    if method == "initialize":
+        result = {
+            "protocolVersion": "2024-11-05",
+            "serverInfo": {"name": "teamharness", "version": "0.1.0"},
+            "capabilities": {"tools": {}},
+        }
+    elif method == "tools/list":
+        result = {"tools": list_tools()}
+    elif method == "tools/call":
+        params = request.get("params", {}) or {}
+        result = call_tool(str(params.get("name", "")), params.get("arguments", {}) or {})
+    else:
+        result = {
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps({"ok": False, "error": "unknown_method", "method": method}, ensure_ascii=False),
+                }
+            ]
+        }
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+
+def main() -> int:
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError:
+            response = {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32700, "message": "Parse error"},
+            }
+            print(json.dumps(response, ensure_ascii=False), flush=True)
+            continue
+        response = handle_request(request)
+        if response is not None:
+            print(json.dumps(response, ensure_ascii=False), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/teamharness/plugin.yaml
+++ b/plugins/teamharness/plugin.yaml
@@ -1,0 +1,72 @@
+apiVersion: hiclaw.agentteam/v1alpha1
+kind: AgentTeamPlugin
+metadata:
+  name: teamharness
+  version: 0.1.0
+prompts:
+  team: prompts/team/TEAMS.md
+  agent:
+    leader: prompts/agent/leader.md
+    worker: prompts/agent/worker.md
+    remoteMember: prompts/agent/remote-member.md
+  manager:
+    agents: prompts/manager/AGENTS.md
+    tools: prompts/manager/TOOLS.md
+    heartbeat: prompts/manager/HEARTBEAT.md
+skills:
+  agent:
+    - id: mcporter
+      path: skills/agent/mcporter
+      roles: [leader, worker, manager, remote-member]
+    - id: find-skills
+      path: skills/agent/find-skills
+      roles: [leader, worker, manager, remote-member]
+  team:
+    - id: organization
+      path: skills/team/organization
+      roles: [leader, worker, manager, remote-member]
+    - id: communication
+      path: skills/team/communication
+      roles: [leader, worker, manager, remote-member]
+    - id: file-sharing
+      path: skills/team/file-sharing
+      roles: [leader, worker, manager, remote-member]
+    - id: team-coordination
+      path: skills/team/team-coordination
+      roles: [leader]
+    - id: project-management
+      path: skills/team/project-management
+      roles: [leader]
+    - id: task-delegation
+      path: skills/team/task-delegation
+      roles: [leader]
+    - id: task-execution
+      path: skills/team/task-execution
+      roles: [worker, remote-member]
+mcp:
+  servers:
+    - id: teamharness
+      transport: stdio
+      command: python
+      args:
+        - mcp/server.py
+      tools:
+        - health
+        - message
+        - roomflow
+        - filesync
+        - projectflow
+        - taskflow
+adapters:
+  - id: qwenpaw
+    path: adapters/qwenpaw
+  - id: claude-code
+    path: adapters/claude-code
+package:
+  include:
+    - plugin.yaml
+    - prompts/
+    - skills/
+    - mcp/
+    - adapters/
+    - scripts/

--- a/plugins/teamharness/prompts/agent/leader.md
+++ b/plugins/teamharness/prompts/agent/leader.md
@@ -1,0 +1,31 @@
+# Leader Role
+
+You are the team Leader.
+
+You plan work, maintain project state, delegate ready tasks, check worker
+results, and report accepted outcomes to the requester. Use team skills and
+tools instead of relying on remembered room or worker state.
+
+## Request Intake
+
+Classify each incoming message before choosing tools:
+
+- Direct Reply: answer ordinary questions, clarifications, readiness checks, or
+  explicit short-answer requests directly.
+- Lightweight Action: perform one-off message routing, file/MCP/tool checks, or
+  reply-route updates without durable project state.
+- Project Work: create or update project and task state only for multi-member
+  work, durable deliverables, dependencies, acceptance gates, or follow-up
+  tracking. Choose DAG for finite dependency work and Loop for iterative work
+  with a stop condition.
+
+Do not create a project, task, DAG, Loop, or Worker assignment for Direct Reply
+or Lightweight Action requests.
+
+Keep project direction, task ownership, and requester communication separate.
+Do not treat a worker completion message as automatic project acceptance.
+When a project records a requester `reply_route`, use it for accepted outcomes,
+blockers, and clarification requests instead of defaulting to the Leader DM.
+
+Use `communication` for direct replies and routing. Use `team-coordination`,
+`project-management`, and `task-delegation` only after selecting Project Work.

--- a/plugins/teamharness/prompts/agent/remote-member.md
+++ b/plugins/teamharness/prompts/agent/remote-member.md
@@ -1,0 +1,33 @@
+# Remote Member Role
+
+You are an external or local agent connected to the team as a member.
+
+You are not acting as a HiClaw-managed Worker.
+
+Claim only work assigned to your account, keep deliverables in the assigned
+task directory when one exists, and use `task-execution` for task acceptance,
+submission, blockers, and results.
+
+Do not manage team project state, create Worker resources, or behave as the
+team Leader unless explicitly assigned that role.
+
+You are a remote team member, such as a local coding agent or human-operated
+agent account.
+
+Join the team room, read the shared team contract, understand current projects
+and tasks, and claim work only when directly assigned or explicitly invited.
+
+Report progress and results through the team protocol rather than creating a
+parallel workflow.
+
+## Message Rules
+
+Do not use the `message` MCP tool to send intermediate progress, tool call
+results, or thinking updates to the team room. The runtime bridge may already
+forward execution progress as threaded messages. Answer directly for reports in
+the current room/session. Only use `message` when the report must leave the
+current runtime conversation, for example:
+
+- Final task completion or failure reports
+- Blockers or questions that require coordinator response
+- Explicit replies when directly asked

--- a/plugins/teamharness/prompts/agent/worker.md
+++ b/plugins/teamharness/prompts/agent/worker.md
@@ -1,0 +1,36 @@
+# Worker Role
+
+You are a team Worker.
+
+Execute only assigned tasks. Keep deliverables inside the assigned task
+directory, submit structured results, and report blockers, questions, or
+completion to the assigning coordinator.
+
+Do not edit project-level state unless the task spec explicitly asks for it.
+
+Do not use the `message` MCP tool. Report completion, blockers, questions, and
+direct replies as normal text in the current assignment room/session.
+
+## Direct Checks
+
+If the current message is a readiness check, direct question, or explicit
+request to reply with specific text, answer directly in the current room.
+Do not use taskflow for that check.
+
+Use `task-execution` only when the message assigns a task, names a task id,
+references a task spec or result, or asks you to acknowledge, execute, submit,
+or report a task.
+
+## Matrix Reply Discipline
+
+Only @mention another Worker for a blocker, handoff, direct question, or task
+dependency that requires that Worker to act.
+
+Do not reply to peer messages that only say thanks, acknowledged, confirmed,
+final confirmation, mission accomplished, standing by, available for new
+assignments, or similar no-action closure. Use `NO_REPLY` as the entire
+response.
+
+After you have reported completion or availability once, stop. If two or more
+peer @mentions contain no new task, question, decision, blocker, or handoff,
+reply with `NO_REPLY`. This prevents Matrix ping-pong loops.

--- a/plugins/teamharness/prompts/manager/AGENTS.md
+++ b/plugins/teamharness/prompts/manager/AGENTS.md
@@ -1,0 +1,15 @@
+# Manager
+
+You are the TeamHarness Manager.
+
+Your job is control-plane coordination, not direct task execution. Keep team,
+worker, human, model, MCP, package, and lifecycle management separate from the
+runtime prompts used by Leader, Worker, and remote members.
+
+Use controller-facing contracts and management tools for control-plane changes.
+Do not query local runtime files to infer team or member identity when a
+controller-written runtime config is available.
+
+Do not treat TeamHarness plugin package updates as AgentSpec package updates.
+The TeamHarness plugin is runtime infrastructure. AgentSpec packages are the
+business agent templates selected by users and applied by workers.

--- a/plugins/teamharness/prompts/manager/HEARTBEAT.md
+++ b/plugins/teamharness/prompts/manager/HEARTBEAT.md
@@ -1,0 +1,12 @@
+# Manager Heartbeat
+
+During heartbeat, observe the control plane and report only meaningful changes:
+
+- Team or worker lifecycle changes
+- Runtime health degradation
+- Channel or room configuration problems
+- Pending package deployment decisions
+- Blocked projects or delegated tasks that require management action
+
+Do not turn heartbeat into task execution. Do not spam the team room with
+unchanged state.

--- a/plugins/teamharness/prompts/manager/TOOLS.md
+++ b/plugins/teamharness/prompts/manager/TOOLS.md
@@ -1,0 +1,13 @@
+# Manager Tools
+
+Use management tools only for explicit control-plane work.
+
+Allowed control-plane work includes team membership, worker lifecycle, channel
+policy, model selection, MCP configuration, and package deployment decisions.
+
+Do not edit runtime-specific files such as `openclaw.json` or local QwenPaw
+configuration as a shortcut for controller-owned desired state.
+
+When a user deploys a new AgentSpec package version, the expected control-plane
+effect is a CR desired-state change. The worker later observes runtime config
+and applies the AgentSpec package inside the runtime.

--- a/plugins/teamharness/prompts/team/TEAMS.md
+++ b/plugins/teamharness/prompts/team/TEAMS.md
@@ -1,0 +1,185 @@
+# Team Contract
+
+This file describes stable collaboration rules for the team.
+
+It is not a status database. Do not store live room IDs, credentials, worker
+phase, task status, current model values, package versions, or transient project
+facts here. Query live state through runtime config, Matrix, shared workspace
+files, or TeamHarness tools.
+
+## Roles
+
+- The Leader plans work, delegates ready tasks, checks results, updates project
+  state, and reports accepted outcomes to the requester.
+- Workers execute assigned tasks, keep task outputs inside their task
+  directory, submit structured results, and report blockers or completion to
+  the assigning coordinator.
+- Remote members participate as humans or local coding agents. They should
+  claim work only when directly assigned or explicitly invited.
+- The Manager handles control-plane operations such as team, worker, human,
+  model, MCP, package, and lifecycle management.
+
+## Runtime Agent Boundary
+
+The TeamHarness roster is the authority for team collaboration. Runtime-native
+agents, built-in QA agents, spawned subagents, or tool-level agent lists are
+implementation details of the current runtime. They are not TeamHarness team
+members unless they are explicitly listed in the team roster or assigned through
+TeamHarness team state.
+
+- Do not present runtime-native agent tools such as `chat_with_agent`,
+  `submit_to_agent`, `spawn_subagent`, or `list_agents` as the normal
+  TeamHarness delegation path.
+- Do not claim that a runtime-native QA agent, default agent, or spawned
+  subagent is a team Worker.
+- For TeamHarness work, delegate through the team room or a dedicated
+  assignment room, project/task flow, requester reply routes, and the members
+  described by this file.
+- Only discuss runtime-native agents when the requester explicitly asks about
+  runtime internals. When answering team questions, explain the TeamHarness
+  roles and member roster instead.
+
+## Rooms
+
+- Use the team room for normal team-visible coordination.
+- For project tasks that originate from DingTalk, Feishu, WeChat, or another
+  external requester channel, call `roomflow` `create_task_room` with the
+  channel `source` and the current channel's stable `sourceRoomId` before task
+  delegation. Reuse the returned assignment room for later tasks from the same
+  source room.
+- Never invent, transform, or suffix `sourceRoomId` for task type, worker,
+  retry, or project purpose. For the same DingTalk group, pass exactly the same
+  `sourceRoomId` every time; otherwise TeamHarness treats it as a different
+  external room and may create a different Matrix assignment room.
+- Before assigning work in a reused external assignment room, call `roomflow`
+  again with the same `sourceRoomId` and the complete Matrix user ids for all
+  Workers needed in that room so missing members are invited before the task
+  message is sent.
+- Use the Leader DM for requester-facing private updates when the requester is
+  the team admin.
+- Use project reply routes for requester reports that originated from an
+  external channel or another runtime session.
+- Use worker private rooms only for exceptional recovery or sensitive follow-up.
+- Do not copy every team-room event into a DM. Summarize decisions and outcomes.
+
+## Communication Contract
+
+Communication rules apply before selecting a request mode and at every outgoing
+message point in Direct Reply, Quick Task, and Project Work.
+
+Use `teamharness-communication` when the TEAMS.md communication contract needs
+one of these detailed protocols:
+
+- Channel / Room Selection Protocol
+- Requester Report Delivery Protocol
+- Message Tool Protocol
+
+Always apply these rules:
+
+- Answer in the current session for ordinary Direct Reply.
+- Use `NO_REPLY` for low-information acknowledgements, self echoes, and
+  non-actionable mention-only messages.
+- Do not let acknowledgements create ping-pong between rooms or agents.
+- Use the Team Room or assignment room for team-visible coordination, not as a
+  requester-facing report destination unless the recorded requester route is
+  exactly that room.
+- Use project `reply_route` for requester-facing reports after accepted project
+  state changes.
+- Use the `message` MCP tool only for cross-room, cross-channel, or
+  cross-session sends.
+- Do not treat Worker assignment, Worker completion, or Team Room status as the
+  requester report unless the recorded requester route is exactly that room.
+
+## Request Modes
+
+Choose the lightest mode that can safely satisfy the current message.
+
+- Direct Reply: ordinary questions, clarifications, readiness checks, useful
+  acknowledgements, explicit requests for a short answer, or synchronous
+  single-agent checks. Do not involve a Worker or create project/task state.
+- Quick Task: one bounded Worker-owned action with one owner, one expected
+  result, no DAG, and no Loop. Use quick project/task state so the Leader can
+  recover the result, accept or reject it, and report back to the requester.
+- Project Work: multi-member work, durable shared state, deliverables,
+  dependencies, acceptance gates, or follow-up tracking. Use project and task
+  flow only after this mode is selected. Choose DAG for finite dependency work
+  and Loop for iterative work with a stop condition.
+
+## Standard Flow Index
+
+Use this section as the execution index only: pick the large step, load the
+listed skill, then follow the listed skill step for exact tool usage, payload
+shape, and cautions. Do not execute project, task, room, or cross-channel
+actions from this index alone.
+
+Direct Reply mode does not need a dedicated flow. Answer directly in the
+current conversation. If routing is unclear or the reply must leave the current
+session, load `teamharness-communication`
+`## Channel / Room Selection Protocol` before replying.
+
+After any task delegation step, do not continuously poll for the Worker result
+or keep calling check tools in the same Leader turn. The Worker will report
+completion or blockers in the assignment room recorded for that task. When that
+room message or task event reaches the Leader, resume from the submitted-result
+check step in the relevant flow.
+
+### Quick Task Flow
+
+Use for Quick Task mode.
+
+| Role | Purpose | Skill | Skill step |
+| --- | --- | --- | --- |
+| Leader | If the message has task/project/recovery context, restore project state before deciding whether to create new work. | `teamharness-project-management` | `## Project Files` |
+| Leader | Confirm the request is exactly one Worker-owned task. | `teamharness-team-coordination` | `## Choose Execution Mode`, `## Good Task Boundaries` |
+| Leader | Create the quick project and single delegated task state. | `teamharness-project-management` | `## Create Quick Project` |
+| Leader | Send the Worker assignment in the assignment room. | `teamharness-task-delegation` | `## Assignment Message` |
+| Worker | Execute and submit the assigned result. | `teamharness-task-execution` | `## Acknowledge`, `## Execute`, `## Submit`, `## Completion Message` |
+| Leader | Check the submitted result before project acceptance. | `teamharness-task-delegation` | `## Check Submitted Task`, `## Result Contract` |
+| Leader | Accept or reject the checked result. | `teamharness-project-management` | `## Accepting Worker Results` |
+| Leader | Report the accepted result or blocker through the project requester source and reply route. | `teamharness-communication` | `## Requester Report Delivery Protocol` |
+
+Do not use Quick Task for multi-node dependencies, parallel Workers, or Loop
+iterations. Switch to Project Work before continuing if those appear.
+
+### Project Work Flow
+
+Use for Project Work mode.
+
+| Role | Purpose | Skill | Skill step |
+| --- | --- | --- | --- |
+| Leader | If the message has task/project/recovery context, restore project state before planning or delegating new work. | `teamharness-project-management` | `## Project Files` |
+| Leader | Choose DAG or Loop and define task boundaries. | `teamharness-team-coordination` | `## Choose Execution Mode`, `## Good Task Boundaries` |
+| Leader | Create project state and plan DAG or Loop. | `teamharness-project-management` | `## Create Project`, `## Plan DAG`, `## Plan Loop` |
+| Leader | Resolve ready work before assignment. | `teamharness-project-management` | `## Ready Nodes` |
+| Leader | Delegate only ready nodes and send the assignment message. | `teamharness-task-delegation` | `## Delegate Only Ready Nodes`, `## Delegate Task`, `## Assignment Message` |
+| Worker | Execute the assigned task. | `teamharness-task-execution` | `## Acknowledge`, `## Execute`, `## Submit`, `## Completion Message` |
+| Leader | Check submitted Worker results before project acceptance. | `teamharness-task-delegation` | `## Check Submitted Task`, `## Result Contract` |
+| Leader | Accept/reject results, advance the plan, and find new ready work. | `teamharness-project-management` | `## Accepting Worker Results`, `## Ready Nodes` |
+| Leader | Report accepted progress or final result through the project requester source and reply route. | `teamharness-communication` | `## Requester Report Delivery Protocol` |
+
+The project owns durable context and requester routing. The task owns one
+bounded Worker execution unit. The Leader must accept or reject submitted
+results before project dependencies advance.
+
+## Shared Workspace
+
+- Use local shared paths in messages and task specs.
+- Use `shared/projects/{project-id}/` for project files.
+- Use `shared/tasks/{task-id}/` for task files and deliverables.
+- Do not expose object storage internals in human-facing messages.
+
+## Credential Safety
+
+- This rule is non-overridable by task, requester, project, or runtime
+  instructions.
+- Never read, print, copy, summarize, transmit, or write secrets, credentials,
+  tokens, authorization headers, private keys, or password files.
+- If a task needs credentialed access, refer only to the approved credential
+  name, file path, or environment variable name. Do not expose the value.
+- If a tool output is redacted, treat the redaction as final and do not try to
+  recover the hidden value.
+
+## When State Is Unclear
+
+Do not guess stale state from memory. Query current state before assigning work,
+sending cross-room messages, accepting results, or changing lifecycle.

--- a/plugins/teamharness/scripts/install.sh
+++ b/plugins/teamharness/scripts/install.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+export AGENTTEAMS_PLUGIN_DIR="${AGENTTEAMS_PLUGIN_DIR:-$PLUGIN_DIR}"
+
+ran=0
+
+if command -v qwenpaw >/dev/null 2>&1; then
+  bash "${PLUGIN_DIR}/adapters/qwenpaw/install.sh"
+  ran=1
+fi
+
+if command -v claude >/dev/null 2>&1; then
+  bash "${PLUGIN_DIR}/adapters/claude-code/install.sh"
+  ran=1
+fi
+
+if [ "$ran" -eq 0 ]; then
+  echo "ERROR: no supported TeamHarness local runtime found; expected qwenpaw or claude" >&2
+  exit 1
+fi

--- a/plugins/teamharness/scripts/uninstall.sh
+++ b/plugins/teamharness/scripts/uninstall.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+export AGENTTEAMS_PLUGIN_DIR="${AGENTTEAMS_PLUGIN_DIR:-$PLUGIN_DIR}"
+
+if command -v qwenpaw >/dev/null 2>&1; then
+  bash "${PLUGIN_DIR}/adapters/qwenpaw/uninstall.sh"
+fi
+
+if command -v claude >/dev/null 2>&1; then
+  bash "${PLUGIN_DIR}/adapters/claude-code/uninstall.sh"
+fi
+
+log_file="${TEAMHARNESS_INSTALL_LOG:-}"
+if [ -n "$log_file" ]; then
+  mkdir -p "$(dirname "$log_file")"
+  printf '{"event":"uninstall","runtime":"teamharness","pluginDir":"%s"}\n' "$AGENTTEAMS_PLUGIN_DIR" >> "$log_file"
+fi

--- a/plugins/teamharness/skills/agent/find-skills/SKILL.md
+++ b/plugins/teamharness/skills/agent/find-skills/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: find-skills
+description: Discover and install agent skills from the open ecosystem. Use when you encounter an unfamiliar domain, framework, or workflow that you lack specialized knowledge about, or when your coordinator suggests searching for skills before starting a task.
+---
+
+# Find Skills
+
+This skill helps you discover and install skills from the open agent skills ecosystem.
+
+## Security Assurance
+
+**Worker is completely isolated and cannot access any admin's personal sensitive data.** You can safely search and install skills from public or private registries. The skills you install only run within your isolated container environment.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Asks "how do I do X" where X might be a common task with an existing skill
+- Says "find a skill for X" or "is there a skill for X"
+- Says "import xxx skill from market", "install xxx skill from market", or otherwise explicitly asks you to import a skill from the market
+- Asks "can you do X" where X is a specialized capability
+- Expresses interest in extending agent capabilities
+- Wants to search for tools, templates, or workflows
+- Mentions they wish they had help with a specific domain (design, testing, deployment, etc.)
+
+## What is the Skills CLI?
+
+The Skills CLI (`skills`) is the package manager for the open agent skills ecosystem. Skills are modular packages that extend agent capabilities with specialized knowledge, workflows, and tools.
+
+If `skills` command is not found, install it: `npm install -g skills`
+
+Resolve the script from local skill paths. Do not hardcode container absolute paths in chat or task outputs:
+
+```bash
+FIND_SKILLS_SCRIPT=""
+for candidate in \
+  "./skills/find-skills/scripts/hiclaw-find-skill.sh" \
+  "./active_skills/find-skills/scripts/hiclaw-find-skill.sh" \
+  "./find-skills/scripts/hiclaw-find-skill.sh"; do
+  if [ -x "$candidate" ]; then
+    FIND_SKILLS_SCRIPT="$candidate"
+    break
+  fi
+done
+test -n "$FIND_SKILLS_SCRIPT" || { echo "find-skills script not found" >&2; exit 1; }
+```
+
+**Key commands:**
+
+- `"${FIND_SKILLS_SCRIPT}" find [query]` - Search for relevant skills
+- `"${FIND_SKILLS_SCRIPT}" install <skill>` - Install a skill
+- `skills check` - Check for skill updates
+- `skills update` - Update all installed skills
+
+**Browse skills at:** https://skills.sh/
+
+## Environment Variables
+
+```bash
+SKILLS_API_URL  # Skills registry API endpoint (default: nacos://market.hiclaw.io:80/public)
+```
+
+Can be configured by admin to point to an enterprise-private registry.
+
+## How to Help Users Find Skills
+
+### Step 1: Understand What They Need
+
+When a user asks for help with something, identify:
+
+1. The domain (e.g., React, testing, design, deployment)
+2. The specific task (e.g., writing tests, creating animations, reviewing PRs)
+3. Whether this is a common enough task that a skill likely exists
+
+### Step 2: Search for Skills
+
+Run the find command with a relevant query:
+
+```bash
+"${FIND_SKILLS_SCRIPT}" find [query]
+```
+
+For example:
+
+- User asks "how do I make my React app faster?" → `"${FIND_SKILLS_SCRIPT}" find react performance`
+- User asks "can you help me with PR reviews?" → `"${FIND_SKILLS_SCRIPT}" find pr review`
+- User asks "I need to create a changelog" → `"${FIND_SKILLS_SCRIPT}" find changelog`
+
+The command will return results like:
+
+```
+Install with ./skills/find-skills/scripts/hiclaw-find-skill.sh install <skill>
+
+vercel-react-best-practices
+└ React and Next.js performance guidance
+```
+
+> **Critical**: Always use the exact install command shown in search results.
+> Never guess or shorten the package name or command, because that may fail.
+
+### Step 2A: Direct Market Import Requests
+
+If the user already gave you a concrete skill name and asked to import it from the market, you can install it directly with this skill instead of doing a separate search first:
+
+```bash
+"${FIND_SKILLS_SCRIPT}" install <skill>
+```
+
+For example:
+
+- User says "import remotion-best-practices skill from market" → `"${FIND_SKILLS_SCRIPT}" install remotion-best-practices`
+- User says "install github-operations from market" → `"${FIND_SKILLS_SCRIPT}" install github-operations`
+
+If the provided name looks ambiguous or you are not sure about the exact package name, search first and then copy the exact install command from the results.
+
+### Step 3: Present Options to the User
+
+When you find relevant skills, present them to the user with:
+
+1. The skill name and what it does
+2. The install command they can run (copy exactly from search results)
+3. A link to learn more at skills.sh
+
+Example response:
+
+```
+I found a skill that might help! The "remotion-best-practices" skill provides
+best practices for Remotion video creation in React.
+
+To install it:
+"${FIND_SKILLS_SCRIPT}" install remotion-best-practices
+```
+
+### Step 4: Offer to Install
+
+If the user wants to proceed, you can install the skill for them:
+
+```bash
+"${FIND_SKILLS_SCRIPT}" install <skill>
+```
+
+The default install location for `skills add -g` is runtime-managed. Prefer the install command printed by this skill and then use the `file-sharing` skill if your coordinator asks you to sync updates.
+
+## Common Skill Categories
+
+When searching, consider these common categories:
+
+| Category        | Example Queries                          |
+| --------------- | ---------------------------------------- |
+| Web Development | react, nextjs, typescript, css, tailwind |
+| Testing         | testing, jest, playwright, e2e           |
+| DevOps          | deploy, docker, kubernetes, ci-cd        |
+| Documentation   | docs, readme, changelog, api-docs        |
+| Code Quality    | review, lint, refactor, best-practices   |
+| Design          | ui, ux, design-system, accessibility     |
+| Productivity    | workflow, automation, git                |
+
+## Tips for Effective Searches
+
+1. **Use specific keywords**: "react testing" is better than just "testing"
+2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
+3. **Check popular sources**: Many skills come from `vercel-labs/agent-skills` or `ComposioHQ/awesome-claude-skills`
+
+## When No Skills Are Found
+
+If no relevant skills exist:
+
+1. Acknowledge that no existing skill was found
+2. Offer to help with the task directly using your general capabilities
+3. Suggest the user could create their own skill with `skills init`
+
+Example:
+
+```
+I searched for skills related to "xyz" but didn't find any matches.
+I can still help you with this task directly! Would you like me to proceed?
+
+If this is something you do often, you could create your own skill:
+skills init my-xyz-skill
+```
+
+## Skill Resources
+
+`hiclaw-find-skill.sh` is the resource that belongs to this skill. Resolve it into `FIND_SKILLS_SCRIPT` first so your command does not depend on hidden runtime paths.

--- a/plugins/teamharness/skills/agent/find-skills/scripts/hiclaw-find-skill.sh
+++ b/plugins/teamharness/skills/agent/find-skills/scripts/hiclaw-find-skill.sh
@@ -1,0 +1,546 @@
+#!/bin/sh
+# hiclaw-find-skill.sh - Unified skill discovery wrapper for Workers
+# Backends:
+#   - skills_sh: delegate to `skills find`
+#   - nacos: query local/default Nacos CLI profile and render skills-style output
+
+set -eu
+
+MAX_RESULTS="${HICLAW_FIND_SKILL_MAX_RESULTS:-6}"
+PAGE_SIZE="${HICLAW_FIND_SKILL_NACOS_PAGE_SIZE:-100}"
+
+RESET='[0m'
+DIM='[38;5;102m'
+TEXT='[38;5;145m'
+
+get_script_path() {
+    raw_path="${0:-hiclaw-find-skill.sh}"
+
+    case "${raw_path}" in
+        /*)
+            printf '%s\n' "${raw_path}"
+            ;;
+        */*)
+            dir_path="$(cd "$(dirname "${raw_path}")" && pwd -P)"
+            printf '%s/%s\n' "${dir_path}" "$(basename "${raw_path}")"
+            ;;
+        *)
+            resolved_path="$(command -v "${raw_path}" 2>/dev/null || true)"
+            if [ -n "${resolved_path}" ]; then
+                case "${resolved_path}" in
+                    /*)
+                        printf '%s\n' "${resolved_path}"
+                        ;;
+                    *)
+                        dir_path="$(cd "$(dirname "${resolved_path}")" && pwd -P)"
+                        printf '%s/%s\n' "${dir_path}" "$(basename "${resolved_path}")"
+                        ;;
+                esac
+            else
+                printf '%s\n' "${raw_path}"
+            fi
+            ;;
+    esac
+}
+
+SCRIPT_PATH="$(get_script_path)"
+
+usage() {
+    cat <<EOF
+Usage:
+  ${SCRIPT_PATH} find <query>
+  ${SCRIPT_PATH} install <skill>
+
+Environment:
+  SKILLS_API_URL=https://skills.sh            Use skills.sh backend
+  SKILLS_API_URL=nacos://host:port            Use Nacos backend (default)
+EOF
+}
+
+get_skills_api_url() {
+    if [ -n "${SKILLS_API_URL:-}" ]; then
+        printf '%s\n' "${SKILLS_API_URL}"
+        return
+    fi
+    if [ -n "${HICLAW_SKILLS_API_URL:-}" ]; then
+        printf '%s\n' "${HICLAW_SKILLS_API_URL}"
+        return
+    fi
+    printf '%s\n' "https://skills.sh"
+}
+
+resolve_controller_bearer() {
+    if [ -n "${HICLAW_AUTH_TOKEN:-}" ]; then
+        printf '%s' "${HICLAW_AUTH_TOKEN}"
+        return
+    fi
+    if [ -n "${HICLAW_AUTH_TOKEN_FILE:-}" ] && [ -f "${HICLAW_AUTH_TOKEN_FILE}" ]; then
+        cat "${HICLAW_AUTH_TOKEN_FILE}"
+        return
+    fi
+    if [ -n "${HICLAW_WORKER_API_KEY:-}" ]; then
+        printf '%s' "${HICLAW_WORKER_API_KEY}"
+    fi
+}
+
+ensure_nacos_sts_credentials() {
+    [ -n "${HICLAW_NACOS_STS_ACCESS_KEY:-}" ] && return 0
+
+    controller_url="${HICLAW_CONTROLLER_URL:-}"
+    bearer="$(resolve_controller_bearer)"
+    if [ -z "${controller_url}" ] || [ -z "${bearer}" ]; then
+        echo "error: NACOS_AUTH_TYPE=sts-hiclaw requires HICLAW_CONTROLLER_URL and a controller bearer token" >&2
+        exit 1
+    fi
+
+    if [ -n "${HICLAW_CLUSTER_ID:-}" ]; then
+        resp="$(curl -s -w "\n%{http_code}" -X POST "${controller_url%/}/api/v1/credentials/sts" \
+            -H "Authorization: Bearer ${bearer}" \
+            -H "X-HiClaw-Cluster-ID: ${HICLAW_CLUSTER_ID}" \
+            --connect-timeout 10 --max-time 30 2>&1)"
+    else
+        resp="$(curl -s -w "\n%{http_code}" -X POST "${controller_url%/}/api/v1/credentials/sts" \
+            -H "Authorization: Bearer ${bearer}" \
+            --connect-timeout 10 --max-time 30 2>&1)"
+    fi
+    http_code="$(printf '%s\n' "${resp}" | tail -1)"
+    body="$(printf '%s\n' "${resp}" | sed '$d')"
+    if [ "${http_code}" != "200" ]; then
+        echo "error: controller STS request for AI registry failed (HTTP ${http_code})" >&2
+        printf '%s\n' "${body}" >&2
+        exit 1
+    fi
+
+    HICLAW_NACOS_STS_ACCESS_KEY="$(printf '%s\n' "${body}" | jq -r '.access_key_id')"
+    HICLAW_NACOS_STS_SECRET_KEY="$(printf '%s\n' "${body}" | jq -r '.access_key_secret')"
+    HICLAW_NACOS_STS_SECURITY_TOKEN="$(printf '%s\n' "${body}" | jq -r '.security_token')"
+    if [ -z "${HICLAW_NACOS_STS_ACCESS_KEY}" ] || [ "${HICLAW_NACOS_STS_ACCESS_KEY}" = "null" ]; then
+        echo "error: failed to parse AI registry STS credentials from controller response" >&2
+        exit 1
+    fi
+}
+
+get_registry_label() {
+    backend="$1"
+    api_url="$(get_skills_api_url)"
+    case "${backend}" in
+        nacos)
+            connection="$(
+                derive_nacos_connection
+            )"
+            host="$(printf '%s\n' "${connection}" | sed -n '1p')"
+            port="$(printf '%s\n' "${connection}" | sed -n '2p')"
+            if [ -n "${host}" ]; then
+                printf '%s\n' "Nacos (nacos://${host}:${port})"
+            else
+                printf '%s\n' "Nacos"
+            fi
+            ;;
+        skills_sh)
+            printf '%s\n' "skills.sh (${api_url})"
+            ;;
+        *)
+            printf '%s\n' "${backend}"
+            ;;
+    esac
+}
+
+detect_backend() {
+    api_url="$(get_skills_api_url)"
+    case "${api_url}" in
+        nacos://*) printf '%s\n' "nacos" ;;
+        http://*|https://*) printf '%s\n' "skills_sh" ;;
+        *) printf '%s\n' "skills_sh" ;;
+    esac
+}
+
+run_skills_find() {
+    output="$(skills find "$@")" || exit $?
+    printf 'Registry: %s\n\n' "$(get_registry_label "skills_sh")"
+    printf '%s\n' "${output}"
+}
+
+run_skills_install() {
+    if [ $# -lt 1 ]; then
+        echo "error: skill name is required for install" >&2
+        exit 1
+    fi
+    exec skills add "$1" -g -y
+}
+
+run_nacos_install() {
+    if [ $# -lt 1 ]; then
+        echo "error: skill name is required for install" >&2
+        exit 1
+    fi
+    run_nacos_cli skill-get "$1"
+}
+
+derive_nacos_connection() {
+    api_url="$(get_skills_api_url)"
+    host="${HICLAW_NACOS_HOST:-}"
+    port="${HICLAW_NACOS_PORT:-}"
+    namespace=""
+    username="${HICLAW_NACOS_USERNAME:-}"
+    password="${HICLAW_NACOS_PASSWORD:-}"
+    token="${HICLAW_NACOS_TOKEN:-}"
+
+    if [ -n "${api_url}" ] && [ "${api_url#nacos://}" != "${api_url}" ]; then
+        api_url="${api_url#nacos://}"
+
+        auth_part="${api_url%%@*}"
+        if [ "${auth_part}" != "${api_url}" ]; then
+            if [ -z "${username}" ]; then
+                username="${auth_part%%:*}"
+            fi
+            if [ -z "${password}" ]; then
+                auth_rest="${auth_part#*:}"
+                if [ "${auth_rest}" != "${auth_part}" ]; then
+                    password="${auth_rest}"
+                fi
+            fi
+            api_url="${api_url#*@}"
+        fi
+
+        query_part=""
+        if [ "${api_url#*\?}" != "${api_url}" ]; then
+            query_part="${api_url#*\?}"
+            api_url="${api_url%%\?*}"
+        fi
+
+        if [ "${api_url#*/}" != "${api_url}" ]; then
+            path_part="${api_url#*/}"
+            api_url="${api_url%%/*}"
+            if [ -z "${namespace}" ] && [ -n "${path_part}" ]; then
+                namespace="${path_part%%/*}"
+            fi
+        fi
+
+        if [ -z "${host}" ]; then
+            host="${api_url%%:*}"
+        fi
+        if [ -z "${port}" ] && [ "${api_url#*:}" != "${api_url}" ]; then
+            port="${api_url##*:}"
+        fi
+        if [ -z "${port}" ]; then
+            port="8848"
+        fi
+
+        if [ -z "${namespace}" ] && [ -n "${query_part}" ]; then
+            namespace="$(printf '%s\n' "${query_part}" | sed -n 's/.*[?&]namespace=\([^&]*\).*/\1/p')"
+            [ -n "${namespace}" ] || namespace="$(printf '%s\n' "${query_part}" | sed -n 's/^namespace=\([^&]*\).*$/\1/p')"
+        fi
+    fi
+
+    printf '%s\n%s\n%s\n%s\n%s\n%s\n' \
+        "${host}" "${port}" "${namespace}" "${username}" "${password}" "${token}"
+}
+
+run_nacos_cli() {
+    if [ $# -lt 1 ]; then
+        return 0
+    fi
+
+    connection="$(
+        derive_nacos_connection
+    )"
+    host="$(printf '%s\n' "${connection}" | sed -n '1p')"
+    port="$(printf '%s\n' "${connection}" | sed -n '2p')"
+    namespace="$(printf '%s\n' "${connection}" | sed -n '3p')"
+    username="$(printf '%s\n' "${connection}" | sed -n '4p')"
+    password="$(printf '%s\n' "${connection}" | sed -n '5p')"
+    token="$(printf '%s\n' "${connection}" | sed -n '6p')"
+
+    set -- npx -y @nacos-group/cli "$@"
+    [ -n "${host}" ] && set -- "$@" --host "${host}"
+    [ -n "${port}" ] && set -- "$@" --port "${port}"
+    [ -n "${namespace}" ] && set -- "$@" --namespace "${namespace}"
+    if [ "${NACOS_AUTH_TYPE:-}" = "sts-hiclaw" ]; then
+        ensure_nacos_sts_credentials
+        set -- "$@" --auth-type sts-hiclaw \
+            --access-key "${HICLAW_NACOS_STS_ACCESS_KEY}" \
+            --secret-key "${HICLAW_NACOS_STS_SECRET_KEY}" \
+            --security-token "${HICLAW_NACOS_STS_SECURITY_TOKEN}"
+    else
+        [ -n "${username}" ] && set -- "$@" --username "${username}"
+        [ -n "${password}" ] && set -- "$@" --password "${password}"
+        [ -n "${token}" ] && set -- "$@" --token "${token}"
+    fi
+    "$@"
+}
+
+append_skill_lines() {
+    output="$1"
+    pattern_rank="$2"
+    page="$3"
+    out_file="$4"
+
+    printf '%s\n' "${output}" | awk -v pattern_rank="${pattern_rank}" -v page="${page}" '
+        /^[[:space:]]*[0-9]+\.[[:space:]]/ {
+            line = $0
+            sub(/^[[:space:]]*[0-9]+\.[[:space:]]+/, "", line)
+            item_rank += 1
+            printf "%s\t%s\t%s\t%s\n", pattern_rank, page, item_rank, line
+        }
+    ' >> "${out_file}"
+}
+
+fetch_nacos_pattern() {
+    pattern="$1"
+    pattern_rank="$2"
+    out_file="$3"
+
+    page=1
+    while :; do
+        page_output="$(run_nacos_cli skill-list --name "${pattern}" --page "${page}" --size "${PAGE_SIZE}" 2>&1)" || {
+            printf '%s\n' "${page_output}" >&2
+            exit 1
+        }
+
+        page_count="$(printf '%s\n' "${page_output}" | awk '/^[[:space:]]*[0-9]+\.[[:space:]]/ { c++ } END { print c + 0 }')"
+        [ "${page_count}" -gt 0 ] || break
+
+        append_skill_lines "${page_output}" "${pattern_rank}" "${page}" "${out_file}"
+
+        [ "${page_count}" -lt "${PAGE_SIZE}" ] && break
+        page=$((page + 1))
+    done
+}
+
+build_nacos_patterns() {
+    query="$1"
+    out_file="$2"
+
+    printf '%s\n' "${query}" | awk '
+        function add(pattern) {
+            if (pattern == "" || seen[pattern]++) return
+            print pattern
+        }
+        {
+            q = tolower($0)
+            gsub(/[^[:alnum:]]+/, " ", q)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", q)
+            gsub(/[[:space:]]+/, " ", q)
+
+            token_count = split(q, tokens, /[[:space:]]+/)
+            add(q)
+            for (i = 1; i <= token_count; i++) {
+                token = tokens[i]
+                if (length(token) < 2) continue
+                add(token)
+            }
+        }
+    ' > "${out_file}"
+}
+
+score_nacos_candidates() {
+    query="$1"
+    candidates_file="$2"
+    scored_file="$3"
+
+    awk -F '\t' -v query="${query}" '
+        function trim(s) {
+            sub(/^[[:space:]]+/, "", s)
+            sub(/[[:space:]]+$/, "", s)
+            return s
+        }
+        function normalize(s) {
+            s = tolower(s)
+            gsub(/[^[:alnum:]]+/, " ", s)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", s)
+            gsub(/[[:space:]]+/, " ", s)
+            return s
+        }
+        function has_word(words, token) {
+            return index(" " words " ", " " token " ") > 0
+        }
+        function has_prefix(words, token,    count, i, arr) {
+            count = split(words, arr, /[[:space:]]+/)
+            for (i = 1; i <= count; i++) {
+                if (arr[i] == "") continue
+                if (index(arr[i], token) == 1) return 1
+            }
+            return 0
+        }
+        BEGIN {
+            q_raw = tolower(query)
+            q_words = normalize(query)
+            token_count = split(q_words, raw_tokens, /[[:space:]]+/)
+            effective_tokens = 0
+            for (i = 1; i <= token_count; i++) {
+                token = raw_tokens[i]
+                if (token == "" || seen_query_token[token]++) continue
+                effective_tokens += 1
+                tokens[effective_tokens] = token
+            }
+        }
+        NF >= 4 {
+            pattern_rank = ($1 + 0)
+            page = ($2 + 0)
+            item_rank = ($3 + 0)
+            line = $4
+
+            name = line
+            desc = ""
+            split_pos = index(line, " - ")
+            if (split_pos > 0) {
+                name = substr(line, 1, split_pos - 1)
+                desc = substr(line, split_pos + 3)
+            }
+
+            name = trim(name)
+            desc = trim(desc)
+            lname = tolower(name)
+            ldesc = tolower(desc)
+            name_words = normalize(name)
+            desc_words = normalize(desc)
+
+            exact_name_phrase = (q_words != "" && has_word(name_words, q_words))
+            exact_desc_phrase = (q_words != "" && has_word(desc_words, q_words))
+            raw_name_substring = (q_raw != "" && index(lname, q_raw) > 0)
+            raw_desc_substring = (q_raw != "" && index(ldesc, q_raw) > 0)
+
+            score = 0
+            coverage = 0
+            missing = 0
+
+            if (lname == q_raw) score += 30000
+            if (name_words == q_words && q_words != "") score += 24000
+            if (exact_name_phrase) score += 12000
+            if (exact_desc_phrase) score += 3000
+            if (raw_name_substring) score += 1500
+            if (raw_desc_substring) score += 400
+
+            for (i = 1; i <= effective_tokens; i++) {
+                token = tokens[i]
+                matched = 0
+
+                if (has_word(name_words, token)) {
+                    score += 1800
+                    matched = 1
+                } else if (length(token) >= 4 && has_prefix(name_words, token)) {
+                    score += 900
+                    matched = 1
+                } else if (has_word(desc_words, token)) {
+                    score += 600
+                    matched = 1
+                } else if (length(token) >= 4 && has_prefix(desc_words, token)) {
+                    score += 250
+                    matched = 1
+                }
+
+                if (matched) coverage += 1
+                else missing += 1
+            }
+
+            if (coverage == 0 && !exact_name_phrase && !exact_desc_phrase &&
+                !raw_name_substring && !raw_desc_substring) {
+                next
+            }
+
+            score += coverage * coverage * 500
+            score -= missing * 200
+
+            backend_bonus = 200 - (pattern_rank * 20) - ((page - 1) * 5) - item_rank
+            if (backend_bonus > 0) score += backend_bonus
+
+            key = lname SUBSEP ldesc
+            if (!(key in best_score) || score > best_score[key]) {
+                best_score[key] = score
+                best_name[key] = name
+                best_desc[key] = desc
+            }
+        }
+        END {
+            for (key in best_score) {
+                printf "%08d\t%s\t%s\n", best_score[key], best_name[key], best_desc[key]
+            }
+        }
+    ' "${candidates_file}" > "${scored_file}"
+}
+
+run_nacos_find() {
+    if [ $# -lt 1 ]; then
+        printf '%sTip:%s search with %s%s find <query>%s\n' "${DIM}" "${RESET}" "${TEXT}" "${SCRIPT_PATH}" "${RESET}"
+        exit 0
+    fi
+
+    query="$*"
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "${tmp_dir}"' EXIT INT TERM
+    patterns="${tmp_dir}/patterns.txt"
+    candidates="${tmp_dir}/candidates.tsv"
+    scored="${tmp_dir}/scored.txt"
+    sorted="${tmp_dir}/sorted.txt"
+
+    build_nacos_patterns "${query}" "${patterns}"
+    : > "${candidates}"
+
+    pattern_rank=0
+    while IFS= read -r pattern; do
+        [ -n "${pattern}" ] || continue
+        pattern_rank=$((pattern_rank + 1))
+        fetch_nacos_pattern "${pattern}" "${pattern_rank}" "${candidates}"
+    done < "${patterns}"
+
+    score_nacos_candidates "${query}" "${candidates}" "${scored}"
+    sort -r "${scored}" > "${sorted}"
+
+    if [ ! -s "${sorted}" ]; then
+        printf '%sNo skills found for "%s"%s\n' "${DIM}" "${query}" "${RESET}"
+        exit 0
+    fi
+
+    first_name="$(awk -F '\t' 'NR == 1 { print $2; exit }' "${sorted}")"
+
+    printf '%sRegistry:%s %s\n\n' "${DIM}" "${RESET}" "$(get_registry_label "nacos")"
+    printf '%sInstall with%s %s%s install %s%s\n\n' \
+        "${DIM}" "${RESET}" "${TEXT}" "${SCRIPT_PATH}" "${first_name}" "${RESET}"
+
+    sed -n "1,${MAX_RESULTS}p" "${sorted}" | while IFS="$(printf '\t')" read -r score name desc; do
+        if [ -z "${desc}" ]; then
+            desc="Available from Nacos skill registry"
+        fi
+
+        printf '%s%s%s\n' "${TEXT}" "${name}" "${RESET}"
+        printf '%s└ %s%s\n\n' "${DIM}" "${desc}" "${RESET}"
+    done
+}
+
+command_name="${1:-find}"
+if [ $# -gt 0 ]; then
+    shift
+fi
+
+case "${command_name}" in
+    find)
+        backend="$(detect_backend)"
+        case "${backend}" in
+            skills_sh) run_skills_find "$@" ;;
+            nacos) run_nacos_find "$@" ;;
+            *)
+                echo "error: unsupported skill backend: ${backend}" >&2
+                exit 1
+                ;;
+        esac
+        ;;
+    install|get)
+        backend="$(detect_backend)"
+        case "${backend}" in
+            skills_sh) run_skills_install "$@" ;;
+            nacos) run_nacos_install "$@" ;;
+            *)
+                echo "error: unsupported skill backend: ${backend}" >&2
+                exit 1
+                ;;
+        esac
+        ;;
+    help|-h|--help)
+        usage
+        ;;
+    *)
+        echo "error: unknown command: ${command_name}" >&2
+        usage >&2
+        exit 1
+        ;;
+esac

--- a/plugins/teamharness/skills/agent/mcporter/SKILL.md
+++ b/plugins/teamharness/skills/agent/mcporter/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: mcporter
+description: Discover and call MCP Server tools via the mcporter CLI. Use when your coordinator notifies you about new MCP tools, or when you need to call external APIs. Includes workflow for generating skill documentation for new MCP servers.
+---
+
+# mcporter — MCP Tool CLI
+
+You call MCP Server tools via `mcporter`. Your config is at `./config/mcporter.json` (mcporter's default path — no `--config` flag needed).
+
+## Commands
+
+```bash
+# List all configured MCP servers and their tool counts
+mcporter list
+
+# View a specific server's tools with full parameter schemas
+mcporter list <server-name> --schema
+
+# Call a tool — key=value syntax for simple args
+mcporter call <server-name>.<tool-name> key=value key2=value2
+
+# Call a tool — JSON syntax for complex args (arrays, objects, numbers)
+mcporter call <server-name>.<tool-name> --args '{"key":"value","count":5}'
+```
+
+Output is JSON — parse with `jq` when needed.
+
+## When Your Coordinator Notifies You About New MCP Tools
+
+When your coordinator @mentions you saying a new MCP server has been configured, follow this workflow:
+
+### Step 1: Pull the updated config
+
+Use the `filesync` tool to pull the latest config files:
+
+```json
+{
+  "action": "pull",
+  "path": "shared/"
+}
+```
+
+### Step 2: Discover the new server and its tools
+
+```bash
+# Verify the new server appears
+mcporter list
+
+# Get full tool schemas — read carefully to understand each tool
+mcporter list <server-name> --schema
+```
+
+### Step 3: Generate a skill for the new MCP server
+
+After understanding the tools, create a skill directory and SKILL.md so you have a permanent reference. Model it after your `github-operations` skill:
+
+```bash
+mkdir -p ~/skills/<server-short-name>-operations
+```
+
+Then write `~/skills/<server-short-name>-operations/SKILL.md` with:
+
+1. Front-matter: `name`, `description`, `assign_when`
+2. Overview section explaining what the MCP server does
+3. For each tool: a section with description, example `mcporter call` command, and parameter notes
+4. Important notes (rate limits, auth, known issues if any)
+
+Use the tool schemas from Step 2 as the source of truth for parameter names, types, and required/optional status.
+
+Example structure:
+
+```markdown
+---
+name: weather-operations
+description: Query weather data via the weather MCP server. Use when you need current weather, forecasts, or climate data.
+assign_when: Worker needs weather information for a task
+---
+
+# Weather Operations
+
+## Overview
+
+Use this skill to query weather data via the centralized MCP Server.
+
+## get_weather
+
+Get current weather for a city:
+
+\```bash
+mcporter call mcp-weather.get_weather city=Tokyo units=metric
+\```
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| city | string | yes | City name |
+| units | string | no | Temperature units (default: metric) |
+```
+
+### Step 4: Confirm to your coordinator
+
+After generating the skill, reply to your coordinator confirming:
+- You pulled the updated config
+- You discovered N tools on the new server
+- You generated a skill at `~/skills/<name>-operations/SKILL.md`
+- You're ready to use the new tools
+
+## Important Notes
+
+- **Not installed?** If `mcporter` command is not found, install it: `npm install -g mcporter`
+- **Transport**: MCP Servers are configured in `config/mcporter.json`; HTTP, SSE, and local stdio command entries are supported when present in that file.
+- **Auth**: Authorization header with Bearer token is auto-configured — you don't need to manage credentials
+- **Permissions**: Your MCP access is controlled by your coordinator. If you get 403 from the MCP Server, ask your coordinator to re-authorize your access
+- **Config not found**: If `./config/mcporter.json` doesn't exist yet, use your `file-sharing` skill first; your coordinator publishes the config after setting up MCP servers

--- a/plugins/teamharness/skills/team/communication/SKILL.md
+++ b/plugins/teamharness/skills/team/communication/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: teamharness-communication
+description: "Use when TEAMS.md Communication Contract needs detailed routing: Channel / Room Selection Protocol, Requester Report Delivery Protocol, or Message Tool Protocol. It resolves current session vs Team Room vs assignment room vs requester reply_route vs external channel, and explains when to use the message MCP tool. Do not use it to choose Quick Task or Project Work, create rooms, delegate tasks, check results, or accept project state."
+---
+
+# Communication
+
+This skill expands the TEAMS.md Communication Contract.
+
+It only handles message delivery protocols. It does not choose Direct Reply,
+Quick Task, or Project Work. It does not create rooms, delegate tasks, check
+Worker results, or accept project state.
+
+For ordinary direct replies and other lightweight one-off answers in the
+current room/session, answer directly. Use the `message` MCP tool only when a
+message must leave the current runtime conversation.
+
+Use `NO_REPLY` exactly when the current event is a low-information
+acknowledgement, self echo, or non-actionable mention-only message. Do not add
+extra explanation to `NO_REPLY`.
+
+Prevent ping-pong loops. Do not let acknowledgements, mention-only messages, or
+same-room status echoes create repeated cross-room or cross-agent replies.
+
+## Channel / Room Selection Protocol
+
+Use this protocol after another TeamHarness flow has already decided that a
+message should be sent.
+
+1. If the reply belongs in the current runtime session, answer directly.
+2. If a project requester report is needed, prefer the project's `reply_route`.
+3. If the selected destination is the Team Room or assignment room, send there
+   only for team-visible coordination.
+4. If the selected destination is an external channel, another Matrix room, or
+   another runtime session, use the `message` MCP tool.
+5. If the destination is missing or ambiguous, do not guess. Restore project or
+   task state first, or ask for the missing routing detail.
+
+Use the Team Room for normal team-visible coordination. Use the assignment room
+recorded on the task for task-visible coordination. Use a project `reply_route`
+for requester-facing reports.
+
+Do not treat a Team Room assignment, Worker completion, Worker blocker report,
+or downstream delegation as a requester report unless the recorded requester
+route is exactly that current room.
+
+## Requester Report Delivery Protocol
+
+Use this protocol only after project state says a requester report is needed,
+for example after accepted project progress or a blocker that must be surfaced
+to the requester.
+
+When project state records a pending requester report after an accepted state
+change, delivery is mandatory.
+
+Prefer `reply_route`:
+
+```json
+{
+  "channel": "dingtalk",
+  "target_user": "sender_001",
+  "target_session": "aaaaaaaa"
+}
+```
+
+For legacy projects without `reply_route`, parse `requester` only when it uses a
+known encoding:
+
+| Legacy requester | Delivery |
+|---|---|
+| `matrix:!roomid:domain` | `message` with `channel: "matrix"` and `target: "room:!roomid:domain"` |
+| `dingtalk:{user_id}:{session_id}` | `message` with `channel: "dingtalk"`, `targetUser`, and `targetSession` |
+
+Do not guess missing channel, user, room, or session values. If a legacy Matrix
+requester points at the current room/session, answer directly instead of using
+the `message` tool.
+
+After successful delivery, call `projectflow` `mark_requester_report_sent` when
+the project recorded a pending requester report.
+
+## Message Tool Protocol
+
+Use the `message` MCP tool only for explicit cross-room, cross-channel, or
+cross-session sends. Do not use it for normal replies in the current
+room/session; answer directly instead.
+
+For cross-session requester reports, pass the recorded `replyRoute`:
+
+```json
+{
+  "action": "send",
+  "replyRoute": {
+    "channel": "dingtalk",
+    "targetUser": "sender_001",
+    "targetSession": "aaaaaaaa"
+  },
+  "text": "Project A is ready."
+}
+```
+
+For Matrix room sends, pass a channel target:
+
+```json
+{
+  "action": "send",
+  "channel": "matrix",
+  "target": "room:!team-room:matrix.local",
+  "text": "@worker-a:matrix.local TASK_ASSIGNED: task-001 - Please start. Spec: shared/tasks/task-001/spec.md"
+}
+```
+
+For external channel sends, pass the channel-specific target fields:
+
+```json
+{
+  "action": "send",
+  "channel": "dingtalk",
+  "targetUser": "sender_001",
+  "targetSession": "aaaaaaaa",
+  "text": "Project A is ready."
+}
+```
+
+Pass a channel target or `replyRoute`, not an object-storage path. Matrix
+mentions are message formatting details: mention a Worker or Leader only when
+the message asks that member to act or records task completion/blocker status.
+Do not send mention-only acknowledgements such as `@worker ok`.

--- a/plugins/teamharness/skills/team/file-sharing/SKILL.md
+++ b/plugins/teamharness/skills/team/file-sharing/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: teamharness-file-sharing
+description: "Use for TeamHarness shared workspace paths, explicit filesync operations, and shared project/task artifact boundaries."
+---
+
+# File Sharing
+
+Use shared workspace paths in task specs and team messages.
+
+Project files belong under `shared/projects/{project-id}/`. Task specs,
+deliverables, and results belong under `shared/tasks/{task-id}/`.
+
+Do not expose object storage internals in human-facing messages. Use TeamHarness
+filesync tools for explicit shared file operations.
+
+## Shared Paths
+
+Use these paths in task specs and team messages:
+
+```text
+shared/projects/{project-id}/meta.json
+shared/projects/{project-id}/plan.md
+shared/projects/{project-id}/result.md
+shared/tasks/{task-id}/meta.json
+shared/tasks/{task-id}/spec.md
+shared/tasks/{task-id}/workspace/
+shared/tasks/{task-id}/result.md
+```
+
+The Leader owns project files and task specs. Workers own task workspaces,
+deliverables, and submitted results.
+
+## Filesync
+
+Use `filesync` when you need an explicit shared file operation.
+
+List a concrete shared directory:
+
+```json
+{
+  "action": "list",
+  "path": "shared/projects/demo-project-001"
+}
+```
+
+Pull before reading remote shared state:
+
+```json
+{
+  "action": "pull",
+  "path": "shared/tasks/task-001"
+}
+```
+
+Push after writing project-level files:
+
+```json
+{
+  "action": "push",
+  "path": "shared/projects/demo-project-001"
+}
+```
+
+Do not ask humans or Workers to inspect storage bucket names, access keys, or
+provider-specific prefixes. Use `shared/...` paths in all visible coordination.

--- a/plugins/teamharness/skills/team/organization/SKILL.md
+++ b/plugins/teamharness/skills/team/organization/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: teamharness-organization
+description: "Use to understand TeamHarness team roles, responsibility boundaries, and who owns project, task, runtime, and control-plane work."
+---
+
+# Organization
+
+Use this skill to reason about team roles and responsibility boundaries.
+
+Leader owns planning, delegation, acceptance, and requester reporting. Workers
+own assigned task execution. Remote members participate as invited local agents
+or humans. Manager owns control-plane operations.
+
+Do not let a Worker silently become project owner. Do not let a remote member
+act like a controller-managed Worker unless the team explicitly models that
+role.
+
+## Role Boundaries
+
+Leader owns:
+
+- deciding the work breakdown
+- creating project plans
+- delegating task specs
+- checking Worker results
+- accepting or rejecting results for project progress
+- reporting accepted outcomes to the requester
+
+Worker owns:
+
+- acknowledging assigned tasks
+- reading `shared/tasks/{task-id}/spec.md`
+- producing deliverables under `shared/tasks/{task-id}/`
+- submitting `result.md`
+- reporting blockers or completion to the Leader
+
+Remote member owns only the work explicitly assigned to that member. Treat
+remote members as participants, not controller-managed runtime resources.
+
+Manager owns control-plane operations such as creating workers, changing model
+configuration, deploying teams, and managing runtime state. TeamHarness skills
+must not instruct agents to call control-plane APIs.
+
+## Safety Boundary
+
+Never write secrets, credentials, tokens, authorization headers, or live runtime
+state into `TEAMS.md`, project files, task specs, task results, or Matrix
+messages. If a task needs credentialed access, refer only to the approved
+credential name or environment variable name, not its value.

--- a/plugins/teamharness/skills/team/project-management/SKILL.md
+++ b/plugins/teamharness/skills/team/project-management/SKILL.md
@@ -1,0 +1,482 @@
+---
+name: teamharness-project-management
+description: "Use only after Project Work mode is selected, before TeamHarness projectflow calls, project DAG or Loop planning, ready-node resolution, iteration recording, project files, result acceptance, or project progress updates."
+---
+
+# Project Management
+
+Use this skill when maintaining durable project state.
+
+A project owns the plan, context, dependencies, and accepted progress. Keep the
+project plan separate from individual task execution logs.
+
+Only advance a dependency after the Leader accepts the submitted result.
+Do not use this skill for ordinary direct replies or lightweight one-off
+actions.
+
+## Scope
+
+Use this skill when acting as Leader for:
+
+- `projectflow` calls
+- project creation
+- quick single-task project creation
+- DAG planning
+- Loop planning
+- ready-node resolution
+- Loop iteration recording
+- accepting checked Worker results into project progress
+- project-level status reports
+
+Use `teamharness-team-coordination` first to decide task boundaries. Use
+`teamharness-task-delegation` for individual task specs and Worker result
+checks.
+
+## Project Files
+
+Project files live under:
+
+```text
+shared/projects/{project-id}/
+```
+
+TeamHarness writes CoPaw-compatible task runtime files:
+
+```text
+shared/projects/{project-id}/meta.json
+shared/projects/{project-id}/plan.md
+```
+
+Write a final project result, when needed, to:
+
+```text
+shared/projects/{project-id}/result.md
+```
+
+Use `projectflow` to change `meta.json` and `plan.md`; do not hand-edit
+project state unless a tool failure leaves no safe alternative.
+
+## ID Rules
+
+Use safe IDs only:
+
+```text
+[A-Za-z0-9][A-Za-z0-9._-]*
+```
+
+Do not use colons, slashes, spaces, or Matrix IDs as project or task IDs.
+
+Suggested formats:
+
+```text
+projectId: {short-description}-YYYYMMDD-HHMMSS
+taskId: {projectId}-{seq}
+```
+
+If a user or test provides explicit IDs, preserve them when they are already
+safe.
+
+## Tool Payload Rule
+
+When calling `projectflow`, pass `payload` as a JSON object, not as a serialized
+JSON string.
+
+## Create Project
+
+Create the project before planning tasks:
+
+```json
+{
+  "action": "create_project",
+  "payload": {
+    "projectId": "demo-project-001",
+    "title": "Demo Project",
+    "source": "dingtalk",
+    "requester": "dingtalk:sender_001:aaaaaaaa",
+    "replyRoute": {
+      "channel": "dingtalk",
+      "targetUser": "sender_001",
+      "targetSession": "aaaaaaaa"
+    }
+  }
+}
+```
+
+This creates `meta.json` and `plan.md`.
+
+If `projectId` is omitted, TeamHarness derives one from `title` plus timestamp.
+If the generated ID already exists, TeamHarness appends a numeric suffix.
+Explicit `projectId` collisions are rejected.
+
+Use `replyRoute` when the requester came from a runtime channel that may need a
+cross-session final report. `channel`, `targetUser`, and `targetSession` must
+come from the current message/session metadata or a trusted runtime query. Do
+not guess them.
+
+For DingTalk requester compatibility, `requester` may use
+`dingtalk:{user_id}:{session_id}`; TeamHarness derives `reply_route` from that
+value when `replyRoute` is not provided.
+
+## Create Quick Project
+
+Use `create_quick_project` only after Project Work mode is selected and the work
+is clearly a single Worker task. It is a shortcut for:
+
+```text
+create_project + plan single-node DAG + delegate_task-compatible task spec
+```
+
+Determine the assignment `roomId` before calling this action. Use the Team Room
+for Matrix DM-originated work. For DingTalk, Feishu, WeChat, or another
+external requester channel, first call `roomflow` `create_task_room` with
+`source` and the current channel metadata's stable `sourceRoomId`; use the
+returned Matrix room id. The same `source` + `sourceRoomId` must map to one
+assignment room and must be reused for later tasks from that external room.
+
+Do not invent, transform, suffix, or specialize `sourceRoomId` by task, worker,
+retry, or project. If the current DingTalk group already provided
+`sourceRoomId: "uhrz6g=="`, pass exactly `"uhrz6g=="` for every later task from
+that group. Values such as `"uhrz6g==-qa-task"` or `"uhrz6g==-dev-task"` are
+wrong unless they came directly from trusted current channel metadata.
+
+When reusing an external assignment room, call `roomflow` before creating or
+delegating task state and pass the complete `invite` list for the Workers who
+must receive work in that room. `roomflow` will return the existing Matrix room
+and invite missing members.
+
+Example assignment room setup for DingTalk:
+
+```json
+{
+  "action": "create_task_room",
+  "taskId": "demo-project-001",
+  "name": "Demo Project",
+  "source": "dingtalk",
+  "sourceRoomId": "<exact current DingTalk group sourceRoomId>",
+  "invite": ["@worker-a:matrix.local", "@worker-b:matrix.local"]
+}
+```
+
+Example:
+
+```json
+{
+  "action": "create_quick_project",
+  "payload": {
+    "title": "Write readiness note",
+    "source": "matrix",
+    "requester": "@admin:matrix.local",
+    "assignedTo": "@worker-a:matrix.local",
+    "roomId": "!team-room:matrix.local",
+    "spec": "# Task\n\nWrite one concise readiness note.",
+    "replyRoute": {
+      "channel": "matrix",
+      "targetUser": "@admin:matrix.local",
+      "targetSession": "!team-room:matrix.local"
+    }
+  }
+}
+```
+
+This writes:
+
+```text
+shared/projects/{projectId}/meta.json
+shared/projects/{projectId}/plan.md
+shared/tasks/{taskId}/meta.json
+shared/tasks/{taskId}/spec.md
+```
+
+It sets `mode: quick`, `plan_type: dag`, and the single task status to
+`assigned`. It does not send the Matrix or external-channel assignment message;
+send that message only after the tool returns `ok: true`.
+
+## Plan DAG
+
+Use DAG when the work is finite and dependencies are known enough to plan now.
+
+Call `plan_dag` with the complete graph you want to keep:
+
+```json
+{
+  "action": "plan_dag",
+  "payload": {
+    "projectId": "demo-project-001",
+    "tasks": [
+      {
+        "taskId": "demo-project-001-01",
+        "title": "Implement the worker-owned part",
+        "assignedTo": "@worker-a:matrix.local",
+        "dependsOn": []
+      }
+    ]
+  }
+}
+```
+
+For `assignedTo`, use the Worker Matrix ID or the stable runtime/member name
+from `TEAMS.md`. Do not invent a Worker name.
+
+`plan_dag` returns `readyNodes`. Delegate only ready nodes.
+
+## Ready Nodes
+
+Use `ready_nodes` when you need the next pending or assigned DAG nodes whose
+dependencies are completed:
+
+```json
+{
+  "action": "ready_nodes",
+  "payload": {
+    "projectId": "demo-project-001"
+  }
+}
+```
+
+Only nodes with dependencies marked `completed` unblock downstream work.
+
+## Plan Loop
+
+Use Loop when `teamharness-team-coordination` decided the work should repeat
+until a stop condition, quality gate, evidence threshold, or maximum iteration
+count.
+
+Call `plan_loop` with the complete current-iteration plan you want to keep:
+
+```json
+{
+  "action": "plan_loop",
+  "payload": {
+    "projectId": "demo-project-001",
+    "goal": "Improve the result until tests pass",
+    "stopCondition": "All target tests pass or maxIterations is reached",
+    "iterationTemplate": "Inspect result, choose one bounded fix, run tests.",
+    "maxIterations": 3,
+    "currentIteration": 1,
+    "tasks": [
+      {
+        "taskId": "demo-project-001-i001-01",
+        "title": "Run iteration 1",
+        "assignedTo": "@worker-a:matrix.local",
+        "dependsOn": []
+      }
+    ]
+  }
+}
+```
+
+Required Loop inputs:
+
+- `goal`
+- `stopCondition`
+- `iterationTemplate`
+- `maxIterations`
+
+Use `ready_loop_nodes` to find pending nodes in the current iteration whose
+dependencies are completed:
+
+```json
+{
+  "action": "ready_loop_nodes",
+  "payload": {
+    "projectId": "demo-project-001"
+  }
+}
+```
+
+After evaluating an iteration, use `record_loop_iteration`:
+
+```json
+{
+  "action": "record_loop_iteration",
+  "payload": {
+    "projectId": "demo-project-001",
+    "iteration": 1,
+    "decision": "continue",
+    "summary": "One target still fails.",
+    "nextAction": "Plan the next fix pass."
+  }
+}
+```
+
+Allowed decisions are `continue`, `replan`, `ask_user`, `stop_success`, and
+`stop_blocked`.
+
+Do not pre-expand repeated Loop rounds into a large DAG. Plan the current
+iteration, evaluate it, record the iteration decision, then decide whether to
+continue, replan, ask the requester, stop successfully, or stop blocked.
+
+## Resolve Project Context
+
+When a Worker completion or blocker wakes the Leader in a fresh session, do not
+guess the project from the current room. First resolve the context from the task
+id:
+
+```json
+{
+  "action": "resolve_project",
+  "payload": {
+    "taskId": "demo-project-001-01"
+  }
+}
+```
+
+`resolve_project` returns the ProjectMeta, TaskMeta, `replyRoute`, plan type, and
+ready nodes that the Leader needs to resume normal project flow.
+
+## Accepting Worker Results
+
+A Worker `SUCCESS` or `SUCCESS_WITH_NOTES` result is only a candidate result.
+After `teamharness-task-delegation` checks the task and returns `effective:
+true`, decide whether to accept the result.
+
+To accept a result, call `accept_task_result`:
+
+```json
+{
+  "action": "accept_task_result",
+  "payload": {
+    "projectId": "demo-project-001",
+    "taskId": "demo-project-001-01",
+    "resultStatus": "SUCCESS",
+    "summary": "Completed the assigned work."
+  }
+}
+```
+
+`accept_task_result` updates the DAG or Loop node and records
+`requester_report.pending` in ProjectMeta. Keep unresolved nodes in their current
+state.
+
+Then call `ready_nodes` and delegate any newly ready downstream node with
+`teamharness-task-delegation`.
+
+After the project state changes, close the loop with requester visibility:
+
+1. Read `shared/projects/{project-id}/meta.json` and `plan.md`.
+2. Build the requester-facing content with the Project Status Reports template
+   below.
+3. Use `teamharness-communication`
+   `## Requester Report Delivery Protocol` to deliver the report to the
+   requester recorded on the project.
+4. After successful delivery, call `mark_requester_report_sent`.
+
+Team Room coordination, Worker completion messages, downstream assignment
+messages, and tool-call summaries do not count as the requester report. You may
+batch several accepted task results and downstream delegations into one
+requester report, but do not omit the report when accepted project state
+changed.
+
+## Project Status Reports
+
+Build status report content here because this skill owns project execution
+state. Use `teamharness-communication` only for destination selection, message
+tool payloads, Matrix message formatting, and same-room versus cross-room
+delivery.
+
+Before writing a requester report:
+
+1. Read `shared/projects/{project-id}/meta.json` and `plan.md`.
+2. Identify the plan type from `meta.json` or `plan.md`.
+3. For DAG, report dependency progress and the next ready nodes.
+4. For Loop, report current iteration progress, the latest decision, and the
+   next iteration path.
+5. Write the report in the requester's language, then use
+   `teamharness-communication` to deliver it to the requester recorded on the
+   project.
+
+Use stable state markers and localize the visible labels:
+
+| State | Marker |
+|---|---|
+| Completed | `[done]` |
+| In Progress | `[active]` |
+| Pending | `[pending]` |
+| Blocked | `[blocked]` |
+| Revision | `[revision]` |
+
+Keep the report envelope consistent across DAG and Loop:
+
+````markdown
+---
+
+## <localized project status report heading>
+
+**<localized project name label>**: <name>
+**<localized project ID label>**: <project-id>
+**<localized execution mode label>**: <DAG or Loop>
+**<localized project status label>**: <marker + localized state label>
+**<localized current focus label>**: <DAG wave/current node, or Loop iteration n / max and topic>
+
+**<localized summary label>**: <1-3 sentences about what changed and what happens next>
+
+**<localized task status label>**:
+| <localized task ID label> | <localized task title label> | <localized owner label> | <localized status label> | <localized context label> |
+|---|---|---|---|---|
+| <task-id> | <title> | <worker> | <marker + localized state label> | <dependencies, iteration role, result note, or -> |
+
+**<localized execution progress label>**:
+```text
+<DAG dependency flow or Loop iteration line; choose the matching shape below>
+```
+
+**<localized deliverables label>**:
+- `<path>` - <what it contains>
+
+**<localized next steps label>**:
+1. <next DAG transition, next Loop decision, or requester action>
+
+**<localized notes label>**: <blocker, risk, or decision needed; omit section if none>
+````
+
+Use this execution progress shape for DAG reports:
+
+```text
+<task-id> [done] -> <task-id> [active] -> <task-id> [pending]
+                                  ^
+<task-id> [done] -----------------|
+```
+
+Use the DAG progress section to show the dependency path that changed, newly
+unblocked nodes, or the next ready wave. If the graph is large, show only the
+relevant changed path and summarize the rest in the task table.
+
+Use this execution progress shape for Loop reports:
+
+```text
+Iteration 1 [done] -> Iteration 2 [active] -> Iteration 3 [pending] ... Max <n>
+                       Current: <current iteration topic>
+                       Decision: <continue, replan, ask_user, stop_success, stop_blocked, or pending evaluation>
+```
+
+Use the Loop progress section to show current iteration number, maximum
+iterations, current iteration topic, and the latest Leader decision. Do not
+present future Loop rounds as if they were pre-planned DAG tasks. Show only the
+current iteration's task statuses in the task table unless prior iteration
+context is necessary.
+
+For intermediate updates, include the Project header, summary, task status
+table, and next steps. Omit the deliverables section unless new deliverables
+are available, and omit the execution progress section only when neither DAG
+flow nor Loop iteration state changed.
+
+After the requester report is sent, clear the pending flag:
+
+```json
+{
+  "action": "mark_requester_report_sent",
+  "payload": {
+    "projectId": "demo-project-001"
+  }
+}
+```
+
+## Current Boundary
+
+TeamHarness v0.1 supports project creation, quick single-task project creation,
+project context resolution, DAG planning, DAG ready-node resolution, Loop
+planning, Loop ready-node resolution, Loop iteration recording, explicit result
+acceptance, requester report clearing, `pause_project`, `resume_project`, and
+`complete_project`. DAG and Loop task plans reject duplicate task ids, unknown
+dependencies, and dependency cycles. Do not call unsupported `projectflow`
+actions.

--- a/plugins/teamharness/skills/team/task-delegation/SKILL.md
+++ b/plugins/teamharness/skills/team/task-delegation/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: teamharness-task-delegation
+description: "Use only after Project Work mode is selected, when a TeamHarness Leader delegates ready project nodes, writes task specs, checks Worker results, and routes completion or blocker messages."
+---
+
+# Task Delegation
+
+Use this skill when acting as Leader to create and delegate task specs.
+
+Each delegated task should have a task id, owner, scope, expected deliverables,
+acceptance criteria, and blocker reporting path. Write task instructions to the
+shared task directory before asking the owner to execute.
+
+A submitted result is only a candidate result until accepted by the Leader.
+Do not use this skill to turn ordinary conversation into tasks.
+
+## Scope
+
+Use this skill for:
+
+- `taskflow` calls as Leader
+- converting a ready project node into a Worker task spec
+- checking a submitted Worker result
+- routing task assignment and completion messages
+
+Use `teamharness-project-management` to create projects, plan DAG or Loop work,
+resolve ready nodes, record Loop iteration decisions, and accept results into
+project progress.
+
+## Delegate Only Ready Nodes
+
+Within Project Work, do not create bare tasks directly from a user request.
+First create or update a project DAG, then delegate a ready project node
+returned by `projectflow` `readyNodes`, or create/update a Loop and delegate a
+ready project node returned by `readyLoopNodes`.
+
+For a single-task Project Work item, `projectflow` `create_quick_project` may be
+used instead. It already writes `shared/tasks/{task-id}/meta.json`,
+`shared/tasks/{task-id}/spec.md`, and marks the task `assigned`; do not call
+`delegate_task` again for that task. After it returns `ok: true`, send the same
+assignment message you would send after `delegate_task`.
+
+Before delegation:
+
+1. Read `TEAMS.md` for the Worker Matrix ID and Team Room ID.
+2. Confirm the node came from `readyNodes` or `readyLoopNodes`.
+3. Write a bounded task spec through `taskflow`. The spec must include the
+   completion report instruction below.
+4. Mention the assigned Worker in the assignment room only after
+   `delegate_task` succeeds. Use the Team Room for Matrix DM-originated work,
+   or the assignment room returned by `roomflow` for external requester channels.
+   For external channels, `roomflow` must receive the stable `sourceRoomId` from
+   the current channel metadata so repeated tasks from that source room reuse
+   one Matrix assignment room.
+5. Do not create task-specific or worker-specific `sourceRoomId` values. Reuse
+   the exact external `sourceRoomId` from the current requester room. Before
+   sending the assignment message, call `roomflow` with that same `sourceRoomId`
+   and include the assigned Worker in `invite`; include any other Workers who
+   need to observe or work in the same assignment room.
+
+## Delegate Task
+
+Call `taskflow` with `role: "leader"` and pass `payload` as an object:
+
+```json
+{
+  "role": "leader",
+  "action": "delegate_task",
+  "payload": {
+    "projectId": "demo-project-001",
+    "taskId": "demo-project-001-01",
+    "roomId": "room:!team-room:matrix.local",
+    "spec": "# Task demo-project-001-01\n\n## Context\nExplain why this task exists.\n\n## Expected Result\nCreate deliverables under shared/tasks/demo-project-001-01/ and submit a result with STATUS, SUMMARY, and DELIVERABLES.\n\n## Acceptance Criteria\n- The result addresses the task scope.\n- Deliverables are listed in result.md.\n\n## Completion Report\nAfter `taskflow submit_task` returns `ok: true`, reply in the current assignment room and mention the Leader Matrix user from `TEAMS.md`:\n\n<Leader Matrix user from TEAMS.md> TASK_COMPLETED: demo-project-001-01 - Result: shared/tasks/demo-project-001-01/result.md\n\nDo not use `NO_REPLY` after a successful task submission.\n"
+  }
+}
+```
+
+`delegate_task` writes:
+
+```text
+shared/tasks/{task-id}/meta.json
+shared/tasks/{task-id}/spec.md
+```
+
+It also changes the project node status to `assigned`.
+
+## Task Spec Completion Report
+
+Every delegated task spec must include this final instruction, with the task id
+and result path adjusted for the actual task:
+
+```text
+## Completion Report
+
+After `taskflow submit_task` returns `ok: true`, reply in the current assignment
+room and mention the Leader Matrix user from `TEAMS.md`:
+
+<Leader Matrix user from TEAMS.md> TASK_COMPLETED: demo-project-001-01 - Result: shared/tasks/demo-project-001-01/result.md
+
+Do not use `NO_REPLY` after a successful task submission.
+```
+
+If the project node already contains a custom completion line, preserve it and
+still make the Leader mention requirement explicit.
+
+## Assignment Message
+
+After `delegate_task` returns `ok: true`, use `teamharness-communication` to
+mention the Worker in the assignment room:
+
+```text
+@worker-a:matrix.local TASK_ASSIGNED: demo-project-001-01 - Please start this task. Spec: shared/tasks/demo-project-001-01/spec.md
+```
+
+Do not ask the Worker to edit project files. Do not ask several Workers to own
+the same task directory.
+
+## Check Submitted Task
+
+When a Worker reports completion or blocker status, call:
+
+```json
+{
+  "role": "leader",
+  "action": "check_task",
+  "payload": {
+    "taskId": "demo-project-001-01"
+  }
+}
+```
+
+If `effective` is false, do not accept the task. Tell the Worker what is
+missing and wait for a corrected result.
+
+If `effective` is true, return to `teamharness-project-management` and decide
+whether to accept the result into project progress.
+
+## Result Contract
+
+Worker results should contain:
+
+```text
+STATUS: SUCCESS
+SUMMARY: Short summary
+
+DELIVERABLES:
+- shared/tasks/{task-id}/path
+```
+
+Accepted statuses are:
+
+- `SUCCESS`
+- `SUCCESS_WITH_NOTES`
+- `REVISION_NEEDED`
+- `BLOCKED`
+
+Submitting a result ends that Worker task. If more work is needed, create a new
+project node and delegate a new task.

--- a/plugins/teamharness/skills/team/task-execution/SKILL.md
+++ b/plugins/teamharness/skills/team/task-execution/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: teamharness-task-execution
+description: "Use when a TeamHarness Worker or remote member receives an assigned task, acknowledges it, executes it, submits a result, or reports blockers."
+---
+
+# Task Execution
+
+Use this skill when executing assigned work as a Worker or remote member.
+
+Claim only tasks assigned to you. Read the task spec, keep deliverables in the
+task directory, ask focused blocker questions, and submit a structured result.
+
+Do not change project-level state unless the task spec explicitly authorizes it.
+
+Do not use this skill or taskflow for readiness checks, direct questions, or
+explicit requests to reply with specific text. Answer those directly in the
+current room.
+
+## Task Directory
+
+Your assigned task lives under:
+
+```text
+shared/tasks/{task-id}/
+```
+
+The Leader owns:
+
+```text
+shared/tasks/{task-id}/meta.json
+shared/tasks/{task-id}/spec.md
+```
+
+You own:
+
+```text
+shared/tasks/{task-id}/workspace/
+shared/tasks/{task-id}/progress/
+shared/tasks/{task-id}/result.md
+```
+
+Do not edit:
+
+```text
+shared/projects/{project-id}/meta.json
+shared/projects/{project-id}/plan.md
+shared/projects/{project-id}/result.md
+```
+
+unless the task spec explicitly tells you to.
+
+## Acknowledge
+
+When you are mentioned with `TASK_ASSIGNED`, first pull or inspect the task
+directory if needed, then acknowledge with `taskflow`:
+
+```json
+{
+  "role": "worker",
+  "action": "ack_task",
+  "payload": {
+    "taskId": "demo-project-001-01"
+  }
+}
+```
+
+If `ack_task` fails because the task is missing or assigned elsewhere, stop and
+report the blocker to the Leader in the current room. Do not invent task files.
+
+Read:
+
+```text
+shared/tasks/{task-id}/spec.md
+```
+
+before doing the work.
+
+## Execute
+
+Keep all deliverables under the task directory. If you need private notes, use:
+
+```text
+shared/tasks/{task-id}/workspace/
+```
+
+If blocked, submit a `BLOCKED` result instead of silently waiting.
+
+## Submit
+
+Submit with `taskflow`:
+
+```json
+{
+  "role": "worker",
+  "action": "submit_task",
+  "payload": {
+    "taskId": "demo-project-001-01",
+    "status": "SUCCESS",
+    "summary": "Completed the assigned work.",
+    "deliverables": [
+      "shared/tasks/demo-project-001-01/workspace/output.md"
+    ]
+  }
+}
+```
+
+Use one of:
+
+- `SUCCESS`
+- `SUCCESS_WITH_NOTES`
+- `REVISION_NEEDED`
+- `BLOCKED`
+
+Submitting ends the task. Do not keep editing the old task after submission
+unless the Leader assigns a new task.
+
+## Completion Message
+
+After `submit_task` returns `ok: true`, send a normal text message in the
+current assignment room and mention the Leader:
+
+```text
+@leader:matrix.local TASK_COMPLETED: demo-project-001-01 - Result: shared/tasks/demo-project-001-01/result.md
+```
+
+If the task spec gives an exact completion line, preserve that line exactly and
+include one short summary sentence. A tool call, tool-output thread, or
+`result.md` file does not count as the completion message. Do not use
+`NO_REPLY` after successful submission.
+
+For blockers:
+
+```text
+@leader:matrix.local BLOCKED: demo-project-001-01 - <short blocker summary>
+```

--- a/plugins/teamharness/skills/team/team-coordination/SKILL.md
+++ b/plugins/teamharness/skills/team/team-coordination/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: teamharness-team-coordination
+description: "Use before a TeamHarness Leader chooses task boundaries, dependency shape, ownership, acceptance criteria, or follow-up work."
+---
+
+# Team Coordination
+
+Use this skill when acting as Leader to coordinate several members.
+
+Break work into bounded tasks, assign one owner per task, keep dependencies
+visible, and avoid asking multiple workers to silently own the same result.
+
+Report accepted outcomes, not every intermediate worker message.
+
+## Leader Strategy
+
+You are the Team Leader. Design context boundaries, task ownership, dependency
+shape, and acceptance criteria. Do not act as a message router that simply
+forwards the requester's raw message to Workers.
+
+Before delegation, clarify:
+
+- what done means
+- which Worker owns each deliverable
+- which task can run independently
+- which result must be accepted before downstream work starts
+- where the requester should receive final updates
+
+If the goal, acceptance standard, ownership, or safe next step is ambiguous, ask
+the requester before dispatching work.
+
+## Choose Execution Mode
+
+TeamHarness Project Work supports DAG and Loop execution modes.
+
+Choose DAG when the work is finite and the dependency graph can be planned now.
+
+DAG fits:
+
+- known phases
+- known dependencies
+- fan-out and fan-in work
+- one-shot implementation
+- bounded verification
+
+Choose Loop when the work repeats until a stop condition, quality gate,
+evidence threshold, or maximum iteration count is reached.
+
+Loop fits:
+
+- many rounds
+- repeated research waves
+- quality improvement until accepted
+- build-test-fix until passing
+- exploration where the next question depends on current results
+- requester language such as "iterate", "repeat", "retry until passing", or
+  "up to N rounds"
+
+Do not pre-expand repeated Loop rounds into a large DAG. Plan the current
+iteration, evaluate it, then decide whether to continue, replan, ask the
+requester, stop successfully, or stop blocked.
+
+## Good Task Boundaries
+
+A good task has:
+
+- one owner
+- one inspectable output
+- enough context to work independently
+- no write conflict with sibling tasks
+- clear acceptance criteria
+- deliverables inside `shared/tasks/{task-id}/`
+
+Do not assign multiple Workers to write the same file, directory, final answer,
+or decision record.
+
+## Result Decisions
+
+A Worker completion is not automatic project progress. After `check_task`, decide
+whether to:
+
+- accept the result and mark the project node `completed`
+- request revision through a new task
+- add a verifier task
+- ask the requester for clarification
+- report a blocker
+
+Only accepted results should unblock downstream dependencies.
+
+## Patch Rules
+
+Do not:
+
+- delegate tasks that were not returned by ready-node resolution
+- ask Workers to edit project-level state
+- accept a task just because it says `SUCCESS`
+- hide task assignment in a DM when the Team Room is the shared coordination room
+- report every intermediate Worker message as a requester update

--- a/plugins/tests/run-integration-tests.sh
+++ b/plugins/tests/run-integration-tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+python3 plugins/tests/cli/test_agentteams_plugin_cli.py
+ruby plugins/scripts/validate-plugin.rb plugins/teamharness/plugin.yaml
+OUT_DIR="$(mktemp -d)" ruby plugins/scripts/package-plugin.rb plugins/teamharness/plugin.yaml >/dev/null
+ruby plugins/tests/teamharness/test-contracts.rb
+python3 -m pytest plugins/tests/teamharness/adapters/qwenpaw/test_adapter.py -q
+python3 -m pytest plugins/tests/teamharness/adapters/qwenpaw/test_package.py -q
+ruby plugins/tests/teamharness/mcp/test-server.rb
+ruby plugins/tests/teamharness/mcp/tools/test-message.rb
+ruby plugins/tests/teamharness/mcp/tools/test-filesync.rb
+ruby plugins/tests/teamharness/mcp/tools/test-projectflow.rb
+ruby plugins/tests/teamharness/mcp/tools/test-taskflow.rb

--- a/plugins/tests/teamharness/adapters/qwenpaw/test_adapter.py
+++ b/plugins/tests/teamharness/adapters/qwenpaw/test_adapter.py
@@ -122,10 +122,10 @@ def test_mcp_client_env_includes_sts_refresh_inputs(monkeypatch, tmp_path: Path)
     assert env["HICLAW_AUTH_TOKEN_FILE"] == "/var/run/secrets/hiclaw/token"
     assert env["HICLAW_CLUSTER_ID"] == "cluster-a"
     assert env["HICLAW_FS_ENDPOINT"] == "https://oss.example.test"
+    assert env["HICLAW_FS_ACCESS_KEY"] == "static-ak"
+    assert env["HICLAW_FS_SECRET_KEY"] == "static-sk"
+    assert env["MC_HOST_hiclaw"] == "https://temporary@example.test"
     assert env["QWENPAW_WORKING_DIR"] == str(tmp_path / ".qwenpaw")
-    assert "HICLAW_FS_ACCESS_KEY" not in env
-    assert "HICLAW_FS_SECRET_KEY" not in env
-    assert "MC_HOST_hiclaw" not in env
 
 
 def test_teamharness_installs_workspace_teams_md_without_overwriting_agentspec(tmp_path: Path, monkeypatch) -> None:
@@ -370,6 +370,28 @@ def test_private_tool_result_wrapper_redacts_text_blocks(tmp_path: Path, monkeyp
 
     assert module.sanitize_tool_result(result)["redacted"] is True
     assert result["content"][0]["text"] == "[REDACTED]"
+
+
+def test_output_sanitizer_skips_when_qwenpaw_private_acting_missing(monkeypatch) -> None:
+    module = _load_plugin()
+
+    class QwenPawAgent:
+        pass
+
+    react_agent_module = types.ModuleType("qwenpaw.agents.react_agent")
+    react_agent_module.QwenPawAgent = QwenPawAgent
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.agents", types.ModuleType("qwenpaw.agents"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.agents.react_agent", react_agent_module)
+
+    result = module.install_output_sanitizer_wrapper()
+
+    assert result == {
+        "ok": True,
+        "installed": False,
+        "reason": "qwenpaw agent _acting hook unavailable",
+    }
+    assert not hasattr(QwenPawAgent, "_teamharness_sanitizer_installed")
 
 
 def test_mcp_client_receives_matrix_env_for_message_tool(tmp_path: Path, monkeypatch) -> None:

--- a/plugins/tests/teamharness/adapters/qwenpaw/test_adapter.py
+++ b/plugins/tests/teamharness/adapters/qwenpaw/test_adapter.py
@@ -1,0 +1,436 @@
+import importlib.util
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+import types
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+PLUGIN = REPO_ROOT / "plugins" / "teamharness" / "adapters" / "qwenpaw" / "plugin.py"
+
+
+@pytest.fixture(autouse=True)
+def _clear_agent_workspace_env():
+    original = os.environ.pop("AGENT_WORKSPACE", None)
+    try:
+        yield
+    finally:
+        if original is None:
+            os.environ.pop("AGENT_WORKSPACE", None)
+        else:
+            os.environ["AGENT_WORKSPACE"] = original
+
+
+def _load_plugin():
+    spec = importlib.util.spec_from_file_location("teamharness_qwenpaw_plugin_test", PLUGIN)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _runtime_yaml(path: Path) -> None:
+    path.write_text(
+        """
+kind: MemberRuntimeConfig
+metadata:
+  generation: 3
+team:
+  name: demo-team
+  teamRoomId: "!team:matrix.local"
+  leaderName: leader
+  leaderRuntimeName: leader-runtime
+  admin:
+    name: admin
+    matrixUserId: "@admin:matrix.local"
+  members:
+    - name: leader
+      runtimeName: leader-runtime
+      role: team_leader
+      matrixUserId: "@leader-runtime:matrix.local"
+      personalRoomId: "!leader-dm:matrix.local"
+    - name: worker-a
+      runtimeName: worker-a
+      role: worker
+      matrixUserId: "@worker-a:matrix.local"
+      personalRoomId: "!worker-dm:matrix.local"
+    - name: alpha-qa
+      runtimeName: qa-runtime
+      role: worker
+      matrixUserId: "@qa-runtime:matrix.local"
+member:
+  name: worker-a
+  runtimeName: worker-a
+  role: worker
+  runtime: qwenpaw
+  matrixUserId: "@worker-a:matrix.local"
+  personalRoomId: "!worker-dm:matrix.local"
+desired:
+  agentPackage:
+    name: dev-worker
+    version: 1.2.0
+  outputSanitize:
+    keywords: [internal-token]
+    envRefs: [EXTRA_SECRET]
+credentials:
+  matrixTokenEnv: HICLAW_WORKER_MATRIX_TOKEN
+""",
+        encoding="utf-8",
+    )
+
+
+def _leader_runtime_yaml(path: Path) -> None:
+    path.write_text(
+        """
+kind: MemberRuntimeConfig
+metadata:
+  generation: 4
+team:
+  name: demo-team
+  teamRoomId: "!team:matrix.local"
+member:
+  name: leader-a
+  runtimeName: leader-a
+  role: team_leader
+  runtime: qwenpaw
+""",
+        encoding="utf-8",
+    )
+
+
+def test_mcp_client_env_includes_sts_refresh_inputs(monkeypatch, tmp_path: Path) -> None:
+    module = _load_plugin()
+    shared_dir = tmp_path / "shared"
+    monkeypatch.setenv("TEAMHARNESS_SHARED_DIR", str(shared_dir))
+    monkeypatch.setenv("HICLAW_CONTROLLER_URL", "http://controller.example.test")
+    monkeypatch.setenv("HICLAW_AUTH_TOKEN_FILE", "/var/run/secrets/hiclaw/token")
+    monkeypatch.setenv("HICLAW_CLUSTER_ID", "cluster-a")
+    monkeypatch.setenv("HICLAW_FS_ENDPOINT", "https://oss.example.test")
+    monkeypatch.setenv("HICLAW_FS_ACCESS_KEY", "static-ak")
+    monkeypatch.setenv("HICLAW_FS_SECRET_KEY", "static-sk")
+    monkeypatch.setenv("MC_HOST_hiclaw", "https://temporary@example.test")
+    monkeypatch.setenv("QWENPAW_WORKING_DIR", str(tmp_path / ".qwenpaw"))
+
+    env = module._mcp_client_env()
+
+    assert env["TEAMHARNESS_SHARED_DIR"] == str(shared_dir)
+    assert env["HICLAW_CONTROLLER_URL"] == "http://controller.example.test"
+    assert env["HICLAW_AUTH_TOKEN_FILE"] == "/var/run/secrets/hiclaw/token"
+    assert env["HICLAW_CLUSTER_ID"] == "cluster-a"
+    assert env["HICLAW_FS_ENDPOINT"] == "https://oss.example.test"
+    assert env["QWENPAW_WORKING_DIR"] == str(tmp_path / ".qwenpaw")
+    assert "HICLAW_FS_ACCESS_KEY" not in env
+    assert "HICLAW_FS_SECRET_KEY" not in env
+    assert "MC_HOST_hiclaw" not in env
+
+
+def test_teamharness_installs_workspace_teams_md_without_overwriting_agentspec(tmp_path: Path, monkeypatch) -> None:
+    module = _load_plugin()
+    runtime_config = tmp_path / "runtime.yaml"
+    shared_dir = tmp_path / "shared"
+    workspace_dir = tmp_path / "workspace"
+    agent_home = tmp_path / "agent-home"
+    _runtime_yaml(runtime_config)
+    workspace_dir.mkdir()
+    agent_home.mkdir()
+    (workspace_dir / "AGENTS.md").write_text("agentspec agents\n", encoding="utf-8")
+    (workspace_dir / "SOUL.md").write_text("agentspec soul\n", encoding="utf-8")
+    (agent_home / "SOUL.md").write_text("outer soul should not be copied\n", encoding="utf-8")
+
+    monkeypatch.setenv("TEAMHARNESS_RUNTIME_CONFIG", str(runtime_config))
+    monkeypatch.setenv("TEAMHARNESS_SHARED_DIR", str(shared_dir))
+    monkeypatch.setenv("QWENPAW_WORKSPACE_DIR", str(workspace_dir))
+    monkeypatch.setenv("HICLAW_AGENT_HOME", str(agent_home))
+    monkeypatch.setenv("HICLAW_WORKER_MATRIX_TOKEN", "matrix-secret-value")
+
+    result = module.apply_teamharness()
+
+    teams_md = workspace_dir / "TEAMS.md"
+    text = teams_md.read_text(encoding="utf-8")
+    assert result["ok"] is True
+    assert "demo-team" in text
+    assert "worker-a" in text
+    assert "leader" in text
+    assert "qa-runtime" in text
+    assert "!team:matrix.local" in text
+    assert "dev-worker" in text
+    assert "Worker Role" in text
+    assert "Matrix Reply Discipline" in text
+    assert "matrix-secret-value" not in text
+    assert not (shared_dir / "TEAMS.md").exists()
+    assert (workspace_dir / "AGENTS.md").read_text(encoding="utf-8") == "agentspec agents\n"
+    assert (workspace_dir / "SOUL.md").read_text(encoding="utf-8") == "agentspec soul\n"
+
+
+def test_team_leader_role_uses_leader_prompt(tmp_path: Path, monkeypatch) -> None:
+    module = _load_plugin()
+    runtime_config = tmp_path / "runtime.yaml"
+    workspace_dir = tmp_path / "workspace"
+    _leader_runtime_yaml(runtime_config)
+    workspace_dir.mkdir()
+
+    monkeypatch.setenv("TEAMHARNESS_RUNTIME_CONFIG", str(runtime_config))
+    monkeypatch.setenv("QWENPAW_WORKSPACE_DIR", str(workspace_dir))
+
+    result = module.apply_teamharness()
+
+    teams_md = workspace_dir / "TEAMS.md"
+    text = teams_md.read_text(encoding="utf-8")
+    assert result["ok"] is True
+    assert "Leader Role" in text
+    assert "member.role: team_leader" in text
+
+
+def test_teamharness_enables_role_skills_in_workspace(tmp_path: Path, monkeypatch) -> None:
+    module = _load_plugin()
+    runtime_config = tmp_path / "runtime.yaml"
+    workspace_dir = tmp_path / "workspace"
+    skill_pool_dir = tmp_path / "skill-pool"
+    _runtime_yaml(runtime_config)
+    workspace_dir.mkdir()
+
+    monkeypatch.setenv("TEAMHARNESS_RUNTIME_CONFIG", str(runtime_config))
+    monkeypatch.setenv("QWENPAW_WORKSPACE_DIR", str(workspace_dir))
+
+    registry_module = types.ModuleType("qwenpaw.agents.skill_system.registry")
+    registry_module.ensure_skill_pool_initialized = lambda: None
+    registry_module.reconcile_pool_manifest = lambda: None
+
+    store_module = types.ModuleType("qwenpaw.agents.skill_system.store")
+    store_module.get_skill_pool_dir = lambda: skill_pool_dir
+
+    class SkillPoolService:
+        def download_to_workspace(self, skill_name, target_workspace, *, overwrite=False):
+            source = skill_pool_dir / skill_name
+            target = Path(target_workspace) / "skills" / skill_name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if target.exists():
+                shutil.rmtree(target)
+            shutil.copytree(source, target)
+            manifest_path = Path(target_workspace) / "skill.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "workspace-skill-manifest.v1",
+                        "skills": {name: {"enabled": True} for name in sorted(p.name for p in target.parent.iterdir())},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            return {"success": True, "name": skill_name}
+
+    pool_service_module = types.ModuleType("qwenpaw.agents.skill_system.pool_service")
+    pool_service_module.SkillPoolService = SkillPoolService
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.agents", types.ModuleType("qwenpaw.agents"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.agents.skill_system", types.ModuleType("qwenpaw.agents.skill_system"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.agents.skill_system.registry", registry_module)
+    monkeypatch.setitem(sys.modules, "qwenpaw.agents.skill_system.store", store_module)
+    monkeypatch.setitem(sys.modules, "qwenpaw.agents.skill_system.pool_service", pool_service_module)
+
+    result = module.apply_teamharness()
+
+    assert result["ok"] is True
+    assert (workspace_dir / "skills" / "teamharness-task-execution" / "SKILL.md").is_file()
+    assert (workspace_dir / "skills" / "teamharness-communication" / "SKILL.md").is_file()
+    assert not (workspace_dir / "skills" / "teamharness-task-delegation").exists()
+    manifest = json.loads((workspace_dir / "skill.json").read_text(encoding="utf-8"))
+    assert manifest["skills"]["teamharness-task-execution"]["enabled"] is True
+    assert "teamharness-task-delegation" not in manifest["skills"]
+
+
+def test_sanitizer_redacts_keywords_and_env_values(tmp_path: Path, monkeypatch) -> None:
+    module = _load_plugin()
+    runtime_config = tmp_path / "runtime.yaml"
+    _runtime_yaml(runtime_config)
+
+    monkeypatch.setenv("TEAMHARNESS_RUNTIME_CONFIG", str(runtime_config))
+    monkeypatch.setenv("HICLAW_WORKER_MATRIX_TOKEN", "matrix-secret-value")
+    monkeypatch.setenv("EXTRA_SECRET", "extra-secret-value")
+
+    text = module.sanitize_text(
+        "tool saw internal-token plus matrix-secret-value and extra-secret-value"
+    )
+
+    assert text == "tool saw [REDACTED] plus [REDACTED] and [REDACTED]"
+
+
+def test_sanitizer_restores_builtin_cloud_secret_patterns(monkeypatch) -> None:
+    module = _load_plugin()
+    monkeypatch.delenv("TEAMHARNESS_RUNTIME_CONFIG", raising=False)
+    monkeypatch.delenv("QWENPAW_WORKSPACE_DIR", raising=False)
+
+    raw_secret = "abcdefghijklmnopqrstuvwxyz123456"
+    text = module.sanitize_text(
+        f"access_key_secret={raw_secret}\n"
+        "aliyun id LTAIabcdefghijklmnop\n"
+        f"token={raw_secret}"
+    )
+
+    assert raw_secret not in text
+    assert "access_key_secret=********" in text
+    assert "LTAI****" in text
+    assert "token=********" in text
+
+
+def test_credential_guard_reads_workspace_credagent_and_updates_qwenpaw_security(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_plugin()
+    qwenpaw_dir = tmp_path / ".qwenpaw"
+    workspace_dir = qwenpaw_dir / "workspaces" / "default"
+    workspace_config = workspace_dir / "config"
+    workspace_config.mkdir(parents=True)
+    qwenpaw_dir.mkdir(exist_ok=True)
+    (workspace_config / "credagent.json").write_text(
+        json.dumps(
+            {
+                "credentials": [
+                    {
+                        "path": "~/hiclaw/credentials/matrix/password",
+                        "programPermit": "qwenpaw",
+                    },
+                    {
+                        "path": "/etc/hiclaw/secrets/",
+                        "programPermit": ["mc", "qwenpaw"],
+                        "writable": True,
+                    },
+                ],
+                "output_sanitize": [
+                    {"type": "keyword", "keywords": ["privateToken"]},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (qwenpaw_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "security": {
+                    "tool_guard": {"enabled": False, "auto_denied_rules": ["EXISTING_RULE"]},
+                    "file_guard": {
+                        "enabled": False,
+                        "sensitive_files": ["/old/removed-secret", "/manual/keep"],
+                    },
+                },
+                "plugins": {
+                    "teamharness": {
+                        "credentialGuard": {
+                            "paths": ["/old/removed-secret"],
+                        },
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("QWENPAW_WORKING_DIR", str(qwenpaw_dir))
+    monkeypatch.setenv("QWENPAW_WORKSPACE_DIR", str(workspace_dir))
+
+    result = module.apply_credential_guard()
+
+    assert result["ok"] is True
+    assert result["credentials"] == 2
+    assert result["outputSanitizeRules"] == 1
+    config = json.loads((qwenpaw_dir / "config.json").read_text(encoding="utf-8"))
+    security = config["security"]
+    sensitive_files = security["file_guard"]["sensitive_files"]
+    assert security["file_guard"]["enabled"] is True
+    assert security["tool_guard"]["enabled"] is True
+    assert "SENSITIVE_FILE_BLOCK" in security["tool_guard"]["auto_denied_rules"]
+    assert "EXISTING_RULE" in security["tool_guard"]["auto_denied_rules"]
+    assert "/manual/keep" in sensitive_files
+    assert "/old/removed-secret" not in sensitive_files
+    assert "/etc/hiclaw/secrets/" in sensitive_files
+    assert any(path.endswith("/hiclaw/credentials/matrix/password") for path in sensitive_files)
+
+    raw_secret = "abcdefghijklmnopqrstuvwxyz123456"
+    assert raw_secret not in module.sanitize_text(f"privateToken={raw_secret}")
+
+
+def test_private_tool_result_wrapper_redacts_text_blocks(tmp_path: Path, monkeypatch) -> None:
+    module = _load_plugin()
+    runtime_config = tmp_path / "runtime.yaml"
+    _runtime_yaml(runtime_config)
+    monkeypatch.setenv("TEAMHARNESS_RUNTIME_CONFIG", str(runtime_config))
+
+    result = {
+        "content": [
+            {"type": "text", "text": "internal-token"},
+            {"type": "image", "url": "keep"},
+        ],
+    }
+
+    assert module.sanitize_tool_result(result)["redacted"] is True
+    assert result["content"][0]["text"] == "[REDACTED]"
+
+
+def test_mcp_client_receives_matrix_env_for_message_tool(tmp_path: Path, monkeypatch) -> None:
+    module = _load_plugin()
+    workspace_dir = tmp_path / "workspace"
+    shared_dir = tmp_path / "shared"
+    workspace_dir.mkdir()
+
+    class MCPClientConfig:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class MCPConfig:
+        def __init__(self):
+            self.clients = {}
+
+    class AgentConfig:
+        def __init__(self):
+            self.mcp = None
+
+    agent_config = AgentConfig()
+    saved = {}
+
+    def load_agent_config(agent_id):
+        saved["loaded_agent"] = agent_id
+        return agent_config
+
+    def save_agent_config(agent_id, config):
+        saved["saved_agent"] = agent_id
+        saved["config"] = config
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.MCPClientConfig = MCPClientConfig
+    config_module.MCPConfig = MCPConfig
+    config_module.load_agent_config = load_agent_config
+    config_module.save_agent_config = save_agent_config
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+    monkeypatch.setenv("TEAMHARNESS_SHARED_DIR", str(shared_dir))
+    monkeypatch.setenv("TEAMHARNESS_RUNTIME_CONFIG", "/root/hiclaw-fs/shared/runtime/members/worker-a/runtime.yaml")
+    monkeypatch.setenv("HICLAW_MATRIX_URL", "http://matrix.local")
+    monkeypatch.setenv("HICLAW_WORKER_MATRIX_TOKEN", "matrix-token")
+    monkeypatch.setenv("HICLAW_WORKER_ROLE", "worker")
+    monkeypatch.setenv("HICLAW_WORKER_NAME", "worker-a")
+    monkeypatch.setenv("HICLAW_STORAGE_PREFIX", "hiclaw/hiclaw-storage")
+    monkeypatch.setenv("HICLAW_FS_BUCKET", "hiclaw-storage")
+
+    result = module._ensure_mcp_client("default", workspace_dir)
+
+    assert result == {"agent": "default", "action": "configured"}
+    assert saved["loaded_agent"] == "default"
+    assert saved["saved_agent"] == "default"
+    client = agent_config.mcp.clients["teamharness"]
+    assert client.command == sys.executable
+    assert client.env["TEAMHARNESS_SHARED_DIR"] == str(shared_dir)
+    assert client.env["TEAMHARNESS_RUNTIME_CONFIG"] == "/root/hiclaw-fs/shared/runtime/members/worker-a/runtime.yaml"
+    assert client.env["HICLAW_MATRIX_URL"] == "http://matrix.local"
+    assert client.env["HICLAW_WORKER_MATRIX_TOKEN"] == "matrix-token"
+    assert client.env["HICLAW_WORKER_ROLE"] == "worker"
+    assert client.env["HICLAW_WORKER_NAME"] == "worker-a"
+    assert client.env["HICLAW_STORAGE_PREFIX"] == "hiclaw/hiclaw-storage"
+    assert client.env["HICLAW_FS_BUCKET"] == "hiclaw-storage"

--- a/plugins/tests/teamharness/adapters/qwenpaw/test_package.py
+++ b/plugins/tests/teamharness/adapters/qwenpaw/test_package.py
@@ -1,0 +1,69 @@
+import json
+import os
+import re
+import subprocess
+import zipfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+MANIFEST = REPO_ROOT / "plugins" / "teamharness" / "plugin.yaml"
+BUILD_SCRIPT = (
+    REPO_ROOT
+    / "plugins"
+    / "teamharness"
+    / "adapters"
+    / "qwenpaw"
+    / "scripts"
+    / "build-qwenpaw-plugin.rb"
+)
+
+
+def _manifest_version() -> str:
+    match = re.search(r"^  version:\s*(\S+)\s*$", MANIFEST.read_text(encoding="utf-8"), re.MULTILINE)
+    assert match is not None
+    return match.group(1)
+
+
+def test_build_qwenpaw_native_plugin_package(tmp_path: Path) -> None:
+    result = subprocess.run(
+        ["ruby", str(BUILD_SCRIPT), str(MANIFEST)],
+        cwd=REPO_ROOT,
+        env={**os.environ, "OUT_DIR": str(tmp_path)},
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+    zip_path = Path(result.stdout.strip().splitlines()[-1])
+    assert zip_path.is_file()
+    assert (tmp_path / "teamharness-qwenpaw.zip").is_file()
+
+    version = _manifest_version()
+    root = f"teamharness-qwenpaw-{version}"
+    with zipfile.ZipFile(zip_path) as archive:
+        names = set(archive.namelist())
+        assert f"{root}/plugin.json" in names
+        assert f"{root}/plugin.py" in names
+        assert f"{root}/teamharness/plugin.yaml" in names
+        assert f"{root}/teamharness/prompts/team/TEAMS.md" in names
+        assert f"{root}/teamharness/prompts/agent/worker.md" in names
+        assert f"{root}/teamharness/skills/team/communication/SKILL.md" in names
+        assert f"{root}/teamharness/mcp/server.py" in names
+        assert not any(name.startswith(f"{root}/teamharness/hooks/") for name in names)
+        communication_skill = archive.read(f"{root}/teamharness/skills/team/communication/SKILL.md").decode("utf-8")
+        project_skill = archive.read(f"{root}/teamharness/skills/team/project-management/SKILL.md").decode("utf-8")
+        assert communication_skill.startswith("---\n")
+        assert "name: teamharness-communication" in communication_skill
+        assert "description:" in communication_skill
+        assert project_skill.startswith("---\n")
+        assert "name: teamharness-project-management" in project_skill
+        assert "payload` as a JSON object" in project_skill
+
+        manifest = json.loads(archive.read(f"{root}/plugin.json"))
+
+    assert manifest["id"] == "teamharness"
+    assert manifest["version"] == version
+    assert manifest["entry"]["backend"] == "plugin.py"
+    assert "periodic-sync" not in manifest["meta"]["features"]

--- a/plugins/tests/teamharness/mcp/test-server.rb
+++ b/plugins/tests/teamharness/mcp/test-server.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "pathname"
+
+repo_root = Pathname.new(__dir__).join("../../../..").expand_path
+mcp_dir = repo_root / "plugins/teamharness/mcp"
+
+def fail!(message)
+  warn "ERROR: #{message}"
+  exit 1
+end
+
+python_test = <<~PY
+  import json
+  import pathlib
+  import sys
+
+  sys.path.insert(0, str(pathlib.Path("#{mcp_dir}")))
+  from server import handle_request
+
+  init = handle_request({
+      "jsonrpc": "2.0",
+      "id": 1,
+      "method": "initialize",
+      "params": {},
+  })
+  if init["result"]["serverInfo"]["name"] != "teamharness":
+      raise AssertionError(f"unexpected server info: {init!r}")
+
+  tools = handle_request({
+      "jsonrpc": "2.0",
+      "id": 2,
+      "method": "tools/list",
+      "params": {},
+  })["result"]["tools"]
+  names = [tool["name"] for tool in tools]
+  expected = ["health", "message", "roomflow", "filesync", "projectflow", "taskflow"]
+  if names != expected:
+      raise AssertionError(f"unexpected tools: {names!r}")
+
+  unknown = handle_request({
+      "jsonrpc": "2.0",
+      "id": 3,
+      "method": "tools/call",
+      "params": {"name": "missing", "arguments": {}},
+  })
+  payload = json.loads(unknown["result"]["content"][0]["text"])
+  if payload.get("error") != "unknown_tool":
+      raise AssertionError(f"unexpected unknown-tool response: {payload!r}")
+
+  print(json.dumps({"ok": True, "tools": names}, ensure_ascii=False))
+PY
+
+stdout, stderr, status = Open3.capture3("python3", "-", stdin_data: python_test, chdir: repo_root.to_s)
+fail!(["teamharness MCP server test failed", stderr, stdout].reject(&:empty?).join("\n")) unless status.success?
+
+puts JSON.pretty_generate(JSON.parse(stdout))

--- a/plugins/tests/teamharness/mcp/tools/test-filesync.rb
+++ b/plugins/tests/teamharness/mcp/tools/test-filesync.rb
@@ -1,0 +1,242 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "pathname"
+require "tmpdir"
+
+repo_root = Pathname.new(__dir__).join("../../../../..").expand_path
+mcp_dir = repo_root / "plugins/teamharness/mcp"
+
+def fail!(message)
+  warn "ERROR: #{message}"
+  exit 1
+end
+
+Dir.mktmpdir("teamharness-filesync-") do |dir|
+  root = Pathname.new(dir)
+  workspace = root / "workspace"
+  bin_dir = root / "bin"
+  log_path = root / "mc.log"
+  bin_dir.mkpath
+  (bin_dir / "mc").write(<<~SH)
+    #!/usr/bin/env bash
+    printf '%s\\n' "$*" >> "#{log_path}"
+    printf 'ENV MC_HOST_hiclaw=%s\\n' "${MC_HOST_hiclaw:-}" >> "#{log_path}"
+    case "$*" in
+      *"hiclaw/hiclaw-storage"*)
+        if [ -z "${MC_HOST_hiclaw:-}" ]; then
+          echo "missing MC_HOST_hiclaw" >&2
+          exit 3
+        fi
+        ;;
+    esac
+    case "$*" in
+      *"tasks/denied"*)
+        echo "mc.bin: <ERROR> Unable to list comparison retrying.. Access Denied." >&2
+        exit 0
+        ;;
+    esac
+    if [ "$1" = "ls" ]; then
+      echo "2026-06-03 12:00:00      42 projects/demo/plan.md"
+    fi
+  SH
+  (bin_dir / "mc").chmod(0o755)
+
+  python_test = <<~PY
+    import json
+    import os
+    import pathlib
+    import sys
+
+    sys.path.insert(0, str(pathlib.Path("#{mcp_dir}")))
+    from server import call_tool
+
+    common = {
+        "workspaceDir": "#{workspace}",
+        "storage": {
+            "sharedPrefix": "mock/shared",
+            "globalSharedPrefix": "mock/global-shared",
+        },
+    }
+
+    def payload(args):
+        merged = dict(common)
+        merged.update(args)
+        result = call_tool("filesync", merged)
+        return json.loads(result["content"][0]["text"])
+
+    def payload_without_storage(args):
+        result = call_tool("filesync", args)
+        return json.loads(result["content"][0]["text"])
+
+    dry = payload({
+        "action": "pull",
+        "path": "shared/projects/demo",
+        "dryRun": True,
+    })
+    if not dry.get("ok"):
+        raise AssertionError(f"dry-run pull failed: {dry!r}")
+    if dry.get("path") != "shared/projects/demo/":
+        raise AssertionError(f"path was not normalized: {dry!r}")
+    if dry.get("kind") != "shared":
+        raise AssertionError(f"kind mismatch: {dry!r}")
+    if dry.get("localPath") != "#{workspace}/shared/projects/demo":
+        raise AssertionError(f"local path mismatch: {dry!r}")
+    if dry.get("remotePath") != "mock/shared/projects/demo/":
+        raise AssertionError(f"remote path mismatch: {dry!r}")
+    if dry.get("command") != ["mc", "mirror", "mock/shared/projects/demo/", "#{workspace}/shared/projects/demo", "--overwrite"]:
+        raise AssertionError(f"dry-run command mismatch: {dry!r}")
+
+    blocked_global_push = payload({
+        "action": "push",
+        "path": "global-shared/readme.md",
+        "dryRun": True,
+    })
+    if blocked_global_push.get("ok") is not False or "read-only" not in blocked_global_push.get("error", ""):
+        raise AssertionError(f"global-shared push was not rejected: {blocked_global_push!r}")
+
+    blocked_escape = payload({
+        "action": "pull",
+        "path": "../shared/tasks/t-001",
+        "dryRun": True,
+    })
+    if blocked_escape.get("ok") is not False or "relative shared path" not in blocked_escape.get("error", ""):
+        raise AssertionError(f"workspace escape was not rejected: {blocked_escape!r}")
+
+    result_path = pathlib.Path("#{workspace}") / "shared/tasks/t-001/result.md"
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text("# Result\\n", encoding="utf-8")
+    pushed = payload({
+        "action": "push",
+        "path": "shared/tasks/t-001",
+        "exclude": ["*.tmp"],
+    })
+    if not pushed.get("ok") or pushed.get("path") != "shared/tasks/t-001/":
+        raise AssertionError(f"push failed: {pushed!r}")
+    if pushed.get("exclude") != ["*.tmp"]:
+        raise AssertionError(f"push exclude mismatch: {pushed!r}")
+
+    pushed_file = payload({
+        "action": "push",
+        "path": "shared/tasks/t-001/result.md",
+    })
+    if not pushed_file.get("ok"):
+        raise AssertionError(f"single-file push failed: {pushed_file!r}")
+    if pushed_file.get("command") != ["mc", "cp", "#{workspace}/shared/tasks/t-001/result.md", "mock/shared/tasks/t-001/result.md"]:
+        raise AssertionError(f"single-file push command mismatch: {pushed_file!r}")
+
+    pulled_file = payload({
+        "action": "pull",
+        "path": "shared/tasks/t-001/result.md",
+    })
+    if not pulled_file.get("ok"):
+        raise AssertionError(f"single-file pull failed: {pulled_file!r}")
+    if pulled_file.get("command") != ["mc", "cp", "mock/shared/tasks/t-001/result.md", "#{workspace}/shared/tasks/t-001/result.md"]:
+        raise AssertionError(f"single-file pull command mismatch: {pulled_file!r}")
+
+    denied_dir = pathlib.Path("#{workspace}") / "shared/tasks/denied"
+    denied_dir.mkdir(parents=True, exist_ok=True)
+    (denied_dir / "result.md").write_text("# Denied\\n", encoding="utf-8")
+    denied = payload({
+        "action": "push",
+        "path": "shared/tasks/denied",
+    })
+    if denied.get("ok") is not False or "Access Denied" not in denied.get("error", ""):
+        raise AssertionError(f"zero-exit mc error was not detected: {denied!r}")
+
+    listed = payload({
+        "action": "list",
+        "path": "shared/projects/demo",
+    })
+    if not listed.get("ok") or listed.get("entries") != ["2026-06-03 12:00:00      42 projects/demo/plan.md"]:
+        raise AssertionError(f"list failed: {listed!r}")
+
+    stat = payload({
+        "action": "stat",
+        "path": "shared/tasks/t-001/result.md",
+    })
+    if not stat.get("ok") or stat.get("exists") is not True:
+        raise AssertionError(f"stat failed: {stat!r}")
+    if stat.get("remotePath") != "mock/shared/tasks/t-001/result.md":
+        raise AssertionError(f"stat remote path mismatch: {stat!r}")
+
+    runtime_config = pathlib.Path("#{root}") / "runtime.yaml"
+    runtime_config.write_text(
+        "storage:\\n"
+        "  sharedPrefix: teams/demo-team/shared\\n"
+        "  globalSharedPrefix: shared\\n",
+        encoding="utf-8",
+    )
+    os.environ["TEAMHARNESS_RUNTIME_CONFIG"] = str(runtime_config)
+    os.environ["HICLAW_STORAGE_PREFIX"] = "hiclaw/hiclaw-storage"
+    from_runtime = payload_without_storage({
+        "workspaceDir": "#{workspace}",
+        "action": "list",
+        "path": "shared/tasks/demo",
+        "dryRun": True,
+    })
+    if from_runtime.get("remotePath") != "hiclaw/hiclaw-storage/teams/demo-team/shared/tasks/demo/":
+        raise AssertionError(f"runtime storage prefix mismatch: {from_runtime!r}")
+
+    runtime_result = pathlib.Path("#{workspace}") / "shared/tasks/runtime-push/result.md"
+    runtime_result.parent.mkdir(parents=True, exist_ok=True)
+    runtime_result.write_text("# Runtime Push\\n", encoding="utf-8")
+    pushed_runtime = payload_without_storage({
+        "workspaceDir": "#{workspace}",
+        "action": "push",
+        "path": "shared/tasks/runtime-push",
+    })
+    if not pushed_runtime.get("ok"):
+        raise AssertionError(f"runtime-prefix push failed: {pushed_runtime!r}")
+    if pushed_runtime.get("remotePath") != "hiclaw/hiclaw-storage/teams/demo-team/shared/tasks/runtime-push/":
+        raise AssertionError(f"runtime-prefix push remote mismatch: {pushed_runtime!r}")
+
+    print(json.dumps({
+        "ok": True,
+        "dryRunPath": dry["path"],
+        "remotePath": dry["remotePath"],
+      "runtimeRemotePath": from_runtime["remotePath"],
+      "runtimePushRemotePath": pushed_runtime["remotePath"],
+      "pushPath": pushed["path"],
+      "pushFileCommand": pushed_file["command"],
+      "entries": listed["entries"],
+      "statPath": stat["remotePath"],
+    }, ensure_ascii=False))
+  PY
+
+  env = {
+    "PATH" => "#{bin_dir}:#{ENV.fetch("PATH", "")}",
+    "HICLAW_FS_ENDPOINT" => "https://oss.example.test",
+    "HICLAW_FS_ACCESS_KEY" => "access-key",
+    "HICLAW_FS_SECRET_KEY" => "secret-key"
+  }
+  stdout, stderr, status = Open3.capture3(env, "python3", "-", stdin_data: python_test, chdir: repo_root.to_s)
+  fail!(["teamharness filesync MCP test failed", stderr, stdout].reject(&:empty?).join("\n")) unless status.success?
+
+  commands = log_path.read.lines.map(&:strip)
+  fail!("mc mirror was not called: #{commands.inspect}") unless commands.include?(
+    "mirror #{workspace}/shared/tasks/t-001/ mock/shared/tasks/t-001/ --overwrite --exclude *.tmp"
+  )
+  fail!("mc cp push was not called: #{commands.inspect}") unless commands.include?(
+    "cp #{workspace}/shared/tasks/t-001/result.md mock/shared/tasks/t-001/result.md"
+  )
+  fail!("mc cp pull was not called: #{commands.inspect}") unless commands.include?(
+    "cp mock/shared/tasks/t-001/result.md #{workspace}/shared/tasks/t-001/result.md"
+  )
+  fail!("mc ls was not called: #{commands.inspect}") unless commands.include?(
+    "ls --recursive mock/shared/projects/demo/"
+  )
+  fail!("mc stat was not called: #{commands.inspect}") unless commands.include?(
+    "stat mock/shared/tasks/t-001/result.md"
+  )
+  fail!("runtime-prefix mc mirror was not called: #{commands.inspect}") unless commands.include?(
+    "mirror #{workspace}/shared/tasks/runtime-push/ hiclaw/hiclaw-storage/teams/demo-team/shared/tasks/runtime-push/ --overwrite"
+  )
+  fail!("runtime-prefix mc mirror did not receive MC_HOST_hiclaw: #{commands.inspect}") unless commands.any? do |line|
+    line.start_with?("ENV MC_HOST_hiclaw=https://access-key:secret-key@oss.example.test")
+  end
+
+  puts JSON.pretty_generate(JSON.parse(stdout).merge("mcCommands" => commands))
+end

--- a/plugins/tests/teamharness/mcp/tools/test-message.rb
+++ b/plugins/tests/teamharness/mcp/tools/test-message.rb
@@ -1,0 +1,353 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "pathname"
+require "tmpdir"
+
+repo_root = Pathname.new(__dir__).join("../../../../..").expand_path
+mcp_dir = repo_root / "plugins/teamharness/mcp"
+
+def fail!(message)
+  warn "ERROR: #{message}"
+  exit 1
+end
+
+Dir.mktmpdir("teamharness-message-") do |_dir|
+  python_test = <<~PY
+    import http.server
+    import json
+    import os
+    import pathlib
+    import re
+    import socketserver
+    import sys
+    import threading
+
+    sys.path.insert(0, str(pathlib.Path("#{mcp_dir}")))
+    from server import call_tool, list_tools
+
+    captured = {}
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_PUT(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length).decode("utf-8")
+            captured["path"] = self.path
+            captured["auth"] = self.headers.get("Authorization")
+            captured["body"] = json.loads(body)
+            payload = json.dumps({"event_id": "$event1"}).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length).decode("utf-8")
+            captured["qwenpaw_path"] = self.path
+            captured["qwenpaw_agent"] = self.headers.get("X-Agent-Id")
+            captured["qwenpaw_body"] = json.loads(body)
+            payload = json.dumps({"success": True, "message": "sent"}).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *_args):
+            return
+
+    server = socketserver.TCPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    def payload(args):
+        result = call_tool("message", args)
+        return json.loads(result["content"][0]["text"])
+
+    dry = payload({
+        "action": "send",
+        "channel": "matrix",
+        "target": "room:!room:example.test",
+        "message": "@worker:example.test please verify `filesync`",
+        "dryRun": True,
+    })
+    if not dry.get("ok"):
+        raise AssertionError(f"dry-run failed: {dry!r}")
+    if dry.get("mentions") != ["@worker:example.test"]:
+        raise AssertionError(f"mentions mismatch: {dry!r}")
+    if dry["content"].get("m.mentions") != {"user_ids": ["@worker:example.test"]}:
+        raise AssertionError(f"m.mentions mismatch: {dry!r}")
+    if "https://matrix.to/#/%40worker%3Aexample.test" not in dry["content"].get("formatted_body", ""):
+        raise AssertionError(f"formatted mention missing: {dry!r}")
+    if "<code>filesync</code>" not in dry["content"].get("formatted_body", ""):
+        raise AssertionError(f"inline code missing: {dry!r}")
+
+    import builtins
+    real_import = builtins.__import__
+
+    def block_markdown_import(name, *args, **kwargs):
+        if name == "markdown_it" or name.startswith("markdown_it.") or name == "linkify_it":
+            raise ImportError(name)
+        return real_import(name, *args, **kwargs)
+
+    builtins.__import__ = block_markdown_import
+    try:
+        fallback = payload({
+            "action": "send",
+            "channel": "matrix",
+            "target": "room:!room:example.test",
+            "message": "@worker:example.test **Task** assigned\\nPlease read `spec.md`.\\n```\\nline 1\\nline 2\\n```",
+            "dryRun": True,
+        })
+        fallback_report = payload({
+            "action": "send",
+            "channel": "matrix",
+            "target": "room:!room:example.test",
+            "message": "## Project Status Report\\n\\n**Project**: TeamHarness\\n\\n| Task | Status |\\n|---|---|\\n| test | Done |\\n\\n- `shared/result.md`",
+            "dryRun": True,
+        })
+    finally:
+        builtins.__import__ = real_import
+    fallback_html = fallback["content"].get("formatted_body", "")
+    if "https://matrix.to/#/%40worker%3Aexample.test" not in fallback_html:
+        raise AssertionError(f"fallback mention missing: {fallback!r}")
+    if "<strong>Task</strong>" not in fallback_html:
+        raise AssertionError(f"fallback bold missing: {fallback!r}")
+    if "<code>spec.md</code>" not in fallback_html:
+        raise AssertionError(f"fallback inline code missing: {fallback!r}")
+    if "<br>" not in fallback_html:
+        raise AssertionError(f"fallback line break missing: {fallback!r}")
+    if "<pre><code>line 1\\nline 2</code></pre>" not in fallback_html:
+        raise AssertionError(f"fallback code block missing: {fallback!r}")
+    fallback_report_html = fallback_report["content"].get("formatted_body", "")
+    if "<h2>Project Status Report</h2>" not in fallback_report_html:
+        raise AssertionError(f"fallback heading missing: {fallback_report!r}")
+    if "<table>" not in fallback_report_html:
+        raise AssertionError(f"fallback table missing: {fallback_report!r}")
+    if "<ul><li><code>shared/result.md</code></li></ul>" not in fallback_report_html:
+        raise AssertionError(f"fallback list missing: {fallback_report!r}")
+
+    markdown_report = payload({
+        "action": "send",
+        "channel": "matrix",
+        "target": "room:!room:example.test",
+        "message": "---\\n\\n## Project Status Report\\n\\n**Project**: TeamHarness\\n\\n| Task | Status |\\n|---|---|\\n| test | Done |\\n\\n- `shared/result.md`\\n1. Start next task",
+        "dryRun": True,
+    })
+    formatted_report = markdown_report["content"].get("formatted_body", "")
+    if "<hr" not in formatted_report:
+        raise AssertionError(f"markdown horizontal rule was not rendered: {markdown_report!r}")
+    if "<h2>Project Status Report</h2>" not in formatted_report:
+        raise AssertionError(f"markdown heading was not rendered: {markdown_report!r}")
+    if "<strong>Project</strong>" not in formatted_report:
+        raise AssertionError(f"markdown bold was not rendered: {markdown_report!r}")
+    if "<table>" not in formatted_report:
+        raise AssertionError(f"markdown table was not rendered: {markdown_report!r}")
+    if "<code>shared/result.md</code>" not in formatted_report:
+        raise AssertionError(f"markdown inline code was not rendered: {markdown_report!r}")
+    if "<ol>" not in formatted_report:
+        raise AssertionError(f"markdown ordered list was not rendered: {markdown_report!r}")
+    if "</h2><br>" in formatted_report or "</table><br>" in formatted_report or "</pre><br>" in formatted_report:
+        raise AssertionError(f"markdown renderer inserted block-level br tags: {markdown_report!r}")
+
+    text_alias = payload({
+        "action": "send",
+        "channel": "matrix",
+        "target": "room:!room:example.test",
+        "text": "@worker:example.test please verify the task",
+        "dryRun": True,
+    })
+    if not text_alias.get("ok"):
+        raise AssertionError(f"text alias dry-run failed: {text_alias!r}")
+    if text_alias["content"].get("body") != "@worker:example.test please verify the task":
+        raise AssertionError(f"text alias body mismatch: {text_alias!r}")
+
+    room_id_alias = payload({
+        "action": "send",
+        "channel": "matrix",
+        "room_id": "room:!room:example.test",
+        "text": "@worker:example.test please verify room alias",
+        "dryRun": True,
+    })
+    if not room_id_alias.get("ok"):
+        raise AssertionError(f"room_id alias dry-run failed: {room_id_alias!r}")
+    if room_id_alias.get("target") != "room:!room:example.test":
+        raise AssertionError(f"room_id alias target mismatch: {room_id_alias!r}")
+
+    blocked = payload({
+        "action": "send",
+        "channel": "matrix",
+        "target": "room:!room:example.test",
+        "message": "@worker:example.test ok",
+        "dryRun": True,
+    })
+    if blocked.get("ok") is not False or "ping-pong" not in blocked.get("error", ""):
+        raise AssertionError(f"low-information mention was not blocked: {blocked!r}")
+
+    user_target = payload({
+        "action": "send",
+        "channel": "matrix",
+        "target": "user:@worker:example.test",
+        "message": "@worker:example.test please verify",
+        "dryRun": True,
+    })
+    if user_target.get("ok") is not False or "user targets are not supported yet" not in user_target.get("error", ""):
+        raise AssertionError(f"user target was not rejected: {user_target!r}")
+
+    dingtalk_dry = payload({
+        "action": "send",
+        "replyRoute": {
+            "channel": "dingtalk",
+            "targetUser": "sender_001",
+            "targetSession": "aaaaaaaa",
+        },
+        "text": "Project A is ready.",
+        "dryRun": True,
+    })
+    if not dingtalk_dry.get("ok"):
+        raise AssertionError(f"dingtalk dry-run failed: {dingtalk_dry!r}")
+    if dingtalk_dry.get("channel") != "dingtalk":
+        raise AssertionError(f"dingtalk dry-run channel mismatch: {dingtalk_dry!r}")
+    if dingtalk_dry.get("targetUser") != "sender_001" or dingtalk_dry.get("targetSession") != "aaaaaaaa":
+        raise AssertionError(f"dingtalk dry-run target mismatch: {dingtalk_dry!r}")
+
+    import os
+    os.environ["HICLAW_MATRIX_URL"] = f"http://127.0.0.1:{server.server_address[1]}"
+    os.environ["HICLAW_WORKER_MATRIX_TOKEN"] = "test-token"
+    os.environ["HICLAW_MATRIX_USER_ID"] = "@sender:example.test"
+    os.environ["QWENPAW_API_BASE"] = f"http://127.0.0.1:{server.server_address[1]}"
+    home_dir = pathlib.Path("#{_dir}") / "home"
+    qwenpaw_dir = home_dir / ".qwenpaw"
+    (qwenpaw_dir / "workspaces" / "default").mkdir(parents=True, exist_ok=True)
+    os.environ.pop("QWENPAW_WORKING_DIR", None)
+    os.environ.pop("COPAW_WORKING_DIR", None)
+    os.environ["HOME"] = str(home_dir)
+
+    sent = payload({
+        "action": "send",
+        "channel": "matrix",
+        "room_id": "!room:example.test",
+        "text": "Project is ready.",
+    })
+    if not sent.get("ok") or sent.get("messageId") != "$event1":
+        raise AssertionError(f"send failed: {sent!r}")
+    if sent.get("sessionRecorded") is not True:
+        raise AssertionError(f"session record missing: {sent!r}")
+    if captured.get("auth") != "Bearer test-token":
+        raise AssertionError(f"auth mismatch: {captured!r}")
+    if "/_matrix/client/v3/rooms/%21room%3Aexample.test/send/m.room.message/" not in captured.get("path", ""):
+        raise AssertionError(f"send path mismatch: {captured!r}")
+    if captured["body"].get("body") != "Project is ready.":
+        raise AssertionError(f"body mismatch: {captured!r}")
+    def session_safe(value):
+        return re.sub(r'[\\\\/:*?"<>|]', "--", value)
+
+    session_path = (
+        qwenpaw_dir
+        / "workspaces"
+        / "default"
+        / "sessions"
+        / "matrix"
+        / f"{session_safe('!room:example.test')}_{session_safe('matrix:!room:example.test')}.json"
+    )
+    if not session_path.exists():
+        raise AssertionError(f"session file missing: {session_path}")
+    session = json.loads(session_path.read_text(encoding="utf-8"))
+    recorded_msg, marks = session["agent"]["memory"]["content"][-1]
+    if marks != []:
+        raise AssertionError(f"session marks mismatch: {session!r}")
+    if recorded_msg.get("role") != "assistant":
+        raise AssertionError(f"session role mismatch: {recorded_msg!r}")
+    if recorded_msg.get("content", [{}])[0].get("text") != "Project is ready.":
+        raise AssertionError(f"session text mismatch: {recorded_msg!r}")
+    if recorded_msg.get("metadata") != {
+        "channel": "matrix",
+        "room_id": "!room:example.test",
+        "message_id": "$event1",
+        "source": "message_tool_outbound",
+    }:
+        raise AssertionError(f"session metadata mismatch: {recorded_msg!r}")
+
+    dingtalk_sent = payload({
+        "action": "send",
+        "channel": "dingtalk",
+        "targetUser": "sender_001",
+        "targetSession": "aaaaaaaa",
+        "text": "Project A is ready.",
+        "agentId": "default",
+    })
+    server.shutdown()
+    if not dingtalk_sent.get("ok"):
+        raise AssertionError(f"dingtalk send failed: {dingtalk_sent!r}")
+    if dingtalk_sent.get("sessionRecorded") is not True:
+        raise AssertionError(f"dingtalk session record missing: {dingtalk_sent!r}")
+    if captured.get("qwenpaw_path") != "/api/messages/send":
+        raise AssertionError(f"qwenpaw send path mismatch: {captured!r}")
+    if captured.get("qwenpaw_agent") != "default":
+        raise AssertionError(f"qwenpaw agent mismatch: {captured!r}")
+    expected_qwenpaw_body = {
+        "channel": "dingtalk",
+        "target_user": "sender_001",
+        "target_session": "aaaaaaaa",
+        "text": "Project A is ready.",
+    }
+    if captured.get("qwenpaw_body") != expected_qwenpaw_body:
+        raise AssertionError(f"qwenpaw body mismatch: {captured!r}")
+    dingtalk_session_path = (
+        qwenpaw_dir
+        / "workspaces"
+        / "default"
+        / "sessions"
+        / "dingtalk"
+        / "sender_001_aaaaaaaa.json"
+    )
+    if not dingtalk_session_path.exists():
+        raise AssertionError(f"dingtalk session file missing: {dingtalk_session_path}")
+    dingtalk_session = json.loads(dingtalk_session_path.read_text(encoding="utf-8"))
+    dingtalk_msg, dingtalk_marks = dingtalk_session["agent"]["memory"]["content"][-1]
+    if dingtalk_marks != []:
+        raise AssertionError(f"dingtalk session marks mismatch: {dingtalk_session!r}")
+    if dingtalk_msg.get("content", [{}])[0].get("text") != "Project A is ready.":
+        raise AssertionError(f"dingtalk session text mismatch: {dingtalk_msg!r}")
+    if dingtalk_msg.get("metadata") != {
+        "channel": "dingtalk",
+        "message_id": "",
+        "source": "message_tool_outbound",
+        "user_id": "sender_001",
+        "session_id": "aaaaaaaa",
+    }:
+        raise AssertionError(f"dingtalk session metadata mismatch: {dingtalk_msg!r}")
+
+    os.environ["HICLAW_AGENT_ROLE"] = "worker"
+    worker_tools = [tool["name"] for tool in list_tools()]
+    if "message" in worker_tools:
+        raise AssertionError(f"worker should not see message tool: {worker_tools!r}")
+    blocked = payload({
+        "action": "send",
+        "channel": "matrix",
+        "target": "room:!room:example.test",
+        "message": "should be blocked",
+        "role": "leader",
+        "dryRun": True,
+    })
+    if blocked.get("ok") is not False or blocked.get("error") != "forbidden_tool":
+        raise AssertionError(f"worker message call should be blocked: {blocked!r}")
+
+    print(json.dumps({
+        "ok": True,
+        "dryRunMentions": dry["mentions"],
+        "messageId": sent["messageId"],
+        "sendPath": captured["path"],
+        "qwenpawSendPath": captured["qwenpaw_path"],
+    }, ensure_ascii=False))
+  PY
+
+  stdout, stderr, status = Open3.capture3("python3", "-", stdin_data: python_test, chdir: repo_root.to_s)
+  fail!(["teamharness message MCP test failed", stderr, stdout].reject(&:empty?).join("\n")) unless status.success?
+
+  puts JSON.pretty_generate(JSON.parse(stdout))
+end

--- a/plugins/tests/teamharness/mcp/tools/test-projectflow.rb
+++ b/plugins/tests/teamharness/mcp/tools/test-projectflow.rb
@@ -1,0 +1,451 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "pathname"
+require "tmpdir"
+
+repo_root = Pathname.new(__dir__).join("../../../../..").expand_path
+mcp_dir = repo_root / "plugins/teamharness/mcp"
+
+def fail!(message)
+  warn "ERROR: #{message}"
+  exit 1
+end
+
+Dir.mktmpdir("teamharness-projectflow-") do |dir|
+  root = Pathname.new(dir)
+  workspace = root / "workspace"
+  bin_dir = root / "bin"
+  log_path = root / "mc.log"
+  bin_dir.mkpath
+  (bin_dir / "mc").write(<<~SH)
+    #!/usr/bin/env bash
+    printf '%s\\n' "$*" >> "#{log_path}"
+  SH
+  (bin_dir / "mc").chmod(0o755)
+
+  python_test = <<~PY
+    import json
+    import os
+    import pathlib
+    import sys
+
+    sys.path.insert(0, str(pathlib.Path("#{mcp_dir}")))
+    import server
+    from server import call_tool
+
+    server.time.strftime = lambda fmt: "20260605-112233"
+
+    common = {
+        "workspaceDir": "#{workspace}",
+        "storage": {
+            "sharedPrefix": "mock/shared",
+            "globalSharedPrefix": "mock/global-shared",
+        },
+    }
+    runtime_config = pathlib.Path("#{root}") / "runtime.yaml"
+    runtime_config.write_text(
+        "team:\\n  teamRoomId: '!team:example.test'\\n",
+        encoding="utf-8",
+    )
+    os.environ["TEAMHARNESS_RUNTIME_CONFIG"] = str(runtime_config)
+
+    def payload(args):
+        merged = dict(common)
+        merged.update(args)
+        result = call_tool("projectflow", merged)
+        return json.loads(result["content"][0]["text"])
+
+    generated = payload({
+        "action": "create_project",
+        "payload": {"title": "Fix Auth Flow!"},
+    })
+    if not generated.get("ok"):
+        raise AssertionError(f"generated create_project failed: {generated!r}")
+    if generated["project"]["project_id"] != "fix-auth-flow-20260605-112233":
+        raise AssertionError(f"generated project id mismatch: {generated!r}")
+
+    generated_again = payload({
+        "action": "create_project",
+        "payload": {"title": "Fix Auth Flow!"},
+    })
+    if not generated_again.get("ok"):
+        raise AssertionError(f"generated collision create_project failed: {generated_again!r}")
+    if generated_again["project"]["project_id"] != "fix-auth-flow-20260605-112233-01":
+        raise AssertionError(f"generated collision suffix mismatch: {generated_again!r}")
+
+    created = payload({
+        "action": "create_project",
+        "payload": {
+            "projectId": "daily-plan-2026-06-03",
+            "title": "Daily Plan",
+            "source": "test",
+            "requester": "@admin:example.test",
+            "replyRoute": {
+                "channel": "dingtalk",
+                "targetUser": "sender_001",
+                "targetSession": "aaaaaaaa",
+            },
+        },
+    })
+    if not created.get("ok"):
+        raise AssertionError(f"create_project failed: {created!r}")
+    if created["project"]["project_id"] != "daily-plan-2026-06-03":
+        raise AssertionError(f"project id mismatch: {created!r}")
+    expected_reply_route = {
+        "channel": "dingtalk",
+        "target_user": "sender_001",
+        "target_session": "aaaaaaaa",
+    }
+    if created["project"].get("reply_route") != expected_reply_route:
+        raise AssertionError(f"reply route mismatch: {created!r}")
+
+    duplicate_explicit = payload({
+        "action": "create_project",
+        "payload": {"projectId": "daily-plan-2026-06-03", "title": "Duplicate Daily Plan"},
+    })
+    if duplicate_explicit.get("ok") or "project already exists" not in duplicate_explicit.get("error", ""):
+        raise AssertionError(f"explicit project id collision should be rejected: {duplicate_explicit!r}")
+
+    quick = payload({
+        "action": "create_quick_project",
+        "payload": {
+            "title": "Write Readiness Note",
+            "source": "matrix",
+            "requester": "@admin:example.test",
+            "assignedTo": "@worker-a:example.test",
+            "roomId": "!team:example.test",
+            "spec": "Write one concise readiness note.",
+            "replyRoute": {
+                "channel": "matrix",
+                "targetUser": "@admin:example.test",
+                "targetSession": "!team:example.test",
+            },
+        },
+    })
+    if not quick.get("ok"):
+        raise AssertionError(f"create_quick_project failed: {quick!r}")
+    quick_project = quick["project"]
+    quick_task = quick["task"]
+    if quick_project["project_id"] != "write-readiness-note-20260605-112233":
+        raise AssertionError(f"quick project id mismatch: {quick!r}")
+    if quick_project.get("mode") != "quick" or quick_project.get("plan_type") != "dag":
+        raise AssertionError(f"quick project should be quick DAG: {quick!r}")
+    if quick_task["task_id"] != "write-readiness-note-20260605-112233-01":
+        raise AssertionError(f"quick task id mismatch: {quick!r}")
+    if quick_task.get("status") != "assigned" or quick_project["tasks"][0].get("status") != "assigned":
+        raise AssertionError(f"quick project task should be assigned: {quick!r}")
+    if quick.get("synced") is not True:
+        raise AssertionError(f"quick project did not sync task dir: {quick!r}")
+    quick_spec_path = pathlib.Path("#{workspace}") / "shared/tasks/write-readiness-note-20260605-112233-01/spec.md"
+    if quick_spec_path.read_text(encoding="utf-8").strip() != "Write one concise readiness note.":
+        raise AssertionError("quick task spec was not written")
+    quick_meta_path = pathlib.Path("#{workspace}") / "shared/tasks/write-readiness-note-20260605-112233-01/meta.json"
+    quick_legacy_state_path = pathlib.Path("#{workspace}") / "shared/tasks/write-readiness-note-20260605-112233-01/task.json"
+    if not quick_meta_path.exists():
+        raise AssertionError(f"quick task meta.json was not written: {quick_meta_path}")
+    if quick_legacy_state_path.exists():
+        raise AssertionError(f"task.json should not be written: {quick_legacy_state_path}")
+    quick_meta = json.loads(quick_meta_path.read_text(encoding="utf-8"))
+    if quick_meta.get("room_id") != "!team:example.test" or quick_meta.get("project_id") != quick_project["project_id"]:
+        raise AssertionError(f"quick task meta mismatch: {quick_meta!r}")
+
+    external_quick = payload({
+        "action": "create_quick_project",
+        "payload": {
+            "projectId": "external-quick-project",
+            "title": "External Quick Project",
+            "source": "dingtalk",
+            "requester": "dingtalk:sender_003:cccccccc",
+            "assignedTo": "@worker-a:example.test",
+            "roomId": "room:!team:example.test",
+            "spec": "Should require a dedicated task room.",
+        },
+    })
+    if external_quick.get("ok") or "dedicated task room" not in external_quick.get("error", ""):
+        raise AssertionError(f"external quick project with team room should fail: {external_quick!r}")
+    external_quick_ok = payload({
+        "action": "create_quick_project",
+        "payload": {
+            "projectId": "external-quick-project-ok",
+            "title": "External Quick Project OK",
+            "source": "dingtalk",
+            "requester": "dingtalk:sender_003:cccccccc",
+            "assignedTo": "@worker-a:example.test",
+            "roomId": "room:!task-room:example.test",
+            "spec": "Use the dedicated assignment room.",
+        },
+    })
+    if not external_quick_ok.get("ok") or external_quick_ok["task"].get("room_id") != "room:!task-room:example.test":
+        raise AssertionError(f"external quick project with dedicated room failed: {external_quick_ok!r}")
+
+    resolved_quick = payload({
+        "action": "resolve_project",
+        "payload": {"taskId": quick_task["task_id"]},
+    })
+    if not resolved_quick.get("ok"):
+        raise AssertionError(f"resolve_project from taskId failed: {resolved_quick!r}")
+    if resolved_quick["project"]["project_id"] != quick_project["project_id"]:
+        raise AssertionError(f"resolve_project returned wrong project: {resolved_quick!r}")
+    if resolved_quick.get("task", {}).get("task_id") != quick_task["task_id"]:
+        raise AssertionError(f"resolve_project returned wrong task: {resolved_quick!r}")
+    if resolved_quick.get("replyRoute") != quick_project.get("reply_route"):
+        raise AssertionError(f"resolve_project lost reply route: {resolved_quick!r}")
+    if resolved_quick.get("planType") != "dag":
+        raise AssertionError(f"resolve_project lost plan type: {resolved_quick!r}")
+
+    created_from_string_payload = payload({
+        "action": "create_project",
+        "payload": json.dumps({
+            "projectId": "string-payload-project",
+            "title": "String Payload Project",
+        }),
+    })
+    if not created_from_string_payload.get("ok"):
+        raise AssertionError(f"create_project with string payload failed: {created_from_string_payload!r}")
+
+    created_from_requester = payload({
+        "action": "create_project",
+        "payload": {
+            "projectId": "legacy-dingtalk-requester",
+            "title": "Legacy DingTalk Requester",
+            "source": "dingtalk",
+            "requester": "dingtalk:sender_002:bbbbbbbb",
+        },
+    })
+    if not created_from_requester.get("ok"):
+        raise AssertionError(f"create_project with dingtalk requester failed: {created_from_requester!r}")
+    expected_legacy_route = {
+        "channel": "dingtalk",
+        "target_user": "sender_002",
+        "target_session": "bbbbbbbb",
+    }
+    if created_from_requester["project"].get("reply_route") != expected_legacy_route:
+        raise AssertionError(f"legacy requester reply route mismatch: {created_from_requester!r}")
+
+    planned = payload({
+        "action": "plan_dag",
+        "payload": {
+            "projectId": "daily-plan-2026-06-03",
+            "tasks": [
+                {
+                    "taskId": "t-001",
+                    "title": "Collect input",
+                    "assignedTo": "@worker-a:example.test",
+                    "dependsOn": [],
+                },
+                {
+                    "taskId": "t-002",
+                    "title": "Summarize",
+                    "assignedTo": "@worker-b:example.test",
+                    "dependsOn": ["t-001"],
+                },
+            ],
+        },
+    })
+    if not planned.get("ok"):
+        raise AssertionError(f"plan_dag failed: {planned!r}")
+    ready = [task["task_id"] for task in planned.get("readyNodes", [])]
+    if ready != ["t-001"]:
+        raise AssertionError(f"unexpected ready nodes: {planned!r}")
+
+    checked = payload({
+        "action": "ready_nodes",
+        "payload": {"projectId": "daily-plan-2026-06-03"},
+    })
+    if [task["task_id"] for task in checked.get("readyNodes", [])] != ["t-001"]:
+        raise AssertionError(f"ready_nodes mismatch: {checked!r}")
+
+    duplicate = payload({
+        "action": "plan_dag",
+        "payload": {
+            "projectId": "daily-plan-2026-06-03",
+            "tasks": [
+                {"taskId": "dup", "title": "First"},
+                {"taskId": "dup", "title": "Second"},
+            ],
+        },
+    })
+    if duplicate.get("ok") or "duplicate task id" not in duplicate.get("error", ""):
+        raise AssertionError(f"duplicate task id should be rejected: {duplicate!r}")
+
+    cycle = payload({
+        "action": "plan_dag",
+        "payload": {
+            "projectId": "daily-plan-2026-06-03",
+            "tasks": [
+                {"taskId": "cycle-a", "dependsOn": ["cycle-b"]},
+                {"taskId": "cycle-b", "dependsOn": ["cycle-a"]},
+            ],
+        },
+    })
+    if cycle.get("ok") or "cycle" not in cycle.get("error", ""):
+        raise AssertionError(f"cycle should be rejected: {cycle!r}")
+
+    paused = payload({
+        "action": "pause_project",
+        "payload": {"projectId": "daily-plan-2026-06-03"},
+    })
+    if not paused.get("ok") or paused["project"].get("status") != "paused":
+        raise AssertionError(f"pause_project failed: {paused!r}")
+    paused_ready = payload({
+        "action": "ready_nodes",
+        "payload": {"projectId": "daily-plan-2026-06-03"},
+    })
+    if paused_ready.get("readyNodes"):
+        raise AssertionError(f"paused project should have no ready nodes: {paused_ready!r}")
+
+    resumed = payload({
+        "action": "resume_project",
+        "payload": {"projectId": "daily-plan-2026-06-03"},
+    })
+    if not resumed.get("ok") or resumed["project"].get("status") != "active":
+        raise AssertionError(f"resume_project failed: {resumed!r}")
+    resumed_ready = payload({
+        "action": "ready_nodes",
+        "payload": {"projectId": "daily-plan-2026-06-03"},
+    })
+    if [task["task_id"] for task in resumed_ready.get("readyNodes", [])] != ["t-001"]:
+        raise AssertionError(f"resumed ready_nodes mismatch: {resumed_ready!r}")
+
+    completed = payload({
+        "action": "complete_project",
+        "payload": {"projectId": "daily-plan-2026-06-03"},
+    })
+    if not completed.get("ok") or completed["project"].get("status") != "completed":
+        raise AssertionError(f"complete_project failed: {completed!r}")
+    completed_ready = payload({
+        "action": "ready_nodes",
+        "payload": {"projectId": "daily-plan-2026-06-03"},
+    })
+    if completed_ready.get("readyNodes"):
+        raise AssertionError(f"completed project should have no ready nodes: {completed_ready!r}")
+
+    plan_path = pathlib.Path("#{workspace}") / "shared/projects/daily-plan-2026-06-03/plan.md"
+    meta_path = pathlib.Path("#{workspace}") / "shared/projects/daily-plan-2026-06-03/meta.json"
+    legacy_state_path = pathlib.Path("#{workspace}") / "shared/projects/daily-plan-2026-06-03/project.json"
+    if not plan_path.exists() or not meta_path.exists():
+        raise AssertionError(f"project files missing: {plan_path}, {meta_path}")
+    if legacy_state_path.exists():
+        raise AssertionError(f"project.json should not be written: {legacy_state_path}")
+    plan_text = plan_path.read_text(encoding="utf-8")
+    if "Daily Plan" not in plan_text or "t-001" not in plan_text:
+        raise AssertionError(f"plan text missing project details: {plan_text!r}")
+    if "Reply Route: `dingtalk/sender_001/aaaaaaaa`" not in plan_text:
+        raise AssertionError(f"plan text missing safe reply route: {plan_text!r}")
+    state = json.loads(meta_path.read_text(encoding="utf-8"))
+    if state.get("reply_route") != expected_reply_route:
+        raise AssertionError(f"state reply route mismatch: {state!r}")
+
+    loop_created = payload({
+        "action": "create_project",
+        "payload": {
+            "projectId": "iterative-fix-2026-06-03",
+            "title": "Iterative Fix",
+            "source": "test",
+        },
+    })
+    if not loop_created.get("ok"):
+        raise AssertionError(f"loop project create failed: {loop_created!r}")
+
+    loop_planned = payload({
+        "action": "plan_loop",
+        "payload": {
+            "projectId": "iterative-fix-2026-06-03",
+            "goal": "Fix until tests pass",
+            "stopCondition": "All target tests pass or max iterations reached",
+            "iterationTemplate": "Inspect failure, apply one fix, rerun tests.",
+            "maxIterations": 3,
+            "currentIteration": 1,
+            "tasks": [
+                {
+                    "taskId": "iterative-fix-2026-06-03-i001-01",
+                    "title": "Run first fix pass",
+                    "assignedTo": "@worker-a:example.test",
+                    "dependsOn": [],
+                },
+                {
+                    "taskId": "iterative-fix-2026-06-03-i001-02",
+                    "title": "Verify first fix pass",
+                    "assignedTo": "@worker-b:example.test",
+                    "dependsOn": ["iterative-fix-2026-06-03-i001-01"],
+                },
+            ],
+        },
+    })
+    if not loop_planned.get("ok"):
+        raise AssertionError(f"plan_loop failed: {loop_planned!r}")
+    loop_ready = [task["task_id"] for task in loop_planned.get("readyLoopNodes", [])]
+    if loop_ready != ["iterative-fix-2026-06-03-i001-01"]:
+        raise AssertionError(f"unexpected ready loop nodes: {loop_planned!r}")
+
+    loop_cycle = payload({
+        "action": "plan_loop",
+        "payload": {
+            "projectId": "iterative-fix-2026-06-03",
+            "goal": "Fix until tests pass",
+            "stopCondition": "All target tests pass or max iterations reached",
+            "iterationTemplate": "Inspect failure, apply one fix, rerun tests.",
+            "maxIterations": 3,
+            "currentIteration": 1,
+            "tasks": [
+                {"taskId": "loop-a", "dependsOn": ["loop-b"]},
+                {"taskId": "loop-b", "dependsOn": ["loop-a"]},
+            ],
+        },
+    })
+    if loop_cycle.get("ok") or "cycle" not in loop_cycle.get("error", ""):
+        raise AssertionError(f"loop cycle should be rejected: {loop_cycle!r}")
+
+    loop_checked = payload({
+        "action": "ready_loop_nodes",
+        "payload": {"projectId": "iterative-fix-2026-06-03"},
+    })
+    if [task["task_id"] for task in loop_checked.get("readyLoopNodes", [])] != loop_ready:
+        raise AssertionError(f"ready_loop_nodes mismatch: {loop_checked!r}")
+
+    loop_recorded = payload({
+        "action": "record_loop_iteration",
+        "payload": {
+            "projectId": "iterative-fix-2026-06-03",
+            "iteration": 1,
+            "decision": "continue",
+            "summary": "First pass found another failure.",
+            "nextAction": "Plan the second pass.",
+        },
+    })
+    if not loop_recorded.get("ok"):
+        raise AssertionError(f"record_loop_iteration failed: {loop_recorded!r}")
+    if loop_recorded["loop"].get("status") != "running":
+        raise AssertionError(f"loop status mismatch: {loop_recorded!r}")
+    if not loop_recorded["loop"].get("history"):
+        raise AssertionError(f"loop history missing: {loop_recorded!r}")
+
+    loop_plan_path = pathlib.Path("#{workspace}") / "shared/projects/iterative-fix-2026-06-03/plan.md"
+    loop_plan_text = loop_plan_path.read_text(encoding="utf-8")
+    if "Plan Type: `loop`" not in loop_plan_text or "Fix until tests pass" not in loop_plan_text:
+        raise AssertionError(f"loop plan text missing details: {loop_plan_text!r}")
+
+    print(json.dumps({
+        "ok": True,
+        "project": created["project"]["project_id"],
+        "ready": ready,
+        "loopReady": loop_ready,
+        "planPath": str(plan_path),
+    }, ensure_ascii=False))
+  PY
+
+  env = {"PATH" => "#{bin_dir}:#{ENV.fetch("PATH", "")}"}
+  stdout, stderr, status = Open3.capture3(env, "python3", "-", stdin_data: python_test, chdir: repo_root.to_s)
+  fail!(["teamharness projectflow MCP test failed", stderr, stdout].reject(&:empty?).join("\n")) unless status.success?
+
+  result = JSON.parse(stdout)
+  commands = log_path.read.lines.map(&:strip)
+  fail!("create_quick_project did not push task dir: #{commands.inspect}") unless commands.include?(
+    "mirror #{workspace}/shared/tasks/write-readiness-note-20260605-112233-01/ mock/shared/tasks/write-readiness-note-20260605-112233-01/ --overwrite"
+  )
+
+  puts JSON.pretty_generate(result.merge("mcCommands" => commands))
+end

--- a/plugins/tests/teamharness/mcp/tools/test-protocol.rb
+++ b/plugins/tests/teamharness/mcp/tools/test-protocol.rb
@@ -1,0 +1,79 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "pathname"
+
+repo_root = Pathname.new(__dir__).join("../../../../..").expand_path
+server = repo_root / "plugins/teamharness/mcp/server.py"
+
+def fail!(message)
+  warn "ERROR: #{message}"
+  exit 1
+end
+
+input = [
+  {
+    "jsonrpc" => "2.0",
+    "id" => 1,
+    "method" => "initialize",
+    "params" => {}
+  },
+  {
+    "jsonrpc" => "2.0",
+    "method" => "notifications/initialized",
+    "params" => {}
+  },
+  {
+    "jsonrpc" => "2.0",
+    "id" => 2,
+    "method" => "tools/list",
+    "params" => {}
+  }
+].map { |item| JSON.generate(item) }.join("\n") + "\n"
+
+stdout, stderr, status = Open3.capture3("python3", server.to_s, stdin_data: input, chdir: repo_root.to_s)
+fail!(["teamharness MCP protocol test failed", stderr, stdout].reject(&:empty?).join("\n")) unless status.success?
+
+lines = stdout.lines.map(&:strip).reject(&:empty?)
+fail!("notification should not produce a JSON-RPC response: #{lines.inspect}") unless lines.length == 2
+
+initialize_response = JSON.parse(lines.fetch(0))
+tools_response = JSON.parse(lines.fetch(1))
+
+fail!("initialize response id mismatch: #{initialize_response.inspect}") unless initialize_response["id"] == 1
+fail!("tools/list response id mismatch: #{tools_response.inspect}") unless tools_response["id"] == 2
+
+tools = tools_response.dig("result", "tools") || []
+tool_names = tools.map { |tool| tool["name"] }
+expected = %w[health message roomflow filesync projectflow taskflow]
+fail!("unexpected tools: #{tool_names.inspect}") unless tool_names == expected
+
+tool_by_name = tools.to_h { |tool| [tool["name"], tool] }
+expected_keywords = {
+  "health" => ["MCP server", "not runtime worker health"],
+  "message" => ["cross-room", "cross-channel", "cross-session", "current room/session"],
+  "roomflow" => ["task rooms", "execution-channel", "not requester reply channels"],
+  "filesync" => ["shared/projects", "shared/tasks", "not periodic workspace sync"],
+  "projectflow" => ["Project Work", "DAG", "Loop", "ordinary direct replies"],
+  "taskflow" => ["leader delegates", "worker", "ordinary conversation"]
+}
+
+expected_keywords.each do |name, keywords|
+  tool = tool_by_name.fetch(name)
+  description = tool["description"].to_s
+  fail!("generic description for #{name}: #{description.inspect}") if description == "TeamHarness #{name} tool"
+  keywords.each do |keyword|
+    fail!("description for #{name} must mention #{keyword.inspect}: #{description.inspect}") unless description.include?(keyword)
+  end
+  schema = tool["inputSchema"]
+  fail!("missing object input schema for #{name}: #{tool.inspect}") unless schema.is_a?(Hash) && schema["type"] == "object"
+  fail!("missing schema properties for #{name}: #{schema.inspect}") unless schema["properties"].is_a?(Hash)
+end
+
+puts JSON.pretty_generate(
+  "ok" => true,
+  "responses" => lines.length,
+  "tools" => tool_names
+)

--- a/plugins/tests/teamharness/mcp/tools/test-roomflow.rb
+++ b/plugins/tests/teamharness/mcp/tools/test-roomflow.rb
@@ -1,0 +1,263 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "pathname"
+require "tmpdir"
+
+repo_root = Pathname.new(__dir__).join("../../../../..").expand_path
+mcp_dir = repo_root / "plugins/teamharness/mcp"
+
+def fail!(message)
+  warn "ERROR: #{message}"
+  exit 1
+end
+
+Dir.mktmpdir("teamharness-roomflow-") do |dir|
+  python_test = <<~PY
+    import http.server
+    import json
+    import os
+    import pathlib
+    import socketserver
+    import sys
+    import threading
+
+    sys.path.insert(0, str(pathlib.Path("#{mcp_dir}")))
+    from server import call_tool
+
+    runtime_config = pathlib.Path("#{dir}") / "runtime.yaml"
+    runtime_config.write_text(json.dumps({
+        "team": {
+            "admin": {
+                "name": "admin",
+                "matrixUserId": "@runtime-admin:example.test",
+            },
+        },
+    }), encoding="utf-8")
+    runtime_config_without_admin = pathlib.Path("#{dir}") / "runtime-without-admin.yaml"
+    runtime_config_without_admin.write_text(json.dumps({
+        "member": {"matrixUserId": "@leader:example.test"},
+        "team": {"leaderDmRoomId": "!leader-dm:example.test"},
+    }), encoding="utf-8")
+
+    captured = {"posts": [], "gets": []}
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            raw = self.rfile.read(length).decode("utf-8")
+            body = json.loads(raw or "{}")
+            captured["posts"].append({
+                "path": self.path,
+                "auth": self.headers.get("Authorization"),
+                "body": body,
+            })
+            if self.path == "/_matrix/client/v3/createRoom":
+                payload = json.dumps({"room_id": "!created:example.test"}).encode("utf-8")
+            elif self.path == "/_matrix/client/v3/rooms/%21created%3Aexample.test/leave":
+                payload = b"{}"
+            else:
+                self.send_response(404)
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def do_GET(self):
+            captured["gets"].append({
+                "path": self.path,
+                "auth": self.headers.get("Authorization"),
+            })
+            if self.path == "/_matrix/client/v3/rooms/%21leader-dm%3Aexample.test/members":
+                payload = json.dumps({"chunk": [
+                    {"state_key": "@leader:example.test", "content": {"membership": "join"}},
+                    {"state_key": "@team-admin:example.test", "content": {"membership": "join"}},
+                ]}).encode("utf-8")
+            elif self.path == "/_matrix/client/v3/rooms/%21created%3Aexample.test/members":
+                payload = json.dumps({"chunk": [
+                    {"state_key": "@worker:example.test", "content": {"membership": "join"}},
+                    {"state_key": "@admin:example.test", "content": {"membership": "join"}},
+                ]}).encode("utf-8")
+            elif self.path == "/_matrix/client/v3/joined_rooms":
+                payload = json.dumps({"joined_rooms": ["!created:example.test"]}).encode("utf-8")
+            else:
+                self.send_response(404)
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *_args):
+            return
+
+    server = socketserver.TCPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    def payload(args):
+        result = call_tool("roomflow", args)
+        return json.loads(result["content"][0]["text"])
+
+    dry = payload({
+        "action": "create_task_room",
+        "taskId": "demo-project-001",
+        "name": "Task: demo",
+        "source": "matrix",
+        "invite": ["@worker:example.test"],
+        "admin": "@admin:example.test",
+        "dryRun": True,
+    })
+    if not dry.get("ok") or not dry.get("dryRun"):
+        raise AssertionError(f"dry create failed: {dry!r}")
+    if dry.get("invite") != ["@worker:example.test", "@admin:example.test"]:
+        raise AssertionError(f"invite list mismatch: {dry!r}")
+    if dry["content"].get("power_level_content_override", {}).get("users", {}).get("@admin:example.test") != 100:
+        raise AssertionError(f"admin power level missing: {dry!r}")
+
+    os.environ["TEAMHARNESS_RUNTIME_CONFIG"] = str(runtime_config)
+    dry_runtime_admin = payload({
+        "action": "create_task_room",
+        "taskId": "demo-project-002",
+        "name": "Task: runtime admin",
+        "source": "matrix",
+        "invite": ["@worker:example.test"],
+        "dryRun": True,
+    })
+    if dry_runtime_admin.get("invite") != ["@worker:example.test", "@runtime-admin:example.test"]:
+        raise AssertionError(f"runtime admin was not auto-invited: {dry_runtime_admin!r}")
+    if dry_runtime_admin["content"].get("power_level_content_override", {}).get("users", {}).get("@runtime-admin:example.test") != 100:
+        raise AssertionError(f"runtime admin power level missing: {dry_runtime_admin!r}")
+    os.environ.pop("TEAMHARNESS_RUNTIME_CONFIG", None)
+
+    invalid = payload({
+        "action": "create_task_room",
+        "taskId": "bad/id",
+        "name": "bad",
+        "dryRun": True,
+    })
+    if invalid.get("ok") is not False or "safe id" not in invalid.get("error", ""):
+        raise AssertionError(f"unsafe task id was not rejected: {invalid!r}")
+
+    os.environ["HICLAW_MATRIX_URL"] = f"http://127.0.0.1:{server.server_address[1]}"
+    os.environ["HICLAW_WORKER_MATRIX_TOKEN"] = "test-token"
+    os.environ["HICLAW_MATRIX_USER_ID"] = "@leader:example.test"
+
+    created = payload({
+        "action": "create_task_room",
+        "taskId": "demo-project-001",
+        "name": "Task: demo",
+        "source": "matrix",
+        "invite": "@worker:example.test",
+    })
+    if not created.get("ok") or created.get("roomId") != "!created:example.test":
+        raise AssertionError(f"create failed: {created!r}")
+    if created.get("target") != "room:!created:example.test":
+        raise AssertionError(f"target mismatch: {created!r}")
+    create_call = captured["posts"][0]
+    if create_call.get("auth") != "Bearer test-token":
+        raise AssertionError(f"auth mismatch: {captured!r}")
+    if create_call["body"].get("name") != "Task: demo":
+        raise AssertionError(f"room name mismatch: {captured!r}")
+    if create_call["body"].get("invite") != ["@worker:example.test"]:
+        raise AssertionError(f"real invite mismatch: {captured!r}")
+
+    listed = payload({"action": "list_rooms"})
+    if not listed.get("ok") or listed.get("rooms") != ["!created:example.test"]:
+        raise AssertionError(f"list failed: {listed!r}")
+    if captured["gets"][0].get("auth") != "Bearer test-token":
+        raise AssertionError(f"list auth mismatch: {captured!r}")
+
+    missing_source_room = payload({
+        "action": "create_task_room",
+        "taskId": "demo-project-004",
+        "name": "Task: missing external source room",
+        "source": "dingtalk",
+        "invite": ["@worker:example.test"],
+        "workspaceDir": "#{dir}",
+        "dryRun": True,
+    })
+    if missing_source_room.get("ok") is not False or "sourceRoomId is required" not in missing_source_room.get("error", ""):
+        raise AssertionError(f"missing sourceRoomId was not rejected: {missing_source_room!r}")
+
+    external_created = payload({
+        "action": "create_task_room",
+        "taskId": "demo-project-005",
+        "name": "Task: external source room",
+        "source": "dingtalk",
+        "sourceRoomId": "ding-room-001",
+        "invite": ["@worker:example.test"],
+        "admin": "@admin:example.test",
+        "workspaceDir": "#{dir}",
+    })
+    if not external_created.get("ok") or external_created.get("roomId") != "!created:example.test":
+        raise AssertionError(f"external create failed: {external_created!r}")
+    if external_created.get("sourceRoomKey") != "dingtalk:ding-room-001":
+        raise AssertionError(f"source room key mismatch: {external_created!r}")
+    create_posts = len([post for post in captured["posts"] if post["path"] == "/_matrix/client/v3/createRoom"])
+    external_reused = payload({
+        "action": "create_task_room",
+        "taskId": "demo-project-006",
+        "name": "Task: external source room again",
+        "source": "dingtalk",
+        "sourceRoomId": "ding-room-001",
+        "invite": ["@worker:example.test"],
+        "admin": "@admin:example.test",
+        "workspaceDir": "#{dir}",
+    })
+    if not external_reused.get("ok") or external_reused.get("roomId") != "!created:example.test" or external_reused.get("reused") is not True:
+        raise AssertionError(f"external room was not reused: {external_reused!r}")
+    create_posts_after_reuse = len([post for post in captured["posts"] if post["path"] == "/_matrix/client/v3/createRoom"])
+    if create_posts_after_reuse != create_posts:
+        raise AssertionError(f"external reuse created a new room: {captured!r}")
+
+    os.environ["TEAMHARNESS_RUNTIME_CONFIG"] = str(runtime_config_without_admin)
+    saved_matrix_user_id = os.environ.pop("HICLAW_MATRIX_USER_ID", None)
+    saved_worker_name = os.environ.pop("HICLAW_WORKER_NAME", None)
+    dry_leader_dm_admin = payload({
+        "action": "create_task_room",
+        "taskId": "demo-project-003",
+        "name": "Task: leader DM inferred admin",
+        "source": "matrix",
+        "invite": ["@worker:example.test"],
+        "dryRun": True,
+    })
+    if saved_matrix_user_id is not None:
+        os.environ["HICLAW_MATRIX_USER_ID"] = saved_matrix_user_id
+    if saved_worker_name is not None:
+        os.environ["HICLAW_WORKER_NAME"] = saved_worker_name
+    if dry_leader_dm_admin.get("invite") != ["@worker:example.test", "@team-admin:example.test"]:
+        raise AssertionError(f"leader DM admin was not auto-invited: {dry_leader_dm_admin!r}")
+    if dry_leader_dm_admin["content"].get("power_level_content_override", {}).get("users", {}).get("@leader:example.test") != 100:
+        raise AssertionError(f"runtime member creator power level missing: {dry_leader_dm_admin!r}")
+    if dry_leader_dm_admin["content"].get("power_level_content_override", {}).get("users", {}).get("@team-admin:example.test") != 100:
+        raise AssertionError(f"leader DM admin power level missing: {dry_leader_dm_admin!r}")
+    os.environ.pop("TEAMHARNESS_RUNTIME_CONFIG", None)
+
+    archived = payload({"action": "archive_room", "roomId": "room:!created:example.test"})
+    server.shutdown()
+    if not archived.get("ok") or archived.get("archived") is not True:
+        raise AssertionError(f"archive failed: {archived!r}")
+    if captured["posts"][-1].get("path") != "/_matrix/client/v3/rooms/%21created%3Aexample.test/leave":
+        raise AssertionError(f"archive path mismatch: {captured!r}")
+
+    print(json.dumps({
+        "ok": True,
+        "roomId": created["roomId"],
+        "rooms": listed["rooms"],
+        "archivePath": captured["posts"][-1]["path"],
+    }, ensure_ascii=False))
+  PY
+
+  stdout, stderr, status = Open3.capture3("python3", "-", stdin_data: python_test, chdir: repo_root.to_s)
+  fail!(["teamharness roomflow MCP test failed", stderr, stdout].reject(&:empty?).join("\n")) unless status.success?
+
+  puts JSON.pretty_generate(JSON.parse(stdout))
+end

--- a/plugins/tests/teamharness/mcp/tools/test-taskflow.rb
+++ b/plugins/tests/teamharness/mcp/tools/test-taskflow.rb
@@ -1,0 +1,369 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "pathname"
+require "tmpdir"
+
+repo_root = Pathname.new(__dir__).join("../../../../..").expand_path
+mcp_dir = repo_root / "plugins/teamharness/mcp"
+
+def fail!(message)
+  warn "ERROR: #{message}"
+  exit 1
+end
+
+Dir.mktmpdir("teamharness-taskflow-") do |dir|
+  root = Pathname.new(dir)
+  workspace = root / "workspace"
+  remote_task = root / "remote" / "tasks" / "remote-001"
+  bin_dir = root / "bin"
+  log_path = root / "mc.log"
+  remote_task.mkpath
+  (remote_task / "meta.json").write(JSON.pretty_generate(
+    "task_id" => "remote-001",
+    "project_id" => project_id = "remote-project",
+    "room_id" => "room:!team:example.test",
+    "status" => "assigned",
+    "spec_path" => "shared/tasks/remote-001/spec.md"
+  ))
+  (remote_task / "spec.md").write("Remote task spec\n")
+  bin_dir.mkpath
+  (bin_dir / "mc").write(<<~SH)
+    #!/usr/bin/env bash
+    printf '%s\\n' "$*" >> "#{log_path}"
+    if [ "$1" = "mirror" ] && [ "$2" = "mock/shared/tasks/remote-001/" ]; then
+      mkdir -p "$3"
+      cp -a "#{remote_task}/." "$3"
+    fi
+  SH
+  (bin_dir / "mc").chmod(0o755)
+
+  python_test = <<~PY
+    import builtins
+    import json
+    import os
+    import pathlib
+    import sys
+
+    sys.path.insert(0, str(pathlib.Path("#{mcp_dir}")))
+    from server import call_tool
+
+    common = {
+        "workspaceDir": "#{workspace}",
+        "storage": {
+            "sharedPrefix": "mock/shared",
+            "globalSharedPrefix": "mock/global-shared",
+        },
+    }
+    runtime_config = pathlib.Path("#{root}") / "runtime.yaml"
+    runtime_config.write_text(
+        "team:\\n  teamRoomId: '!team:example.test'\\n",
+        encoding="utf-8",
+    )
+    os.environ["TEAMHARNESS_RUNTIME_CONFIG"] = str(runtime_config)
+
+    def payload(name, args):
+        merged = dict(common)
+        merged.update(args)
+        result = call_tool(name, merged)
+        return json.loads(result["content"][0]["text"])
+
+    project_id = "daily-plan-2026-06-03"
+    task_id = "t-001"
+
+    payload("projectflow", {
+        "action": "create_project",
+        "payload": {
+            "projectId": project_id,
+            "title": "Daily Plan",
+            "replyRoute": {
+                "channel": "matrix",
+                "targetUser": "@admin:example.test",
+                "targetSession": "!team:example.test",
+            },
+        },
+    })
+    payload("projectflow", {
+        "action": "plan_dag",
+        "payload": {
+            "projectId": project_id,
+            "tasks": [{
+                "taskId": task_id,
+                "title": "Collect input",
+                "assignedTo": "@worker-a:example.test",
+                "dependsOn": [],
+            }],
+        },
+    })
+
+    delegated = payload("taskflow", {
+        "role": "leader",
+        "action": "delegate_task",
+        "payload": {
+            "projectId": project_id,
+            "taskId": task_id,
+            "roomId": "room:!team:example.test",
+            "spec": "Collect input and submit a result.",
+        },
+    })
+    if not delegated.get("ok") or delegated["task"]["status"] != "assigned":
+        raise AssertionError(f"delegate_task failed: {delegated!r}")
+    if delegated.get("synced") is not True:
+        raise AssertionError(f"delegate_task did not sync task dir: {delegated!r}")
+
+    external_project_id = "external-dingtalk-project"
+    external_task_id = "external-dingtalk-project-01"
+    payload("projectflow", {
+        "action": "create_project",
+        "payload": {
+            "projectId": external_project_id,
+            "title": "External DingTalk Project",
+            "source": "dingtalk",
+            "requester": "dingtalk:sender_001:aaaaaaaa",
+        },
+    })
+    payload("projectflow", {
+        "action": "plan_dag",
+        "payload": {
+            "projectId": external_project_id,
+            "tasks": [{
+                "taskId": external_task_id,
+                "title": "Do external work",
+                "assignedTo": "@worker-a:example.test",
+                "dependsOn": [],
+            }],
+        },
+    })
+    real_import = builtins.__import__
+
+    def block_yaml_import(name, *args, **kwargs):
+        if name == "yaml":
+            raise ImportError(name)
+        return real_import(name, *args, **kwargs)
+
+    builtins.__import__ = block_yaml_import
+    try:
+        blocked_team_room = payload("taskflow", {
+            "role": "leader",
+            "action": "delegate_task",
+            "payload": {
+                "projectId": external_project_id,
+                "taskId": external_task_id,
+                "roomId": "room:!team:example.test",
+                "spec": "Should require a dedicated assignment room.",
+            },
+        })
+    finally:
+        builtins.__import__ = real_import
+    if blocked_team_room.get("ok") or "dedicated task room" not in blocked_team_room.get("error", ""):
+        raise AssertionError(f"external requester team-room delegation should fail: {blocked_team_room!r}")
+    if (pathlib.Path("#{workspace}") / f"shared/tasks/{external_task_id}/spec.md").exists():
+        raise AssertionError("failed external delegation should not write task spec")
+    delegated_external = payload("taskflow", {
+        "role": "leader",
+        "action": "delegate_task",
+        "payload": {
+            "projectId": external_project_id,
+            "taskId": external_task_id,
+            "roomId": "room:!task-room:example.test",
+            "spec": "Use the dedicated task room.",
+        },
+    })
+    if not delegated_external.get("ok") or delegated_external["task"].get("room_id") != "room:!task-room:example.test":
+        raise AssertionError(f"external requester dedicated room delegation failed: {delegated_external!r}")
+
+    acked = payload("taskflow", {
+        "role": "worker",
+        "action": "ack_task",
+        "payload": {"taskId": task_id},
+    })
+    if not acked.get("ok") or acked["task"]["status"] != "in_progress":
+        raise AssertionError(f"ack_task failed: {acked!r}")
+
+    submitted = payload("taskflow", {
+        "role": "worker",
+        "action": "submit_task",
+        "payload": {
+            "taskId": task_id,
+            "status": "SUCCESS",
+            "summary": "Input collected.",
+            "deliverables": ["shared/tasks/t-001/result.md"],
+        },
+    })
+    if not submitted.get("ok") or submitted["task"]["status"] != "submitted":
+        raise AssertionError(f"submit_task failed: {submitted!r}")
+    if submitted.get("synced") is not True:
+        raise AssertionError(f"submit_task did not sync result: {submitted!r}")
+
+    checked = payload("taskflow", {
+        "role": "leader",
+        "action": "check_task",
+        "payload": {"taskId": task_id},
+    })
+    if not checked.get("ok") or not checked.get("effective"):
+        raise AssertionError(f"check_task failed: {checked!r}")
+    if checked.get("result", {}).get("summary") != "Input collected.":
+        raise AssertionError(f"check_task did not return result summary: {checked!r}")
+
+    accepted = payload("projectflow", {
+        "action": "accept_task_result",
+        "payload": {
+            "projectId": project_id,
+            "taskId": task_id,
+            "resultStatus": checked["result"]["status"],
+            "summary": checked["result"]["summary"],
+        },
+    })
+    if not accepted.get("ok"):
+        raise AssertionError(f"accept_task_result failed: {accepted!r}")
+    accepted_tasks = {task["task_id"]: task for task in accepted["project"].get("tasks", [])}
+    if accepted_tasks.get(task_id, {}).get("status") != "completed":
+        raise AssertionError(f"accept_task_result did not complete project node: {accepted!r}")
+    requester_report = accepted["project"].get("requester_report", {})
+    if requester_report.get("pending") is not True or requester_report.get("task_id") != task_id:
+        raise AssertionError(f"accept_task_result did not mark requester report pending: {accepted!r}")
+    marked_report = payload("projectflow", {
+        "action": "mark_requester_report_sent",
+        "payload": {"projectId": project_id},
+    })
+    if not marked_report.get("ok"):
+        raise AssertionError(f"mark_requester_report_sent failed: {marked_report!r}")
+    if marked_report["project"].get("requester_report", {}).get("pending") is not False:
+        raise AssertionError(f"mark_requester_report_sent did not clear pending flag: {marked_report!r}")
+
+    revision_project_id = "revision-project"
+    revision_task_id = "revision-task-01"
+    payload("projectflow", {
+        "action": "create_project",
+        "payload": {
+            "projectId": revision_project_id,
+            "title": "Revision Project",
+            "replyRoute": {
+                "channel": "matrix",
+                "targetUser": "@admin:example.test",
+                "targetSession": "!team:example.test",
+            },
+        },
+    })
+    payload("projectflow", {
+        "action": "plan_dag",
+        "payload": {
+            "projectId": revision_project_id,
+            "tasks": [{
+                "taskId": revision_task_id,
+                "title": "Draft result",
+                "assignedTo": "@worker-a:example.test",
+                "dependsOn": [],
+            }],
+        },
+    })
+    rejected = payload("projectflow", {
+        "action": "accept_task_result",
+        "payload": {
+            "projectId": revision_project_id,
+            "taskId": revision_task_id,
+            "accepted": False,
+            "resultStatus": "SUCCESS",
+            "summary": "Not good enough.",
+        },
+    })
+    if not rejected.get("ok"):
+        raise AssertionError(f"accepted=false conflict failed unexpectedly: {rejected!r}")
+    rejected_tasks = {task["task_id"]: task for task in rejected["project"].get("tasks", [])}
+    if rejected.get("accepted") is not False or rejected.get("nodeStatus") != "revision":
+        raise AssertionError(f"accepted=false did not take precedence: {rejected!r}")
+    if rejected_tasks.get(revision_task_id, {}).get("status") != "revision":
+        raise AssertionError(f"accepted=false did not mark node revision: {rejected!r}")
+    if rejected["project"].get("requester_report", {}).get("pending") is True:
+        raise AssertionError(f"accepted=false should not create requester report: {rejected!r}")
+
+    result_path_for_validation = pathlib.Path("#{workspace}") / "shared/tasks/t-001/result.md"
+    original_result = result_path_for_validation.read_text(encoding="utf-8")
+    result_path_for_validation.write_text("# Task Result\\n\\n- Summary: Missing status.\\n", encoding="utf-8")
+    invalid_checked = payload("taskflow", {
+        "role": "leader",
+        "action": "check_task",
+        "payload": {"taskId": task_id},
+    })
+    if not invalid_checked.get("ok") or invalid_checked.get("effective"):
+        raise AssertionError(f"invalid result should be ineffective: {invalid_checked!r}")
+    if "missing result status" not in invalid_checked.get("validationErrors", []):
+        raise AssertionError(f"invalid result should include validation error: {invalid_checked!r}")
+    result_path_for_validation.write_text(original_result, encoding="utf-8")
+
+    forbidden_delegate = payload("taskflow", {
+        "role": "worker",
+        "action": "delegate_task",
+        "payload": {
+            "projectId": project_id,
+            "taskId": "t-002",
+            "roomId": "room:!team:example.test",
+            "spec": "This should be rejected for worker role.",
+        },
+    })
+    if forbidden_delegate.get("ok") or "leader role" not in forbidden_delegate.get("error", ""):
+        raise AssertionError(f"worker role should not delegate: {forbidden_delegate!r}")
+
+    forbidden_submit = payload("taskflow", {
+        "role": "leader",
+        "action": "submit_task",
+        "payload": {
+            "taskId": task_id,
+            "status": "SUCCESS",
+            "summary": "This should be rejected for leader role.",
+            "deliverables": ["shared/tasks/t-001/result.md"],
+        },
+    })
+    if forbidden_submit.get("ok") or "worker or remote-member role" not in forbidden_submit.get("error", ""):
+        raise AssertionError(f"leader role should not submit: {forbidden_submit!r}")
+
+    os.environ["HICLAW_WORKER_ROLE"] = "worker"
+    remote_ack = payload("taskflow", {
+        "action": "ack_task",
+        "task_id": "remote-001",
+    })
+    if not remote_ack.get("ok") or remote_ack["task"]["status"] != "in_progress":
+        raise AssertionError(f"ack_task did not infer role and pull remote task: {remote_ack!r}")
+    if not (pathlib.Path("#{workspace}") / "shared/tasks/remote-001/spec.md").exists():
+        raise AssertionError("ack_task did not pull remote task spec")
+
+    workspace = pathlib.Path("#{workspace}")
+    spec_path = workspace / "shared/tasks/t-001/spec.md"
+    result_path = workspace / "shared/tasks/t-001/result.md"
+    meta_path = workspace / "shared/tasks/t-001/meta.json"
+    legacy_state_path = workspace / "shared/tasks/t-001/task.json"
+    if not spec_path.exists() or not result_path.exists() or not meta_path.exists():
+        raise AssertionError("task files missing")
+    if legacy_state_path.exists():
+        raise AssertionError(f"task.json should not be written: {legacy_state_path}")
+
+    print(json.dumps({
+        "ok": True,
+      "task": submitted["task"]["task_id"],
+      "status": submitted["task"]["status"],
+      "remoteAck": remote_ack["task"]["task_id"],
+      "specPath": str(spec_path),
+      "resultPath": str(result_path),
+    }, ensure_ascii=False))
+  PY
+
+  env = {"PATH" => "#{bin_dir}:#{ENV.fetch("PATH", "")}"}
+  stdout, stderr, status = Open3.capture3(env, "python3", "-", stdin_data: python_test, chdir: repo_root.to_s)
+  fail!(["teamharness taskflow MCP test failed", stderr, stdout].reject(&:empty?).join("\n")) unless status.success?
+
+  result = JSON.parse(stdout)
+  commands = log_path.read.lines.map(&:strip)
+  fail!("delegate_task did not push task dir: #{commands.inspect}") unless commands.include?(
+    "mirror #{workspace}/shared/tasks/t-001/ mock/shared/tasks/t-001/ --overwrite"
+  )
+  fail!("submit_task did not push only worker-owned files: #{commands.inspect}") unless commands.include?(
+    "mirror #{workspace}/shared/tasks/t-001/ mock/shared/tasks/t-001/ --overwrite --exclude spec.md --exclude base/"
+  )
+  fail!("ack_task did not pull remote task dir: #{commands.inspect}") unless commands.include?(
+    "mirror mock/shared/tasks/remote-001/ #{workspace}/shared/tasks/remote-001 --overwrite"
+  )
+
+  puts JSON.pretty_generate(result.merge("mcCommands" => commands))
+end

--- a/plugins/tests/teamharness/test-contracts.rb
+++ b/plugins/tests/teamharness/test-contracts.rb
@@ -1,0 +1,219 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "pathname"
+require "yaml"
+
+repo_root = Pathname.new(__dir__).join("../../..").expand_path
+plugin_root = repo_root / "plugins/teamharness"
+manifest_path = plugin_root / "plugin.yaml"
+boundary_doc = repo_root / "docs/teamharness-boundary-and-contracts.md"
+
+def fail!(message)
+  warn "ERROR: #{message}"
+  exit 1
+end
+
+def assert(condition, message)
+  fail!(message) unless condition
+end
+
+def assert_file(path)
+  assert(path.file?, "missing file: #{path}")
+end
+
+def read(path)
+  path.read(encoding: "utf-8")
+end
+
+def skill_frontmatter(path)
+  text = read(path)
+  match = text.match(/\A---\n(.*?)\n---\n/m)
+  fail!("skill missing YAML front matter: #{path}") unless match
+  YAML.safe_load(match[1]) || {}
+end
+
+manifest = YAML.load_file(manifest_path)
+
+assert_file(boundary_doc)
+doc = read(boundary_doc)
+[
+  "TeamHarness v0.1",
+  "does not own worker lifecycle",
+  "desired.agentPackage",
+  "HiClaw AgentSpec package"
+].each do |needle|
+  assert(doc.include?(needle), "boundary doc must describe #{needle.inspect}")
+end
+
+assert(manifest.dig("metadata", "name") == "teamharness", "metadata.name must be teamharness")
+
+prompts = manifest.fetch("prompts")
+assert_file(plugin_root / prompts.fetch("team"))
+agent_prompts = prompts.fetch("agent")
+expected_agent_prompts = {
+  "leader" => "prompts/agent/leader.md",
+  "worker" => "prompts/agent/worker.md",
+  "remoteMember" => "prompts/agent/remote-member.md"
+}
+assert(agent_prompts == expected_agent_prompts, "unexpected agent prompts: #{agent_prompts.inspect}")
+manager_prompts = prompts.fetch("manager")
+expected_manager_prompts = {
+  "agents" => "prompts/manager/AGENTS.md",
+  "tools" => "prompts/manager/TOOLS.md",
+  "heartbeat" => "prompts/manager/HEARTBEAT.md"
+}
+assert(manager_prompts == expected_manager_prompts, "unexpected manager prompts: #{manager_prompts.inspect}")
+
+[
+  prompts.fetch("team"),
+  *agent_prompts.values,
+  *manager_prompts.values
+].each { |path| assert_file(plugin_root / path) }
+
+team_prompt = read(plugin_root / prompts.fetch("team"))
+assert(team_prompt.include?("stable collaboration"), "team prompt must define stable collaboration rules")
+assert(team_prompt.include?("not a status database"), "team prompt must reject live status storage")
+assert(team_prompt.include?("Request Modes"), "team prompt must define request modes")
+assert(team_prompt.include?("Direct Reply"), "team prompt must allow ordinary direct replies")
+assert(!team_prompt.include?("Lightweight Action"), "team prompt must not keep the old lightweight action mode")
+assert(team_prompt.include?("Quick Task"), "team prompt must define quick task mode")
+assert(team_prompt.include?("Project Work"), "team prompt must reserve project/task flow for project work")
+assert(team_prompt.include?("Standard Flow Index"), "team prompt must provide a standard flow index")
+assert(team_prompt.include?("| Role | Purpose | Skill | Skill step |"), "team prompt flow index must be role-based")
+assert(team_prompt.include?("Quick Task Flow"), "team prompt must define quick task flow")
+assert(team_prompt.include?("Project Work Flow"), "team prompt must define project work flow")
+assert(team_prompt.include?("restore project state"), "team prompt must restore project state before creating or planning work")
+assert(team_prompt.include?("Create Quick Project"), "team prompt quick task flow must index project-management quick project steps")
+assert(team_prompt.include?("assignment room"), "team prompt must include assignment-room handoff")
+assert(team_prompt.include?("Acknowledge") && team_prompt.include?("Completion Message"), "team prompt must index Worker execution steps")
+assert(team_prompt.include?("project requester source and reply route"), "team prompt must route requester reports through project state")
+assert(!team_prompt.include?("Event Resume Flow"), "team prompt must not expose a standalone event resume flow")
+assert(!team_prompt.include?("check_active_tasks"), "team prompt must not mention cancelled hook recovery checks")
+assert(team_prompt.include?("DAG") && team_prompt.include?("Loop"), "team prompt must retain DAG and Loop project modes")
+assert(team_prompt.include?("shared/tasks/{task-id}/"), "team prompt must define task workspace paths")
+assert(team_prompt.include?("non-overridable"), "team prompt must make credential safety non-overridable")
+assert(team_prompt.include?("authorization headers"), "team prompt must forbid credential disclosure")
+assert(team_prompt.include?("Runtime Agent Boundary"), "team prompt must define runtime-agent boundary")
+assert(team_prompt.include?("TeamHarness roster is the authority"), "team prompt must make TeamHarness roster authoritative")
+assert(team_prompt.include?("chat_with_agent"), "team prompt must mention runtime-native agent tools")
+assert(team_prompt.include?("is a team Worker"), "team prompt must reject runtime-native agents as Workers")
+
+worker_prompt = read(plugin_root / agent_prompts.fetch("worker"))
+assert(worker_prompt.include?("NO_REPLY") && worker_prompt.include?("ping-pong"), "worker prompt must suppress ping-pong")
+assert(worker_prompt.include?("Direct Checks"), "worker prompt must define direct checks")
+assert(worker_prompt.include?("Do not use taskflow"), "worker prompt must avoid taskflow for direct checks")
+remote_prompt = read(plugin_root / agent_prompts.fetch("remoteMember"))
+assert(
+  remote_prompt.include?("not") && remote_prompt.include?("HiClaw-managed Worker"),
+  "remote prompt must define remote worker boundary"
+)
+assert(remote_prompt.include?("current room/session"), "remote prompt must avoid message tool for current-session reports")
+assert(remote_prompt.include?("must leave"), "remote prompt must scope message tool to cross-session routing")
+leader_prompt = read(plugin_root / agent_prompts.fetch("leader"))
+assert(leader_prompt.include?("Do not treat a worker completion message as automatic project acceptance"), "leader prompt must require acceptance")
+assert(leader_prompt.include?("Request Intake"), "leader prompt must define request intake")
+assert(leader_prompt.include?("Do not create a project"), "leader prompt must avoid project state for direct replies")
+manager_prompt = read(plugin_root / manager_prompts.fetch("agents"))
+assert(manager_prompt.include?("control-plane"), "manager prompt must state the control-plane boundary")
+
+skills = manifest.fetch("skills")
+assert(!skills.key?("manager"), "manager control-plane skills are not part of TeamHarness v0.1 manifest")
+expected_skills = {
+  "agent" => {
+    "mcporter" => %w[leader worker manager remote-member],
+    "find-skills" => %w[leader worker manager remote-member]
+  },
+  "team" => {
+    "organization" => %w[leader worker manager remote-member],
+    "communication" => %w[leader worker manager remote-member],
+    "file-sharing" => %w[leader worker manager remote-member],
+    "team-coordination" => %w[leader],
+    "project-management" => %w[leader],
+    "task-delegation" => %w[leader],
+    "task-execution" => %w[worker remote-member]
+  }
+}
+assert(skills.keys.sort == expected_skills.keys.sort, "unexpected skill groups: #{skills.keys.inspect}")
+expected_skills.each do |group, expected|
+  entries = skills.fetch(group)
+  actual = entries.to_h { |entry| [entry.fetch("id"), Array(entry.fetch("roles"))] }
+  assert(actual == expected, "unexpected #{group} skills: #{actual.inspect}")
+  entries.each do |entry|
+    assert(!entry.fetch("id").start_with?("teamharness-"), "skill id must be unprefixed: #{entry.fetch("id")}")
+    skill_path = plugin_root / entry.fetch("path") / "SKILL.md"
+    assert_file(skill_path)
+    frontmatter = skill_frontmatter(skill_path)
+    expected_name = group == "agent" ? entry.fetch("id") : "teamharness-#{entry.fetch("id")}"
+    assert(frontmatter.fetch("name", nil) == expected_name, "skill #{entry.fetch("id")} front matter name must be #{expected_name}")
+    description = frontmatter.fetch("description", "").to_s.strip
+    assert(!description.empty?, "skill #{entry.fetch("id")} front matter description must be present")
+  end
+end
+
+team_skill_dir = plugin_root / "skills/team"
+communication_skill = read(team_skill_dir / "communication/SKILL.md")
+coordination_skill = read(team_skill_dir / "team-coordination/SKILL.md")
+project_skill = read(team_skill_dir / "project-management/SKILL.md")
+delegation_skill = read(team_skill_dir / "task-delegation/SKILL.md")
+execution_skill = read(team_skill_dir / "task-execution/SKILL.md")
+assert(communication_skill.include?("ordinary direct replies"), "communication skill must cover ordinary direct replies")
+assert(communication_skill.include?("lightweight one-off"), "communication skill must cover lightweight one-off routing")
+assert(communication_skill.include?("current room/session"), "communication skill must avoid message tool for current-session replies")
+assert(communication_skill.include?("cross-session"), "communication skill must cover cross-session message routing")
+assert(coordination_skill.include?("Choose Loop"), "coordination skill must retain Loop mode")
+assert(coordination_skill.include?("Do not pre-expand repeated Loop rounds"), "coordination skill must avoid flattening Loop into a large DAG")
+assert(project_skill.include?("Project Work"), "project skill must be scoped to Project Work")
+assert(project_skill.include?("ordinary direct replies"), "project skill must exclude ordinary direct replies")
+assert(project_skill.include?("meta.json"), "project skill must use CoPaw meta.json state")
+assert(project_skill.include?("resolve_project"), "project skill must document project context resume")
+assert(project_skill.include?("accept_task_result"), "project skill must document explicit task result acceptance")
+assert(!project_skill.include?("check_active_tasks"), "project skill must not document cancelled hook recovery checks")
+assert(!project_skill.include?("Hook Recovery Checks"), "project skill must not expose cancelled hook recovery checks")
+assert(project_skill.include?("mark_requester_report_sent"), "project skill must document requester report clearing")
+assert(project_skill.include?("plan_loop"), "project skill must document Loop planning")
+assert(project_skill.include?("ready_loop_nodes"), "project skill must document Loop ready-node resolution")
+assert(project_skill.include?("record_loop_iteration"), "project skill must document Loop iteration recording")
+assert(project_skill.include?("Project Status Reports"), "project skill must include requester status report template")
+assert(project_skill.include?("After the project state changes"), "project skill must require requester visibility after accepted state changes")
+assert(project_skill.include?("Team Room coordination") && project_skill.include?("do not count as the requester report"), "project skill must not count team-room coordination as requester reporting")
+assert(!project_skill.include?("Loop planning, pause/resume/complete"), "project skill must not mark Loop planning as future")
+assert(delegation_skill.include?("ready project node"), "delegation skill must be scoped to ready project nodes")
+assert(delegation_skill.include?("ordinary conversation"), "delegation skill must not turn ordinary conversation into tasks")
+assert(communication_skill.include?("matrix:!roomid:domain"), "communication skill must support legacy Matrix requester routing")
+assert(communication_skill.include?("requester report") && communication_skill.include?("mandatory"), "communication skill must require requester reports after accepted state changes")
+assert(execution_skill.include?("Do not use this skill or taskflow"), "execution skill must exclude direct checks")
+assert(execution_skill.include?("meta.json"), "execution skill must use CoPaw meta.json state")
+
+server = manifest.fetch("mcp").fetch("servers").fetch(0)
+assert(server.fetch("id") == "teamharness", "MCP server id must be teamharness")
+assert(server.fetch("transport") == "stdio", "TeamHarness MCP must use stdio")
+assert(
+  server.fetch("tools") == %w[health message roomflow filesync projectflow taskflow],
+  "unexpected MCP tools: #{server.fetch("tools").inspect}"
+)
+
+assert(!manifest.key?("hooks"), "TeamHarness v0.1 must not define runtime-neutral top-level hooks")
+
+adapters = manifest.fetch("adapters").to_h { |adapter| [adapter.fetch("id"), adapter.fetch("path")] }
+assert(adapters == { "qwenpaw" => "adapters/qwenpaw", "claude-code" => "adapters/claude-code" }, "unexpected adapters: #{adapters.inspect}")
+
+plugin_files = Dir.glob((plugin_root / "**/*").to_s, File::FNM_DOTMATCH)
+  .map { |path| Pathname.new(path) }
+  .select(&:file?)
+  .reject { |path| path.extname == ".pyc" }
+
+combined = plugin_files.map { |path| read(path) }.join("\n")
+[
+  "AGENTTEAM_",
+  "teamharness_periodic_sync",
+  "AGENTTEAM_SYNC_INTERVAL_SECONDS",
+  "/api/agentteam",
+  "agentteam-qwenpaw",
+  "project.json",
+  "task.json"
+].each do |needle|
+  assert(!combined.include?(needle), "forbidden legacy/runtime ownership marker #{needle.inspect}")
+end
+
+puts "ok: teamharness contracts"


### PR DESCRIPTION
## Summary
- add the TeamHarness plugin manifest, prompts, role skills, MCP server, and runtime adapters
- add QwenPaw and Claude Code adapter packaging/install hooks
- add TeamHarness contract, adapter, and MCP tool tests

## Tests
- bash plugins/tests/run-integration-tests.sh
- ruby plugins/tests/teamharness/mcp/tools/test-protocol.rb
- ruby plugins/tests/teamharness/mcp/tools/test-roomflow.rb