### PR TITLE
fix(controller): keep modelProvider auth in reconcilers

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -9,6 +9,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 
 - **OpenHuman runtime**: OpenHuman added as the fourth Worker runtime with native Matrix support via `channel-matrix` feature flag; includes controller routing (K8s + Docker backends), Dockerfile, entrypoint script, agent template, Helm chart integration, and Makefile build targets.
 - **Multi model providers**: Worker, Team, and Manager specs can now select a Higress model provider via `spec.modelProvider`; the controller resolves the provider, injects the matching gateway URL into runtime config, and authorizes consumers only on the selected AI route.
+- **modelProvider authorization boundary**: Controller reconcilers now own provider-specific AI route authorization, while provisioning keeps using the default gateway authorization path to avoid duplicate provider coupling.
 - **Matrix AppService mode**: The controller can register as a Matrix Application Service and provision/log in users with the `as_token` instead of per-user passwords (legacy password auth is preserved when disabled). Enabled by default via `HICLAW_MATRIX_APPSERVICE_ENABLED`; the install script and the Helm `runtime-env` Secret generate and persist `HICLAW_MATRIX_APPSERVICE_AS_TOKEN` / `HICLAW_MATRIX_APPSERVICE_HS_TOKEN`. Set `HICLAW_MATRIX_APPSERVICE_USER_NAMESPACE_REGEX` to narrow the exclusive user namespace when running against a shared / pre-existing homeserver.
 
 **Bug Fixes**

--- a/hiclaw-controller/internal/controller/manager_container_test.go
+++ b/hiclaw-controller/internal/controller/manager_container_test.go
@@ -229,7 +229,7 @@ func TestCreateManagerContainerUsesDefaultResourcesWhenSpecResourcesUnset(t *tes
 	}
 }
 
