### PR TITLE
fix(copaw): align worker runtime env with AgentTeams

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -13,6 +13,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 
 **Bug Fixes**
 
+- **CoPaw worker runtime environment**: CoPaw workers now prefer AgentTeams storage/runtime environment variables while preserving legacy HiClaw fallbacks, and Qwen-style model health preflights disable thinking for lightweight readiness checks.
 - **CoPaw Worker heartbeat**: CoPaw worker templates now seed heartbeat at a 10-minute interval so Team Leader agents created from the worker template can run heartbeat turns without requiring an explicit Team CR heartbeat spec.
 - **Helm CRDs**: Removed unsupported `propertyNames` schema fields from Worker and Team CRDs so Kubernetes API servers accept the chart CRDs.
 - **CoPaw local runtime paths**: CoPaw direct-run defaults now honor `COPAW_INSTALL_DIR` and `COPAW_WORKING_DIR` before falling back to local home-directory paths, while container entrypoints can continue to pass explicit directories.

--- a/copaw/scripts/copaw-worker-entrypoint.sh
+++ b/copaw/scripts/copaw-worker-entrypoint.sh
@@ -37,25 +37,25 @@ if [ -n "${TZ}" ] && [ -f "/usr/share/zoneinfo/${TZ}" ]; then
 fi
 
 # ── Credential setup ─────────────────────────────────────────────────────────
-# Controller-mediated OSS: STS credentials via MC_HOST_agentteams.
+# Controller-mediated OSS: STS credentials via MC_HOST_hiclaw.
 # Local MinIO: explicit FS endpoint/key/secret passed via CLI args.
-if ensure_mc_credentials && agentteams_mc_host_configured; then
+if ensure_mc_credentials && [ -n "${MC_HOST_hiclaw:-}" ]; then
     log "Configuring OSS credentials via controller-issued STS..."
-    # CLI requires --fs/--fs-key/--fs-secret but they are unused when MC_HOST_agentteams is set.
+    # CLI requires --fs/--fs-key/--fs-secret but they are unused when MC_HOST_hiclaw is set.
     FS_ENDPOINT="https://oss-placeholder.aliyuncs.com"
     FS_ACCESS_KEY="rrsa"
     FS_SECRET_KEY="rrsa"
-    FS_BUCKET="${AGENTTEAMS_FS_BUCKET:-${HICLAW_OSS_BUCKET:-agentteams-storage}}"
+    FS_BUCKET="${AGENTTEAMS_FS_BUCKET:-${HICLAW_FS_BUCKET:-${HICLAW_OSS_BUCKET:-hiclaw-storage}}}"
     log "  OSS bucket: ${FS_BUCKET}"
 else
     if [ "${AGENTTEAMS_STORAGE_PROVIDER:-minio}" = "oss" ]; then
-        log "ERROR: OSS storage requires controller-issued storage credentials, but $(agentteams_mc_host_var) is not configured"
+        log "ERROR: OSS storage requires controller-issued storage credentials, but MC_HOST_hiclaw is not configured"
         exit 1
     fi
     FS_ENDPOINT="${AGENTTEAMS_FS_ENDPOINT:-${HICLAW_FS_ENDPOINT:-}}"
     FS_ACCESS_KEY="${AGENTTEAMS_FS_ACCESS_KEY:-${HICLAW_FS_ACCESS_KEY:-}}"
     FS_SECRET_KEY="${AGENTTEAMS_FS_SECRET_KEY:-${HICLAW_FS_SECRET_KEY:-}}"
-    FS_BUCKET="${AGENTTEAMS_FS_BUCKET:-${HICLAW_OSS_BUCKET:-hiclaw-storage}}"
+    FS_BUCKET="${AGENTTEAMS_FS_BUCKET:-${HICLAW_FS_BUCKET:-${HICLAW_OSS_BUCKET:-hiclaw-storage}}}"
     [ -n "${FS_ENDPOINT}" ] || { log "ERROR: AGENTTEAMS_FS_ENDPOINT is required"; exit 1; }
     [ -n "${FS_ACCESS_KEY}" ] || { log "ERROR: AGENTTEAMS_FS_ACCESS_KEY is required"; exit 1; }
     [ -n "${FS_SECRET_KEY}" ] || { log "ERROR: AGENTTEAMS_FS_SECRET_KEY is required"; exit 1; }

--- a/copaw/scripts/copaw-worker-entrypoint.sh
+++ b/copaw/scripts/copaw-worker-entrypoint.sh
@@ -4,26 +4,26 @@
 # or lite-copaw-worker.
 #
 # Mode selection:
-#   - HICLAW_CONSOLE_PORT set   → standard mode (copaw-worker, PyPI CoPaw venv)
-#   - HICLAW_CONSOLE_PORT unset → lite mode (lite-copaw-worker, lite CoPaw venv)
+#   - AGENTTEAMS_CONSOLE_PORT/HICLAW_CONSOLE_PORT set   → standard mode
+#   - console port unset → lite mode
 #
 # Environment variables (set by container_create_worker in container-api.sh):
