### PR TITLE
docs(AGENTS.md): add Current Initiatives section for cross-PR context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,19 @@ This file helps AI Agents (and human developers) quickly understand the project 
 
 HiClaw is an open-source Agent Teams system that uses IM (Matrix protocol) for multi-Agent collaboration with human-in-the-loop oversight. It consists of a Manager Agent (coordinator) and Worker Agents (task executors), connected via an AI Gateway (Higress), Matrix Homeserver (Tuwunel), and HTTP file storage (MinIO or cloud OSS). Production-style deployments use the Kubernetes operator and Helm chart; local installs use Docker Compose scripts under `install/`.
 
+## Current Initiatives
+
+Active cross-cutting efforts that affect multiple PRs. **Check this section before reviewing or submitting code** — your change may overlap with or depend on one of these initiatives.
+
+| Initiative | Tracking | Impact |
+|------------|----------|--------|
+| **HiClaw → AgentTeams rename** | #861, PR #951 | All new `HICLAW_*` env vars must also support `AGENTTEAMS_*` via `shared/lib/resolve-env.sh`. New CRDs must register under both `hiclaw.io` and `agentteams.io` groups. Phase 0 is backwards-compatible; existing `HICLAW_*` vars keep working. |
+| **CRD status.conditions** | #924, PR #946 | Controller reconcilers are being refactored to report structured conditions. Changes to reconciler status logic should coordinate with this PR. |
+| **Sandbox worker runtime** | PR #941 | Adds a new `sandbox` runtime option. Changes to worker lifecycle, Dockerfile, or runtime selection should be aware of this addition. |
+| **Team / Worker CRD decoupling** | PR #910 | Separates org membership from runtime definition. Changes to Team or Worker CRD specs should check compatibility. |
+
+> **Maintainers**: update this table when a major initiative starts or lands. Remove entries once merged and released. Keep it short — only efforts that span multiple files or affect other contributors' PRs belong here.
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
## Summary

Add a **Current Initiatives** table to the top of `AGENTS.md` (after "What is HiClaw", before "Project Structure").

**Problem**: AI agents (Claude Code, Codex, Cursor, etc.) reviewing individual PRs lack visibility into project-wide ongoing efforts. For example, PR #943 adds a new `HICLAW_DM_POLICY` env var without knowing that PR #951 is renaming `HICLAW_*` → `AGENTTEAMS_*` — the agent reviewing #943 in isolation would miss this conflict.

**Solution**: Since `AGENTS.md` is automatically loaded by all major AI coding tools, adding a short initiatives table here gives every agent (and human) the project-wide context needed for accurate PR reviews and contributions.

Current initiatives listed:
- HiClaw → AgentTeams rename (#861, PR #951)
- CRD status.conditions (#924, PR #946)
- Sandbox worker runtime (PR #941)
- Team / Worker CRD decoupling (PR #910)

Includes a maintainer note to keep the table updated as initiatives land or new ones start.

## Test plan
- [ ] Verify AGENTS.md renders correctly on GitHub
- [ ] Confirm no existing section anchors are broken


🤖 Generated with [Claude Code](https://claude.com/claude-code)