-func TestReconcileManagerInfrastructurePassesModelProviderToProvision(t *testing.T) {
+func TestReconcileManagerInfrastructureKeepsModelProviderOutOfProvision(t *testing.T) {
 	prov := mocks.NewMockManagerProvisioner()
 	r := &ManagerReconciler{Provisioner: prov}
 	m := &v1beta1.Manager{}
@@ -246,12 +246,12 @@ func TestReconcileManagerInfrastructurePassesModelProviderToProvision(t *testing
 	if len(prov.Calls.ProvisionManager) != 1 {
 		t.Fatalf("ProvisionManager calls=%d, want 1", len(prov.Calls.ProvisionManager))
 	}
-	if got := prov.Calls.ProvisionManager[0].ModelProviderID; got != "qwen-http-api" {
-		t.Fatalf("ProvisionManager ModelProviderID=%q, want qwen-http-api", got)
+	if got := prov.Calls.ProvisionManager[0].Name; got != "default" {
+		t.Fatalf("ProvisionManager Name=%q, want default", got)
 	}
 }
 
-func TestReconcileManagerInfrastructureRestoresModelProviderAuth(t *testing.T) {
+func TestReconcileManagerInfrastructureRestoresGatewayAuth(t *testing.T) {
 	prov := mocks.NewMockManagerProvisioner()
 	r := &ManagerReconciler{Provisioner: prov}
 	m := &v1beta1.Manager{}
@@ -273,7 +273,7 @@ func TestReconcileManagerInfrastructureRestoresModelProviderAuth(t *testing.T) {
 	if call.Name != "default" {
 		t.Fatalf("EnsureManagerGatewayAuth name=%q, want default", call.Name)
 	}
-	if call.ModelProviderID != "openai-http-api" {
-		t.Fatalf("EnsureManagerGatewayAuth ModelProviderID=%q, want openai-http-api", call.ModelProviderID)
+	if call.GatewayKey == "" {
+		t.Fatal("EnsureManagerGatewayAuth GatewayKey is empty")
 	}
 }

--- a/hiclaw-controller/internal/controller/manager_reconcile_infra.go
+++ b/hiclaw-controller/internal/controller/manager_reconcile_infra.go
@@ -14,10 +14,6 @@ import (
 // provisioned (MatrixUserID set), it refreshes credentials and restores gateway auth.
 func (r *ManagerReconciler) reconcileManagerInfrastructure(ctx context.Context, s *managerScope) (reconcile.Result, error) {
 	m := s.manager
-	modelProviderID := ""
-	if s.modelProviderInfo != nil {
-		modelProviderID = s.modelProviderInfo.HttpApiID
-	}
 
 	if m.Status.MatrixUserID != "" {
 		refreshResult, err := r.Provisioner.RefreshManagerCredentials(ctx, m.Name)
@@ -30,7 +26,7 @@ func (r *ManagerReconciler) reconcileManagerInfrastructure(ctx context.Context, 
 		// "non-fatal", which masked real failures (e.g. Higress Console PUT
 		// returning non-200) and left the data plane stuck with an empty
 		// allowedConsumers list until a subsequent event happened to retry.
-		if err := r.Provisioner.EnsureManagerGatewayAuth(ctx, m.Name, refreshResult.GatewayKey, modelProviderID); err != nil {
+		if err := r.Provisioner.EnsureManagerGatewayAuth(ctx, m.Name, refreshResult.GatewayKey); err != nil {
 			return reconcile.Result{}, fmt.Errorf("restore manager gateway auth: %w", err)
 		}
 
@@ -49,8 +45,7 @@ func (r *ManagerReconciler) reconcileManagerInfrastructure(ctx context.Context, 
 	logger.Info("provisioning manager infrastructure", "name", m.Name)
 
 	provResult, err := r.Provisioner.ProvisionManager(ctx, service.ManagerProvisionRequest{
-		Name:            m.Name,
-		ModelProviderID: modelProviderID,
+		Name: m.Name,
 	})
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("provision manager: %w", err)

--- a/hiclaw-controller/internal/controller/member_reconcile.go
+++ b/hiclaw-controller/internal/controller/member_reconcile.go
@@ -174,17 +174,12 @@ func ReconcileMemberInfra(ctx context.Context, d MemberDeps, m MemberContext, st
 
 	log.FromContext(ctx).Info("provisioning member infrastructure", "name", m.Name, "runtimeName", m.RuntimeName, "role", m.Role)
 
-	modelProviderID := ""
-	if m.ModelProviderInfo != nil {
-		modelProviderID = m.ModelProviderInfo.HttpApiID
-	}
 	provResult, err := d.Provisioner.ProvisionWorker(ctx, service.WorkerProvisionRequest{
-		Name:            m.RuntimeName,
-		CredentialName:  m.Name,
-		ModelProviderID: modelProviderID,
-		Role:            m.Role.String(),
-		TeamName:        m.TeamName,
-		TeamLeaderName:  m.TeamLeaderName,
+		Name:           m.RuntimeName,
+		CredentialName: m.Name,
+		Role:           m.Role.String(),
+		TeamName:       m.TeamName,
+		TeamLeaderName: m.TeamLeaderName,
 	})
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("provision worker: %w", err)

--- a/hiclaw-controller/internal/controller/team_controller_test.go
+++ b/hiclaw-controller/internal/controller/team_controller_test.go
@@ -322,9 +322,6 @@ func TestReconcileMemberInfraUsesCRNameForCredentialKey(t *testing.T) {
 	if req.CredentialName != "alpha-worker-lead" {
 		t.Fatalf("ProvisionWorker CredentialName=%q, want CR name alpha-worker-lead", req.CredentialName)
 	}
-	if req.ModelProviderID != "qwen-http-api" {
-		t.Fatalf("ProvisionWorker ModelProviderID=%q, want qwen-http-api", req.ModelProviderID)
-	}
 }
 
 func TestReconcileMemberRefreshUsesCRNameCredentialAndRuntimeMatrixName(t *testing.T) {

--- a/hiclaw-controller/internal/service/interfaces.go
+++ b/hiclaw-controller/internal/service/interfaces.go
@@ -13,7 +13,7 @@ type WorkerProvisioner interface {
 	DeprovisionWorker(ctx context.Context, req WorkerDeprovisionRequest) error
 	RefreshCredentials(ctx context.Context, workerName string) (*RefreshResult, error)
 	RefreshWorkerCredentials(ctx context.Context, credentialName, workerName string) (*RefreshResult, error)
-	EnsureWorkerGatewayAuth(ctx context.Context, workerName, gatewayKey, modelProviderID string) error
+	EnsureWorkerGatewayAuth(ctx context.Context, workerName, gatewayKey string) error
 	ReconcileExpose(ctx context.Context, workerName string, desired []v1beta1.ExposePort, current []v1beta1.ExposedPortStatus) ([]v1beta1.ExposedPortStatus, error)
 	EnsureServiceAccount(ctx context.Context, workerName string) error
 	DeleteServiceAccount(ctx context.Context, workerName string) error
@@ -65,7 +65,7 @@ type ManagerProvisioner interface {
 	DeprovisionManager(ctx context.Context, name string) error
 	RefreshCredentials(ctx context.Context, name string) (*RefreshResult, error)
 	RefreshManagerCredentials(ctx context.Context, managerName string) (*RefreshResult, error)
-	EnsureManagerGatewayAuth(ctx context.Context, managerName, gatewayKey, modelProviderID string) error
+	EnsureManagerGatewayAuth(ctx context.Context, managerName, gatewayKey string) error
 	EnsureManagerServiceAccount(ctx context.Context, managerName string) error
 	DeleteManagerServiceAccount(ctx context.Context, managerName string) error
 	DeleteCredentials(ctx context.Context, name string) error

--- a/hiclaw-controller/internal/service/provisioner.go
+++ b/hiclaw-controller/internal/service/provisioner.go
@@ -20,12 +20,11 @@ import (
 
 // WorkerProvisionRequest describes the infrastructure to provision for a worker.
 type WorkerProvisionRequest struct {
-	Name            string
-	CredentialName  string
-	ModelProviderID string
-	Role            string // "standalone" | "team_leader" | "worker"
-	TeamName        string
-	TeamLeaderName  string
+	Name           string
+	CredentialName string
+	Role           string // "standalone" | "team_leader" | "worker"
+	TeamName       string
+	TeamLeaderName string
 }
 
 // WorkerProvisionResult contains all outputs from a successful provision.
@@ -467,7 +466,7 @@ func (p *Provisioner) ProvisionWorker(ctx context.Context, req WorkerProvisionRe
 		_ = p.creds.Save(ctx, credentialName, creds)
 	}
 
-	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, req.ModelProviderID); err != nil {
+	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, ""); err != nil {
 		return nil, fmt.Errorf("AI route authorization failed: %w", err)
 	}
 	// Higress WASM key-auth plugin needs ~1-2s to sync after route update.
@@ -674,7 +673,7 @@ func (p *Provisioner) RefreshManagerCredentials(ctx context.Context, managerName
 // EnsureManagerGatewayAuth ensures the Manager's gateway consumer exists and is
 // authorized on AI routes. Called during container recreation to restore auth
 // that may have been lost (e.g. after upgrade with fresh Higress state).
-func (p *Provisioner) EnsureManagerGatewayAuth(ctx context.Context, managerName, gatewayKey, modelProviderID string) error {
+func (p *Provisioner) EnsureManagerGatewayAuth(ctx context.Context, managerName, gatewayKey string) error {
 	consumerName := "manager"
 	_, err := p.gateway.EnsureConsumer(ctx, gateway.ConsumerRequest{
 		Name:          consumerName,
@@ -683,7 +682,7 @@ func (p *Provisioner) EnsureManagerGatewayAuth(ctx context.Context, managerName,
 	if err != nil {
 		return fmt.Errorf("ensure consumer: %w", err)
 	}
-	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, modelProviderID); err != nil {
+	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, ""); err != nil {
 		return fmt.Errorf("authorize AI routes: %w", err)
 	}
 	return nil
@@ -694,7 +693,7 @@ func (p *Provisioner) EnsureManagerGatewayAuth(ctx context.Context, managerName,
 // to defensively restore auth that may have been lost (e.g. if the Higress
 // route was rewritten, or after upgrade with fresh Higress state). Mirrors
 // EnsureManagerGatewayAuth but uses the worker-scoped consumer name.
-func (p *Provisioner) EnsureWorkerGatewayAuth(ctx context.Context, workerName, gatewayKey, modelProviderID string) error {
+func (p *Provisioner) EnsureWorkerGatewayAuth(ctx context.Context, workerName, gatewayKey string) error {
 	consumerName := "worker-" + workerName
 	_, err := p.gateway.EnsureConsumer(ctx, gateway.ConsumerRequest{
 		Name:          consumerName,
@@ -703,7 +702,7 @@ func (p *Provisioner) EnsureWorkerGatewayAuth(ctx context.Context, workerName, g
 	if err != nil {
 		return fmt.Errorf("ensure consumer: %w", err)
 	}
-	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, modelProviderID); err != nil {
+	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, ""); err != nil {
 		return fmt.Errorf("authorize AI routes: %w", err)
 	}
 	return nil
@@ -1228,8 +1227,7 @@ func (p *Provisioner) DeleteManagerRoomAlias(ctx context.Context, managerName st
 
 // ManagerProvisionRequest describes the infrastructure to provision for a Manager.
 type ManagerProvisionRequest struct {
-	Name            string
-	ModelProviderID string
+	Name string
 }
 
 // ManagerProvisionResult contains all outputs from a successful Manager provision.
@@ -1353,7 +1351,7 @@ func (p *Provisioner) ProvisionManager(ctx context.Context, req ManagerProvision
 		_ = p.creds.Save(ctx, managerName, creds)
 	}
 
-	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, req.ModelProviderID); err != nil {
+	if err := p.gateway.AuthorizeAIRoutes(ctx, consumerName, ""); err != nil {
 		return nil, fmt.Errorf("AI route authorization failed: %w", err)
 	}
 	// Higress WASM key-auth plugin needs ~1-2s to sync after route update.

--- a/hiclaw-controller/test/testutil/mocks/manager_provisioner.go
+++ b/hiclaw-controller/test/testutil/mocks/manager_provisioner.go
@@ -15,7 +15,7 @@ type MockManagerProvisioner struct {
 	DeprovisionManagerFn          func(ctx context.Context, name string) error
 	RefreshCredentialsFn          func(ctx context.Context, name string) (*service.RefreshResult, error)
 	RefreshManagerCredentialsFn   func(ctx context.Context, managerName string) (*service.RefreshResult, error)
-	EnsureManagerGatewayAuthFn    func(ctx context.Context, managerName, gatewayKey, modelProviderID string) error
+	EnsureManagerGatewayAuthFn    func(ctx context.Context, managerName, gatewayKey string) error
 	EnsureManagerServiceAccountFn func(ctx context.Context, managerName string) error
 	DeleteManagerServiceAccountFn func(ctx context.Context, managerName string) error
 	DeleteCredentialsFn           func(ctx context.Context, name string) error
@@ -51,9 +51,8 @@ func NewMockManagerProvisioner() *MockManagerProvisioner {
 }
 
 type managerGatewayAuthCall struct {
-	Name            string
-	GatewayKey      string
-	ModelProviderID string
+	Name       string
+	GatewayKey string
 }
 
 func (m *MockManagerProvisioner) Reset() {
@@ -164,17 +163,16 @@ func (m *MockManagerProvisioner) RefreshManagerCredentials(ctx context.Context, 
 	}, nil
 }
 
-func (m *MockManagerProvisioner) EnsureManagerGatewayAuth(ctx context.Context, managerName, gatewayKey, modelProviderID string) error {
+func (m *MockManagerProvisioner) EnsureManagerGatewayAuth(ctx context.Context, managerName, gatewayKey string) error {
 	m.mu.Lock()
 	m.Calls.EnsureManagerGatewayAuth = append(m.Calls.EnsureManagerGatewayAuth, managerGatewayAuthCall{
-		Name:            managerName,
-		GatewayKey:      gatewayKey,
-		ModelProviderID: modelProviderID,
+		Name:       managerName,
+		GatewayKey: gatewayKey,
 	})
 	fn := m.EnsureManagerGatewayAuthFn
 	m.mu.Unlock()
 	if fn != nil {
-		return fn(ctx, managerName, gatewayKey, modelProviderID)
+		return fn(ctx, managerName, gatewayKey)
 	}
 	return nil
 }

--- a/hiclaw-controller/test/testutil/mocks/provisioner.go
+++ b/hiclaw-controller/test/testutil/mocks/provisioner.go
@@ -16,7 +16,7 @@ type MockProvisioner struct {
 	DeprovisionWorkerFn        func(ctx context.Context, req service.WorkerDeprovisionRequest) error
 	RefreshCredentialsFn       func(ctx context.Context, workerName string) (*service.RefreshResult, error)
 	RefreshWorkerCredentialsFn func(ctx context.Context, credentialName, workerName string) (*service.RefreshResult, error)
-	EnsureWorkerGatewayAuthFn  func(ctx context.Context, workerName, gatewayKey, modelProviderID string) error
+	EnsureWorkerGatewayAuthFn  func(ctx context.Context, workerName, gatewayKey string) error
 	ReconcileExposeFn          func(ctx context.Context, workerName string, desired []v1beta1.ExposePort, current []v1beta1.ExposedPortStatus) ([]v1beta1.ExposedPortStatus, error)
 	EnsureServiceAccountFn     func(ctx context.Context, workerName string) error
 	DeleteServiceAccountFn     func(ctx context.Context, workerName string) error
@@ -58,9 +58,8 @@ type workerCredentialCall struct {
 }
 
 type gatewayAuthCall struct {
-	Name            string
-	GatewayKey      string
-	ModelProviderID string
+	Name       string
+	GatewayKey string
 }
 
 type humanLoginCall struct {
@@ -190,17 +189,16 @@ func (m *MockProvisioner) RefreshWorkerCredentials(ctx context.Context, credenti
 	}, nil
 }
 
-func (m *MockProvisioner) EnsureWorkerGatewayAuth(ctx context.Context, workerName, gatewayKey, modelProviderID string) error {
+func (m *MockProvisioner) EnsureWorkerGatewayAuth(ctx context.Context, workerName, gatewayKey string) error {
 	m.mu.Lock()
 	m.Calls.EnsureWorkerGatewayAuth = append(m.Calls.EnsureWorkerGatewayAuth, gatewayAuthCall{
-		Name:            workerName,
-		GatewayKey:      gatewayKey,
-		ModelProviderID: modelProviderID,
+		Name:       workerName,
+		GatewayKey: gatewayKey,
 	})
 	fn := m.EnsureWorkerGatewayAuthFn
 	m.mu.Unlock()
 	if fn != nil {
-		return fn(ctx, workerName, gatewayKey, modelProviderID)
+		return fn(ctx, workerName, gatewayKey)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- keep provider-specific AI route authorization in the Manager/Worker/Team reconcilers
- remove `ModelProviderID` from provisioning requests and gateway-auth restore interfaces
- leave provisioning on the default gateway authorization path so provider scoping is not duplicated across controller and service layers
- update mocks and focused assertions for the new boundary

## Tests

- `go test ./internal/controller ./internal/service ./test/testutil/mocks`
- `go test ./...`
