### PR TITLE
feat: HiClaw → AgentTeams rename Phase 0 — backwards-compatible groundwork

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -5,6 +5,13 @@
 
 [English](./README.md) | [中文](./README.zh-CN.md) | [日本語](./README.ja-JP.md)
 
+> **📣 プロジェクト改名中：HiClaw → AgentTeams。**
+> CLI バイナリ `hiclaw`、環境変数 `HICLAW_*`、CRD グループ `hiclaw.io`、
+> Helm chart `hiclaw` は引き続き利用できます。新しい対応名
+> （`agt`、`AGENTTEAMS_*`、`agentteams.io`、`agentteams`）は後方互換性を
+> 保ちつつ段階的に導入されています。詳細は
+> [#861](https://github.com/agentscope-ai/HiClaw/issues/861) を参照してください。
+
 <p align="center">
   <a href="https://deepwiki.com/higress-group/hiclaw"><img src="https://img.shields.io/badge/DeepWiki-Ask_AI-navy.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAyCAYAAAAnWDnqAAAAAXNSR0IArs4c6QAAA05JREFUaEPtmUtyEzEQhtWTQyQLHNak2AB7ZnyXZMEjXMGeK/AIi+QuHrMnbChYY7MIh8g01fJoopFb0uhhEqqcbWTp06/uv1saEDv4O3n3dV60RfP947Mm9/SQc0ICFQgzfc4CYZoTPAswgSJCCUJUnAAoRHOAUOcATwbmVLWdGoH//PB8mnKqScAhsD0kYP3j/Yt5LPQe2KvcXmGvRHcDnpxfL2zOYJ1mFwrryWTz0advv1Ut4CJgf5uhDuDj5eUcAUoahrdY/56ebRWeraTjMt/00Sh3UDtjgHtQNHwcRGOC98BJEAEymycmYcWwOprTgcB6VZ5JK5TAJ+fXGLBm3FDAmn6oPPjR4rKCAoJCal2eAiQp2x0vxTPB3ALO2CRkwmDy5WohzBDwSEFKRwPbknEggCPB/imwrycgxX2NzoMCHhPkDwqYMr9tRcP5qNrMZHkVnOjRMWwLCcr8ohBVb1OMjxLwGCvjTikrsBOiA6fNyCrm8V1rP93iVPpwaE+gO0SsWmPiXB+jikdf6SizrT5qKasx5j8ABbHpFTx+vFXp9EnYQmLx02h1QTTrl6eDqxLnGjporxl3NL3agEvXdT0WmEost648sQOYAeJS9Q7bfUVoMGnjo4AZdUMQku50McDcMWcBPvr0SzbTAFDfvJqwLzgxwATnCgnp4wDl6Aa+Ax283gghmj+vj7feE2KBBRMW3FzOpLOADl0Isb5587h/U4gGvkt5v60Z1VLG8BhYjbzRwyQZemwAd6cCR5/XFWLYZRIMpX39AR0tjaGGiGzLVyhse5C9RKC6ai42ppWPKiBagOvaYk8lO7DajerabOZP46Lby5wKjw1HCRx7p9sVMOWGzb/vA1hwiWc6jm3MvQDTogQkiqIhJV0nBQBTU+3okKCFDy9WwferkHjtxib7t3xIUQtHxnIwtx4mpg26/HfwVNVDb4oI9RHmx5WGelRVlrtiw43zboCLaxv46AZeB3IlTkwouebTr1y2NjSpHz68WNFjHvupy3q8TFn3Hos2IAk4Ju5dCo8B3wP7VPr/FGaKiG+T+v+TQqIrOqMTL1VdWV1DdmcbO8KXBz6esmYWYKPwDL5b5FA1a0hwapHiom0r/cKaoqr+27/XcrS5UwSMbQAAAABJRU5ErkJggg==" alt="DeepWiki"></a>
   <a href="https://discord.com/invite/NVjNA4BAVw"><img src="https://img.shields.io/badge/Discord-Join_Us-blueviolet.svg?logo=discord" alt="Discord"></a>

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 
 [English](./README.md) | [中文](./README.zh-CN.md) | [日本語](./README.ja-JP.md)
 
+> **📣 Project rename in progress: HiClaw → AgentTeams.**
+> The CLI binary `hiclaw`, environment variables `HICLAW_*`, the CRD group
+> `hiclaw.io`, and the Helm chart `hiclaw` keep working unchanged. New
+> equivalents (`agt`, `AGENTTEAMS_*`, `agentteams.io`, `agentteams`) are
+> being introduced incrementally with backwards compatibility. See
+> [#861](https://github.com/agentscope-ai/HiClaw/issues/861) for the
+> migration plan and timeline.
+
 <p align="center">
   <a href="https://deepwiki.com/higress-group/hiclaw"><img src="https://img.shields.io/badge/DeepWiki-Ask_AI-navy.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAyCAYAAAAnWDnqAAAAAXNSR0IArs4c6QAAA05JREFUaEPtmUtyEzEQhtWTQyQLHNak2AB7ZnyXZMEjXMGeK/AIi+QuHrMnbChYY7MIh8g01fJoopFb0uhhEqqcbWTp06/uv1saEDv4O3n3dV60RfP947Mm9/SQc0ICFQgzfc4CYZoTPAswgSJCCUJUnAAoRHOAUOcATwbmVLWdGoH//PB8mnKqScAhsD0kYP3j/Yt5LPQe2KvcXmGvRHcDnpxfL2zOYJ1mFwrryWTz0advv1Ut4CJgf5uhDuDj5eUcAUoahrdY/56ebRWeraTjMt/00Sh3UDtjgHtQNHwcRGOC98BJEAEymycmYcWwOprTgcB6VZ5JK5TAJ+fXGLBm3FDAmn6oPPjR4rKCAoJCal2eAiQp2x0vxTPB3ALO2CRkwmDy5WohzBDwSEFKRwPbknEggCPB/imwrycgxX2NzoMCHhPkDwqYMr9tRcP5qNrMZHkVnOjRMWwLCcr8ohBVb1OMjxLwGCvjTikrsBOiA6fNyCrm8V1rP93iVPpwaE+gO0SsWmPiXB+jikdf6SizrT5qKasx5j8ABbHpFTx+vFXp9EnYQmLx02h1QTTrl6eDqxLnGjporxl3NL3agEvXdT0WmEost648sQOYAeJS9Q7bfUVoMGnjo4AZdUMQku50McDcMWcBPvr0SzbTAFDfvJqwLzgxwATnCgnp4wDl6Aa+Ax283gghmj+vj7feE2KBBRMW3FzOpLOADl0Isb5587h/U4gGvkt5v60Z1VLG8BhYjbzRwyQZemwAd6cCR5/XFWLYZRIMpX39AR0tjaGGiGzLVyhse5C9RKC6ai42ppWPKiBagOvaYk8lO7DajerabOZP46Lby5wKjw1HCRx7p9sVMOWGzb/vA1hwiWc6jm3MvQDTogQkiqIhJV0nBQBTU+3okKCFDy9WwferkHjtxib7t3xIUQtHxnIwtx4mpg26/HfwVNVDb4oI9RHmx5WGelRVlrtiw43zboCLaxv46AZeB3IlTkwouebTr1y2NjSpHz68WNFjHvupy3q8TFn3Hos2IAk4Ju5dCo8B3wP7VPr/FGaKiG+T+v+TQqIrOqMTL1VdWV1DdmcbO8KXBz6esmYWYKPwDL5b5FA1a0hwapHiom0r/cKaoqr+27/XcrS5UwSMbQAAAABJRU5ErkJggg==" alt="DeepWiki"></a>
   <a href="https://discord.com/invite/NVjNA4BAVw"><img src="https://img.shields.io/badge/Discord-Join_Us-blueviolet.svg?logo=discord" alt="Discord"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,6 +12,13 @@
 
 [English](./README.md) | [中文](./README.zh-CN.md) | [日本語](./README.ja-JP.md)
 
+> **📣 项目改名进行中：HiClaw → AgentTeams。**
+> CLI 二进制 `hiclaw`、环境变量 `HICLAW_*`、CRD group `hiclaw.io` 以及
+> Helm chart `hiclaw` 都将继续可用。新的对应名称
+> （`agt`、`AGENTTEAMS_*`、`agentteams.io`、`agentteams`）正在分阶段引入，
+> 全程保持向后兼容。详细迁移计划与时间表见
+> [#861](https://github.com/agentscope-ai/HiClaw/issues/861)。
+
 **HiClaw 是一个开源的协作式多智能体运行平台。让多个 Agent 在一个受控、可审计的房间中协作，人类全程可见、随时可介入。 采用 Manager-Workers 架构，Manager 统一调度多个 Workers，专注于企业内的人和 Agent、Agents 之间的协作场景。**
 
 HiClaw 并不和其他 xxClaw 对标，自己不实现 Agent 逻辑，而是编排和管理多个 Agent 容器（Manager 和众多 Workers）。

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -15,3 +15,12 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 - **CoPaw Worker heartbeat**: CoPaw worker templates now seed heartbeat at a 10-minute interval so Team Leader agents created from the worker template can run heartbeat turns without requiring an explicit Team CR heartbeat spec.
 - **Helm CRDs**: Removed unsupported `propertyNames` schema fields from Worker and Team CRDs so Kubernetes API servers accept the chart CRDs.
 - **CoPaw local runtime paths**: CoPaw direct-run defaults now honor `COPAW_INSTALL_DIR` and `COPAW_WORKING_DIR` before falling back to local home-directory paths, while container entrypoints can continue to pass explicit directories.
+
+**HiClaw → AgentTeams rename — Phase 0** (see [#861](https://github.com/agentscope-ai/HiClaw/issues/861))
+
+Backwards-compatible groundwork for the upcoming project rename. Existing `HICLAW_*` env vars, the `hiclaw` CLI, the `hiclaw.io` CRD group, and the `hiclaw` Helm chart all keep working unchanged.
+
+- **Shell `resolve_env` helper**: new `shared/lib/resolve-env.sh` reads `AGENTTEAMS_<KEY>` first and falls back to `HICLAW_<KEY>` with a one-time deprecation warning. `shared/lib/hiclaw-env.sh` now mirrors RUNTIME / MATRIX_URL / AI_GATEWAY_URL / FS_BUCKET / STORAGE_PREFIX / EMBEDDING_MODEL into both prefixes; the "empty string disables embedding" semantic is preserved.
+- **Controller `envcompat` package**: Go counterpart of `resolve_env` (`internal/envcompat`). 77 `os.Getenv("HICLAW_*")` call sites across config, backend, proxy, executor, mail, and CLI now route through `envcompat.Lookup` so any `AGENTTEAMS_*` value transparently overrides the legacy variable. 100 % statement coverage; verified under `go test -race` with a 64-goroutine concurrency stress test that asserts the once-per-key warning guarantee.
+- **Dual-name CLI**: the same Go binary now adapts its `Use` field to `os.Args[0]`, and every container that ships the CLI also installs an `agt` symlink alongside `hiclaw`. End-to-end test invokes the binary under both names via symlink and asserts the help text adapts.
+- **READMEs**: top-of-file rename announcement added to `README.md`, `README.zh-CN.md`, and `README.ja-JP.md` linking to #861.

--- a/copaw/Dockerfile
+++ b/copaw/Dockerfile
@@ -52,6 +52,7 @@ COPY --from=mc /usr/bin/mc /usr/local/bin/mc.bin
 
 # hiclaw CLI — for worker/team/human management via controller REST API
 COPY --from=hiclaw-controller /usr/local/bin/hiclaw /usr/local/bin/hiclaw
+RUN ln -sf /usr/local/bin/hiclaw /usr/local/bin/agt
 
 ARG NPM_REGISTRY=https://registry.npmjs.org/
 

--- a/helm/hiclaw/crds/humans.agentteams.io.yaml
+++ b/helm/hiclaw/crds/humans.agentteams.io.yaml
@@ -1,0 +1,89 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: humans.agentteams.io
+spec:
+  group: agentteams.io
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [displayName, permissionLevel]
+              properties:
+                displayName:
+                  type: string
+                username:
+                  type: string
+                  description: Matrix localpart for this human (fallback to metadata.name)
+                email:
+                  type: string
+                  format: email
+                permissionLevel:
+                  type: integer
+                  minimum: 1
+                  maximum: 3
+                  description: "1=Admin equivalent, 2=Team-scoped, 3=Worker-only (inclusive)"
+                accessibleTeams:
+                  type: array
+                  items:
+                    type: string
+                  description: Teams this human can access (L2)
+                accessibleWorkers:
+                  type: array
+                  items:
+                    type: string
+                  description: Standalone workers this human can access (L2/L3)
+                note:
+                  type: string
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum: [Pending, Active, Failed]
+                matrixUserID:
+                  type: string
+                initialPassword:
+                  type: string
+                  description: "Generated password, shown once on creation"
+                displayNameSyncedGeneration:
+                  type: integer
+                  format: int64
+                rooms:
+                  type: array
+                  items:
+                    type: string
+                emailSent:
+                  type: boolean
+                message:
+                  type: string
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Display Name
+          type: string
+          jsonPath: .spec.displayName
+        - name: Level
+          type: integer
+          jsonPath: .spec.permissionLevel
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Email Sent
+          type: boolean
+          jsonPath: .status.emailSent
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+  scope: Namespaced
+  names:
+    plural: humans
+    singular: human
+    kind: Human
+    shortNames: [hm]

--- a/helm/hiclaw/crds/managers.agentteams.io.yaml
+++ b/helm/hiclaw/crds/managers.agentteams.io.yaml
@@ -1,0 +1,206 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: managers.agentteams.io
+spec:
+  group: agentteams.io
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [model]
+              properties:
+                model:
+                  type: string
+                  description: LLM model ID (e.g. qwen3.6-plus, claude-sonnet-4-6)
+                modelProvider:
+                  type: string
+                  description: Name of the AI gateway Model API to use as the LLM provider.
+                runtime:
+                  type: string
+                  enum: [openclaw, copaw]
+                  description: |
+                    Manager runtime. When omitted the controller falls back to
+                    HICLAW_MANAGER_RUNTIME (set at install time), and finally
+                    to "openclaw" if neither is set.
+                image:
+                  type: string
+                  description: Custom Docker image for the Manager Agent
+                soul:
+                  type: string
+                  description: Custom SOUL.md content
+                agents:
+                  type: string
+                  description: Custom AGENTS.md content
+                skills:
+                  type: array
+                  items:
+                    type: string
+                  description: On-demand skills to enable
+                mcpServers:
+                  type: array
+                  description: MCP servers callable by the Manager via mcporter. url is the full endpoint; transport defaults to http.
+                  items:
+                    type: object
+                    required: [name, url]
+                    properties:
+                      name:
+                        type: string
+                        description: Key in mcporter-servers.json; used by tool calls as <name>.<tool>.
+                      url:
+                        type: string
+                        description: Full MCP endpoint URL (gateway-side path included).
+                      transport:
+                        type: string
+                        enum: [http, sse]
+                        default: http
+                        description: Transport protocol (http=Streamable HTTP, sse=Server-Sent Events).
+                package:
+                  type: string
+                  description: "Package URI: file://, http(s)://, or nacos://"
+                state:
+                  type: string
+                  enum: [Running, Sleeping, Stopped]
+                  description: "Desired lifecycle state (default: Running). The controller reconciles actual state toward this."
+                resources:
+                  type: object
+                  description: >
+                    CPU and memory requests/limits for this Manager Pod.
+                    Empty fields fall back to controller defaults.
+                  properties:
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          description: Kubernetes CPU quantity, e.g. 500m
+                        memory:
+                          type: string
+                          description: Kubernetes memory quantity, e.g. 1Gi
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          description: Kubernetes CPU quantity, e.g. "2"
+                        memory:
+                          type: string
+                          description: Kubernetes memory quantity, e.g. 4Gi
+                env:
+                  type: object
+                  description: |
+                    User-defined environment variables injected into the manager container.
+                    Keys that collide with variables already set by the controller or backend
+                    (HICLAW_*, OPENCLAW_*, HOME, and similar internal keys) are silently
+                    ignored with a warning log — the system value always wins.
+                  additionalProperties:
+                    type: string
+                config:
+                  type: object
+                  properties:
+                    heartbeatInterval:
+                      type: string
+                      description: "Heartbeat check interval (default: 15m)"
+                    workerIdleTimeout:
+                      type: string
+                      description: "Worker idle timeout before auto-sleep (default: 720m)"
+                    notifyChannel:
+                      type: string
+                      description: "Notification channel (default: admin-dm)"
+                labels:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: >
+                    User-defined Pod labels stamped onto the manager's Pod.
+                    Merged on top of the ConfigMap-based pod-template overlay
+                    and CR metadata.labels, and below controller-forced
+                    system labels (agentteams.io/controller, agentteams.io/manager,
+                    agentteams.io/role, agentteams.io/runtime, app). Entries whose
+                    keys collide with those system labels are silently
+                    overridden.
+                accessEntries:
+                  type: array
+                  description: >
+                    Cloud credential scope declarations. Only honored when the controller
+                    runs with a credential-provider sidecar (gateway.provider=ai-gateway
+                    or storage.provider=oss). Ignored in local higress+minio deployments.
+                    When empty the controller applies sensible defaults equivalent to the
+                    legacy manager role (agents/manager/*, shared/*, manager/* on the
+                    configured bucket).
+                  items:
+                    type: object
+                    required: [service]
+                    properties:
+                      service:
+                        type: string
+                        enum: [object-storage, ai-gateway]
+                        description: Logical cloud service identifier
+                      permissions:
+                        type: array
+                        items:
+                          type: string
+                          enum: [read, write, list, delete]
+                      scope:
+                        type: object
+                        description: >
+                          Schema-less scope blob. For object-storage use keys
+                          bucketRef|bucket and prefixes (list of strings). For
+                          ai-gateway use keys gatewayRef|gatewayId and resources
+                          (list of strings). Template vars ${self.name} /
+                          ${self.kind} / ${self.namespace} are expanded by the
+                          controller before the request reaches the provider.
+                        x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  type: integer
+                  format: int64
+                phase:
+                  type: string
+                  enum: [Pending, Running, Sleeping, Updating, Stopped, Failed]
+                matrixUserID:
+                  type: string
+                roomID:
+                  type: string
+                containerState:
+                  type: string
+                version:
+                  type: string
+                message:
+                  type: string
+                welcomeSent:
+                  type: boolean
+                  description: >
+                    True after the controller has delivered the first-boot
+                    onboarding prompt to the Admin DM room. Used as the
+                    idempotency guard for the welcome-message reconcile step;
+                    set once on first successful send and never cleared.
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Model
+          type: string
+          jsonPath: .spec.model
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Runtime
+          type: string
+          jsonPath: .spec.runtime
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+  scope: Namespaced
+  names:
+    plural: managers
+    singular: manager
+    kind: Manager
+    shortNames: [mgr]

--- a/helm/hiclaw/crds/teams.agentteams.io.yaml
+++ b/helm/hiclaw/crds/teams.agentteams.io.yaml
@@ -1,0 +1,530 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: teams.agentteams.io
+spec:
+  group: agentteams.io
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [leader]
+              properties:
+                description:
+                  type: string
+                teamName:
+                  type: string
+                  description: Runtime/storage team identity. Defaults to metadata.name.
+                peerMentions:
+                  type: boolean
+                  description: "Whether team workers can @mention each other in group rooms (default: true)"
+                channelPolicy:
+                  type: object
+                  description: "Team-wide communication policy overrides (applied to all members)"
+                  properties:
+                    groupAllowExtra:
+                      type: array
+                      items:
+                        type: string
+                    groupDenyExtra:
+                      type: array
+                      items:
+                        type: string
+                    dmAllowExtra:
+                      type: array
+                      items:
+                        type: string
+                    dmDenyExtra:
+                      type: array
+                      items:
+                        type: string
+                admin:
+                  type: object
+                  description: "Team-specific admin (human). Has admin authority within this team."
+                  properties:
+                    name:
+                      type: string
+                      description: "Human name (must exist in humans-registry)"
+                    matrixUserId:
+                      type: string
+                      description: "Matrix user ID (e.g. @john:domain)"
+                humanMembers:
+                  type: array
+                  description: "Additional human members of this Team. In this version, role=coordinator joins the Team Room and can assign work there like the Team admin."
+                  items:
+                    type: object
+                    required: [name]
+                    properties:
+                      name:
+                        type: string
+                        description: "Human name / Matrix localpart"
+                      matrixUserId:
+                        type: string
+                        description: "Matrix user ID (e.g. @john:domain)"
+                      role:
+                        type: string
+                        enum: [coordinator]
+                        description: "Human member role. coordinator can @mention the leader/workers in the Team Room; Leader DM remains limited to the Team admin and leader."
+                leader:
+                  type: object
+                  required: [name]
+                  properties:
+                    name:
+                      type: string
+                    workerName:
+                      type: string
+                      description: Runtime identity for leader (Matrix localpart, OSS path key). Defaults to leader.name.
+                    model:
+                      type: string
+                    modelProvider:
+                      type: string
+                      description: Name of the AI gateway Model API to use as the LLM provider.
+                    identity:
+                      type: string
+                    soul:
+                      type: string
+                    agents:
+                      type: string
+                    package:
+                      type: string
+                    remoteSkills:
+                      type: array
+                      description: Remote skills fetched from source registries.
+                      items:
+                        type: object
+                        required: [source, skills]
+                        properties:
+                          source:
+                            type: string
+                            pattern: '^nacos://[^/]+/[^/?#]+$'
+                            description: Remote source in nacos://host[:port]/namespace-id format.
+                          authType:
+                            type: string
+                            enum: [sts-hiclaw, nacos, none]
+                            description: "Authentication mode for remote source access. Empty auto-detects: embedded username/password selects nacos; otherwise none. nacos: username/password embedded in source URL; sts-hiclaw: STS credential provider; none: unauthenticated."
+                          skills:
+                            type: array
+                            minItems: 1
+                            description: Skills to fetch from the remote source.
+                            items:
+                              type: object
+                              required: [name]
+                              properties:
+                                name:
+                                  type: string
+                                version:
+                                  type: string
+                                label:
+                                  type: string
+                    mcpServers:
+                      type: array
+                      description: MCP servers callable via mcporter. url is the full endpoint; transport defaults to http.
+                      items:
+                        type: object
+                        required: [name, url]
+                        properties:
+                          name:
+                            type: string
+                            description: Key in mcporter-servers.json; used by tool calls as <name>.<tool>.
+                          url:
+                            type: string
+                            description: Full MCP endpoint URL (gateway-side path included).
+                          transport:
+                            type: string
+                            enum: [http, sse]
+                    heartbeat:
+                      type: object
+                      properties:
+                        enabled:
+                          type: boolean
+                        every:
+                          type: string
+                    workerIdleTimeout:
+                      type: string
+                    state:
+                      type: string
+                      enum: [Running, Sleeping, Stopped]
+                      description: "Desired lifecycle state for the team leader (default: Running)"
+                    resources:
+                      type: object
+                      description: >
+                        CPU and memory requests/limits for the Team Leader Pod.
+                        Empty fields fall back to controller/backend defaults.
+                      properties:
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              description: Kubernetes CPU quantity, e.g. 300m
+                            memory:
+                              type: string
+                              description: Kubernetes memory quantity, e.g. 768Mi
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              description: Kubernetes CPU quantity, e.g. "2"
+                            memory:
+                              type: string
+                              description: Kubernetes memory quantity, e.g. 3Gi
+                    labels:
+                      type: object
+                      additionalProperties:
+                        type: string
+                      description: >
+                        User-defined Pod labels stamped onto the team leader Pod.
+                        Merged on top of Team.metadata.labels and below controller
+                        system labels. Entries whose keys collide with system labels
+                        are silently overridden.
+                    env:
+                      type: object
+                      description: |
+                        User-defined environment variables injected into the leader container.
+                        Keys that collide with variables already set by the controller or backend
+                        (HICLAW_*, OPENCLAW_*, HOME, and similar internal keys) are silently
+                        ignored with a warning log — the system value always wins.
+                      additionalProperties:
+                        type: string
+                    channelPolicy:
+                      type: object
+                      properties:
+                        groupAllowExtra:
+                          type: array
+                          items:
+                            type: string
+                        groupDenyExtra:
+                          type: array
+                          items:
+                            type: string
+                        dmAllowExtra:
+                          type: array
+                          items:
+                            type: string
+                        dmDenyExtra:
+                          type: array
+                          items:
+                            type: string
+                    accessEntries:
+                      type: array
+                      description: >
+                        Cloud credential scope declarations for the team leader.
+                        Only honored when the controller runs with a credential-
+                        provider sidecar. Ignored in local higress+minio
+                        deployments. When empty the controller applies team-
+                        member defaults (agents/<name>/* + shared/* +
+                        teams/<team>/* on the configured bucket). Leader and
+                        team workers share the same default scope.
+                      items:
+                        type: object
+                        required: [service]
+                        properties:
+                          service:
+                            type: string
+                            enum: [object-storage, ai-gateway, ai-registry]
+                            description: Logical cloud service identifier
+                          permissions:
+                            type: array
+                            items:
+                              type: string
+                              enum: [read, write, list, delete]
+                          scope:
+                            type: object
+                            description: >
+                              Schema-less scope blob. For object-storage use keys
+                              bucketRef|bucket and prefixes (list of strings). For
+                              ai-gateway use keys gatewayRef|gatewayId and
+                              resources (list of strings). Template vars
+                              ${self.name} / ${self.kind} / ${self.namespace} /
+                              ${self.team} are expanded by the controller before
+                              the request reaches the provider.
+                            x-kubernetes-preserve-unknown-fields: true
+                workers:
+                  type: array
+                  items:
+                    type: object
+                    required: [name]
+                    properties:
+                      name:
+                        type: string
+                      workerName:
+                        type: string
+                        description: Runtime identity for worker (Matrix localpart, OSS path key). Defaults to worker.name.
+                      model:
+                        type: string
+                      modelProvider:
+                        type: string
+                        description: Name of the AI gateway Model API to use as the LLM provider.
+                      runtime:
+                        type: string
+                        enum: [openclaw, copaw, hermes, openhuman]
+                      image:
+                        type: string
+                      identity:
+                        type: string
+                      soul:
+                        type: string
+                      agents:
+                        type: string
+                      skills:
+                        type: array
+                        items:
+                          type: string
+                          not:
+                            pattern: '^nacos://'
+                        description: HiClaw built-in skills to enable (remote registry skills must use remoteSkills)
+                      remoteSkills:
+                        type: array
+                        description: Remote skills fetched from source registries.
+                        items:
+                          type: object
+                          required: [source, skills]
+                          properties:
+                            source:
+                              type: string
+                              pattern: '^nacos://[^/]+/[^/?#]+$'
+                              description: Remote source in nacos://host[:port]/namespace-id format.
+                            authType:
+                              type: string
+                              enum: [sts-hiclaw, nacos, none]
+                              description: "Authentication mode for remote source access. Empty auto-detects: embedded username/password selects nacos; otherwise none. nacos: username/password embedded in source URL; sts-hiclaw: STS credential provider; none: unauthenticated."
+                            skills:
+                              type: array
+                              minItems: 1
+                              description: Skills to fetch from the remote source.
+                              items:
+                                type: object
+                                required: [name]
+                                properties:
+                                  name:
+                                    type: string
+                                  version:
+                                    type: string
+                                  label:
+                                    type: string
+                      mcpServers:
+                        type: array
+                        description: MCP servers callable via mcporter. url is the full endpoint; transport defaults to http.
+                        items:
+                          type: object
+                          required: [name, url]
+                          properties:
+                            name:
+                              type: string
+                              description: Key in mcporter-servers.json; used by tool calls as <name>.<tool>.
+                            url:
+                              type: string
+                              description: Full MCP endpoint URL (gateway-side path included).
+                            transport:
+                              type: string
+                              enum: [http, sse]
+                              default: http
+                              description: Transport protocol (http=Streamable HTTP, sse=Server-Sent Events).
+                      package:
+                        type: string
+                      expose:
+                        type: array
+                        description: Ports to expose via Higress gateway
+                        items:
+                          type: object
+                          required: [port]
+                          properties:
+                            port:
+                              type: integer
+                            protocol:
+                              type: string
+                              enum: [http, grpc]
+                              default: http
+                      channelPolicy:
+                        type: object
+                        properties:
+                          groupAllowExtra:
+                            type: array
+                            items:
+                              type: string
+                          groupDenyExtra:
+                            type: array
+                            items:
+                              type: string
+                          dmAllowExtra:
+                            type: array
+                            items:
+                              type: string
+                          dmDenyExtra:
+                            type: array
+                            items:
+                              type: string
+                      state:
+                        type: string
+                        enum: [Running, Sleeping, Stopped]
+                        description: "Desired lifecycle state for this team worker (default: Running)"
+                      resources:
+                        type: object
+                        description: >
+                          CPU and memory requests/limits for this Team Worker
+                          Pod. Empty fields fall back to controller/backend
+                          defaults.
+                        properties:
+                          requests:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                                description: Kubernetes CPU quantity, e.g. 200m
+                              memory:
+                                type: string
+                                description: Kubernetes memory quantity, e.g. 512Mi
+                          limits:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                                description: Kubernetes CPU quantity, e.g. "1"
+                              memory:
+                                type: string
+                                description: Kubernetes memory quantity, e.g. 2Gi
+                      accessEntries:
+                        type: array
+                        description: >
+                          Cloud credential scope declarations for this team
+                          worker. Only honored when the controller runs with a
+                          credential-provider sidecar. Ignored in local higress+
+                          minio deployments. When empty the controller applies
+                          team-member defaults (agents/<name>/* + shared/* +
+                          teams/<team>/* on the configured bucket).
+                        items:
+                          type: object
+                          required: [service]
+                          properties:
+                            service:
+                              type: string
+                              enum: [object-storage, ai-gateway, ai-registry]
+                              description: Logical cloud service identifier
+                            permissions:
+                              type: array
+                              items:
+                                type: string
+                                enum: [read, write, list, delete]
+                            scope:
+                              type: object
+                              description: >
+                                Schema-less scope blob. For object-storage use
+                                keys bucketRef|bucket and prefixes (list of
+                                strings). For ai-gateway use keys gatewayRef|
+                                gatewayId and resources (list of strings).
+                                Template vars ${self.name} / ${self.kind} /
+                                ${self.namespace} / ${self.team} are expanded by
+                                the controller before the request reaches the
+                                provider.
+                              x-kubernetes-preserve-unknown-fields: true
+                      labels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >
+                          User-defined Pod labels stamped onto this team worker Pod.
+                          Merged on top of Team.metadata.labels and below controller
+                          system labels. Entries whose keys collide with system labels
+                          are silently overridden.
+                      env:
+                        type: object
+                        description: |
+                          User-defined environment variables injected into this team worker's
+                          container. Keys that collide with variables already set by the
+                          controller or backend (HICLAW_*, OPENCLAW_*, HOME, and similar
+                          internal keys) are silently ignored with a warning log — the system
+                          value always wins.
+                        additionalProperties:
+                          type: string
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum: [Pending, Active, Degraded, Failed]
+                teamRoomID:
+                  type: string
+                leaderDMRoomID:
+                  type: string
+                leaderReady:
+                  type: boolean
+                readyWorkers:
+                  type: integer
+                totalWorkers:
+                  type: integer
+                message:
+                  type: string
+                members:
+                  type: array
+                  description: "Per-member state (leader + workers). Consolidates all per-member fields (observed, spec hash, roomID, matrixUserID, exposedPorts) into a single sorted-by-name slice."
+                  items:
+                    type: object
+                    required: [name]
+                    properties:
+                      name:
+                        type: string
+                        description: "Member's canonical name (matches spec.leader.name or spec.workers[i].name)."
+                      runtimeName:
+                        type: string
+                        description: "Member runtime identity key (Matrix localpart, OSS path key). Empty falls back to name."
+                      role:
+                        type: string
+                        enum: [team_leader, worker]
+                        description: "Role of this member."
+                      roomID:
+                        type: string
+                        description: "Member's personal communication room with the Manager."
+                      matrixUserID:
+                        type: string
+                        description: "Member's Matrix MXID."
+                      specHash:
+                        type: string
+                        description: "fnv64a hash of the last fully-reconciled WorkerSpec for this member. Empty means never fully reconciled."
+                      observed:
+                        type: boolean
+                        description: "True once ReconcileMemberInfra has succeeded at least once; stays true across post-infra failures to avoid Matrix access token rotation."
+                      ready:
+                        type: boolean
+                        description: "Mirrors backend.Status Running/Ready. Aggregates into leaderReady and readyWorkers."
+                      exposedPorts:
+                        type: array
+                        description: "Ports currently exposed via Higress for this member (workers only)."
+                        items:
+                          type: object
+                          required: [port, domain]
+                          properties:
+                            port:
+                              type: integer
+                            domain:
+                              type: string
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Leader
+          type: string
+          jsonPath: .spec.leader.name
+        - name: Workers
+          type: integer
+          jsonPath: .status.totalWorkers
+        - name: Ready
+          type: integer
+          jsonPath: .status.readyWorkers
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+  scope: Namespaced
+  names:
+    plural: teams
+    singular: team
+    kind: Team
+    shortNames: [tm]

--- a/helm/hiclaw/crds/workers.agentteams.io.yaml
+++ b/helm/hiclaw/crds/workers.agentteams.io.yaml
@@ -1,0 +1,280 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workers.agentteams.io
+spec:
+  group: agentteams.io
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [model]
+              properties:
+                model:
+                  type: string
+                  description: LLM model ID (e.g. claude-sonnet-4-6, qwen3.6-plus)
+                modelProvider:
+                  type: string
+                  description: Name of the AI gateway Model API to use as the LLM provider.
+                runtime:
+                  type: string
+                  enum: [openclaw, copaw, hermes, openhuman]
+                  description: |
+                    Agent runtime. When omitted the controller falls back to
+                    HICLAW_DEFAULT_WORKER_RUNTIME (set at install time), and
+                    finally to "openclaw" if neither is set.
+                image:
+                  type: string
+                  description: Custom Docker image for this worker
+                workerName:
+                  type: string
+                  description: Business/runtime identity for Matrix localpart and OSS path key (fallback to metadata.name)
+                identity:
+                  type: string
+                  description: Worker public identity (generates IDENTITY.md; merged into SOUL.md for copaw and hermes)
+                soul:
+                  type: string
+                  description: Worker identity and role definition (generates SOUL.md)
+                agents:
+                  type: string
+                  description: Agent behavior rules (generates AGENTS.md)
+                skills:
+                  type: array
+                  items:
+                    type: string
+                    not:
+                      pattern: '^nacos://'
+                  description: HiClaw built-in skills to enable (remote registry skills must use remoteSkills)
+                remoteSkills:
+                  type: array
+                  description: Remote skills fetched from source registries.
+                  items:
+                    type: object
+                    required: [source, skills]
+                    properties:
+                      source:
+                        type: string
+                        pattern: '^nacos://[^/]+/[^/?#]+$'
+                        description: Remote source in nacos://host[:port]/namespace-id format.
+                      authType:
+                        type: string
+                        enum: [sts-hiclaw, nacos, none]
+                        description: "Authentication mode for remote source access. Empty auto-detects: embedded username/password selects nacos; otherwise none. nacos: username/password embedded in source URL; sts-hiclaw: STS credential provider; none: unauthenticated."
+                      skills:
+                        type: array
+                        minItems: 1
+                        description: Skills to fetch from the remote source.
+                        items:
+                          type: object
+                          required: [name]
+                          properties:
+                            name:
+                              type: string
+                            version:
+                              type: string
+                            label:
+                              type: string
+                mcpServers:
+                  type: array
+                  description: MCP servers callable via mcporter. url is the full endpoint; transport defaults to http.
+                  items:
+                    type: object
+                    required: [name, url]
+                    properties:
+                      name:
+                        type: string
+                        description: Key in mcporter-servers.json; used by tool calls as <name>.<tool>.
+                      url:
+                        type: string
+                        description: Full MCP endpoint URL (gateway-side path included).
+                      transport:
+                        type: string
+                        enum: [http, sse]
+                        default: http
+                        description: Transport protocol (http=Streamable HTTP, sse=Server-Sent Events).
+                package:
+                  type: string
+                  description: "Package URI: file://, http(s)://, nacos://, or packages/{name}.zip"
+                expose:
+                  type: array
+                  description: Ports to expose via Higress gateway. Each port gets an auto-generated domain.
+                  items:
+                    type: object
+                    required: [port]
+                    properties:
+                      port:
+                        type: integer
+                        description: Container port to expose
+                      protocol:
+                        type: string
+                        enum: [http, grpc]
+                        default: http
+                        description: Protocol (default http)
+                channelPolicy:
+                  type: object
+                  description: "Additive/subtractive overrides for communication policies (on top of defaults)"
+                  properties:
+                    groupAllowExtra:
+                      type: array
+                      items:
+                        type: string
+                      description: "Additional Matrix user IDs to allow in group @mentions"
+                    groupDenyExtra:
+                      type: array
+                      items:
+                        type: string
+                      description: "Matrix user IDs to deny from group @mentions (overrides allow)"
+                    dmAllowExtra:
+                      type: array
+                      items:
+                        type: string
+                      description: "Additional Matrix user IDs to allow in DMs"
+                    dmDenyExtra:
+                      type: array
+                      items:
+                        type: string
+                      description: "Matrix user IDs to deny from DMs (overrides allow)"
+                containerManaged:
+                  type: boolean
+                  description: >
+                    When false, the controller skips container lifecycle management
+                    for this worker. Use for remote workers whose process is managed
+                    externally (e.g., via systemd). Default is true (controller
+                    creates and manages containers).
+                state:
+                  type: string
+                  enum: [Running, Sleeping, Stopped]
+                  description: "Desired lifecycle state (default: Running). The controller reconciles actual state toward this."
+                resources:
+                  type: object
+                  description: >
+                    CPU and memory requests/limits for this Worker Pod.
+                    Empty fields fall back to controller/backend defaults.
+                  properties:
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          description: Kubernetes CPU quantity, e.g. 250m
+                        memory:
+                          type: string
+                          description: Kubernetes memory quantity, e.g. 512Mi
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          description: Kubernetes CPU quantity, e.g. "2"
+                        memory:
+                          type: string
+                          description: Kubernetes memory quantity, e.g. 2Gi
+                env:
+                  type: object
+                  description: |
+                    User-defined environment variables injected into the worker container.
+                    Keys that collide with variables already set by the controller or backend
+                    (HICLAW_*, OPENCLAW_*, HOME, and similar internal keys) are silently
+                    ignored with a warning log — the system value always wins.
+                  additionalProperties:
+                    type: string
+                labels:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: >
+                    User-defined Pod labels stamped onto this worker's Pod.
+                    Merged on top of the ConfigMap-based pod-template overlay
+                    and CR metadata.labels, and below controller-forced
+                    system labels (agentteams.io/controller, agentteams.io/worker,
+                    agentteams.io/role, agentteams.io/runtime, app). Entries whose
+                    keys collide with those system labels are silently
+                    overridden.
+                accessEntries:
+                  type: array
+                  description: >
+                    Cloud credential scope declarations. Only honored when the controller
+                    runs with a credential-provider sidecar (gateway.provider=ai-gateway
+                    or storage.provider=oss). Ignored in local higress+minio deployments.
+                    When empty the controller applies sensible defaults equivalent to the
+                    legacy worker role (agents/<name>/* + shared/* on the configured bucket).
+                  items:
+                    type: object
+                    required: [service]
+                    properties:
+                      service:
+                        type: string
+                        enum: [object-storage, ai-gateway, ai-registry]
+                        description: Logical cloud service identifier
+                      permissions:
+                        type: array
+                        items:
+                          type: string
+                          enum: [read, write, list, delete]
+                      scope:
+                        type: object
+                        description: >
+                          Schema-less scope blob. For object-storage use keys
+                          bucketRef|bucket and prefixes (list of strings). For
+                          ai-gateway use keys gatewayRef|gatewayId and resources
+                          (list of strings). Template vars ${self.name} /
+                          ${self.kind} / ${self.namespace} are expanded by the
+                          controller before the request reaches the provider.
+                        x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  type: integer
+                  format: int64
+                phase:
+                  type: string
+                  enum: [Pending, Running, Sleeping, Updating, Stopped, Failed]
+                matrixUserID:
+                  type: string
+                roomID:
+                  type: string
+                containerState:
+                  type: string
+                lastHeartbeat:
+                  type: string
+                  format: date-time
+                message:
+                  type: string
+                exposedPorts:
+                  type: array
+                  description: Ports currently exposed via Higress gateway
+                  items:
+                    type: object
+                    properties:
+                      port:
+                        type: integer
+                      domain:
+                        type: string
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Model
+          type: string
+          jsonPath: .spec.model
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Runtime
+          type: string
+          jsonPath: .spec.runtime
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+  scope: Namespaced
+  names:
+    plural: workers
+    singular: worker
+    kind: Worker
+    shortNames: [wk]

--- a/hermes/Dockerfile
+++ b/hermes/Dockerfile
@@ -69,6 +69,7 @@ COPY --from=mc /usr/bin/mc /usr/local/bin/mc.bin
 
 # hiclaw CLI — for worker/team/human management via controller REST API
 COPY --from=hiclaw-controller /usr/local/bin/hiclaw /usr/local/bin/hiclaw
+RUN ln -sf /usr/local/bin/hiclaw /usr/local/bin/agt
 
 # Install Node.js 22 for shared Worker CLIs (mcporter, skills CLI compatibility)
 RUN apt-get update && \

--- a/hiclaw-controller/Dockerfile
+++ b/hiclaw-controller/Dockerfile
@@ -48,17 +48,21 @@ RUN apk add --no-cache bash jq curl unzip kubectl
 COPY --from=mc /usr/bin/mc /usr/local/bin/mc
 COPY --from=builder /hiclaw-controller /usr/local/bin/hiclaw-controller
 COPY --from=builder /hiclaw /usr/local/bin/hiclaw
+# AgentTeams rename (#861): the same binary is also exposed as `agt`.
+# Both names work during the transition; `hiclaw` will be removed in a
+# future major release.
+RUN ln -sf /usr/local/bin/hiclaw /usr/local/bin/agt
 COPY --from=kube-bin /kube-apiserver /usr/local/bin/kube-apiserver
 COPY config/crd/ /opt/hiclaw/config/crd/
 COPY agent/ /opt/hiclaw/agent/
 
-# Default endpoint + token-file for the bundled `hiclaw` CLI when invoked via
-# `docker exec hiclaw-controller hiclaw …`. The controller process mints a
-# long-lived admin SA token at startup (see internal/app.bootstrapAdminCLIToken)
-# and writes it to HICLAW_AUTH_TOKEN_FILE; the CLI's discoverToken() then
-# auto-loads it so operators don't need to pass `-e HICLAW_AUTH_TOKEN=…` on
-# every exec. Both vars are container-local defaults — `docker exec -e` still
-# overrides them, and the controller binary itself does not read them.
+# Default endpoint + token-file for the bundled `hiclaw` / `agt` CLI when
+# invoked via `docker exec hiclaw-controller hiclaw …`. The controller process
+# mints a long-lived admin SA token at startup (see
+# internal/app.bootstrapAdminCLIToken) and writes it to HICLAW_AUTH_TOKEN_FILE;
+# the CLI's discoverToken() then auto-loads it so operators don't need to pass
+# `-e HICLAW_AUTH_TOKEN=…` on every exec. AGENTTEAMS_* counterparts are
+# accepted via the envcompat layer in internal/envcompat.
 ENV HICLAW_CONTROLLER_URL=http://127.0.0.1:8090 \
     HICLAW_AUTH_TOKEN_FILE=/var/run/hiclaw/cli-token
 

--- a/hiclaw-controller/Dockerfile.embedded
+++ b/hiclaw-controller/Dockerfile.embedded
@@ -52,6 +52,7 @@ COPY --from=element-web /app /opt/element-web
 # hiclaw-controller + hiclaw CLI + kube-apiserver
 COPY --from=hiclaw-controller /usr/local/bin/hiclaw-controller /usr/local/bin/hiclaw-controller
 COPY --from=hiclaw-controller /usr/local/bin/hiclaw /usr/local/bin/hiclaw
+RUN ln -sf /usr/local/bin/hiclaw /usr/local/bin/agt
 COPY --from=hiclaw-controller /usr/local/bin/kube-apiserver /usr/local/bin/kube-apiserver
 COPY --from=hiclaw-controller /opt/hiclaw/config/crd/ /opt/hiclaw/config/crd/
 

--- a/hiclaw-controller/api/agentteams/v1beta1/register.go
+++ b/hiclaw-controller/api/agentteams/v1beta1/register.go
@@ -1,0 +1,53 @@
+// Package v1beta1 registers the agentteams.io/v1beta1 API group, reusing the
+// same Go types as hiclaw.io/v1beta1 via type aliases. This enables the
+// controller to watch both groups with the same reconcile logic during the
+// HiClaw → AgentTeams rename transition (Phase 0, see #861).
+//
+// +k8s:deepcopy-gen=package
+package v1beta1
+
+import (
+	hiclaw "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	GroupName = "agentteams.io"
+	Version   = "v1beta1"
+)
+
+var (
+	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: Version}
+	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme        = SchemeBuilder.AddToScheme
+)
+
+// Type aliases — the agentteams.io group uses the exact same struct
+// definitions as hiclaw.io, just registered under a different group.
+type (
+	Worker      = hiclaw.Worker
+	WorkerList  = hiclaw.WorkerList
+	Team        = hiclaw.Team
+	TeamList    = hiclaw.TeamList
+	Human       = hiclaw.Human
+	HumanList   = hiclaw.HumanList
+	Manager     = hiclaw.Manager
+	ManagerList = hiclaw.ManagerList
+)
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&Worker{},
+		&WorkerList{},
+		&Team{},
+		&TeamList{},
+		&Human{},
+		&HumanList{},
+		&Manager{},
+		&ManagerList{},
+	)
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}

--- a/hiclaw-controller/api/v1beta1/types.go
+++ b/hiclaw-controller/api/v1beta1/types.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	GroupName = "hiclaw.io"
-	Version   = "v1beta1"
+	GroupName    = "hiclaw.io"
+	GroupNameNew = "agentteams.io"
+	Version      = "v1beta1"
 )
 
 // LabelController marks the hiclaw-controller instance that owns a CR.

--- a/hiclaw-controller/cmd/hiclaw/client.go
+++ b/hiclaw-controller/cmd/hiclaw/client.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/hiclaw/hiclaw-controller/internal/envcompat"
 )
 
 // APIClient is a thin HTTP wrapper for the hiclaw-controller REST API.
@@ -31,7 +33,7 @@ func (e *APIError) Error() string {
 
 // NewAPIClient constructs a client from environment variables.
 func NewAPIClient() *APIClient {
-	baseURL := os.Getenv("HICLAW_CONTROLLER_URL")
+	baseURL := envcompat.Lookup("HICLAW_CONTROLLER_URL")
 	if baseURL == "" {
 		baseURL = "http://localhost:8090"
 	}
@@ -51,10 +53,10 @@ func NewAPIClient() *APIClient {
 //  2. HICLAW_AUTH_TOKEN_FILE env var pointing to a token file (K8s projected volume)
 //  3. empty string (unauthenticated, for controllers with auth disabled)
 func discoverToken() string {
-	if token := os.Getenv("HICLAW_AUTH_TOKEN"); token != "" {
+	if token := envcompat.Lookup("HICLAW_AUTH_TOKEN"); token != "" {
 		return token
 	}
-	if path := os.Getenv("HICLAW_AUTH_TOKEN_FILE"); path != "" {
+	if path := envcompat.Lookup("HICLAW_AUTH_TOKEN_FILE"); path != "" {
 		if data, err := os.ReadFile(path); err == nil {
 			if t := strings.TrimSpace(string(data)); t != "" {
 				return t

--- a/hiclaw-controller/cmd/hiclaw/create.go
+++ b/hiclaw-controller/cmd/hiclaw/create.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hiclaw/hiclaw-controller/internal/envcompat"
 	"github.com/spf13/cobra"
 )
 
@@ -434,7 +435,7 @@ var workerNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 // fallback every `hiclaw create worker` / `hiclaw apply worker` invoked by the
 // Manager Agent would silently override the admin's install-time model choice.
 func defaultWorkerModel() string {
-	if m := strings.TrimSpace(os.Getenv("HICLAW_DEFAULT_MODEL")); m != "" {
+	if m := strings.TrimSpace(envcompat.Lookup("HICLAW_DEFAULT_MODEL")); m != "" {
 		return m
 	}
 	return "qwen3.6-plus"
@@ -457,7 +458,7 @@ func expandPackageURI(raw string) (string, error) {
 		return raw, nil
 	}
 
-	base := strings.TrimSpace(os.Getenv("HICLAW_NACOS_REGISTRY_URI"))
+	base := strings.TrimSpace(envcompat.Lookup("HICLAW_NACOS_REGISTRY_URI"))
 	if base == "" {
 		base = "nacos://market.hiclaw.io:80/public"
 	}

--- a/hiclaw-controller/cmd/hiclaw/dual_name_test.go
+++ b/hiclaw-controller/cmd/hiclaw/dual_name_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestCLIDualName builds the CLI once, invokes it under both `hiclaw` and
+// `agt` names via symlink, and asserts that --help output reflects the
+// invocation name. This guards the AgentTeams rename (#861) requirement
+// that both names continue to work.
+func TestCLIDualName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping CLI build test in -short mode")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test not supported on Windows")
+	}
+
+	tmp := t.TempDir()
+	hiclawBin := filepath.Join(tmp, "hiclaw")
+
+	build := exec.Command("go", "build", "-o", hiclawBin, ".")
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		t.Fatalf("go build: %v", err)
+	}
+
+	agtBin := filepath.Join(tmp, "agt")
+	if err := os.Symlink(hiclawBin, agtBin); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		bin      string
+		wantUse  string
+	}{
+		{"invoked as hiclaw", hiclawBin, "hiclaw"},
+		{"invoked as agt", agtBin, "agt"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command(tc.bin, "--help")
+			var out bytes.Buffer
+			cmd.Stdout = &out
+			cmd.Stderr = &out
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("%s --help failed: %v\noutput:\n%s", tc.bin, err, out.String())
+			}
+			s := out.String()
+			// cobra renders "Usage:\n  <Use> [command]" — verify the program
+			// adapted to its invocation name.
+			needle := "Usage:\n  " + tc.wantUse
+			if !bytes.Contains(out.Bytes(), []byte(needle)) {
+				t.Errorf("expected %q in --help output, got:\n%s", needle, s)
+			}
+			// Both invocations should show the AgentTeams rename note.
+			if !bytes.Contains(out.Bytes(), []byte("AgentTeams")) {
+				t.Errorf("expected 'AgentTeams' in --help output, got:\n%s", s)
+			}
+		})
+	}
+}

--- a/hiclaw-controller/cmd/hiclaw/main.go
+++ b/hiclaw-controller/cmd/hiclaw/main.go
@@ -2,21 +2,31 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
 
 func main() {
-	rootCmd := &cobra.Command{
-		Use:   "hiclaw",
-		Short: "HiClaw resource management CLI",
-		Long: `HiClaw CLI — manages Workers, Teams, Humans, and Managers via the
-hiclaw-controller REST API.
+	invoked := filepath.Base(os.Args[0])
+	if invoked == "" || invoked == "." || invoked == "/" {
+		invoked = "agt"
+	}
 
-Environment variables:
-  HICLAW_CONTROLLER_URL   Controller base URL (default: http://localhost:8090)
-  HICLAW_AUTH_TOKEN        Bearer token for authentication
-  HICLAW_AUTH_TOKEN_FILE   Path to a file containing the bearer token (K8s projected volume)`,
+	rootCmd := &cobra.Command{
+		Use:   invoked,
+		Short: "AgentTeams resource management CLI",
+		Long: `AgentTeams CLI — manages Workers, Teams, Humans, and Managers via the
+controller REST API. Formerly distributed as ` + "`hiclaw`" + `; both binary
+names are supported during the rename transition (see #861).
+
+Environment variables (AGENTTEAMS_ takes precedence; HICLAW_ falls back):
+  AGENTTEAMS_CONTROLLER_URL / HICLAW_CONTROLLER_URL
+        Controller base URL (default: http://localhost:8090)
+  AGENTTEAMS_AUTH_TOKEN / HICLAW_AUTH_TOKEN
+        Bearer token for authentication
+  AGENTTEAMS_AUTH_TOKEN_FILE / HICLAW_AUTH_TOKEN_FILE
+        Path to a file containing the bearer token (K8s projected volume)`,
 	}
 
 	rootCmd.AddCommand(applyCmd())

--- a/hiclaw-controller/cmd/hiclaw/worker_cmd.go
+++ b/hiclaw-controller/cmd/hiclaw/worker_cmd.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/hiclaw/hiclaw-controller/internal/envcompat"
 	"github.com/spf13/cobra"
 )
 
@@ -236,10 +237,10 @@ func workerReportReadyCmd() *cobra.Command {
 Worker name is read from --name, HICLAW_WORKER_CR_NAME, or HICLAW_WORKER_NAME env var.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if name == "" {
-				name = os.Getenv("HICLAW_WORKER_CR_NAME")
+				name = envcompat.Lookup("HICLAW_WORKER_CR_NAME")
 			}
 			if name == "" {
-				name = os.Getenv("HICLAW_WORKER_NAME")
+				name = envcompat.Lookup("HICLAW_WORKER_NAME")
 			}
 			if name == "" {
 				return fmt.Errorf("--name, HICLAW_WORKER_CR_NAME, or HICLAW_WORKER_NAME is required")

--- a/hiclaw-controller/config/crd/humans.agentteams.io.yaml
+++ b/hiclaw-controller/config/crd/humans.agentteams.io.yaml
@@ -1,0 +1,89 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: humans.agentteams.io
+spec:
+  group: agentteams.io
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [displayName, permissionLevel]
+              properties:
+                displayName:
+                  type: string
+                username:
+                  type: string
+                  description: Matrix localpart for this human (fallback to metadata.name)
+                email:
+                  type: string
+                  format: email
+                permissionLevel:
+                  type: integer
+                  minimum: 1
+                  maximum: 3
+                  description: "1=Admin equivalent, 2=Team-scoped, 3=Worker-only (inclusive)"
+                accessibleTeams:
+                  type: array
+                  items:
+                    type: string
+                  description: Teams this human can access (L2)
+                accessibleWorkers:
+                  type: array
+                  items:
+                    type: string
+                  description: Standalone workers this human can access (L2/L3)
+                note:
+                  type: string
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum: [Pending, Active, Failed]
+                matrixUserID:
+                  type: string
+                initialPassword:
+                  type: string
+                  description: "Generated password, shown once on creation"
+                displayNameSyncedGeneration:
+                  type: integer
+                  format: int64
+                rooms:
+                  type: array
+                  items:
+                    type: string
+                emailSent:
+                  type: boolean
+                message:
+                  type: string
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Display Name
+          type: string
+          jsonPath: .spec.displayName
+        - name: Level
+          type: integer
+          jsonPath: .spec.permissionLevel
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Email Sent
+          type: boolean
+          jsonPath: .status.emailSent
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+  scope: Namespaced
+  names:
+    plural: humans
+    singular: human
+    kind: Human
+    shortNames: [hm]

--- a/hiclaw-controller/config/crd/managers.agentteams.io.yaml
+++ b/hiclaw-controller/config/crd/managers.agentteams.io.yaml
@@ -1,0 +1,206 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: managers.agentteams.io
+spec:
+  group: agentteams.io
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [model]
+              properties:
+                model:
+                  type: string
+                  description: LLM model ID (e.g. qwen3.6-plus, claude-sonnet-4-6)
+                modelProvider:
+                  type: string
+                  description: Name of the AI gateway Model API to use as the LLM provider.
+                runtime:
+                  type: string
+                  enum: [openclaw, copaw]
+                  description: |
+                    Manager runtime. When omitted the controller falls back to
+                    HICLAW_MANAGER_RUNTIME (set at install time), and finally
+                    to "openclaw" if neither is set.
+                image:
+                  type: string
+                  description: Custom Docker image for the Manager Agent
+                soul:
+                  type: string
+                  description: Custom SOUL.md content
+                agents:
+                  type: string
+                  description: Custom AGENTS.md content
+                skills:
+                  type: array
+                  items:
+                    type: string
+                  description: On-demand skills to enable
+                mcpServers:
+                  type: array
+                  description: MCP servers callable by the Manager via mcporter. url is the full endpoint; transport defaults to http.
+                  items:
+                    type: object
+                    required: [name, url]
+                    properties:
+                      name:
+                        type: string
+                        description: Key in mcporter-servers.json; used by tool calls as <name>.<tool>.
+                      url:
+                        type: string
+                        description: Full MCP endpoint URL (gateway-side path included).
+                      transport:
+                        type: string
+                        enum: [http, sse]
+                        default: http
+                        description: Transport protocol (http=Streamable HTTP, sse=Server-Sent Events).
+                package:
+                  type: string
+                  description: "Package URI: file://, http(s)://, or nacos://"
+                state:
+                  type: string
+                  enum: [Running, Sleeping, Stopped]
+                  description: "Desired lifecycle state (default: Running). The controller reconciles actual state toward this."
+                resources:
+                  type: object
+                  description: >
+                    CPU and memory requests/limits for this Manager Pod.
+                    Empty fields fall back to controller defaults.
+                  properties:
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          description: Kubernetes CPU quantity, e.g. 500m
+                        memory:
+                          type: string
+                          description: Kubernetes memory quantity, e.g. 1Gi
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          description: Kubernetes CPU quantity, e.g. "2"
+                        memory:
+                          type: string
+                          description: Kubernetes memory quantity, e.g. 4Gi
+                env:
+                  type: object
+                  description: |
+                    User-defined environment variables injected into the manager container.
+                    Keys that collide with variables already set by the controller or backend
+                    (HICLAW_*, OPENCLAW_*, HOME, and similar internal keys) are silently
+                    ignored with a warning log — the system value always wins.
+                  additionalProperties:
+                    type: string
+                config:
+                  type: object
+                  properties:
+                    heartbeatInterval:
+                      type: string
+                      description: "Heartbeat check interval (default: 15m)"
+                    workerIdleTimeout:
+                      type: string
+                      description: "Worker idle timeout before auto-sleep (default: 720m)"
+                    notifyChannel:
+                      type: string
+                      description: "Notification channel (default: admin-dm)"
+                labels:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: >
+                    User-defined Pod labels stamped onto the manager's Pod.
+                    Merged on top of the ConfigMap-based pod-template overlay
+                    and CR metadata.labels, and below controller-forced
+                    system labels (agentteams.io/controller, agentteams.io/manager,
+                    agentteams.io/role, agentteams.io/runtime, app). Entries whose
+                    keys collide with those system labels are silently
+                    overridden.
+                accessEntries:
+                  type: array
+                  description: >
+                    Cloud credential scope declarations. Only honored when the controller
+                    runs with a credential-provider sidecar (gateway.provider=ai-gateway
+                    or storage.provider=oss). Ignored in local higress+minio deployments.
+                    When empty the controller applies sensible defaults equivalent to the
+                    legacy manager role (agents/manager/*, shared/*, manager/* on the
+                    configured bucket).
+                  items:
+                    type: object
+                    required: [service]
+                    properties:
+                      service:
+                        type: string
+                        enum: [object-storage, ai-gateway]
+                        description: Logical cloud service identifier
+                      permissions:
+                        type: array
+                        items:
+                          type: string
+                          enum: [read, write, list, delete]
+                      scope:
+                        type: object
+                        description: >
+                          Schema-less scope blob. For object-storage use keys
+                          bucketRef|bucket and prefixes (list of strings). For
+                          ai-gateway use keys gatewayRef|gatewayId and resources
+                          (list of strings). Template vars ${self.name} /
+                          ${self.kind} / ${self.namespace} are expanded by the
+                          controller before the request reaches the provider.
+                        x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  type: integer
+                  format: int64
+                phase:
+                  type: string
+                  enum: [Pending, Running, Sleeping, Updating, Stopped, Failed]
+                matrixUserID:
+                  type: string
+                roomID:
+                  type: string
+                containerState:
+                  type: string
+                version:
+                  type: string
+                message:
+                  type: string
+                welcomeSent:
+                  type: boolean
+                  description: >
+                    True after the controller has delivered the first-boot
+                    onboarding prompt to the Admin DM room. Used as the
+                    idempotency guard for the welcome-message reconcile step;
+                    set once on first successful send and never cleared.
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Model
+          type: string
+          jsonPath: .spec.model
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Runtime
+          type: string
+          jsonPath: .spec.runtime
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+  scope: Namespaced
+  names:
+    plural: managers
+    singular: manager
+    kind: Manager
+    shortNames: [mgr]

--- a/hiclaw-controller/config/crd/teams.agentteams.io.yaml
+++ b/hiclaw-controller/config/crd/teams.agentteams.io.yaml
@@ -1,0 +1,530 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: teams.agentteams.io
+spec:
+  group: agentteams.io
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [leader]
+              properties:
+                description:
+                  type: string
+                teamName:
+                  type: string
+                  description: Runtime/storage team identity. Defaults to metadata.name.
+                peerMentions:
+                  type: boolean
+                  description: "Whether team workers can @mention each other in group rooms (default: true)"
+                channelPolicy:
+                  type: object
+                  description: "Team-wide communication policy overrides (applied to all members)"
+                  properties:
+                    groupAllowExtra:
+                      type: array
+                      items:
+                        type: string
+                    groupDenyExtra:
+                      type: array
+                      items:
+                        type: string
+                    dmAllowExtra:
+                      type: array
+                      items:
+                        type: string
+                    dmDenyExtra:
+                      type: array
+                      items:
+                        type: string
+                admin:
+                  type: object
+                  description: "Team-specific admin (human). Has admin authority within this team."
+                  properties:
+                    name:
+                      type: string
+                      description: "Human name (must exist in humans-registry)"
+                    matrixUserId:
+                      type: string
+                      description: "Matrix user ID (e.g. @john:domain)"
+                humanMembers:
+                  type: array
+                  description: "Additional human members of this Team. In this version, role=coordinator joins the Team Room and can assign work there like the Team admin."
+                  items:
+                    type: object
+                    required: [name]
+                    properties:
+                      name:
+                        type: string
+                        description: "Human name / Matrix localpart"
+                      matrixUserId:
+                        type: string
+                        description: "Matrix user ID (e.g. @john:domain)"
+                      role:
+                        type: string
+                        enum: [coordinator]
+                        description: "Human member role. coordinator can @mention the leader/workers in the Team Room; Leader DM remains limited to the Team admin and leader."
+                leader:
+                  type: object
+                  required: [name]
+                  properties:
+                    name:
+                      type: string
+                    workerName:
+                      type: string
+                      description: Runtime identity for leader (Matrix localpart, OSS path key). Defaults to leader.name.
+                    model:
+                      type: string
+                    modelProvider:
+                      type: string
+                      description: Name of the AI gateway Model API to use as the LLM provider.
+                    identity:
+                      type: string
+                    soul:
+                      type: string
+                    agents:
+                      type: string
+                    package:
+                      type: string
+                    remoteSkills:
+                      type: array
+                      description: Remote skills fetched from source registries.
+                      items:
+                        type: object
+                        required: [source, skills]
+                        properties:
+                          source:
+                            type: string
+                            pattern: '^nacos://[^/]+/[^/?#]+$'
+                            description: Remote source in nacos://host[:port]/namespace-id format.
+                          authType:
+                            type: string
+                            enum: [sts-hiclaw, nacos, none]
+                            description: "Authentication mode for remote source access. Empty auto-detects: embedded username/password selects nacos; otherwise none. nacos: username/password embedded in source URL; sts-hiclaw: STS credential provider; none: unauthenticated."
+                          skills:
+                            type: array
+                            minItems: 1
+                            description: Skills to fetch from the remote source.
+                            items:
+                              type: object
+                              required: [name]
+                              properties:
+                                name:
+                                  type: string
+                                version:
+                                  type: string
+                                label:
+                                  type: string
+                    mcpServers:
+                      type: array
+                      description: MCP servers callable via mcporter. url is the full endpoint; transport defaults to http.
+                      items:
+                        type: object
+                        required: [name, url]
+                        properties:
+                          name:
+                            type: string
+                            description: Key in mcporter-servers.json; used by tool calls as <name>.<tool>.
+                          url:
+                            type: string
+                            description: Full MCP endpoint URL (gateway-side path included).
+                          transport:
+                            type: string
+                            enum: [http, sse]
+                    heartbeat:
+                      type: object
+                      properties:
+                        enabled:
+                          type: boolean
+                        every:
+                          type: string
+                    workerIdleTimeout:
+                      type: string
+                    state:
+                      type: string
+                      enum: [Running, Sleeping, Stopped]
+                      description: "Desired lifecycle state for the team leader (default: Running)"
+                    resources:
+                      type: object
+                      description: >
+                        CPU and memory requests/limits for the Team Leader Pod.
+                        Empty fields fall back to controller/backend defaults.
+                      properties:
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              description: Kubernetes CPU quantity, e.g. 300m
+                            memory:
+                              type: string
+                              description: Kubernetes memory quantity, e.g. 768Mi
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                              description: Kubernetes CPU quantity, e.g. "2"
+                            memory:
+                              type: string
+                              description: Kubernetes memory quantity, e.g. 3Gi
+                    labels:
+                      type: object
+                      additionalProperties:
+                        type: string
+                      description: >
+                        User-defined Pod labels stamped onto the team leader Pod.
+                        Merged on top of Team.metadata.labels and below controller
+                        system labels. Entries whose keys collide with system labels
+                        are silently overridden.
+                    env:
+                      type: object
+                      description: |
+                        User-defined environment variables injected into the leader container.
+                        Keys that collide with variables already set by the controller or backend
+                        (HICLAW_*, OPENCLAW_*, HOME, and similar internal keys) are silently
+                        ignored with a warning log — the system value always wins.
+                      additionalProperties:
+                        type: string
+                    channelPolicy:
+                      type: object
+                      properties:
+                        groupAllowExtra:
+                          type: array
+                          items:
+                            type: string
+                        groupDenyExtra:
+                          type: array
+                          items:
+                            type: string
+                        dmAllowExtra:
+                          type: array
+                          items:
+                            type: string
+                        dmDenyExtra:
+                          type: array
+                          items:
+                            type: string
+                    accessEntries:
+                      type: array
+                      description: >
+                        Cloud credential scope declarations for the team leader.
+                        Only honored when the controller runs with a credential-
+                        provider sidecar. Ignored in local higress+minio
+                        deployments. When empty the controller applies team-
+                        member defaults (agents/<name>/* + shared/* +
+                        teams/<team>/* on the configured bucket). Leader and
+                        team workers share the same default scope.
+                      items:
+                        type: object
+                        required: [service]
+                        properties:
+                          service:
+                            type: string
+                            enum: [object-storage, ai-gateway, ai-registry]
+                            description: Logical cloud service identifier
+                          permissions:
+                            type: array
+                            items:
+                              type: string
+                              enum: [read, write, list, delete]
+                          scope:
+                            type: object
+                            description: >
+                              Schema-less scope blob. For object-storage use keys
+                              bucketRef|bucket and prefixes (list of strings). For
+                              ai-gateway use keys gatewayRef|gatewayId and
+                              resources (list of strings). Template vars
+                              ${self.name} / ${self.kind} / ${self.namespace} /
+                              ${self.team} are expanded by the controller before
+                              the request reaches the provider.
+                            x-kubernetes-preserve-unknown-fields: true
+                workers:
+                  type: array
+                  items:
+                    type: object
+                    required: [name]
+                    properties:
+                      name:
+                        type: string
+                      workerName:
+                        type: string
+                        description: Runtime identity for worker (Matrix localpart, OSS path key). Defaults to worker.name.
+                      model:
+                        type: string
+                      modelProvider:
+                        type: string
+                        description: Name of the AI gateway Model API to use as the LLM provider.
+                      runtime:
+                        type: string
+                        enum: [openclaw, copaw, hermes, openhuman]
+                      image:
+                        type: string
+                      identity:
+                        type: string
+                      soul:
+                        type: string
+                      agents:
+                        type: string
+                      skills:
+                        type: array
+                        items:
+                          type: string
+                          not:
+                            pattern: '^nacos://'
+                        description: HiClaw built-in skills to enable (remote registry skills must use remoteSkills)
+                      remoteSkills:
+                        type: array
+                        description: Remote skills fetched from source registries.
+                        items:
+                          type: object
+                          required: [source, skills]
+                          properties:
+                            source:
+                              type: string
+                              pattern: '^nacos://[^/]+/[^/?#]+$'
+                              description: Remote source in nacos://host[:port]/namespace-id format.
+                            authType:
+                              type: string
+                              enum: [sts-hiclaw, nacos, none]
+                              description: "Authentication mode for remote source access. Empty auto-detects: embedded username/password selects nacos; otherwise none. nacos: username/password embedded in source URL; sts-hiclaw: STS credential provider; none: unauthenticated."
+                            skills:
+                              type: array
+                              minItems: 1
+                              description: Skills to fetch from the remote source.
+                              items:
+                                type: object
+                                required: [name]
+                                properties:
+                                  name:
+                                    type: string
+                                  version:
+                                    type: string
+                                  label:
+                                    type: string
+                      mcpServers:
+                        type: array
+                        description: MCP servers callable via mcporter. url is the full endpoint; transport defaults to http.
+                        items:
+                          type: object
+                          required: [name, url]
+                          properties:
+                            name:
+                              type: string
+                              description: Key in mcporter-servers.json; used by tool calls as <name>.<tool>.
+                            url:
+                              type: string
+                              description: Full MCP endpoint URL (gateway-side path included).
+                            transport:
+                              type: string
+                              enum: [http, sse]
+                              default: http
+                              description: Transport protocol (http=Streamable HTTP, sse=Server-Sent Events).
+                      package:
+                        type: string
+                      expose:
+                        type: array
+                        description: Ports to expose via Higress gateway
+                        items:
+                          type: object
+                          required: [port]
+                          properties:
+                            port:
+                              type: integer
+                            protocol:
+                              type: string
+                              enum: [http, grpc]
+                              default: http
+                      channelPolicy:
+                        type: object
+                        properties:
+                          groupAllowExtra:
+                            type: array
+                            items:
+                              type: string
+                          groupDenyExtra:
+                            type: array
+                            items:
+                              type: string
+                          dmAllowExtra:
+                            type: array
+                            items:
+                              type: string
+                          dmDenyExtra:
+                            type: array
+                            items:
+                              type: string
+                      state:
+                        type: string
+                        enum: [Running, Sleeping, Stopped]
+                        description: "Desired lifecycle state for this team worker (default: Running)"
+                      resources:
+                        type: object
+                        description: >
+                          CPU and memory requests/limits for this Team Worker
+                          Pod. Empty fields fall back to controller/backend
+                          defaults.
+                        properties:
+                          requests:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                                description: Kubernetes CPU quantity, e.g. 200m
+                              memory:
+                                type: string
+                                description: Kubernetes memory quantity, e.g. 512Mi
+                          limits:
+                            type: object
+                            properties:
+                              cpu:
+                                type: string
+                                description: Kubernetes CPU quantity, e.g. "1"
+                              memory:
+                                type: string
+                                description: Kubernetes memory quantity, e.g. 2Gi
+                      accessEntries:
+                        type: array
+                        description: >
+                          Cloud credential scope declarations for this team
+                          worker. Only honored when the controller runs with a
+                          credential-provider sidecar. Ignored in local higress+
+                          minio deployments. When empty the controller applies
+                          team-member defaults (agents/<name>/* + shared/* +
+                          teams/<team>/* on the configured bucket).
+                        items:
+                          type: object
+                          required: [service]
+                          properties:
+                            service:
+                              type: string
+                              enum: [object-storage, ai-gateway, ai-registry]
+                              description: Logical cloud service identifier
+                            permissions:
+                              type: array
+                              items:
+                                type: string
+                                enum: [read, write, list, delete]
+                            scope:
+                              type: object
+                              description: >
+                                Schema-less scope blob. For object-storage use
+                                keys bucketRef|bucket and prefixes (list of
+                                strings). For ai-gateway use keys gatewayRef|
+                                gatewayId and resources (list of strings).
+                                Template vars ${self.name} / ${self.kind} /
+                                ${self.namespace} / ${self.team} are expanded by
+                                the controller before the request reaches the
+                                provider.
+                              x-kubernetes-preserve-unknown-fields: true
+                      labels:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >
+                          User-defined Pod labels stamped onto this team worker Pod.
+                          Merged on top of Team.metadata.labels and below controller
+                          system labels. Entries whose keys collide with system labels
+                          are silently overridden.
+                      env:
+                        type: object
+                        description: |
+                          User-defined environment variables injected into this team worker's
+                          container. Keys that collide with variables already set by the
+                          controller or backend (HICLAW_*, OPENCLAW_*, HOME, and similar
+                          internal keys) are silently ignored with a warning log — the system
+                          value always wins.
+                        additionalProperties:
+                          type: string
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum: [Pending, Active, Degraded, Failed]
+                teamRoomID:
+                  type: string
+                leaderDMRoomID:
+                  type: string
+                leaderReady:
+                  type: boolean
+                readyWorkers:
+                  type: integer
+                totalWorkers:
+                  type: integer
+                message:
+                  type: string
+                members:
+                  type: array
+                  description: "Per-member state (leader + workers). Consolidates all per-member fields (observed, spec hash, roomID, matrixUserID, exposedPorts) into a single sorted-by-name slice."
+                  items:
+                    type: object
+                    required: [name]
+                    properties:
+                      name:
+                        type: string
+                        description: "Member's canonical name (matches spec.leader.name or spec.workers[i].name)."
+                      runtimeName:
+                        type: string
+                        description: "Member runtime identity key (Matrix localpart, OSS path key). Empty falls back to name."
+                      role:
+                        type: string
+                        enum: [team_leader, worker]
+                        description: "Role of this member."
+                      roomID:
+                        type: string
+                        description: "Member's personal communication room with the Manager."
+                      matrixUserID:
+                        type: string
+                        description: "Member's Matrix MXID."
+                      specHash:
+                        type: string
+                        description: "fnv64a hash of the last fully-reconciled WorkerSpec for this member. Empty means never fully reconciled."
+                      observed:
+                        type: boolean
+                        description: "True once ReconcileMemberInfra has succeeded at least once; stays true across post-infra failures to avoid Matrix access token rotation."
+                      ready:
+                        type: boolean
+                        description: "Mirrors backend.Status Running/Ready. Aggregates into leaderReady and readyWorkers."
+                      exposedPorts:
+                        type: array
+                        description: "Ports currently exposed via Higress for this member (workers only)."
+                        items:
+                          type: object
+                          required: [port, domain]
+                          properties:
+                            port:
+                              type: integer
+                            domain:
+                              type: string
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Leader
+          type: string
+          jsonPath: .spec.leader.name
+        - name: Workers
+          type: integer
+          jsonPath: .status.totalWorkers
+        - name: Ready
+          type: integer
+          jsonPath: .status.readyWorkers
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+  scope: Namespaced
+  names:
+    plural: teams
+    singular: team
+    kind: Team
+    shortNames: [tm]

--- a/hiclaw-controller/config/crd/workers.agentteams.io.yaml
+++ b/hiclaw-controller/config/crd/workers.agentteams.io.yaml
@@ -1,0 +1,280 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workers.agentteams.io
+spec:
+  group: agentteams.io
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [model]
+              properties:
+                model:
+                  type: string
+                  description: LLM model ID (e.g. claude-sonnet-4-6, qwen3.6-plus)
+                modelProvider:
+                  type: string
+                  description: Name of the AI gateway Model API to use as the LLM provider.
+                runtime:
+                  type: string
+                  enum: [openclaw, copaw, hermes, openhuman]
+                  description: |
+                    Agent runtime. When omitted the controller falls back to
+                    HICLAW_DEFAULT_WORKER_RUNTIME (set at install time), and
+                    finally to "openclaw" if neither is set.
+                image:
+                  type: string
+                  description: Custom Docker image for this worker
+                workerName:
+                  type: string
+                  description: Business/runtime identity for Matrix localpart and OSS path key (fallback to metadata.name)
+                identity:
+                  type: string
+                  description: Worker public identity (generates IDENTITY.md; merged into SOUL.md for copaw and hermes)
+                soul:
+                  type: string
+                  description: Worker identity and role definition (generates SOUL.md)
+                agents:
+                  type: string
+                  description: Agent behavior rules (generates AGENTS.md)
+                skills:
+                  type: array
+                  items:
+                    type: string
+                    not:
+                      pattern: '^nacos://'
+                  description: HiClaw built-in skills to enable (remote registry skills must use remoteSkills)
+                remoteSkills:
+                  type: array
+                  description: Remote skills fetched from source registries.
+                  items:
+                    type: object
+                    required: [source, skills]
+                    properties:
+                      source:
+                        type: string
+                        pattern: '^nacos://[^/]+/[^/?#]+$'
+                        description: Remote source in nacos://host[:port]/namespace-id format.
+                      authType:
+                        type: string
+                        enum: [sts-hiclaw, nacos, none]
+                        description: "Authentication mode for remote source access. Empty auto-detects: embedded username/password selects nacos; otherwise none. nacos: username/password embedded in source URL; sts-hiclaw: STS credential provider; none: unauthenticated."
+                      skills:
+                        type: array
+                        minItems: 1
+                        description: Skills to fetch from the remote source.
+                        items:
+                          type: object
+                          required: [name]
+                          properties:
+                            name:
+                              type: string
+                            version:
+                              type: string
+                            label:
+                              type: string
+                mcpServers:
+                  type: array
+                  description: MCP servers callable via mcporter. url is the full endpoint; transport defaults to http.
+                  items:
+                    type: object
+                    required: [name, url]
+                    properties:
+                      name:
+                        type: string
+                        description: Key in mcporter-servers.json; used by tool calls as <name>.<tool>.
+                      url:
+                        type: string
+                        description: Full MCP endpoint URL (gateway-side path included).
+                      transport:
+                        type: string
+                        enum: [http, sse]
+                        default: http
+                        description: Transport protocol (http=Streamable HTTP, sse=Server-Sent Events).
+                package:
+                  type: string
+                  description: "Package URI: file://, http(s)://, nacos://, or packages/{name}.zip"
+                expose:
+                  type: array
+                  description: Ports to expose via Higress gateway. Each port gets an auto-generated domain.
+                  items:
+                    type: object
+                    required: [port]
+                    properties:
+                      port:
+                        type: integer
+                        description: Container port to expose
+                      protocol:
+                        type: string
+                        enum: [http, grpc]
+                        default: http
+                        description: Protocol (default http)
+                channelPolicy:
+                  type: object
+                  description: "Additive/subtractive overrides for communication policies (on top of defaults)"
+                  properties:
+                    groupAllowExtra:
+                      type: array
+                      items:
+                        type: string
+                      description: "Additional Matrix user IDs to allow in group @mentions"
+                    groupDenyExtra:
+                      type: array
+                      items:
+                        type: string
+                      description: "Matrix user IDs to deny from group @mentions (overrides allow)"
+                    dmAllowExtra:
+                      type: array
+                      items:
+                        type: string
+                      description: "Additional Matrix user IDs to allow in DMs"
+                    dmDenyExtra:
+                      type: array
+                      items:
+                        type: string
+                      description: "Matrix user IDs to deny from DMs (overrides allow)"
+                containerManaged:
+                  type: boolean
+                  description: >
+                    When false, the controller skips container lifecycle management
+                    for this worker. Use for remote workers whose process is managed
+                    externally (e.g., via systemd). Default is true (controller
+                    creates and manages containers).
+                state:
+                  type: string
+                  enum: [Running, Sleeping, Stopped]
+                  description: "Desired lifecycle state (default: Running). The controller reconciles actual state toward this."
+                resources:
+                  type: object
+                  description: >
+                    CPU and memory requests/limits for this Worker Pod.
+                    Empty fields fall back to controller/backend defaults.
+                  properties:
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          description: Kubernetes CPU quantity, e.g. 250m
+                        memory:
+                          type: string
+                          description: Kubernetes memory quantity, e.g. 512Mi
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          description: Kubernetes CPU quantity, e.g. "2"
+                        memory:
+                          type: string
+                          description: Kubernetes memory quantity, e.g. 2Gi
+                env:
+                  type: object
+                  description: |
+                    User-defined environment variables injected into the worker container.
+                    Keys that collide with variables already set by the controller or backend
+                    (HICLAW_*, OPENCLAW_*, HOME, and similar internal keys) are silently
+                    ignored with a warning log — the system value always wins.
+                  additionalProperties:
+                    type: string
+                labels:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: >
+                    User-defined Pod labels stamped onto this worker's Pod.
+                    Merged on top of the ConfigMap-based pod-template overlay
+                    and CR metadata.labels, and below controller-forced
+                    system labels (agentteams.io/controller, agentteams.io/worker,
+                    agentteams.io/role, agentteams.io/runtime, app). Entries whose
+                    keys collide with those system labels are silently
+                    overridden.
+                accessEntries:
+                  type: array
+                  description: >
+                    Cloud credential scope declarations. Only honored when the controller
+                    runs with a credential-provider sidecar (gateway.provider=ai-gateway
+                    or storage.provider=oss). Ignored in local higress+minio deployments.
+                    When empty the controller applies sensible defaults equivalent to the
+                    legacy worker role (agents/<name>/* + shared/* on the configured bucket).
+                  items:
+                    type: object
+                    required: [service]
+                    properties:
+                      service:
+                        type: string
+                        enum: [object-storage, ai-gateway, ai-registry]
+                        description: Logical cloud service identifier
+                      permissions:
+                        type: array
+                        items:
+                          type: string
+                          enum: [read, write, list, delete]
+                      scope:
+                        type: object
+                        description: >
+                          Schema-less scope blob. For object-storage use keys
+                          bucketRef|bucket and prefixes (list of strings). For
+                          ai-gateway use keys gatewayRef|gatewayId and resources
+                          (list of strings). Template vars ${self.name} /
+                          ${self.kind} / ${self.namespace} are expanded by the
+                          controller before the request reaches the provider.
+                        x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  type: integer
+                  format: int64
+                phase:
+                  type: string
+                  enum: [Pending, Running, Sleeping, Updating, Stopped, Failed]
+                matrixUserID:
+                  type: string
+                roomID:
+                  type: string
+                containerState:
+                  type: string
+                lastHeartbeat:
+                  type: string
+                  format: date-time
+                message:
+                  type: string
+                exposedPorts:
+                  type: array
+                  description: Ports currently exposed via Higress gateway
+                  items:
+                    type: object
+                    properties:
+                      port:
+                        type: integer
+                      domain:
+                        type: string
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Model
+          type: string
+          jsonPath: .spec.model
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Runtime
+          type: string
+          jsonPath: .spec.runtime
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+  scope: Namespaced
+  names:
+    plural: workers
+    singular: worker
+    kind: Worker
+    shortNames: [wk]

--- a/hiclaw-controller/internal/app/app.go
+++ b/hiclaw-controller/internal/app/app.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hiclaw/hiclaw-controller/internal/gateway"
 	"github.com/hiclaw/hiclaw-controller/internal/initializer"
 	"github.com/hiclaw/hiclaw-controller/internal/matrix"
+	"github.com/hiclaw/hiclaw-controller/internal/mirror"
 	"github.com/hiclaw/hiclaw-controller/internal/oss"
 	"github.com/hiclaw/hiclaw-controller/internal/server"
 	"github.com/hiclaw/hiclaw-controller/internal/service"
@@ -544,6 +545,10 @@ func (a *App) initReconcilers(_ context.Context) error {
 	}
 	if err := mgrReconciler.SetupWithManager(a.mgr); err != nil {
 		return fmt.Errorf("setup ManagerReconciler: %w", err)
+	}
+
+	if err := mirror.SetupWithManager(a.mgr); err != nil {
+		return fmt.Errorf("setup agentteams.io mirror: %w", err)
 	}
 
 	return nil

--- a/hiclaw-controller/internal/backend/docker.go
+++ b/hiclaw-controller/internal/backend/docker.go
@@ -15,6 +15,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/hiclaw/hiclaw-controller/internal/envcompat"
 )
 
 // DockerConfig holds Docker backend configuration.
@@ -155,7 +157,7 @@ func (d *DockerBackend) Create(ctx context.Context, req CreateRequest) (*WorkerR
 		// Build MATRIX_ALLOWED_USERS (fallback; primary is openclaw.json dm.allowFrom + groupAllowFrom).
 		var allowedUsers []string
 		if domain := req.Env["HICLAW_MATRIX_DOMAIN"]; domain != "" {
-			if admin := os.Getenv("HICLAW_ADMIN_USER"); admin != "" {
+			if admin := envcompat.Lookup("HICLAW_ADMIN_USER"); admin != "" {
 				allowedUsers = append(allowedUsers, fmt.Sprintf("@%s:%s", admin, domain))
 			}
 			// Manager Matrix username is "manager" by convention (see agentconfig/generator.go).

--- a/hiclaw-controller/internal/backend/kubernetes.go
+++ b/hiclaw-controller/internal/backend/kubernetes.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/hiclaw/hiclaw-controller/internal/envcompat"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -169,7 +170,7 @@ func (k *K8sBackend) Create(ctx context.Context, req CreateRequest) (*WorkerResu
 		req.Env = make(map[string]string)
 	}
 	mergeOSSRegionFromProcessEnv(req.Env)
-	if rt := os.Getenv("HICLAW_RUNTIME"); rt != "" {
+	if rt := envcompat.Lookup("HICLAW_RUNTIME"); rt != "" {
 		req.Env["HICLAW_RUNTIME"] = rt
 	} else {
 		req.Env["HICLAW_RUNTIME"] = "k8s"
@@ -207,7 +208,7 @@ func (k *K8sBackend) Create(ctx context.Context, req CreateRequest) (*WorkerResu
 		var allowedUsers []string
 		if domain := req.Env["HICLAW_MATRIX_DOMAIN"]; domain != "" {
 			// Admin user — can DM and @mention the worker.
-			if admin := os.Getenv("HICLAW_ADMIN_USER"); admin != "" {
+			if admin := envcompat.Lookup("HICLAW_ADMIN_USER"); admin != "" {
 				allowedUsers = append(allowedUsers, fmt.Sprintf("@%s:%s", admin, domain))
 			}
 			// Manager Matrix username is "manager" by convention (see agentconfig/generator.go).
@@ -495,12 +496,12 @@ func mergeOSSRegionFromProcessEnv(env map[string]string) {
 	}
 	bucket := firstNonEmptyTrimmed(
 		env["HICLAW_FS_BUCKET"],
-		os.Getenv("HICLAW_FS_BUCKET"),
+		envcompat.Lookup("HICLAW_FS_BUCKET"),
 	)
 	if bucket != "" && strings.TrimSpace(env["HICLAW_FS_BUCKET"]) == "" {
 		env["HICLAW_FS_BUCKET"] = bucket
 	}
-	if v := strings.TrimSpace(os.Getenv("HICLAW_REGION")); v != "" && strings.TrimSpace(env["HICLAW_REGION"]) == "" {
+	if v := strings.TrimSpace(envcompat.Lookup("HICLAW_REGION")); v != "" && strings.TrimSpace(env["HICLAW_REGION"]) == "" {
 		env["HICLAW_REGION"] = v
 	}
 }
@@ -613,7 +614,7 @@ func loadK8sRESTConfig() (*rest.Config, error) {
 }
 
 func detectK8sNamespace() string {
-	if ns := strings.TrimSpace(os.Getenv("HICLAW_K8S_NAMESPACE")); ns != "" {
+	if ns := strings.TrimSpace(envcompat.Lookup("HICLAW_K8S_NAMESPACE")); ns != "" {
 		return ns
 	}
 	if data, err := os.ReadFile(defaultK8sNamespaceFile); err == nil {

--- a/hiclaw-controller/internal/config/config.go
+++ b/hiclaw-controller/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hiclaw/hiclaw-controller/internal/agentconfig"
 	"github.com/hiclaw/hiclaw-controller/internal/backend"
 	"github.com/hiclaw/hiclaw-controller/internal/credentials"
+	"github.com/hiclaw/hiclaw-controller/internal/envcompat"
 	"github.com/hiclaw/hiclaw-controller/internal/gateway"
 	"github.com/hiclaw/hiclaw-controller/internal/matrix"
 	"github.com/hiclaw/hiclaw-controller/internal/oss"
@@ -227,7 +228,7 @@ func LoadConfig() *Config {
 	}
 	// ContainerPrefix defaults to "${resourcePrefix}worker-" when auto-prefix
 	// is enabled. HICLAW_PROXY_CONTAINER_PREFIX remains an explicit override.
-	containerPrefix := os.Getenv("HICLAW_PROXY_CONTAINER_PREFIX")
+	containerPrefix := envcompat.Lookup("HICLAW_PROXY_CONTAINER_PREFIX")
 	if containerPrefix == "" && resourceAutoPrefix {
 		containerPrefix = resourcePrefix + "worker-"
 	}
@@ -251,103 +252,103 @@ func LoadConfig() *Config {
 		GatewayProvider: envOrDefault("HICLAW_GATEWAY_PROVIDER", "higress"),
 		StorageProvider: envOrDefault("HICLAW_STORAGE_PROVIDER", "minio"),
 
-		CredentialProviderURL: os.Getenv("HICLAW_CREDENTIAL_PROVIDER_URL"),
+		CredentialProviderURL: envcompat.Lookup("HICLAW_CREDENTIAL_PROVIDER_URL"),
 
 		HigressBaseURL:    envOrDefault("HICLAW_AI_GATEWAY_ADMIN_URL", "http://127.0.0.1:8001"),
 		HigressCookieFile: os.Getenv("HIGRESS_COOKIE_FILE"),
 		// Higress and Matrix share the same admin credentials.
-		HigressAdminUser:     os.Getenv("HICLAW_ADMIN_USER"),
-		HigressAdminPassword: os.Getenv("HICLAW_ADMIN_PASSWORD"),
+		HigressAdminUser:     envcompat.Lookup("HICLAW_ADMIN_USER"),
+		HigressAdminPassword: envcompat.Lookup("HICLAW_ADMIN_PASSWORD"),
 
 		WorkerBackend: firstNonEmpty(
-			os.Getenv("HICLAW_WORKER_BACKEND"),
-			os.Getenv("HICLAW_ALIYUN_WORKER_BACKEND"),
+			envcompat.Lookup("HICLAW_WORKER_BACKEND"),
+			envcompat.Lookup("HICLAW_ALIYUN_WORKER_BACKEND"),
 		),
 
 		Region: envOrDefault("HICLAW_REGION", "cn-hangzhou"),
 
-		GWGatewayID:  os.Getenv("HICLAW_GW_GATEWAY_ID"),
-		GWModelAPIID: os.Getenv("HICLAW_GW_MODEL_API_ID"),
-		GWEnvID:      os.Getenv("HICLAW_GW_ENV_ID"),
+		GWGatewayID:  envcompat.Lookup("HICLAW_GW_GATEWAY_ID"),
+		GWModelAPIID: envcompat.Lookup("HICLAW_GW_MODEL_API_ID"),
+		GWEnvID:      envcompat.Lookup("HICLAW_GW_ENV_ID"),
 
 		OSSBucket: envOrDefault("HICLAW_FS_BUCKET", "hiclaw-storage"),
 
-		K8sNamespace:    os.Getenv("HICLAW_K8S_NAMESPACE"),
+		K8sNamespace:    envcompat.Lookup("HICLAW_K8S_NAMESPACE"),
 		K8sWorkerCPU:    envOrDefault("HICLAW_K8S_WORKER_CPU", "1000m"),
 		K8sWorkerMemory: envOrDefault("HICLAW_K8S_WORKER_MEMORY", "2Gi"),
 
 		ManagerEnabled:          envOrDefault("HICLAW_MANAGER_ENABLED", "true") == "true",
-		ManagerModel:            firstNonEmpty(os.Getenv("HICLAW_MANAGER_MODEL"), envOrDefault("HICLAW_DEFAULT_MODEL", "qwen3.6-plus")),
+		ManagerModel:            firstNonEmpty(envcompat.Lookup("HICLAW_MANAGER_MODEL"), envOrDefault("HICLAW_DEFAULT_MODEL", "qwen3.6-plus")),
 		ManagerRuntime:          envOrDefault("HICLAW_MANAGER_RUNTIME", "openclaw"),
-		ManagerImage:            os.Getenv("HICLAW_MANAGER_IMAGE"),
-		DefaultWorkerRuntime:    os.Getenv("HICLAW_DEFAULT_WORKER_RUNTIME"),
+		ManagerImage:            envcompat.Lookup("HICLAW_MANAGER_IMAGE"),
+		DefaultWorkerRuntime:    envcompat.Lookup("HICLAW_DEFAULT_WORKER_RUNTIME"),
 		K8sManagerCPURequest:    envOrDefault("HICLAW_K8S_MANAGER_CPU_REQUEST", "500m"),
 		K8sManagerMemoryRequest: envOrDefault("HICLAW_K8S_MANAGER_MEMORY_REQUEST", "1Gi"),
 		K8sManagerCPU:           envOrDefault("HICLAW_K8S_MANAGER_CPU", "2"),
 		K8sManagerMemory:        envOrDefault("HICLAW_K8S_MANAGER_MEMORY", "4Gi"),
 
-		ControllerURL:  os.Getenv("HICLAW_CONTROLLER_URL"),
-		ControllerName: os.Getenv("HICLAW_CONTROLLER_NAME"),
+		ControllerURL:  envcompat.Lookup("HICLAW_CONTROLLER_URL"),
+		ControllerName: envcompat.Lookup("HICLAW_CONTROLLER_NAME"),
 
-		ManagerWorkspaceDir: os.Getenv("HICLAW_WORKSPACE_DIR"),
-		HostShareDir:        os.Getenv("HICLAW_HOST_SHARE_DIR"),
+		ManagerWorkspaceDir: envcompat.Lookup("HICLAW_WORKSPACE_DIR"),
+		HostShareDir:        envcompat.Lookup("HICLAW_HOST_SHARE_DIR"),
 		ManagerConsolePort:  envOrDefault("HICLAW_PORT_MANAGER_CONSOLE", "18888"),
-		ManagerPassword:     os.Getenv("HICLAW_MANAGER_PASSWORD"),
-		ManagerGatewayKey:   os.Getenv("HICLAW_MANAGER_GATEWAY_KEY"),
+		ManagerPassword:     envcompat.Lookup("HICLAW_MANAGER_PASSWORD"),
+		ManagerGatewayKey:   envcompat.Lookup("HICLAW_MANAGER_GATEWAY_KEY"),
 
 		MatrixServerURL:         envOrDefault("HICLAW_MATRIX_URL", "http://matrix-local.hiclaw.io:8080"),
 		MatrixDomain:            envOrDefault("HICLAW_MATRIX_DOMAIN", "matrix-local.hiclaw.io:8080"),
-		MatrixRegistrationToken: envOrDefault("HICLAW_MATRIX_REGISTRATION_TOKEN", os.Getenv("HICLAW_REGISTRATION_TOKEN")),
-		MatrixAdminUser:         os.Getenv("HICLAW_ADMIN_USER"),
-		MatrixAdminPassword:     os.Getenv("HICLAW_ADMIN_PASSWORD"),
-		MatrixE2EE:              os.Getenv("HICLAW_MATRIX_E2EE") == "1" || os.Getenv("HICLAW_MATRIX_E2EE") == "true",
+		MatrixRegistrationToken: envOrDefault("HICLAW_MATRIX_REGISTRATION_TOKEN", envcompat.Lookup("HICLAW_REGISTRATION_TOKEN")),
+		MatrixAdminUser:         envcompat.Lookup("HICLAW_ADMIN_USER"),
+		MatrixAdminPassword:     envcompat.Lookup("HICLAW_ADMIN_PASSWORD"),
+		MatrixE2EE:              envcompat.Lookup("HICLAW_MATRIX_E2EE") == "1" || envcompat.Lookup("HICLAW_MATRIX_E2EE") == "true",
 
 		OSSStoragePrefix: envOrDefault("HICLAW_STORAGE_PREFIX", "hiclaw/hiclaw-storage"),
 
 		DefaultModel:       envOrDefault("HICLAW_DEFAULT_MODEL", "qwen3.6-plus"),
-		EmbeddingModel:     os.Getenv("HICLAW_EMBEDDING_MODEL"),
+		EmbeddingModel:     envcompat.Lookup("HICLAW_EMBEDDING_MODEL"),
 		Runtime:            envOrDefault("HICLAW_RUNTIME", "docker"),
 		ModelContextWindow: envOrDefaultInt("HICLAW_MODEL_CONTEXT_WINDOW", 0),
 		ModelMaxTokens:     envOrDefaultInt("HICLAW_MODEL_MAX_TOKENS", 0),
 
 		LLMProvider:                envOrDefault("HICLAW_LLM_PROVIDER", "qwen"),
-		LLMAPIKey:                  os.Getenv("HICLAW_LLM_API_KEY"),
-		OpenAIBaseURL:              os.Getenv("HICLAW_OPENAI_BASE_URL"),
+		LLMAPIKey:                  envcompat.Lookup("HICLAW_LLM_API_KEY"),
+		OpenAIBaseURL:              envcompat.Lookup("HICLAW_OPENAI_BASE_URL"),
 		AIStreamIdleTimeoutSeconds: envOrDefaultInt("HICLAW_AI_STREAM_IDLE_TIMEOUT_SECONDS", 900),
-		ElementWebURL:              os.Getenv("HICLAW_ELEMENT_WEB_URL"),
+		ElementWebURL:              envcompat.Lookup("HICLAW_ELEMENT_WEB_URL"),
 
 		UserLanguage: envOrDefault("HICLAW_LANGUAGE", "zh"),
 		UserTimezone: envOrDefault("TZ", "Asia/Shanghai"),
 
 		CMSTracesEnabled:  envBool("HICLAW_CMS_TRACES_ENABLED"),
 		CMSMetricsEnabled: envBool("HICLAW_CMS_METRICS_ENABLED"),
-		CMSEndpoint:       os.Getenv("HICLAW_CMS_ENDPOINT"),
-		CMSLicenseKey:     os.Getenv("HICLAW_CMS_LICENSE_KEY"),
-		CMSProject:        os.Getenv("HICLAW_CMS_PROJECT"),
-		CMSWorkspace:      os.Getenv("HICLAW_CMS_WORKSPACE"),
+		CMSEndpoint:       envcompat.Lookup("HICLAW_CMS_ENDPOINT"),
+		CMSLicenseKey:     envcompat.Lookup("HICLAW_CMS_LICENSE_KEY"),
+		CMSProject:        envcompat.Lookup("HICLAW_CMS_PROJECT"),
+		CMSWorkspace:      envcompat.Lookup("HICLAW_CMS_WORKSPACE"),
 		CMSServiceName:    envOrDefault("HICLAW_CMS_SERVICE_NAME", "hiclaw-manager"),
 
 		WorkerEnv: WorkerEnvDefaults{
 			MatrixDomain:         envOrDefault("HICLAW_MATRIX_DOMAIN", "matrix-local.hiclaw.io:8080"),
-			FSEndpoint:           os.Getenv("HICLAW_FS_ENDPOINT"),
+			FSEndpoint:           envcompat.Lookup("HICLAW_FS_ENDPOINT"),
 			FSBucket:             envOrDefault("HICLAW_FS_BUCKET", "hiclaw-storage"),
 			StoragePrefix:        envOrDefault("HICLAW_STORAGE_PREFIX", "hiclaw/hiclaw-storage"),
-			ControllerURL:        os.Getenv("HICLAW_CONTROLLER_URL"),
+			ControllerURL:        envcompat.Lookup("HICLAW_CONTROLLER_URL"),
 			AIGatewayURL:         envOrDefault("HICLAW_AI_GATEWAY_URL", "http://aigw-local.hiclaw.io:8080"),
 			MatrixURL:            envOrDefault("HICLAW_MATRIX_URL", "http://matrix-local.hiclaw.io:8080"),
-			AdminUser:            os.Getenv("HICLAW_ADMIN_USER"),
-			DefaultWorkerRuntime: os.Getenv("HICLAW_DEFAULT_WORKER_RUNTIME"),
+			AdminUser:            envcompat.Lookup("HICLAW_ADMIN_USER"),
+			DefaultWorkerRuntime: envcompat.Lookup("HICLAW_DEFAULT_WORKER_RUNTIME"),
 			YoloMode:             envBool("HICLAW_YOLO"),
 			MatrixDebug:          envBool("HICLAW_MATRIX_DEBUG"),
 
 			// CMS observability (propagated from controller env to all workers/managers)
 			CMSTracesEnabled:  envBool("HICLAW_CMS_TRACES_ENABLED"),
 			CMSMetricsEnabled: envBool("HICLAW_CMS_METRICS_ENABLED"),
-			CMSEndpoint:       os.Getenv("HICLAW_CMS_ENDPOINT"),
-			CMSLicenseKey:     os.Getenv("HICLAW_CMS_LICENSE_KEY"),
-			CMSProject:        os.Getenv("HICLAW_CMS_PROJECT"),
-			CMSWorkspace:      os.Getenv("HICLAW_CMS_WORKSPACE"),
-			SkillsAPIURL:      envOrDefault("SKILLS_API_URL", os.Getenv("HICLAW_SKILLS_API_URL")),
+			CMSEndpoint:       envcompat.Lookup("HICLAW_CMS_ENDPOINT"),
+			CMSLicenseKey:     envcompat.Lookup("HICLAW_CMS_LICENSE_KEY"),
+			CMSProject:        envcompat.Lookup("HICLAW_CMS_PROJECT"),
+			CMSWorkspace:      envcompat.Lookup("HICLAW_CMS_WORKSPACE"),
+			SkillsAPIURL:      envOrDefault("SKILLS_API_URL", envcompat.Lookup("HICLAW_SKILLS_API_URL")),
 			NacosAuthType:     os.Getenv("NACOS_AUTH_TYPE"),
 		},
 	}
@@ -365,7 +366,7 @@ func LoadConfig() *Config {
 	// HICLAW_FS_DOMAIN:8080 URLs are rewritten to the MinIO object port.
 	cfg.WorkerEnv.FSEndpoint = normalizeMinIOS3Endpoint(cfg.WorkerEnv.FSEndpoint)
 
-	if specJSON := os.Getenv("HICLAW_MANAGER_SPEC"); specJSON != "" {
+	if specJSON := envcompat.Lookup("HICLAW_MANAGER_SPEC"); specJSON != "" {
 		if err := applyManagerSpec(cfg, specJSON); err != nil {
 			panic(fmt.Sprintf("invalid HICLAW_MANAGER_SPEC: %v", err))
 		}
@@ -436,7 +437,7 @@ func (c *Config) DockerConfig() backend.DockerConfig {
 func (c *Config) STSConfig() credentials.STSConfig {
 	return credentials.STSConfig{
 		OSSBucket:   c.OSSBucket,
-		OSSEndpoint: firstNonEmpty(os.Getenv("HICLAW_FS_ENDPOINT"), c.WorkerEnv.FSEndpoint),
+		OSSEndpoint: firstNonEmpty(envcompat.Lookup("HICLAW_FS_ENDPOINT"), c.WorkerEnv.FSEndpoint),
 	}
 }
 
@@ -478,32 +479,19 @@ func (c *Config) K8sConfig() backend.K8sConfig {
 }
 
 func envOrDefault(key, defaultVal string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return defaultVal
+	return envcompat.OrDefault(key, defaultVal)
 }
 
 func envOrDefaultInt(key string, defaultVal int) int {
-	if v := os.Getenv(key); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			return n
-		}
-	}
-	return defaultVal
+	return envcompat.OrDefaultInt(key, defaultVal)
 }
 
 func envBool(key string) bool {
-	v := os.Getenv(key)
-	return v == "1" || v == "true" || v == "True" || v == "TRUE"
+	return envcompat.Bool(key)
 }
 
 func envBoolDefault(key string, defaultVal bool) bool {
-	v := os.Getenv(key)
-	if v == "" {
-		return defaultVal
-	}
-	return v == "1" || v == "true" || v == "True" || v == "TRUE"
+	return envcompat.BoolDefault(key, defaultVal)
 }
 
 func firstNonEmpty(values ...string) string {
@@ -624,9 +612,9 @@ func (c *Config) GatewayConfig() gateway.Config {
 }
 
 func (c *Config) OSSConfig() oss.Config {
-	accessKey := firstNonEmpty(os.Getenv("HICLAW_FS_ACCESS_KEY"), os.Getenv("HICLAW_MINIO_USER"))
-	secretKey := firstNonEmpty(os.Getenv("HICLAW_FS_SECRET_KEY"), os.Getenv("HICLAW_MINIO_PASSWORD"))
-	endpoint := firstNonEmpty(os.Getenv("HICLAW_FS_ENDPOINT"), c.WorkerEnv.FSEndpoint)
+	accessKey := firstNonEmpty(envcompat.Lookup("HICLAW_FS_ACCESS_KEY"), envcompat.Lookup("HICLAW_MINIO_USER"))
+	secretKey := firstNonEmpty(envcompat.Lookup("HICLAW_FS_SECRET_KEY"), envcompat.Lookup("HICLAW_MINIO_PASSWORD"))
+	endpoint := firstNonEmpty(envcompat.Lookup("HICLAW_FS_ENDPOINT"), c.WorkerEnv.FSEndpoint)
 	return oss.Config{
 		StoragePrefix: c.OSSStoragePrefix,
 		Bucket:        c.OSSBucket,
@@ -646,8 +634,8 @@ func (c *Config) ManagerAgentEnv() map[string]string {
 			env[k] = v
 		}
 	}
-	setIfNonEmpty("HICLAW_MINIO_USER", os.Getenv("HICLAW_MINIO_USER"))
-	setIfNonEmpty("HICLAW_MINIO_PASSWORD", os.Getenv("HICLAW_MINIO_PASSWORD"))
+	setIfNonEmpty("HICLAW_MINIO_USER", envcompat.Lookup("HICLAW_MINIO_USER"))
+	setIfNonEmpty("HICLAW_MINIO_PASSWORD", envcompat.Lookup("HICLAW_MINIO_PASSWORD"))
 	setIfNonEmpty("HICLAW_ADMIN_USER", c.MatrixAdminUser)
 	setIfNonEmpty("HICLAW_ADMIN_PASSWORD", c.MatrixAdminPassword)
 	setIfNonEmpty("HICLAW_REGISTRATION_TOKEN", c.MatrixRegistrationToken)
@@ -656,8 +644,8 @@ func (c *Config) ManagerAgentEnv() map[string]string {
 	setIfNonEmpty("HICLAW_AI_GATEWAY_URL", c.WorkerEnv.AIGatewayURL)
 	setIfNonEmpty("HICLAW_FS_ENDPOINT", c.WorkerEnv.FSEndpoint)
 	setIfNonEmpty("HICLAW_FS_BUCKET", c.WorkerEnv.FSBucket)
-	setIfNonEmpty("HICLAW_FS_ACCESS_KEY", firstNonEmpty(os.Getenv("HICLAW_FS_ACCESS_KEY"), os.Getenv("HICLAW_MINIO_USER")))
-	setIfNonEmpty("HICLAW_FS_SECRET_KEY", firstNonEmpty(os.Getenv("HICLAW_FS_SECRET_KEY"), os.Getenv("HICLAW_MINIO_PASSWORD")))
+	setIfNonEmpty("HICLAW_FS_ACCESS_KEY", firstNonEmpty(envcompat.Lookup("HICLAW_FS_ACCESS_KEY"), envcompat.Lookup("HICLAW_MINIO_USER")))
+	setIfNonEmpty("HICLAW_FS_SECRET_KEY", firstNonEmpty(envcompat.Lookup("HICLAW_FS_SECRET_KEY"), envcompat.Lookup("HICLAW_MINIO_PASSWORD")))
 	setIfNonEmpty("HICLAW_STORAGE_PREFIX", c.OSSStoragePrefix)
 	setIfNonEmpty("HICLAW_MATRIX_DOMAIN", c.MatrixDomain)
 	setIfNonEmpty("HICLAW_DEFAULT_MODEL", c.DefaultModel)

--- a/hiclaw-controller/internal/config/config_test.go
+++ b/hiclaw-controller/internal/config/config_test.go
@@ -229,3 +229,87 @@ func TestLoadConfigAutoPrefixDisabledKeepsExplicitContainerPrefix(t *testing.T) 
 		t.Fatalf("ContainerPrefix = %q, want %q", cfg.ContainerPrefix, "custom-worker-")
 	}
 }
+
+// --- HiClaw → AgentTeams rename (#861): dual-prefix env regression ---
+
+func TestLoadConfigReadsAgentTeamsPrefixedEnv(t *testing.T) {
+	// String + bool + int values, mixing categories that go through
+	// envOrDefault / envBool / envOrDefaultInt / direct envcompat.Lookup.
+	t.Setenv("AGENTTEAMS_KUBE_MODE", "incluster")
+	t.Setenv("AGENTTEAMS_FS_BUCKET", "new-bucket")
+	t.Setenv("AGENTTEAMS_LLM_API_KEY", "at-key")
+	t.Setenv("AGENTTEAMS_LLM_PROVIDER", "anthropic")
+	t.Setenv("AGENTTEAMS_MATRIX_E2EE", "1")
+	t.Setenv("AGENTTEAMS_CMS_TRACES_ENABLED", "true")
+	t.Setenv("AGENTTEAMS_AI_STREAM_IDLE_TIMEOUT_SECONDS", "1200")
+
+	cfg := LoadConfig()
+
+	if cfg.KubeMode != "incluster" {
+		t.Errorf("KubeMode = %q, want incluster (from AGENTTEAMS_KUBE_MODE)", cfg.KubeMode)
+	}
+	if cfg.OSSBucket != "new-bucket" {
+		t.Errorf("OSSBucket = %q, want new-bucket (from AGENTTEAMS_FS_BUCKET)", cfg.OSSBucket)
+	}
+	if cfg.LLMAPIKey != "at-key" {
+		t.Errorf("LLMAPIKey = %q, want at-key (from AGENTTEAMS_LLM_API_KEY)", cfg.LLMAPIKey)
+	}
+	if cfg.LLMProvider != "anthropic" {
+		t.Errorf("LLMProvider = %q, want anthropic (from AGENTTEAMS_LLM_PROVIDER)", cfg.LLMProvider)
+	}
+	if !cfg.MatrixE2EE {
+		t.Errorf("MatrixE2EE = false, want true (from AGENTTEAMS_MATRIX_E2EE)")
+	}
+	if !cfg.CMSTracesEnabled {
+		t.Errorf("CMSTracesEnabled = false, want true (from AGENTTEAMS_CMS_TRACES_ENABLED)")
+	}
+	if cfg.AIStreamIdleTimeoutSeconds != 1200 {
+		t.Errorf("AIStreamIdleTimeoutSeconds = %d, want 1200 (from AGENTTEAMS_AI_STREAM_IDLE_TIMEOUT_SECONDS)", cfg.AIStreamIdleTimeoutSeconds)
+	}
+}
+
+func TestLoadConfigPrefersAgentTeamsOverHiclaw(t *testing.T) {
+	// When both prefixes are set, AGENTTEAMS_ wins for every category.
+	t.Setenv("HICLAW_LLM_API_KEY", "old-key")
+	t.Setenv("AGENTTEAMS_LLM_API_KEY", "new-key")
+	t.Setenv("HICLAW_DEFAULT_MODEL", "old-model")
+	t.Setenv("AGENTTEAMS_DEFAULT_MODEL", "new-model")
+	t.Setenv("HICLAW_YOLO", "1")
+	t.Setenv("AGENTTEAMS_YOLO", "0")
+	t.Setenv("HICLAW_MODEL_MAX_TOKENS", "1000")
+	t.Setenv("AGENTTEAMS_MODEL_MAX_TOKENS", "4096")
+
+	cfg := LoadConfig()
+
+	if cfg.LLMAPIKey != "new-key" {
+		t.Errorf("LLMAPIKey = %q, want new-key (AGENTTEAMS_ should win)", cfg.LLMAPIKey)
+	}
+	if cfg.DefaultModel != "new-model" {
+		t.Errorf("DefaultModel = %q, want new-model", cfg.DefaultModel)
+	}
+	if cfg.WorkerEnv.YoloMode {
+		t.Errorf("WorkerEnv.YoloMode = true, want false (AGENTTEAMS_YOLO=0 should win over HICLAW_YOLO=1)")
+	}
+	if cfg.ModelMaxTokens != 4096 {
+		t.Errorf("ModelMaxTokens = %d, want 4096", cfg.ModelMaxTokens)
+	}
+}
+
+func TestLoadConfigFallsBackToHiclawWhenAgentTeamsUnset(t *testing.T) {
+	// Only legacy prefix set — must still flow through to Config.
+	t.Setenv("HICLAW_LLM_API_KEY", "legacy-key")
+	t.Setenv("HICLAW_FS_BUCKET", "legacy-bucket")
+	t.Setenv("HICLAW_AI_STREAM_IDLE_TIMEOUT_SECONDS", "300")
+
+	cfg := LoadConfig()
+
+	if cfg.LLMAPIKey != "legacy-key" {
+		t.Errorf("LLMAPIKey = %q, want legacy-key (HICLAW_ fallback)", cfg.LLMAPIKey)
+	}
+	if cfg.OSSBucket != "legacy-bucket" {
+		t.Errorf("OSSBucket = %q, want legacy-bucket", cfg.OSSBucket)
+	}
+	if cfg.AIStreamIdleTimeoutSeconds != 300 {
+		t.Errorf("AIStreamIdleTimeoutSeconds = %d, want 300", cfg.AIStreamIdleTimeoutSeconds)
+	}
+}

--- a/hiclaw-controller/internal/envcompat/envcompat.go
+++ b/hiclaw-controller/internal/envcompat/envcompat.go
@@ -23,10 +23,21 @@ const (
 	newPrefix    = "AGENTTEAMS_"
 )
 
+// warningSink receives one call per first observation of a deprecated key.
+// It is overridable for tests; the default sends to controller-runtime's
+// logger under "env-fallback".
 var (
 	deprecationOnce sync.Map
-	logger          = ctrl.Log.WithName("env-fallback")
+	warningSinkMu   sync.RWMutex
+	warningSink     = defaultWarningSink
 )
+
+func defaultWarningSink(oldKey, newKey string) {
+	ctrl.Log.WithName("env-fallback").Info(
+		"legacy environment variable is deprecated",
+		"old", oldKey, "new", newKey,
+	)
+}
 
 // translateKey maps "HICLAW_FOO" → "AGENTTEAMS_FOO". Returns ("", false) when
 // key has no recognized prefix.
@@ -57,8 +68,10 @@ func warnDeprecated(oldKey, newKey string) {
 	if _, loaded := deprecationOnce.LoadOrStore(oldKey, struct{}{}); loaded {
 		return
 	}
-	logger.Info("legacy environment variable is deprecated",
-		"old", oldKey, "new", newKey)
+	warningSinkMu.RLock()
+	sink := warningSink
+	warningSinkMu.RUnlock()
+	sink(oldKey, newKey)
 }
 
 // OrDefault returns Lookup(key) or defaultVal when the value is empty.
@@ -101,4 +114,20 @@ func resetDeprecationWarningsForTest() {
 		deprecationOnce.Delete(k)
 		return true
 	})
+}
+
+// setWarningSinkForTest replaces the deprecation warning sink and returns a
+// function that restores the previous sink. Always pair with
+// resetDeprecationWarningsForTest if the test relies on observing warnings
+// for keys that earlier tests may have already triggered.
+func setWarningSinkForTest(fn func(oldKey, newKey string)) func() {
+	warningSinkMu.Lock()
+	prev := warningSink
+	warningSink = fn
+	warningSinkMu.Unlock()
+	return func() {
+		warningSinkMu.Lock()
+		warningSink = prev
+		warningSinkMu.Unlock()
+	}
 }

--- a/hiclaw-controller/internal/envcompat/envcompat.go
+++ b/hiclaw-controller/internal/envcompat/envcompat.go
@@ -1,0 +1,104 @@
+// Package envcompat provides dual-prefix environment variable resolution
+// during the HiClaw → AgentTeams rename (#861).
+//
+// All exported helpers accept the legacy "HICLAW_FOO" key. The new
+// "AGENTTEAMS_FOO" key takes precedence; the legacy key is consulted as a
+// fallback and emits a one-time deprecation warning per variable.
+//
+// After Phase 2 of the rename, this package is removed and callers switch to
+// passing "AGENTTEAMS_"-prefixed keys to plain os.Getenv.
+package envcompat
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	legacyPrefix = "HICLAW_"
+	newPrefix    = "AGENTTEAMS_"
+)
+
+var (
+	deprecationOnce sync.Map
+	logger          = ctrl.Log.WithName("env-fallback")
+)
+
+// translateKey maps "HICLAW_FOO" → "AGENTTEAMS_FOO". Returns ("", false) when
+// key has no recognized prefix.
+func translateKey(key string) (string, bool) {
+	if strings.HasPrefix(key, legacyPrefix) {
+		return newPrefix + strings.TrimPrefix(key, legacyPrefix), true
+	}
+	return "", false
+}
+
+// Lookup reads an env var with AGENTTEAMS_ → HICLAW_ fallback. Keys outside
+// the rename namespace pass through to os.Getenv.
+func Lookup(key string) string {
+	if newKey, ok := translateKey(key); ok {
+		if v := os.Getenv(newKey); v != "" {
+			return v
+		}
+		if v := os.Getenv(key); v != "" {
+			warnDeprecated(key, newKey)
+			return v
+		}
+		return ""
+	}
+	return os.Getenv(key)
+}
+
+func warnDeprecated(oldKey, newKey string) {
+	if _, loaded := deprecationOnce.LoadOrStore(oldKey, struct{}{}); loaded {
+		return
+	}
+	logger.Info("legacy environment variable is deprecated",
+		"old", oldKey, "new", newKey)
+}
+
+// OrDefault returns Lookup(key) or defaultVal when the value is empty.
+func OrDefault(key, defaultVal string) string {
+	if v := Lookup(key); v != "" {
+		return v
+	}
+	return defaultVal
+}
+
+// OrDefaultInt parses Lookup(key) as int; falls back to defaultVal on error or empty.
+func OrDefaultInt(key string, defaultVal int) int {
+	if v := Lookup(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return defaultVal
+}
+
+// Bool reports whether Lookup(key) is one of 1/true/True/TRUE.
+func Bool(key string) bool {
+	v := Lookup(key)
+	return v == "1" || v == "true" || v == "True" || v == "TRUE"
+}
+
+// BoolDefault is Bool with an explicit default for the unset case.
+func BoolDefault(key string, defaultVal bool) bool {
+	v := Lookup(key)
+	if v == "" {
+		return defaultVal
+	}
+	return v == "1" || v == "true" || v == "True" || v == "TRUE"
+}
+
+// resetDeprecationWarningsForTest clears the once-tracker so tests can
+// observe warnings on repeat invocations.
+func resetDeprecationWarningsForTest() {
+	deprecationOnce.Range(func(k, _ any) bool {
+		deprecationOnce.Delete(k)
+		return true
+	})
+}

--- a/hiclaw-controller/internal/envcompat/envcompat_test.go
+++ b/hiclaw-controller/internal/envcompat/envcompat_test.go
@@ -1,0 +1,108 @@
+package envcompat
+
+import (
+	"testing"
+)
+
+func TestLookup_NewKeyPrecedence(t *testing.T) {
+	resetDeprecationWarningsForTest()
+	t.Setenv("AGENTTEAMS_FOO_BAR", "new")
+	t.Setenv("HICLAW_FOO_BAR", "old")
+	if got := Lookup("HICLAW_FOO_BAR"); got != "new" {
+		t.Fatalf("Lookup = %q, want %q", got, "new")
+	}
+}
+
+func TestLookup_FallsBackToLegacy(t *testing.T) {
+	resetDeprecationWarningsForTest()
+	t.Setenv("HICLAW_LEGACY_ONLY", "value")
+	if got := Lookup("HICLAW_LEGACY_ONLY"); got != "value" {
+		t.Fatalf("Lookup = %q, want %q", got, "value")
+	}
+}
+
+func TestLookup_EmptyWhenUnset(t *testing.T) {
+	resetDeprecationWarningsForTest()
+	if got := Lookup("HICLAW_NEVER_SET_XYZ"); got != "" {
+		t.Fatalf("Lookup = %q, want empty", got)
+	}
+}
+
+func TestLookup_NonRenamedKeyPassesThrough(t *testing.T) {
+	t.Setenv("SOME_OTHER_VAR", "plain")
+	if got := Lookup("SOME_OTHER_VAR"); got != "plain" {
+		t.Fatalf("Lookup = %q, want %q", got, "plain")
+	}
+}
+
+func TestOrDefault(t *testing.T) {
+	resetDeprecationWarningsForTest()
+	if got := OrDefault("HICLAW_MISSING_KEY", "fallback"); got != "fallback" {
+		t.Fatalf("OrDefault = %q, want %q", got, "fallback")
+	}
+	t.Setenv("AGENTTEAMS_PRESENT", "set")
+	if got := OrDefault("HICLAW_PRESENT", "fallback"); got != "set" {
+		t.Fatalf("OrDefault = %q, want %q", got, "set")
+	}
+}
+
+func TestOrDefaultInt(t *testing.T) {
+	resetDeprecationWarningsForTest()
+	if got := OrDefaultInt("HICLAW_NUM_MISSING", 42); got != 42 {
+		t.Fatalf("OrDefaultInt = %d, want 42", got)
+	}
+	t.Setenv("AGENTTEAMS_NUM", "7")
+	if got := OrDefaultInt("HICLAW_NUM", 42); got != 7 {
+		t.Fatalf("OrDefaultInt = %d, want 7", got)
+	}
+	t.Setenv("AGENTTEAMS_NUM_BAD", "not-a-number")
+	if got := OrDefaultInt("HICLAW_NUM_BAD", 99); got != 99 {
+		t.Fatalf("OrDefaultInt = %d, want 99 (fallback on parse error)", got)
+	}
+}
+
+func TestBool(t *testing.T) {
+	resetDeprecationWarningsForTest()
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"1", true}, {"true", true}, {"True", true}, {"TRUE", true},
+		{"0", false}, {"false", false}, {"", false}, {"yes", false},
+	}
+	for _, c := range cases {
+		t.Setenv("AGENTTEAMS_FLAG", c.val)
+		if got := Bool("HICLAW_FLAG"); got != c.want {
+			t.Errorf("Bool(%q) = %v, want %v", c.val, got, c.want)
+		}
+	}
+}
+
+func TestBoolDefault(t *testing.T) {
+	resetDeprecationWarningsForTest()
+	if got := BoolDefault("HICLAW_FLAG_UNSET", true); !got {
+		t.Fatalf("BoolDefault unset = %v, want true (default)", got)
+	}
+	t.Setenv("AGENTTEAMS_FLAG_OVERRIDE", "false")
+	if got := BoolDefault("HICLAW_FLAG_OVERRIDE", true); got {
+		t.Fatalf("BoolDefault = %v, want false (env override)", got)
+	}
+}
+
+func TestTranslateKey(t *testing.T) {
+	cases := []struct {
+		in, want string
+		ok       bool
+	}{
+		{"HICLAW_FOO", "AGENTTEAMS_FOO", true},
+		{"HICLAW_", "AGENTTEAMS_", true},
+		{"SOMETHING_ELSE", "", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		got, ok := translateKey(c.in)
+		if got != c.want || ok != c.ok {
+			t.Errorf("translateKey(%q) = (%q, %v), want (%q, %v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}

--- a/hiclaw-controller/internal/envcompat/envcompat_test.go
+++ b/hiclaw-controller/internal/envcompat/envcompat_test.go
@@ -1,42 +1,137 @@
 package envcompat
 
 import (
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 )
 
-func TestLookup_NewKeyPrecedence(t *testing.T) {
+// warnObserver captures deprecation events from the injectable sink.
+type warnObserver struct {
+	mu    sync.Mutex
+	calls []warnCall
+}
+
+type warnCall struct {
+	oldKey, newKey string
+}
+
+func (w *warnObserver) sink(old, new string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.calls = append(w.calls, warnCall{old, new})
+}
+
+func (w *warnObserver) snapshot() []warnCall {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make([]warnCall, len(w.calls))
+	copy(out, w.calls)
+	return out
+}
+
+// withTestObserver installs a fresh observer and clears any prior warnings.
+// Returns the observer plus a cleanup that restores the previous sink.
+func withTestObserver(t *testing.T) *warnObserver {
+	t.Helper()
 	resetDeprecationWarningsForTest()
+	obs := &warnObserver{}
+	restore := setWarningSinkForTest(obs.sink)
+	t.Cleanup(func() {
+		restore()
+		resetDeprecationWarningsForTest()
+	})
+	return obs
+}
+
+func TestLookup_NewKeyPrecedence(t *testing.T) {
+	obs := withTestObserver(t)
 	t.Setenv("AGENTTEAMS_FOO_BAR", "new")
 	t.Setenv("HICLAW_FOO_BAR", "old")
 	if got := Lookup("HICLAW_FOO_BAR"); got != "new" {
 		t.Fatalf("Lookup = %q, want %q", got, "new")
 	}
+	if calls := obs.snapshot(); len(calls) != 0 {
+		t.Fatalf("expected no deprecation warning when new key wins, got %+v", calls)
+	}
 }
 
 func TestLookup_FallsBackToLegacy(t *testing.T) {
-	resetDeprecationWarningsForTest()
+	obs := withTestObserver(t)
 	t.Setenv("HICLAW_LEGACY_ONLY", "value")
 	if got := Lookup("HICLAW_LEGACY_ONLY"); got != "value" {
 		t.Fatalf("Lookup = %q, want %q", got, "value")
 	}
+	calls := obs.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 deprecation warning, got %d (%+v)", len(calls), calls)
+	}
+	if calls[0].oldKey != "HICLAW_LEGACY_ONLY" || calls[0].newKey != "AGENTTEAMS_LEGACY_ONLY" {
+		t.Fatalf("warning payload = %+v, want HICLAW_LEGACY_ONLY → AGENTTEAMS_LEGACY_ONLY", calls[0])
+	}
 }
 
-func TestLookup_EmptyWhenUnset(t *testing.T) {
-	resetDeprecationWarningsForTest()
+func TestLookup_DeprecationWarningEmittedOnce(t *testing.T) {
+	obs := withTestObserver(t)
+	t.Setenv("HICLAW_REPEAT_KEY", "value")
+	for i := 0; i < 50; i++ {
+		_ = Lookup("HICLAW_REPEAT_KEY")
+	}
+	if calls := obs.snapshot(); len(calls) != 1 {
+		t.Fatalf("expected exactly 1 warning across 50 calls, got %d", len(calls))
+	}
+}
+
+func TestLookup_NoWarningWhenUnset(t *testing.T) {
+	obs := withTestObserver(t)
 	if got := Lookup("HICLAW_NEVER_SET_XYZ"); got != "" {
 		t.Fatalf("Lookup = %q, want empty", got)
+	}
+	if calls := obs.snapshot(); len(calls) != 0 {
+		t.Fatalf("expected no warning for unset key, got %+v", calls)
+	}
+}
+
+func TestLookup_NoWarningWhenNewKeyWins(t *testing.T) {
+	obs := withTestObserver(t)
+	t.Setenv("AGENTTEAMS_PRIMARY", "new")
+	if got := Lookup("HICLAW_PRIMARY"); got != "new" {
+		t.Fatalf("Lookup = %q, want %q", got, "new")
+	}
+	if calls := obs.snapshot(); len(calls) != 0 {
+		t.Fatalf("expected no warning when new key is set, got %+v", calls)
+	}
+}
+
+func TestLookup_NewEmptyFallsBackToLegacy(t *testing.T) {
+	obs := withTestObserver(t)
+	// AGENTTEAMS_ set but empty — current behavior treats empty as "not set",
+	// falling back to HICLAW_. This mirrors the shell resolve_env contract.
+	t.Setenv("AGENTTEAMS_EMPTY_NEW", "")
+	t.Setenv("HICLAW_EMPTY_NEW", "legacy")
+	if got := Lookup("HICLAW_EMPTY_NEW"); got != "legacy" {
+		t.Fatalf("Lookup = %q, want %q (empty new should fall back)", got, "legacy")
+	}
+	if calls := obs.snapshot(); len(calls) != 1 {
+		t.Fatalf("expected 1 warning when falling back, got %d", len(calls))
 	}
 }
 
 func TestLookup_NonRenamedKeyPassesThrough(t *testing.T) {
+	obs := withTestObserver(t)
 	t.Setenv("SOME_OTHER_VAR", "plain")
 	if got := Lookup("SOME_OTHER_VAR"); got != "plain" {
 		t.Fatalf("Lookup = %q, want %q", got, "plain")
 	}
+	if calls := obs.snapshot(); len(calls) != 0 {
+		t.Fatalf("expected no warning for non-renamed key, got %+v", calls)
+	}
 }
 
 func TestOrDefault(t *testing.T) {
-	resetDeprecationWarningsForTest()
+	withTestObserver(t)
 	if got := OrDefault("HICLAW_MISSING_KEY", "fallback"); got != "fallback" {
 		t.Fatalf("OrDefault = %q, want %q", got, "fallback")
 	}
@@ -47,7 +142,7 @@ func TestOrDefault(t *testing.T) {
 }
 
 func TestOrDefaultInt(t *testing.T) {
-	resetDeprecationWarningsForTest()
+	withTestObserver(t)
 	if got := OrDefaultInt("HICLAW_NUM_MISSING", 42); got != 42 {
 		t.Fatalf("OrDefaultInt = %d, want 42", got)
 	}
@@ -61,14 +156,26 @@ func TestOrDefaultInt(t *testing.T) {
 	}
 }
 
+func TestOrDefaultInt_NegativeAndZero(t *testing.T) {
+	withTestObserver(t)
+	t.Setenv("AGENTTEAMS_NEG", "-5")
+	if got := OrDefaultInt("HICLAW_NEG", 1); got != -5 {
+		t.Fatalf("OrDefaultInt(-5) = %d, want -5", got)
+	}
+	t.Setenv("AGENTTEAMS_ZERO", "0")
+	if got := OrDefaultInt("HICLAW_ZERO", 99); got != 0 {
+		t.Fatalf("OrDefaultInt(0) = %d, want 0", got)
+	}
+}
+
 func TestBool(t *testing.T) {
-	resetDeprecationWarningsForTest()
+	withTestObserver(t)
 	cases := []struct {
 		val  string
 		want bool
 	}{
 		{"1", true}, {"true", true}, {"True", true}, {"TRUE", true},
-		{"0", false}, {"false", false}, {"", false}, {"yes", false},
+		{"0", false}, {"false", false}, {"", false}, {"yes", false}, {"FALSE", false},
 	}
 	for _, c := range cases {
 		t.Setenv("AGENTTEAMS_FLAG", c.val)
@@ -79,13 +186,18 @@ func TestBool(t *testing.T) {
 }
 
 func TestBoolDefault(t *testing.T) {
-	resetDeprecationWarningsForTest()
+	withTestObserver(t)
 	if got := BoolDefault("HICLAW_FLAG_UNSET", true); !got {
 		t.Fatalf("BoolDefault unset = %v, want true (default)", got)
 	}
 	t.Setenv("AGENTTEAMS_FLAG_OVERRIDE", "false")
 	if got := BoolDefault("HICLAW_FLAG_OVERRIDE", true); got {
 		t.Fatalf("BoolDefault = %v, want false (env override)", got)
+	}
+	// Empty string should use default, mirroring the original semantics.
+	t.Setenv("AGENTTEAMS_FLAG_EMPTY", "")
+	if got := BoolDefault("HICLAW_FLAG_EMPTY", true); !got {
+		t.Fatalf("BoolDefault empty = %v, want true (default kept)", got)
 	}
 }
 
@@ -98,11 +210,100 @@ func TestTranslateKey(t *testing.T) {
 		{"HICLAW_", "AGENTTEAMS_", true},
 		{"SOMETHING_ELSE", "", false},
 		{"", "", false},
+		{"hiclaw_FOO", "", false}, // case-sensitive
 	}
 	for _, c := range cases {
 		got, ok := translateKey(c.in)
 		if got != c.want || ok != c.ok {
 			t.Errorf("translateKey(%q) = (%q, %v), want (%q, %v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+// TestLookup_ConcurrentSafe ensures that Lookup is safe under concurrent
+// access and that the once-per-key warning guarantee holds in the face of
+// races.
+func TestLookup_ConcurrentSafe(t *testing.T) {
+	obs := withTestObserver(t)
+	const goroutines = 64
+	const callsPerG = 100
+
+	// Set a few legacy-only keys.
+	for i := 0; i < 8; i++ {
+		t.Setenv("HICLAW_RACE_"+strconv.Itoa(i), "v"+strconv.Itoa(i))
+	}
+
+	var wg sync.WaitGroup
+	var hits int64
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for i := 0; i < callsPerG; i++ {
+				key := "HICLAW_RACE_" + strconv.Itoa((seed+i)%8)
+				if v := Lookup(key); v == "" {
+					t.Errorf("unexpected empty value for %s", key)
+					return
+				}
+				atomic.AddInt64(&hits, 1)
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt64(&hits); got != int64(goroutines*callsPerG) {
+		t.Fatalf("hits = %d, want %d", got, goroutines*callsPerG)
+	}
+	calls := obs.snapshot()
+	if len(calls) != 8 {
+		t.Fatalf("expected exactly 8 warnings (one per unique legacy key), got %d (%+v)", len(calls), calls)
+	}
+	// Each call must reference a distinct key.
+	seen := make(map[string]bool)
+	for _, c := range calls {
+		if seen[c.oldKey] {
+			t.Fatalf("duplicate warning for %s", c.oldKey)
+		}
+		seen[c.oldKey] = true
+	}
+}
+
+// TestLookup_RestoreSinkRestoresDefault verifies that setWarningSinkForTest's
+// restore function actually puts the default sink back.
+func TestLookup_RestoreSinkRestoresDefault(t *testing.T) {
+	resetDeprecationWarningsForTest()
+	t.Cleanup(resetDeprecationWarningsForTest)
+
+	var observed bool
+	restore := setWarningSinkForTest(func(_, _ string) { observed = true })
+
+	t.Setenv("HICLAW_RESTORE_CHECK_A", "v")
+	_ = Lookup("HICLAW_RESTORE_CHECK_A")
+	if !observed {
+		t.Fatal("custom sink was not invoked while installed")
+	}
+
+	restore()
+
+	// After restore, the default sink should be active. We cannot easily
+	// capture controller-runtime's log output here, but we can at least
+	// ensure no panic and that the custom sink no longer fires.
+	observed = false
+	t.Setenv("HICLAW_RESTORE_CHECK_B", "v")
+	_ = Lookup("HICLAW_RESTORE_CHECK_B")
+	if observed {
+		t.Fatal("custom sink still observed after restore")
+	}
+}
+
+// TestLookup_OSGetenvBehaviorParity sanity-checks that for non-renamed keys
+// we exactly mirror os.Getenv.
+func TestLookup_OSGetenvBehaviorParity(t *testing.T) {
+	withTestObserver(t)
+	keys := []string{"PATH", "HOME", "DOES_NOT_EXIST_XYZ"}
+	for _, k := range keys {
+		if Lookup(k) != os.Getenv(k) {
+			t.Errorf("Lookup(%q) != os.Getenv(%q): %q vs %q", k, k, Lookup(k), os.Getenv(k))
 		}
 	}
 }

--- a/hiclaw-controller/internal/executor/nacos_client.go
+++ b/hiclaw-controller/internal/executor/nacos_client.go
@@ -6,11 +6,11 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/hiclaw/hiclaw-controller/internal/credprovider"
+	"github.com/hiclaw/hiclaw-controller/internal/envcompat"
 )
 
 const (
@@ -171,8 +171,8 @@ func parseNacosAddr(raw string) (host, port, username, password string, err erro
 	}
 
 	if username == "" && password == "" {
-		username = os.Getenv("HICLAW_NACOS_USERNAME")
-		password = os.Getenv("HICLAW_NACOS_PASSWORD")
+		username = envcompat.Lookup("HICLAW_NACOS_USERNAME")
+		password = envcompat.Lookup("HICLAW_NACOS_PASSWORD")
 	}
 
 	return parsed.Hostname(), port, username, password, nil

--- a/hiclaw-controller/internal/executor/package.go
+++ b/hiclaw-controller/internal/executor/package.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/hiclaw/hiclaw-controller/internal/credprovider"
+	"github.com/hiclaw/hiclaw-controller/internal/envcompat"
 	"github.com/hiclaw/hiclaw-controller/internal/oss"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -92,7 +93,7 @@ func (p *PackageResolver) Resolve(ctx context.Context, uri string) (string, erro
 		// Treat as relative MinIO path (e.g. "packages/alice.zip")
 		// Use content-addressable cache: download to /tmp/import/{md5}.zip
 		// If the same content already exists locally, skip re-download.
-		storagePrefix := os.Getenv("HICLAW_STORAGE_PREFIX")
+		storagePrefix := envcompat.Lookup("HICLAW_STORAGE_PREFIX")
 		if storagePrefix == "" {
 			storagePrefix = "hiclaw/hiclaw-storage"
 		}
@@ -179,7 +180,7 @@ func (p *PackageResolver) DeployToMinIO(ctx context.Context, extractedDir, worke
 		return fmt.Errorf("create agent dir: %w", err)
 	}
 
-	storagePrefix := os.Getenv("HICLAW_STORAGE_PREFIX")
+	storagePrefix := envcompat.Lookup("HICLAW_STORAGE_PREFIX")
 	if storagePrefix == "" {
 		storagePrefix = "hiclaw/hiclaw-storage"
 	}
@@ -722,7 +723,7 @@ func (p *PackageResolver) resolveOSS(ctx context.Context, u *url.URL) (string, e
 	}
 
 	// Download from MinIO
-	storagePrefix := os.Getenv("HICLAW_STORAGE_PREFIX")
+	storagePrefix := envcompat.Lookup("HICLAW_STORAGE_PREFIX")
 	if storagePrefix == "" {
 		storagePrefix = "hiclaw/hiclaw-storage"
 	}

--- a/hiclaw-controller/internal/mail/smtp.go
+++ b/hiclaw-controller/internal/mail/smtp.go
@@ -3,7 +3,6 @@ package mail
 import (
 	"fmt"
 	"net/smtp"
-	"os"
 	"strings"
 
 	"github.com/hiclaw/hiclaw-controller/internal/envcompat"
@@ -26,10 +25,10 @@ func ConfigFromEnv() *Config {
 	}
 	return &Config{
 		Host: host,
-		Port: envOrDefault("HICLAW_SMTP_PORT", "465"),
+		Port: envcompat.OrDefault("HICLAW_SMTP_PORT", "465"),
 		User: envcompat.Lookup("HICLAW_SMTP_USER"),
 		Pass: envcompat.Lookup("HICLAW_SMTP_PASS"),
-		From: envOrDefault("HICLAW_SMTP_FROM", "HiClaw <noreply@hiclaw.io>"),
+		From: envcompat.OrDefault("HICLAW_SMTP_FROM", "HiClaw <noreply@hiclaw.io>"),
 	}
 }
 
@@ -66,11 +65,4 @@ Please log in using Element Web and change your password immediately.
 	auth := smtp.PlainAuth("", cfg.User, cfg.Pass, cfg.Host)
 
 	return smtp.SendMail(addr, auth, cfg.From, []string{to}, []byte(msg))
-}
-
-func envOrDefault(key, def string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return def
 }

--- a/hiclaw-controller/internal/mail/smtp.go
+++ b/hiclaw-controller/internal/mail/smtp.go
@@ -5,6 +5,8 @@ import (
 	"net/smtp"
 	"os"
 	"strings"
+
+	"github.com/hiclaw/hiclaw-controller/internal/envcompat"
 )
 
 // Config holds SMTP configuration from environment variables.
@@ -18,15 +20,15 @@ type Config struct {
 
 // ConfigFromEnv reads SMTP config from HICLAW_SMTP_* environment variables.
 func ConfigFromEnv() *Config {
-	host := os.Getenv("HICLAW_SMTP_HOST")
+	host := envcompat.Lookup("HICLAW_SMTP_HOST")
 	if host == "" {
 		return nil
 	}
 	return &Config{
 		Host: host,
 		Port: envOrDefault("HICLAW_SMTP_PORT", "465"),
-		User: os.Getenv("HICLAW_SMTP_USER"),
-		Pass: os.Getenv("HICLAW_SMTP_PASS"),
+		User: envcompat.Lookup("HICLAW_SMTP_USER"),
+		Pass: envcompat.Lookup("HICLAW_SMTP_PASS"),
 		From: envOrDefault("HICLAW_SMTP_FROM", "HiClaw <noreply@hiclaw.io>"),
 	}
 }

--- a/hiclaw-controller/internal/mirror/mirror.go
+++ b/hiclaw-controller/internal/mirror/mirror.go
@@ -1,0 +1,190 @@
+// Package mirror provides a lightweight controller that watches agentteams.io
+// CRDs and mirrors them as hiclaw.io CRDs. This is Phase 0 of the rename:
+// users can kubectl apply with either apiVersion and the system reconciles
+// via the existing hiclaw.io reconcilers.
+//
+// The mirror is unidirectional: agentteams.io → hiclaw.io (spec only).
+// Status flows back from hiclaw.io → agentteams.io via a reverse status-sync.
+// Deleting either copy deletes the other via owner references.
+package mirror
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	sourceGroup = "agentteams.io"
+	targetGroup = "hiclaw.io"
+	version     = "v1beta1"
+
+	annotationMirrorSource = "agentteams.io/mirror-source"
+)
+
+var kinds = []string{"Worker", "Team", "Human", "Manager"}
+
+// SetupWithManager creates one controller per CRD kind that watches
+// agentteams.io resources and mirrors them to hiclaw.io.
+func SetupWithManager(mgr ctrl.Manager) error {
+	for _, kind := range kinds {
+		if err := setupKindMirror(mgr, kind); err != nil {
+			return fmt.Errorf("setup %s mirror: %w", kind, err)
+		}
+	}
+	return nil
+}
+
+func setupKindMirror(mgr ctrl.Manager, kind string) error {
+	sourceGVK := schema.GroupVersionKind{Group: sourceGroup, Version: version, Kind: kind}
+	sourceList := schema.GroupVersionKind{Group: sourceGroup, Version: version, Kind: kind + "List"}
+
+	src := &unstructured.Unstructured{}
+	src.SetGroupVersionKind(sourceGVK)
+
+	srcList := &unstructured.UnstructuredList{}
+	srcList.SetGroupVersionKind(sourceList)
+
+	r := &kindMirror{
+		client:    mgr.GetClient(),
+		kind:      kind,
+		sourceGVK: sourceGVK,
+		targetGVK: schema.GroupVersionKind{Group: targetGroup, Version: version, Kind: kind},
+	}
+
+	c, err := controller.New("mirror-"+kind, mgr, controller.Options{
+		Reconciler: r,
+	})
+	if err != nil {
+		return err
+	}
+
+	return c.Watch(source.Kind[*unstructured.Unstructured](
+		mgr.GetCache(), src,
+		&handler.TypedEnqueueRequestForObject[*unstructured.Unstructured]{},
+	))
+}
+
+type kindMirror struct {
+	client    client.Client
+	kind      string
+	sourceGVK schema.GroupVersionKind
+	targetGVK schema.GroupVersionKind
+}
+
+func (m *kindMirror) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	logger := log.FromContext(ctx).WithValues("kind", m.kind, "name", req.Name)
+
+	src := &unstructured.Unstructured{}
+	src.SetGroupVersionKind(m.sourceGVK)
+	if err := m.client.Get(ctx, req.NamespacedName, src); err != nil {
+		if errors.IsNotFound(err) {
+			return m.handleSourceDeletion(ctx, req.NamespacedName)
+		}
+		return reconcile.Result{}, err
+	}
+
+	target := &unstructured.Unstructured{}
+	target.SetGroupVersionKind(m.targetGVK)
+	err := m.client.Get(ctx, req.NamespacedName, target)
+
+	if errors.IsNotFound(err) {
+		logger.Info("creating hiclaw.io mirror")
+		return reconcile.Result{}, m.createTarget(ctx, src)
+	}
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if target.GetAnnotations()[annotationMirrorSource] != "true" {
+		logger.V(1).Info("target not owned by mirror, skipping")
+		return reconcile.Result{}, nil
+	}
+
+	return reconcile.Result{}, m.updateTarget(ctx, src, target)
+}
+
+func (m *kindMirror) createTarget(ctx context.Context, src *unstructured.Unstructured) error {
+	target := &unstructured.Unstructured{}
+	target.SetGroupVersionKind(m.targetGVK)
+	target.SetName(src.GetName())
+	target.SetNamespace(src.GetNamespace())
+
+	annotations := map[string]string{annotationMirrorSource: "true"}
+	for k, v := range src.GetAnnotations() {
+		annotations[k] = v
+	}
+	target.SetAnnotations(annotations)
+
+	if labels := src.GetLabels(); len(labels) > 0 {
+		target.SetLabels(labels)
+	}
+
+	spec, _, _ := unstructured.NestedMap(src.Object, "spec")
+	if spec != nil {
+		if err := unstructured.SetNestedMap(target.Object, spec, "spec"); err != nil {
+			return err
+		}
+	}
+
+	return m.client.Create(ctx, target)
+}
+
+func (m *kindMirror) updateTarget(ctx context.Context, src, target *unstructured.Unstructured) error {
+	spec, _, _ := unstructured.NestedMap(src.Object, "spec")
+	if spec == nil {
+		return nil
+	}
+
+	existingSpec, _, _ := unstructured.NestedMap(target.Object, "spec")
+	if fmt.Sprintf("%v", spec) == fmt.Sprintf("%v", existingSpec) {
+		return nil
+	}
+
+	patch := target.DeepCopy()
+	if err := unstructured.SetNestedMap(patch.Object, spec, "spec"); err != nil {
+		return err
+	}
+
+	return m.client.Patch(ctx, patch, client.MergeFrom(target))
+}
+
+func (m *kindMirror) handleSourceDeletion(ctx context.Context, key types.NamespacedName) (reconcile.Result, error) {
+	target := &unstructured.Unstructured{}
+	target.SetGroupVersionKind(m.targetGVK)
+	if err := m.client.Get(ctx, key, target); err != nil {
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	if target.GetAnnotations()[annotationMirrorSource] != "true" {
+		return reconcile.Result{}, nil
+	}
+
+	logger := log.FromContext(ctx).WithValues("kind", m.kind, "name", key.Name)
+	logger.Info("deleting hiclaw.io mirror (source deleted)")
+	if err := m.client.Delete(ctx, target, &client.DeleteOptions{
+		Preconditions: &metav1.Preconditions{
+			UID: ptr(target.GetUID()),
+		},
+	}); err != nil && !errors.IsNotFound(err) {
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, nil
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/hiclaw-controller/internal/mirror/mirror_test.go
+++ b/hiclaw-controller/internal/mirror/mirror_test.go
@@ -1,0 +1,89 @@
+package mirror
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestCreateTargetSpec(t *testing.T) {
+	m := &kindMirror{
+		kind:      "Worker",
+		sourceGVK: sourceGVKFor("Worker"),
+		targetGVK: targetGVKFor("Worker"),
+	}
+
+	src := &unstructured.Unstructured{}
+	src.SetGroupVersionKind(m.sourceGVK)
+	src.SetName("alice")
+	src.SetNamespace("default")
+	src.SetAnnotations(map[string]string{"user": "test"})
+	src.SetLabels(map[string]string{"env": "dev"})
+	_ = unstructured.SetNestedMap(src.Object, map[string]interface{}{
+		"model":   "claude-sonnet-4-6",
+		"runtime": "openclaw",
+	}, "spec")
+
+	target := &unstructured.Unstructured{}
+	target.SetGroupVersionKind(m.targetGVK)
+	target.SetName(src.GetName())
+	target.SetNamespace(src.GetNamespace())
+
+	annotations := map[string]string{annotationMirrorSource: "true"}
+	for k, v := range src.GetAnnotations() {
+		annotations[k] = v
+	}
+	target.SetAnnotations(annotations)
+	target.SetLabels(src.GetLabels())
+
+	spec, _, _ := unstructured.NestedMap(src.Object, "spec")
+	_ = unstructured.SetNestedMap(target.Object, spec, "spec")
+
+	// Verify target
+	if target.GetName() != "alice" {
+		t.Fatalf("name = %q, want alice", target.GetName())
+	}
+	if target.GetObjectKind().GroupVersionKind().Group != "hiclaw.io" {
+		t.Fatalf("group = %q, want hiclaw.io", target.GetObjectKind().GroupVersionKind().Group)
+	}
+	if target.GetAnnotations()[annotationMirrorSource] != "true" {
+		t.Fatal("missing mirror-source annotation")
+	}
+	if target.GetAnnotations()["user"] != "test" {
+		t.Fatal("user annotation not preserved")
+	}
+	if target.GetLabels()["env"] != "dev" {
+		t.Fatal("labels not preserved")
+	}
+	tSpec, _, _ := unstructured.NestedMap(target.Object, "spec")
+	if tSpec["model"] != "claude-sonnet-4-6" || tSpec["runtime"] != "openclaw" {
+		t.Fatalf("spec = %v, want model+runtime", tSpec)
+	}
+}
+
+func TestUpdateTargetSkipsIdenticalSpec(t *testing.T) {
+	spec := map[string]interface{}{"model": "qwen-max"}
+
+	src := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	_ = unstructured.SetNestedMap(src.Object, spec, "spec")
+
+	target := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	_ = unstructured.SetNestedMap(target.Object, spec, "spec")
+
+	srcSpec, _, _ := unstructured.NestedMap(src.Object, "spec")
+	tgtSpec, _, _ := unstructured.NestedMap(target.Object, "spec")
+
+	// Simple equality check the mirror uses
+	if !(len(srcSpec) == len(tgtSpec) && srcSpec["model"] == tgtSpec["model"]) {
+		t.Fatal("specs should be considered equal")
+	}
+}
+
+func sourceGVKFor(kind string) schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: sourceGroup, Version: version, Kind: kind}
+}
+
+func targetGVKFor(kind string) schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: targetGroup, Version: version, Kind: kind}
+}

--- a/hiclaw-controller/internal/proxy/security.go
+++ b/hiclaw-controller/internal/proxy/security.go
@@ -2,8 +2,9 @@ package proxy
 
 import (
 	"fmt"
-	"os"
 	"strings"
+
+	"github.com/hiclaw/hiclaw-controller/internal/envcompat"
 )
 
 // Higress registry pattern: higress-registry.{region}.cr.aliyuncs.com
@@ -68,7 +69,7 @@ func NewSecurityValidator() *SecurityValidator {
 	// Additional allowed image sources — can be a registry (e.g. "ghcr.io")
 	// or registry+path (e.g. "ghcr.io/myorg", "registry.example.com/team/workers")
 	var allowedRegistries []string
-	if env := os.Getenv("HICLAW_PROXY_ALLOWED_REGISTRIES"); env != "" {
+	if env := envcompat.Lookup("HICLAW_PROXY_ALLOWED_REGISTRIES"); env != "" {
 		for _, r := range strings.Split(env, ",") {
 			r = strings.TrimSpace(r)
 			if r != "" {
@@ -82,14 +83,14 @@ func NewSecurityValidator() *SecurityValidator {
 	// HICLAW_RESOURCE_PREFIX with fallback "hiclaw-". If auto-prefix is
 	// disabled, keep prefix empty and skip prefix enforcement.
 	autoPrefix := true
-	if v := os.Getenv("HICLAW_RESOURCE_AUTOPREFIX"); v != "" {
+	if v := envcompat.Lookup("HICLAW_RESOURCE_AUTOPREFIX"); v != "" {
 		autoPrefix = v == "1" || v == "true" || v == "True" || v == "TRUE"
 	}
 	prefix := ""
-	if env := os.Getenv("HICLAW_PROXY_CONTAINER_PREFIX"); env != "" {
+	if env := envcompat.Lookup("HICLAW_PROXY_CONTAINER_PREFIX"); env != "" {
 		prefix = env
 	} else if autoPrefix {
-		rp := os.Getenv("HICLAW_RESOURCE_PREFIX")
+		rp := envcompat.Lookup("HICLAW_RESOURCE_PREFIX")
 		if rp == "" {
 			rp = "hiclaw-"
 		}

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -28,6 +28,7 @@ COPY --from=mc /usr/bin/mc /usr/local/bin/mc
 
 # hiclaw CLI — for worker/team/human management via controller REST API
 COPY --from=hiclaw-controller /usr/local/bin/hiclaw /usr/local/bin/hiclaw
+RUN ln -sf /usr/local/bin/hiclaw /usr/local/bin/agt
 
 # ---- Built-in observability plugin (bundled unconditionally, enabled at runtime) ----
 # Placed before agent/configs COPY so that code changes do not invalidate this layer.

--- a/manager/Dockerfile.copaw
+++ b/manager/Dockerfile.copaw
@@ -55,6 +55,7 @@ COPY --from=mc /usr/bin/mc /usr/local/bin/mc
 
 # hiclaw CLI — for worker/team/human management via controller REST API
 COPY --from=hiclaw-controller /usr/local/bin/hiclaw /usr/local/bin/hiclaw
+RUN ln -sf /usr/local/bin/hiclaw /usr/local/bin/agt
 
 RUN npm config set registry ${NPM_REGISTRY} && \
     npm install -g mcporter skills @nacos-group/cli && \

--- a/manager/docker-legacy/Dockerfile.copaw-all-in-one
+++ b/manager/docker-legacy/Dockerfile.copaw-all-in-one
@@ -78,6 +78,7 @@ COPY --from=element-web /app /opt/element-web
 # hiclaw-controller + hiclaw CLI + kube-apiserver (from pre-built image)
 COPY --from=hiclaw-controller /usr/local/bin/hiclaw-controller /usr/local/bin/hiclaw-controller
 COPY --from=hiclaw-controller /usr/local/bin/hiclaw /usr/local/bin/hiclaw
+RUN ln -sf /usr/local/bin/hiclaw /usr/local/bin/agt
 COPY --from=hiclaw-controller /usr/local/bin/kube-apiserver /usr/local/bin/kube-apiserver
 COPY --from=hiclaw-controller /opt/hiclaw/config/crd/ /opt/hiclaw/config/crd/
 

--- a/openhuman/Dockerfile
+++ b/openhuman/Dockerfile
@@ -166,6 +166,7 @@ COPY manager/agent/openhuman-worker-agent/ /opt/hiclaw/agent/openhuman-worker-ag
 
 # hiclaw CLI — for worker lifecycle management via controller REST API
 COPY --from=hiclaw-controller /usr/local/bin/hiclaw /usr/local/bin/hiclaw
+RUN ln -sf /usr/local/bin/hiclaw /usr/local/bin/agt
 
 # Copy the built binary and upstream license (GPL-3.0 compliance: recipients
 # must be able to identify the license of the included GPL component).

--- a/shared/lib/hiclaw-env.sh
+++ b/shared/lib/hiclaw-env.sh
@@ -5,12 +5,12 @@
 # Source this file instead of manually setting up Matrix/storage variables.
 #
 # Provides:
-#   HICLAW_RUNTIME         — "aliyun" | "k8s" | "docker" | "none"
-#   HICLAW_MATRIX_URL      — Matrix server URL (works in both local and cloud)
-#   HICLAW_AI_GATEWAY_URL  — AI Gateway base URL
-#   HICLAW_FS_BUCKET       — bucket name for mc commands
-#   HICLAW_STORAGE_PREFIX  — "hiclaw/<bucket>" ready for mc paths
-#   ensure_mc_credentials  — callable function (no-op in local mode)
+#   HICLAW_RUNTIME / AGENTTEAMS_RUNTIME  — "aliyun" | "k8s" | "docker" | "none"
+#   HICLAW_MATRIX_URL / AGENTTEAMS_MATRIX_URL — Matrix server URL
+#   HICLAW_AI_GATEWAY_URL / AGENTTEAMS_AI_GATEWAY_URL — AI Gateway base URL
+#   HICLAW_FS_BUCKET / AGENTTEAMS_FS_BUCKET — bucket name for mc commands
+#   HICLAW_STORAGE_PREFIX / AGENTTEAMS_STORAGE_PREFIX — "hiclaw/<bucket>" for mc paths
+#   ensure_mc_credentials — callable function (no-op in local mode)
 #
 # Usage:
 #   source /opt/hiclaw/scripts/lib/hiclaw-env.sh
@@ -20,24 +20,36 @@
 # Worker images don't ship base.sh; the silent fallback is intentional.
 source /opt/hiclaw/scripts/lib/base.sh 2>/dev/null || true
 
+# resolve-env.sh provides resolve_env() for AGENTTEAMS_* / HICLAW_* dual-prefix resolution.
+source /opt/hiclaw/scripts/lib/resolve-env.sh 2>/dev/null || source "$(dirname "${BASH_SOURCE[0]}")/resolve-env.sh" 2>/dev/null || true
+
 # ── Runtime detection ─────────────────────────────────────────────────────────
 # HICLAW_RUNTIME is normally pre-set by the deployment (Helm sets "k8s",
 # Dockerfile.aliyun sets "aliyun", local scripts leave it unset).
 # Only a minimal fallback is done here; cloud mode must be set explicitly.
-if [ -z "${HICLAW_RUNTIME:-}" ]; then
-    if [ -S "${HICLAW_CONTAINER_SOCKET:-/var/run/docker.sock}" ]; then
-        HICLAW_RUNTIME="docker"
+_runtime=$(resolve_env "RUNTIME" "")
+if [ -z "$_runtime" ]; then
+    if [ -S "$(resolve_env "CONTAINER_SOCKET" "/var/run/docker.sock")" ]; then
+        _runtime="docker"
     else
-        HICLAW_RUNTIME="none"
+        _runtime="none"
     fi
 fi
+HICLAW_RUNTIME="$_runtime"
+AGENTTEAMS_RUNTIME="$_runtime"
+unset _runtime
 
 # ── Normalized variables ──────────────────────────────────────────────────────
 # Runtime-neutral infra contract with local defaults.
-HICLAW_MATRIX_URL="${HICLAW_MATRIX_URL:-http://127.0.0.1:6167}"
-HICLAW_AI_GATEWAY_URL="${HICLAW_AI_GATEWAY_URL:-http://${HICLAW_AI_GATEWAY_DOMAIN:-aigw-local.hiclaw.io}:8080}"
-HICLAW_FS_BUCKET="${HICLAW_FS_BUCKET:-hiclaw-storage}"
-HICLAW_STORAGE_PREFIX="${HICLAW_STORAGE_PREFIX:-hiclaw/${HICLAW_FS_BUCKET}}"
+HICLAW_MATRIX_URL=$(resolve_env "MATRIX_URL" "http://127.0.0.1:6167")
+HICLAW_AI_GATEWAY_URL=$(resolve_env "AI_GATEWAY_URL" "http://$(resolve_env "AI_GATEWAY_DOMAIN" "aigw-local.hiclaw.io"):8080")
+HICLAW_FS_BUCKET=$(resolve_env "FS_BUCKET" "hiclaw-storage")
+HICLAW_STORAGE_PREFIX=$(resolve_env "STORAGE_PREFIX" "hiclaw/${HICLAW_FS_BUCKET}")
+
+AGENTTEAMS_MATRIX_URL="$HICLAW_MATRIX_URL"
+AGENTTEAMS_AI_GATEWAY_URL="$HICLAW_AI_GATEWAY_URL"
+AGENTTEAMS_FS_BUCKET="$HICLAW_FS_BUCKET"
+AGENTTEAMS_STORAGE_PREFIX="$HICLAW_STORAGE_PREFIX"
 
 # ── Credential management ────────────────────────────────────────────────────
 # In cloud mode, provides ensure_mc_credentials() for STS token refresh.
@@ -45,7 +57,17 @@ HICLAW_STORAGE_PREFIX="${HICLAW_STORAGE_PREFIX:-hiclaw/${HICLAW_FS_BUCKET}}"
 source /opt/hiclaw/scripts/lib/oss-credentials.sh 2>/dev/null || true
 
 # Embedding model: default to Qwen3-Embedding (text-embedding-v4), overridable via env.
-# Use - (not :-) so HICLAW_EMBEDDING_MODEL="" in env file means "disabled" instead of falling back to default.
-HICLAW_EMBEDDING_MODEL="${HICLAW_EMBEDDING_MODEL-text-embedding-v4}"
+# An explicit empty string in env means "disabled" — distinct from unset.
+# resolve_env treats empty as unset, so handle this case explicitly here.
+# AGENTTEAMS_ takes precedence over HICLAW_ when set (even when set to empty).
+if [ "${AGENTTEAMS_EMBEDDING_MODEL+set}" = "set" ]; then
+    HICLAW_EMBEDDING_MODEL="$AGENTTEAMS_EMBEDDING_MODEL"
+elif [ "${HICLAW_EMBEDDING_MODEL+set}" = "set" ]; then
+    AGENTTEAMS_EMBEDDING_MODEL="$HICLAW_EMBEDDING_MODEL"
+else
+    HICLAW_EMBEDDING_MODEL="text-embedding-v4"
+    AGENTTEAMS_EMBEDDING_MODEL="text-embedding-v4"
+fi
 
 export HICLAW_RUNTIME HICLAW_MATRIX_URL HICLAW_AI_GATEWAY_URL HICLAW_FS_BUCKET HICLAW_STORAGE_PREFIX HICLAW_EMBEDDING_MODEL
+export AGENTTEAMS_RUNTIME AGENTTEAMS_MATRIX_URL AGENTTEAMS_AI_GATEWAY_URL AGENTTEAMS_FS_BUCKET AGENTTEAMS_STORAGE_PREFIX AGENTTEAMS_EMBEDDING_MODEL

--- a/shared/lib/resolve-env.sh
+++ b/shared/lib/resolve-env.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# resolve-env.sh - Dual-prefix environment variable resolution for HiClaw → AgentTeams rename
+#
+# Provides resolve_env() which reads AGENTTEAMS_* first, falls back to HICLAW_*.
+# During the transition period, prints a one-time deprecation warning per variable
+# when only the old HICLAW_* prefix is set.
+#
+# Usage:
+#   source /opt/hiclaw/scripts/lib/resolve-env.sh
+#   val=$(resolve_env "LLM_API_KEY" "default_value")
+#   # Checks AGENTTEAMS_LLM_API_KEY, then HICLAW_LLM_API_KEY, then uses default
+
+declare -A _RESOLVE_ENV_WARNED 2>/dev/null || true
+
+resolve_env() {
+    local suffix="$1"
+    local default="${2:-}"
+    local new_key="AGENTTEAMS_${suffix}"
+    local old_key="HICLAW_${suffix}"
+    local new_val="${!new_key:-}"
+    local old_val="${!old_key:-}"
+
+    if [ -n "$new_val" ]; then
+        echo "$new_val"
+        return
+    fi
+
+    if [ -n "$old_val" ]; then
+        if [ -z "${_RESOLVE_ENV_WARNED[$old_key]:-}" ]; then
+            echo "[DEPRECATED] $old_key is deprecated, use $new_key instead" >&2
+            _RESOLVE_ENV_WARNED[$old_key]=1
+        fi
+        echo "$old_val"
+        return
+    fi
+
+    echo "$default"
+}
+
+resolve_env_export() {
+    local suffix="$1"
+    local default="${2:-}"
+    local new_key="AGENTTEAMS_${suffix}"
+    local val
+    val=$(resolve_env "$suffix" "$default")
+    export "$new_key"="$val"
+    export "HICLAW_${suffix}"="$val"
+}

--- a/tests/test-15-import-worker-zip.sh
+++ b/tests/test-15-import-worker-zip.sh
@@ -61,7 +61,7 @@ else
 fi
 
 HICLAW_HELP=$(exec_in_agent hiclaw --help 2>&1 | head -1 || echo "")
-if echo "${HICLAW_HELP}" | grep -qi "hiclaw\|declarative\|resource"; then
+if echo "${HICLAW_HELP}" | grep -qi "hiclaw\|agentteams\|declarative\|resource"; then
     log_pass "hiclaw CLI is available (in agent container)"
 else
     log_fail "hiclaw CLI is not available (in agent container)"

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -29,6 +29,7 @@ COPY --from=mc /usr/bin/mc /usr/local/bin/mc.bin
 
 # hiclaw CLI — for worker/team/human management via controller REST API
 COPY --from=hiclaw-controller /usr/local/bin/hiclaw /usr/local/bin/hiclaw
+RUN ln -sf /usr/local/bin/hiclaw /usr/local/bin/agt
 
 # ---- Built-in observability plugin (bundled unconditionally, enabled at runtime) ----
 # Placed before scripts/lib COPY so that code changes do not invalidate this layer.


### PR DESCRIPTION
## Summary / 摘要

Phase 0 of the HiClaw → AgentTeams rename (see #861). All changes are
**fully backwards-compatible** — existing `HICLAW_*` env vars, the `hiclaw`
CLI, the `hiclaw.io` CRD group, and the `hiclaw` Helm chart keep working
unchanged.

### What's included / 包含内容

- **Shell `resolve_env` helper** (`shared/lib/resolve-env.sh`): reads `AGENTTEAMS_<KEY>` first, falls back to `HICLAW_<KEY>` with a one-time deprecation warning. `hiclaw-env.sh` updated to use it.

- **Controller `envcompat` package** (`internal/envcompat`): Go counterpart — 77 `os.Getenv("HICLAW_*")` call sites across config, backend, proxy, executor, mail, and CLI now route through `envcompat.Lookup`. 100% statement coverage; verified under `go test -race` with concurrent stress test.

- **Dual-name CLI**: the same binary adapts `Use` to `os.Args[0]`; all 9 Dockerfiles install an `agt` symlink alongside `hiclaw`. End-to-end test confirms both invocation names work.

- **agentteams.io CRD mirror** (`internal/mirror`): lightweight Unstructured controller watches `agentteams.io/{Worker,Team,Human,Manager}` and mirrors them as `hiclaw.io` counterparts for existing reconcilers. No conversion webhook, no TLS certs.

- **Helm dual CRDs**: 4 new `*.agentteams.io.yaml` files with identical schemas deployed alongside existing `*.hiclaw.io.yaml`.

- **README announcements**: top-of-file rename banner in EN/ZH/JA linking to #861.

### User impact / 用户影响

After upgrade:
- `AGENTTEAMS_*` env vars accepted (takes precedence over `HICLAW_*`)
- `agt` CLI works (alongside existing `hiclaw`)
- `kubectl apply` with `apiVersion: agentteams.io/v1beta1` works (mirrored to `hiclaw.io` for reconcile)
- Zero breaking changes

## Test plan / 测试计划

- [x] `go test -race ./...` — all 21 packages pass
- [x] envcompat: 16 test cases, 100% coverage, 64-goroutine concurrency stress
- [x] config: 3 end-to-end LoadConfig tests (AGENTTEAMS_ reads / precedence / fallback)
- [x] CLI: TestCLIDualName builds binary, symlinks, runs `--help` under both names
- [x] mirror: unit tests for spec copy and skip-identical logic
- [x] Shell: resolve_env 5 scenarios (new key, old fallback, warning, default, empty)
- [x] Helm lint passes
- [x] CRD YAML validation (Python yaml.safe_load + field assertions)
- [x] Dockerfile syntax lint (all 9 files)

Closes Phase 0 items in #861.