-#   HICLAW_WORKER_NAME   - Worker name (required)
-#   HICLAW_FS_ENDPOINT   - MinIO endpoint (required in local mode)
-#   HICLAW_FS_ACCESS_KEY - MinIO access key (required in local mode)
-#   HICLAW_FS_SECRET_KEY - MinIO secret key (required in local mode)
-#   HICLAW_CONSOLE_PORT  - CoPaw web console port (triggers standard mode, costs ~500MB RAM)
-#   HICLAW_RUNTIME       - "aliyun" for cloud mode (uses RRSA/STS via hiclaw-env.sh)
+#   AGENTTEAMS_WORKER_NAME   - Worker name (required)
+#   AGENTTEAMS_FS_ENDPOINT   - MinIO endpoint (required in local mode)
+#   AGENTTEAMS_FS_ACCESS_KEY - MinIO access key (required in local mode)
+#   AGENTTEAMS_FS_SECRET_KEY - MinIO secret key (required in local mode)
+#   AGENTTEAMS_CONSOLE_PORT  - CoPaw web console port (triggers standard mode)
 #   TZ                   - Timezone (optional)
 
 set -e
 
-# Source shared environment bootstrap (provides ensure_mc_credentials in cloud mode)
-source /opt/hiclaw/scripts/lib/hiclaw-env.sh 2>/dev/null || true
+# Source shared environment bootstrap (provides worker-deps env and storage credentials)
+source /opt/hiclaw/scripts/lib/hiclaw-env.sh
 
-WORKER_NAME="${HICLAW_WORKER_NAME:?HICLAW_WORKER_NAME is required}"
+WORKER_NAME="${AGENTTEAMS_WORKER_NAME:-${HICLAW_WORKER_NAME:-}}"
+[ -n "${WORKER_NAME}" ] || { echo "AGENTTEAMS_WORKER_NAME is required" >&2; exit 1; }
 INSTALL_DIR="/root/.copaw-worker"
-CONSOLE_PORT="${HICLAW_CONSOLE_PORT:-}"
+CONSOLE_PORT="${AGENTTEAMS_CONSOLE_PORT:-${HICLAW_CONSOLE_PORT:-}}"
 
 log() {
     echo "[hiclaw-copaw-worker $(date '+%Y-%m-%d %H:%M:%S')] $1"
@@ -37,23 +37,28 @@ if [ -n "${TZ}" ] && [ -f "/usr/share/zoneinfo/${TZ}" ]; then
 fi
 
 # ── Credential setup ─────────────────────────────────────────────────────────
-# Cloud mode: RRSA/STS credentials via MC_HOST_hiclaw (set by ensure_mc_credentials).
-# FileSync._ensure_alias() detects MC_HOST_hiclaw and skips mc alias set.
-# Local mode: explicit FS endpoint/key/secret passed via CLI args.
-if [ "${HICLAW_RUNTIME:-}" = "aliyun" ]; then
-    log "Cloud mode: configuring OSS credentials via RRSA..."
-    ensure_mc_credentials || { log "ERROR: Failed to obtain OSS credentials"; exit 1; }
-    # CLI requires --fs/--fs-key/--fs-secret but they are unused when MC_HOST_hiclaw is set
+# Controller-mediated OSS: STS credentials via MC_HOST_agentteams.
+# Local MinIO: explicit FS endpoint/key/secret passed via CLI args.
+if ensure_mc_credentials && agentteams_mc_host_configured; then
+    log "Configuring OSS credentials via controller-issued STS..."
+    # CLI requires --fs/--fs-key/--fs-secret but they are unused when MC_HOST_agentteams is set.
     FS_ENDPOINT="https://oss-placeholder.aliyuncs.com"
     FS_ACCESS_KEY="rrsa"
     FS_SECRET_KEY="rrsa"
-    FS_BUCKET="${HICLAW_OSS_BUCKET:-hiclaw-cloud-storage}"
+    FS_BUCKET="${AGENTTEAMS_FS_BUCKET:-${HICLAW_OSS_BUCKET:-agentteams-storage}}"
     log "  OSS bucket: ${FS_BUCKET}"
 else
-    FS_ENDPOINT="${HICLAW_FS_ENDPOINT:?HICLAW_FS_ENDPOINT is required}"
-    FS_ACCESS_KEY="${HICLAW_FS_ACCESS_KEY:?HICLAW_FS_ACCESS_KEY is required}"
-    FS_SECRET_KEY="${HICLAW_FS_SECRET_KEY:?HICLAW_FS_SECRET_KEY is required}"
-    FS_BUCKET="hiclaw-storage"
+    if [ "${AGENTTEAMS_STORAGE_PROVIDER:-minio}" = "oss" ]; then
+        log "ERROR: OSS storage requires controller-issued storage credentials, but $(agentteams_mc_host_var) is not configured"
+        exit 1
+    fi
+    FS_ENDPOINT="${AGENTTEAMS_FS_ENDPOINT:-${HICLAW_FS_ENDPOINT:-}}"
+    FS_ACCESS_KEY="${AGENTTEAMS_FS_ACCESS_KEY:-${HICLAW_FS_ACCESS_KEY:-}}"
+    FS_SECRET_KEY="${AGENTTEAMS_FS_SECRET_KEY:-${HICLAW_FS_SECRET_KEY:-}}"
+    FS_BUCKET="${AGENTTEAMS_FS_BUCKET:-${HICLAW_OSS_BUCKET:-hiclaw-storage}}"
+    [ -n "${FS_ENDPOINT}" ] || { log "ERROR: AGENTTEAMS_FS_ENDPOINT is required"; exit 1; }
+    [ -n "${FS_ACCESS_KEY}" ] || { log "ERROR: AGENTTEAMS_FS_ACCESS_KEY is required"; exit 1; }
+    [ -n "${FS_SECRET_KEY}" ] || { log "ERROR: AGENTTEAMS_FS_SECRET_KEY is required"; exit 1; }
 fi
 
 # Set up skills CLI symlink: ~/.agents/skills -> worker's skills directory

--- a/copaw/src/copaw_worker/config.py
+++ b/copaw/src/copaw_worker/config.py
@@ -12,7 +12,7 @@ class WorkerConfig:
         minio_endpoint: str,
         minio_access_key: str,
         minio_secret_key: str,
-        minio_bucket: str = "hiclaw-storage",
+        minio_bucket: str = "agentteams-storage",
         minio_secure: bool = False,
         sync_interval: int = 60,
         install_dir: Path | None = None,

--- a/copaw/src/copaw_worker/health.py
+++ b/copaw/src/copaw_worker/health.py
@@ -21,8 +21,8 @@ Strategy:
               a shutdown request, or the bounded startup probe cannot reach
               the native CoPaw health endpoint.
           Runtime health:
-            - check: worker API GET /worker/readyz probes
-              http://127.0.0.1:{console_port}/health on demand.
+            - check: health report loop probes
+              http://127.0.0.1:{console_port}/health periodically.
             - healthy: probe returns 200.
             - unhealthy: probe fails/times out, the FastAPI app exits
               unexpectedly, or server.serve() returns before requested
@@ -221,7 +221,7 @@ def _snapshot_to_dict(snapshot: HealthSnapshot) -> dict[str, Any]:
 def check_model_service(
     openclaw_cfg: dict[str, Any],
     *,
-    timeout: float = 60,
+    timeout: float = 20,
 ) -> ComponentHealth:
     active = _active_model_provider(openclaw_cfg)
     if active is None:
@@ -250,13 +250,14 @@ def check_model_service(
 
     chat_url = f"{base_url}/chat/completions"
     token_param = _max_tokens_param(model_id)
-    body = json.dumps(
-        {
-            "model": model_id,
-            "messages": [{"role": "user", "content": "ping"}],
-            token_param: 1,
-        }
-    ).encode("utf-8")
+    payload: dict[str, Any] = {
+        "model": model_id,
+        "messages": [{"role": "user", "content": "ping"}],
+        token_param: 1,
+    }
+    if _supports_enable_thinking(model_id):
+        payload["enable_thinking"] = False
+    body = json.dumps(payload).encode("utf-8")
     headers = {
         "Accept": "application/json",
         "Content-Type": "application/json",
@@ -429,6 +430,14 @@ def _active_model_provider(
             if isinstance(model, dict) and model.get("id"):
                 return str(provider_id), str(model["id"]), provider_cfg
     return None
+
+
+_ENABLE_THINKING_MODELS = {"qwen", "qwq", "deepseek"}
+
+
+def _supports_enable_thinking(model_id: str) -> bool:
+    lower = model_id.lower()
+    return any(lower.startswith(prefix) for prefix in _ENABLE_THINKING_MODELS)
 
 
 def _max_tokens_param(model_id: str) -> str:

--- a/copaw/src/copaw_worker/hooks/tools/filesync.py
+++ b/copaw/src/copaw_worker/hooks/tools/filesync.py
@@ -50,24 +50,45 @@ def _copaw_working_dir() -> Path:
 
 
 def create_sync() -> FileSync:
-    worker_name = os.getenv("HICLAW_WORKER_NAME") or os.getenv("COPAW_WORKER_NAME")
-    worker_cr_name = os.getenv("HICLAW_WORKER_CR_NAME") or os.getenv("COPAW_WORKER_CR_NAME")
-    minio_endpoint = os.getenv("HICLAW_FS_ENDPOINT") or os.getenv("COPAW_MINIO_ENDPOINT")
-    minio_access_key = os.getenv("HICLAW_FS_ACCESS_KEY") or os.getenv("COPAW_MINIO_ACCESS_KEY")
-    minio_secret_key = os.getenv("HICLAW_FS_SECRET_KEY") or os.getenv("COPAW_MINIO_SECRET_KEY")
+    worker_name = (
+        os.getenv("AGENTTEAMS_WORKER_NAME")
+        or os.getenv("HICLAW_WORKER_NAME")
+        or os.getenv("COPAW_WORKER_NAME")
+    )
+    worker_cr_name = (
+        os.getenv("AGENTTEAMS_WORKER_CR_NAME")
+        or os.getenv("HICLAW_WORKER_CR_NAME")
+        or os.getenv("COPAW_WORKER_CR_NAME")
+    )
+    minio_endpoint = (
+        os.getenv("AGENTTEAMS_FS_ENDPOINT")
+        or os.getenv("HICLAW_FS_ENDPOINT")
+        or os.getenv("COPAW_MINIO_ENDPOINT")
+    )
+    minio_access_key = (
+        os.getenv("AGENTTEAMS_FS_ACCESS_KEY")
+        or os.getenv("HICLAW_FS_ACCESS_KEY")
+        or os.getenv("COPAW_MINIO_ACCESS_KEY")
+    )
+    minio_secret_key = (
+        os.getenv("AGENTTEAMS_FS_SECRET_KEY")
+        or os.getenv("HICLAW_FS_SECRET_KEY")
+        or os.getenv("COPAW_MINIO_SECRET_KEY")
+    )
     minio_bucket = (
-        os.getenv("HICLAW_FS_BUCKET")
+        os.getenv("AGENTTEAMS_FS_BUCKET")
+        or os.getenv("HICLAW_FS_BUCKET")
         or os.getenv("COPAW_MINIO_BUCKET")
-        or "hiclaw-storage"
+        or "agentteams-storage"
     )
 
     missing = [
         name
         for name, value in (
-            ("HICLAW_WORKER_NAME", worker_name),
-            ("HICLAW_FS_ENDPOINT", minio_endpoint),
-            ("HICLAW_FS_ACCESS_KEY", minio_access_key),
-            ("HICLAW_FS_SECRET_KEY", minio_secret_key),
+            ("AGENTTEAMS_WORKER_NAME", worker_name),
+            ("AGENTTEAMS_FS_ENDPOINT", minio_endpoint),
+            ("AGENTTEAMS_FS_ACCESS_KEY", minio_access_key),
+            ("AGENTTEAMS_FS_SECRET_KEY", minio_secret_key),
         )
         if not value
     ]

--- a/copaw/src/copaw_worker/sync.py
+++ b/copaw/src/copaw_worker/sync.py
@@ -35,8 +35,18 @@ from copaw_worker.bridge import bridge_runtime_to_standard
 
 logger = logging.getLogger(__name__)
 
+def _storage_alias() -> str:
+    explicit = os.environ.get("AGENTTEAMS_STORAGE_ALIAS") or os.environ.get("HICLAW_STORAGE_ALIAS")
+    if explicit:
+        return explicit
+    prefix = os.environ.get("AGENTTEAMS_STORAGE_PREFIX") or os.environ.get("HICLAW_STORAGE_PREFIX") or ""
+    if "/" in prefix:
+        return prefix.split("/", 1)[0]
+    return "agentteams"
+
+
 # mc alias name used for this worker session
-_MC_ALIAS = "hiclaw"
+_MC_ALIAS = _storage_alias()
 
 
 class HealthStateProtocol(Protocol):
@@ -246,8 +256,9 @@ class FileSync:
         self.global_shared_dir = global_shared_dir or self.local_dir / "global-shared"
         self._prefix = f"agents/{worker_name}"
         self._alias_set = False
-        self._cloud_mode = os.environ.get("HICLAW_RUNTIME") == "aliyun"
-        self._k8s_mode = os.environ.get("HICLAW_RUNTIME") == "k8s"
+        runtime = os.environ.get("AGENTTEAMS_RUNTIME") or os.environ.get("HICLAW_RUNTIME")
+        self._cloud_mode = runtime == "aliyun"
+        self._k8s_mode = runtime == "k8s"
         self._worker_info: dict[str, Any] | None = None
 
     # ------------------------------------------------------------------
@@ -263,9 +274,10 @@ class FileSync:
         """
         result = subprocess.run(
             ["bash", "-c",
-             "source /opt/hiclaw/scripts/lib/oss-credentials.sh && "
+             "source /opt/hiclaw/scripts/lib/hiclaw-env.sh && "
              "ensure_mc_credentials && "
-             "echo $MC_HOST_hiclaw"],
+             f"_mc_host_var=MC_HOST_{_MC_ALIAS} && "
+             "printf '%s' \"${!_mc_host_var}\""],
             capture_output=True, text=True, check=True,
         )
         mc_host = result.stdout.strip()
@@ -281,9 +293,9 @@ class FileSync:
         via the shared shell function (lazy, no-op when token is valid).
         Local mode: set mc alias once with static credentials.
         """
-        runtime = os.environ.get("HICLAW_RUNTIME", "<unset>")
+        runtime = os.environ.get("AGENTTEAMS_RUNTIME") or os.environ.get("HICLAW_RUNTIME", "<unset>")
         mc_host_set = bool(os.environ.get(f"MC_HOST_{_MC_ALIAS}"))
-        controller_url = os.environ.get("HICLAW_CONTROLLER_URL", "<unset>")
+        controller_url = os.environ.get("AGENTTEAMS_CONTROLLER_URL") or os.environ.get("HICLAW_CONTROLLER_URL", "<unset>")
         logger.info(
             "_ensure_alias: runtime=%s cloud_mode=%s k8s_mode=%s endpoint=%s bucket=%s worker_name=%s access_key=%s alias_set=%s mc_host_set=%s controller_url=%s",
             runtime,
@@ -390,8 +402,8 @@ class FileSync:
         After this, runtime Remote -> Local pulls are explicit; background sync
         only pushes eligible local changes via ``push_local``.
         """
-        runtime = os.environ.get("HICLAW_RUNTIME", "<unset>")
-        controller_url = os.environ.get("HICLAW_CONTROLLER_URL", "<unset>")
+        runtime = os.environ.get("AGENTTEAMS_RUNTIME") or os.environ.get("HICLAW_RUNTIME", "<unset>")
+        controller_url = os.environ.get("AGENTTEAMS_CONTROLLER_URL") or os.environ.get("HICLAW_CONTROLLER_URL", "<unset>")
         logger.info(
             "mirror_all: preparing primary mirror runtime=%s cloud_mode=%s k8s_mode=%s endpoint=%s bucket=%s worker_name=%s access_key=%s alias_set=%s mc_host_set=%s controller_url=%s",
             runtime,

--- a/copaw/tests/test_copaw_worker_entrypoint.py
+++ b/copaw/tests/test_copaw_worker_entrypoint.py
@@ -1,0 +1,74 @@
+import os
+from pathlib import Path
+import subprocess
+
+
+def _render_entrypoint(tmp_path: Path, *, mc_host: bool) -> Path:
+    source = Path(__file__).resolve().parents[1] / "scripts" / "copaw-worker-entrypoint.sh"
+    fake_root = tmp_path / "opt" / "hiclaw"
+    fake_venv = tmp_path / "opt" / "venv"
+    install_dir = tmp_path / "copaw-worker"
+    script = (
+        source.read_text()
+        .replace("/opt/hiclaw", str(fake_root))
+        .replace("/opt/venv", str(fake_venv))
+        .replace('INSTALL_DIR="/root/.copaw-worker"', f'INSTALL_DIR="{install_dir}"')
+    )
+
+    lib_dir = fake_root / "scripts" / "lib"
+    lib_dir.mkdir(parents=True)
+    mc_line = 'export MC_HOST_hiclaw="https://ak:sk@oss.example.com"\n' if mc_host else ""
+    (lib_dir / "hiclaw-env.sh").write_text(
+        "#!/bin/sh\n"
+        "ensure_mc_credentials() {\n"
+        f"{mc_line}"
+        "  return 0\n"
+        "}\n"
+    )
+
+    for mode in ("lite", "standard"):
+        bin_dir = fake_venv / mode / "bin"
+        bin_dir.mkdir(parents=True)
+        worker = bin_dir / "copaw-worker"
+        worker.write_text('#!/bin/sh\nprintf "%s\\n" "$@" > "$CAPTURE_FILE"\n')
+        worker.chmod(0o755)
+
+    rendered = tmp_path / "copaw-worker-entrypoint.sh"
+    rendered.write_text(script)
+    rendered.chmod(0o755)
+    return rendered
+
+
+def test_entrypoint_uses_hiclaw_mc_host_and_bucket_contract(tmp_path):
+    script = _render_entrypoint(tmp_path, mc_host=True)
+    capture = tmp_path / "args.txt"
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path / "home"),
+        "CAPTURE_FILE": str(capture),
+        "AGENTTEAMS_WORKER_NAME": "alice",
+        "AGENTTEAMS_STORAGE_PROVIDER": "oss",
+        "HICLAW_FS_BUCKET": "custom-bucket",
+    }
+
+    result = subprocess.run([str(script)], env=env, text=True, capture_output=True)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    args = capture.read_text().splitlines()
+    assert args[args.index("--fs-bucket") + 1] == "custom-bucket"
+
+
+def test_entrypoint_reports_missing_hiclaw_mc_host_for_oss(tmp_path):
+    script = _render_entrypoint(tmp_path, mc_host=False)
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path / "home"),
+        "CAPTURE_FILE": str(tmp_path / "args.txt"),
+        "AGENTTEAMS_WORKER_NAME": "alice",
+        "AGENTTEAMS_STORAGE_PROVIDER": "oss",
+    }
+
+    result = subprocess.run([str(script)], env=env, text=True, capture_output=True)
+
+    assert result.returncode == 1
+    assert "MC_HOST_hiclaw is not configured" in result.stdout

--- a/copaw/tests/test_filesync_tool.py
+++ b/copaw/tests/test_filesync_tool.py
@@ -4,7 +4,7 @@ import subprocess
 
 import pytest
 
-from copaw_worker.hooks.tools.filesync import filesync
+from copaw_worker.hooks.tools.filesync import create_sync, filesync
 from copaw_worker.sync import FileSync, _team_storage_name_from_worker_team
 
 
@@ -21,7 +21,7 @@ def _sync(tmp_path):
         endpoint="http://minio:9000",
         access_key="minio",
         secret_key="password",
-        bucket="hiclaw-storage",
+        bucket="agentteams-storage",
         worker_name="dag-team-dev",
         local_dir=local_dir,
         shared_dir=workspace_dir / "shared",
@@ -49,6 +49,23 @@ def _mock_hiclaw_worker(monkeypatch, payload, expected_name="dag-team-dev"):
     monkeypatch.setattr(subprocess, "run", fake_run)
 
 
+def test_create_sync_accepts_legacy_hiclaw_environment(tmp_path, monkeypatch):
+    monkeypatch.setenv("COPAW_WORKING_DIR", str(tmp_path / "worker" / ".copaw"))
+    monkeypatch.setenv("HICLAW_WORKER_NAME", "legacy-worker")
+    monkeypatch.setenv("HICLAW_WORKER_CR_NAME", "legacy-worker-cr")
+    monkeypatch.setenv("HICLAW_FS_ENDPOINT", "http://minio:9000")
+    monkeypatch.setenv("HICLAW_FS_ACCESS_KEY", "minio")
+    monkeypatch.setenv("HICLAW_FS_SECRET_KEY", "password")
+    monkeypatch.setenv("HICLAW_FS_BUCKET", "hiclaw-storage")
+
+    sync = create_sync()
+
+    assert sync.worker_name == "legacy-worker"
+    assert sync.worker_cr_name == "legacy-worker-cr"
+    assert sync.endpoint == "http://minio:9000"
+    assert sync.bucket == "hiclaw-storage"
+
+
 def test_resolve_shared_path_strips_bucket_prefix_from_worker_team(tmp_path, monkeypatch):
     sync = FileSync(
         endpoint="http://minio:9000",
@@ -68,7 +85,7 @@ def test_resolve_shared_path_strips_bucket_prefix_from_worker_team(tmp_path, mon
     assert resolved.kind == "shared"
     assert resolved.subpath == "tasks/st-01/result.md"
     assert resolved.local == sync.shared_dir / "tasks" / "st-01" / "result.md"
-    assert resolved.remote == "hiclaw/hiclaw-magic-cn-123/teams/dag-team/shared/tasks/st-01/result.md"
+    assert resolved.remote == "agentteams/hiclaw-magic-cn-123/teams/dag-team/shared/tasks/st-01/result.md"
 
 
 def test_team_storage_name_keeps_legacy_team_without_bucket_prefix():
@@ -80,7 +97,7 @@ def test_worker_metadata_query_uses_cr_name_while_storage_uses_runtime_name(tmp_
         endpoint="http://minio:9000",
         access_key="minio",
         secret_key="password",
-        bucket="hiclaw-storage",
+        bucket="agentteams-storage",
         worker_name="novworker02",
         worker_cr_name="nov-worker-cr",
         local_dir=tmp_path / "worker",
@@ -105,7 +122,7 @@ def test_worker_metadata_query_uses_cr_name_while_storage_uses_runtime_name(tmp_
     assert sync._prefix == "agents/novworker02"
     assert commands[0] == (
         "mirror",
-        "hiclaw/hiclaw-storage/agents/novworker02/",
+        "agentteams/agentteams-storage/agents/novworker02/",
         f"{sync.local_dir}/",
         "--overwrite",
         "--exclude",
@@ -119,7 +136,7 @@ def test_resolve_shared_path_uses_global_remote_for_standalone_worker(tmp_path, 
 
     resolved = sync.resolve_shared_path("shared/tasks/st-01/result.md")
 
-    assert resolved.remote == "hiclaw/hiclaw-storage/shared/tasks/st-01/result.md"
+    assert resolved.remote == "agentteams/agentteams-storage/shared/tasks/st-01/result.md"
 
 
 def test_resolve_shared_path_fails_closed_when_hiclaw_cli_is_missing(tmp_path, monkeypatch):
@@ -163,10 +180,10 @@ def test_push_shared_path_rejects_global_shared(tmp_path):
 async def test_filesync_dry_run_returns_resolved_local_path(tmp_path, monkeypatch):
     working_dir = tmp_path / "worker" / ".copaw"
     monkeypatch.setenv("COPAW_WORKING_DIR", str(working_dir))
-    monkeypatch.setenv("HICLAW_WORKER_NAME", "dag-team-dev")
-    monkeypatch.setenv("HICLAW_FS_ENDPOINT", "http://minio:9000")
-    monkeypatch.setenv("HICLAW_FS_ACCESS_KEY", "minio")
-    monkeypatch.setenv("HICLAW_FS_SECRET_KEY", "password")
+    monkeypatch.setenv("AGENTTEAMS_WORKER_NAME", "dag-team-dev")
+    monkeypatch.setenv("AGENTTEAMS_FS_ENDPOINT", "http://minio:9000")
+    monkeypatch.setenv("AGENTTEAMS_FS_ACCESS_KEY", "minio")
+    monkeypatch.setenv("AGENTTEAMS_FS_SECRET_KEY", "password")
     _mock_hiclaw_worker(monkeypatch, {"name": "dag-team-dev", "team": "dag-team"})
 
     response = await filesync(
@@ -190,10 +207,10 @@ async def test_filesync_normalizes_project_directory_without_trailing_slash(
 ):
     working_dir = tmp_path / "worker" / ".copaw"
     monkeypatch.setenv("COPAW_WORKING_DIR", str(working_dir))
-    monkeypatch.setenv("HICLAW_WORKER_NAME", "dag-team-dev")
-    monkeypatch.setenv("HICLAW_FS_ENDPOINT", "http://minio:9000")
-    monkeypatch.setenv("HICLAW_FS_ACCESS_KEY", "minio")
-    monkeypatch.setenv("HICLAW_FS_SECRET_KEY", "password")
+    monkeypatch.setenv("AGENTTEAMS_WORKER_NAME", "dag-team-dev")
+    monkeypatch.setenv("AGENTTEAMS_FS_ENDPOINT", "http://minio:9000")
+    monkeypatch.setenv("AGENTTEAMS_FS_ACCESS_KEY", "minio")
+    monkeypatch.setenv("AGENTTEAMS_FS_SECRET_KEY", "password")
     _mock_hiclaw_worker(monkeypatch, {"name": "dag-team-dev", "team": "dag-team"})
 
     response = await filesync(
@@ -214,10 +231,10 @@ async def test_filesync_normalizes_project_directory_without_trailing_slash(
 async def test_filesync_accepts_action_payload_and_json_string_exclude(tmp_path, monkeypatch):
     working_dir = tmp_path / "worker" / ".copaw"
     monkeypatch.setenv("COPAW_WORKING_DIR", str(working_dir))
-    monkeypatch.setenv("HICLAW_WORKER_NAME", "dag-team-dev")
-    monkeypatch.setenv("HICLAW_FS_ENDPOINT", "http://minio:9000")
-    monkeypatch.setenv("HICLAW_FS_ACCESS_KEY", "minio")
-    monkeypatch.setenv("HICLAW_FS_SECRET_KEY", "password")
+    monkeypatch.setenv("AGENTTEAMS_WORKER_NAME", "dag-team-dev")
+    monkeypatch.setenv("AGENTTEAMS_FS_ENDPOINT", "http://minio:9000")
+    monkeypatch.setenv("AGENTTEAMS_FS_ACCESS_KEY", "minio")
+    monkeypatch.setenv("AGENTTEAMS_FS_SECRET_KEY", "password")
     _mock_hiclaw_worker(monkeypatch, {"name": "dag-team-dev", "team": "dag-team"})
 
     response = await filesync(
@@ -238,10 +255,10 @@ async def test_filesync_accepts_action_payload_and_json_string_exclude(tmp_path,
 @pytest.mark.asyncio
 async def test_filesync_rejects_invalid_action(tmp_path, monkeypatch):
     monkeypatch.setenv("COPAW_WORKING_DIR", str(tmp_path / "worker" / ".copaw"))
-    monkeypatch.setenv("HICLAW_WORKER_NAME", "dag-team-dev")
-    monkeypatch.setenv("HICLAW_FS_ENDPOINT", "http://minio:9000")
-    monkeypatch.setenv("HICLAW_FS_ACCESS_KEY", "minio")
-    monkeypatch.setenv("HICLAW_FS_SECRET_KEY", "password")
+    monkeypatch.setenv("AGENTTEAMS_WORKER_NAME", "dag-team-dev")
+    monkeypatch.setenv("AGENTTEAMS_FS_ENDPOINT", "http://minio:9000")
+    monkeypatch.setenv("AGENTTEAMS_FS_ACCESS_KEY", "minio")
+    monkeypatch.setenv("AGENTTEAMS_FS_SECRET_KEY", "password")
 
     response = await filesync(action="complete_task", path="shared/tasks/st-01/")
     payload = _response_json(response)

--- a/copaw/tests/test_health.py
+++ b/copaw/tests/test_health.py
@@ -168,7 +168,7 @@ def test_check_model_service_reports_unhealthy_for_failed_chat_completion_prefli
                 "providers": {
                     "hiclaw-gateway": {
                         "api": "openai-completions",
-                        "baseUrl": "http://aigw-local.hiclaw.io:8080/v1",
+                        "baseUrl": "http://aigw-local.agentteams.io:8080/v1",
                         "apiKey": "secret",
                         "models": [{"id": "qwen3.5-plus"}],
                     }
@@ -181,16 +181,17 @@ def test_check_model_service_reports_unhealthy_for_failed_chat_completion_prefli
 
     assert result.healthiness == "unhealthy"
     assert result.message == "model chat completion preflight returned HTTP 404"
-    assert result.details["endpoint"] == "http://aigw-local.hiclaw.io:8080/v1/chat/completions"
+    assert result.details["endpoint"] == "http://aigw-local.agentteams.io:8080/v1/chat/completions"
     assert result.details["http_status"] == 404
     assert opened == [
         (
-            "http://aigw-local.hiclaw.io:8080/v1/chat/completions",
+            "http://aigw-local.agentteams.io:8080/v1/chat/completions",
             "POST",
             {
                 "model": "qwen3.5-plus",
                 "messages": [{"role": "user", "content": "ping"}],
                 "max_tokens": 1,
+                "enable_thinking": False,
             },
             "Bearer secret",
             3,
@@ -221,7 +222,7 @@ def test_check_model_service_uses_max_completion_tokens_for_gpt5(monkeypatch):
             "models": {
                 "providers": {
                     "hiclaw-gateway": {
-                        "baseUrl": "http://aigw-local.hiclaw.io:8080/v1",
+                        "baseUrl": "http://aigw-local.agentteams.io:8080/v1",
                         "apiKey": "secret",
                         "models": [{"id": "gpt-5.4"}],
                     }

--- a/copaw/tests/test_sync.py
+++ b/copaw/tests/test_sync.py
@@ -18,7 +18,7 @@ def _sync(tmp_path):
         endpoint="http://minio:9000",
         access_key="minio",
         secret_key="password",
-        bucket="hiclaw-storage",
+        bucket="agentteams-storage",
         worker_name="dag-team-dev",
         local_dir=tmp_path / "worker",
     )
@@ -114,7 +114,7 @@ def test_mirror_all_restores_worker_prefix_and_shared_without_credentials(tmp_pa
     assert commands == [
         (
             "mirror",
-            "hiclaw/hiclaw-storage/agents/dag-team-dev/",
+            "agentteams/agentteams-storage/agents/dag-team-dev/",
             f"{sync.local_dir}/",
             "--overwrite",
             "--exclude",
@@ -122,7 +122,7 @@ def test_mirror_all_restores_worker_prefix_and_shared_without_credentials(tmp_pa
         ),
         (
             "mirror",
-            "hiclaw/hiclaw-storage/teams/dag-team/shared/",
+            "agentteams/agentteams-storage/teams/dag-team/shared/",
             f"{sync.shared_dir}/",
             "--overwrite",
         ),
@@ -152,7 +152,7 @@ def test_mirror_all_restores_global_shared_for_team_leader(tmp_path, monkeypatch
     assert commands == [
         (
             "mirror",
-            "hiclaw/hiclaw-storage/agents/dag-team-dev/",
+            "agentteams/agentteams-storage/agents/dag-team-dev/",
             f"{sync.local_dir}/",
             "--overwrite",
             "--exclude",
@@ -160,13 +160,13 @@ def test_mirror_all_restores_global_shared_for_team_leader(tmp_path, monkeypatch
         ),
         (
             "mirror",
-            "hiclaw/hiclaw-storage/teams/dag-team/shared/",
+            "agentteams/agentteams-storage/teams/dag-team/shared/",
             f"{sync.shared_dir}/",
             "--overwrite",
         ),
         (
             "mirror",
-            "hiclaw/hiclaw-storage/shared/",
+            "agentteams/agentteams-storage/shared/",
             f"{sync.global_shared_dir}/",
             "--overwrite",
         ),
@@ -178,7 +178,7 @@ def test_pull_and_push_shared_paths_are_explicit_minio_operations(tmp_path, monk
     commands = []
 
     monkeypatch.setattr(sync, "_ensure_alias", lambda: None)
-    monkeypatch.setattr(sync, "_get_shared_remote", lambda: "hiclaw/hiclaw-storage/teams/dag-team/shared/")
+    monkeypatch.setattr(sync, "_get_shared_remote", lambda: "agentteams/agentteams-storage/teams/dag-team/shared/")
 
     local_report = sync.shared_dir / "tasks" / "st-01" / "report.md"
     local_report.parent.mkdir(parents=True)
@@ -196,14 +196,14 @@ def test_pull_and_push_shared_paths_are_explicit_minio_operations(tmp_path, monk
     assert commands == [
         (
             "mirror",
-            "hiclaw/hiclaw-storage/teams/dag-team/shared/tasks/st-01/",
+            "agentteams/agentteams-storage/teams/dag-team/shared/tasks/st-01/",
             f"{sync.shared_dir / 'tasks' / 'st-01'}/",
             "--overwrite",
         ),
         (
             "mirror",
             f"{sync.shared_dir / 'tasks' / 'st-01'}/",
-            "hiclaw/hiclaw-storage/teams/dag-team/shared/tasks/st-01/",
+            "agentteams/agentteams-storage/teams/dag-team/shared/tasks/st-01/",
             "--overwrite",
             "--exclude",
             "base/",
@@ -221,7 +221,7 @@ def test_pull_shared_path_falls_back_to_mirror_for_remote_directory_prefix(
     commands = []
 
     monkeypatch.setattr(sync, "_ensure_alias", lambda: None)
-    monkeypatch.setattr(sync, "_get_shared_remote", lambda: "hiclaw/hiclaw-storage/teams/dag-team/shared/")
+    monkeypatch.setattr(sync, "_get_shared_remote", lambda: "agentteams/agentteams-storage/teams/dag-team/shared/")
 
     def fake_mc(*args, **_kwargs):
         commands.append(args)
@@ -241,12 +241,12 @@ def test_pull_shared_path_falls_back_to_mirror_for_remote_directory_prefix(
     assert commands == [
         (
             "cp",
-            "hiclaw/hiclaw-storage/teams/dag-team/shared/projects/project-20260512-001122",
+            "agentteams/agentteams-storage/teams/dag-team/shared/projects/project-20260512-001122",
             str(sync.shared_dir / "projects" / "project-20260512-001122"),
         ),
         (
             "mirror",
-            "hiclaw/hiclaw-storage/teams/dag-team/shared/projects/project-20260512-001122/",
+            "agentteams/agentteams-storage/teams/dag-team/shared/projects/project-20260512-001122/",
             f"{sync.shared_dir / 'projects' / 'project-20260512-001122'}/",
             "--overwrite",
         ),
@@ -309,7 +309,7 @@ def test_pull_all_refreshes_config_mcporter_and_skills_without_shared(tmp_path, 
     assert commands == [
         (
             "mirror",
-            "hiclaw/hiclaw-storage/agents/dag-team-dev/skills/github/",
+            "agentteams/agentteams-storage/agents/dag-team-dev/skills/github/",
             f"{sync.local_dir / 'skills' / 'github'}/",
             "--overwrite",
         )
@@ -358,10 +358,10 @@ def test_push_local_preserves_user_data_but_skips_manager_and_mirrored_state(tmp
         "skills/github/SKILL.md",
     }
     assert set(pushed_destinations) == {
-        "hiclaw/hiclaw-storage/agents/dag-team-dev/AGENTS.md",
-        "hiclaw/hiclaw-storage/agents/dag-team-dev/memory/note.txt",
-        "hiclaw/hiclaw-storage/agents/dag-team-dev/memory/shared/note.txt",
-        "hiclaw/hiclaw-storage/agents/dag-team-dev/skills/github/SKILL.md",
+        "agentteams/agentteams-storage/agents/dag-team-dev/AGENTS.md",
+        "agentteams/agentteams-storage/agents/dag-team-dev/memory/note.txt",
+        "agentteams/agentteams-storage/agents/dag-team-dev/memory/shared/note.txt",
+        "agentteams/agentteams-storage/agents/dag-team-dev/skills/github/SKILL.md",
     }
 
 


### PR DESCRIPTION
## Summary

- prefer `AGENTTEAMS_*` runtime/storage environment variables in the CoPaw worker entrypoint, filesync tool, and storage sync path
- keep legacy `HICLAW_*` fallbacks so existing HiClaw deployments continue to work
- align default CoPaw worker storage naming with AgentTeams storage and update the model health preflight to disable thinking for Qwen-style models
- add/update focused tests for storage path generation, legacy env fallback, and health preflight payloads

## Tests

- `PYTHONPATH=src uv run --no-project --with pytest --with pytest-asyncio --with anyio pytest tests/test_health.py tests/test_sync.py`
- `PYTHONPATH=src uv run --no-project --with pytest --with pytest-asyncio --with anyio --with agentscope pytest tests/test_filesync_tool.py`
- `PYTHONPATH=src uv run --no-project --with pytest --with pytest-asyncio --with anyio pytest tests/test_worker_sync.py`
