### PR TITLE
fix(manager): add safe worker deletion wrapper

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -19,6 +19,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 - feat(hiclaw-controller): support a separate agent-pod-template for `deployMode: Remote` Workers via an optional `pod-template-remote.yaml` key on the controller-scoped pod-template ConfigMap; remote-mode Pod creation prefers this key and transparently falls back to `pod-template.yaml` when it is absent or empty, while non-remote/Sandbox paths keep ignoring it.
 - feat(controller): move Kubernetes resources to the `agentteams.io/v1beta1` API group and decouple Team membership through `spec.workerMembers` references to standalone Worker CRs.
 - feat(runtime): let Worker runtimes consume terminal `AGENTTEAMS_*` storage, controller, and auth environment variables while preserving existing `HICLAW_*` deployment compatibility.
+- fix(manager): add a Worker deletion wrapper so Manager uses `hiclaw delete worker <name>` and cleans local records without malformed tool calls.
 
 - **OpenHuman runtime**: OpenHuman added as the fourth Worker runtime with native Matrix support via `channel-matrix` feature flag; includes controller routing (K8s + Docker backends), Dockerfile, entrypoint script, agent template, Helm chart integration, and Makefile build targets.
 - **Multi model providers**: Worker, Team, and Manager specs can now select a Higress model provider via `spec.modelProvider`; the controller resolves the provider, injects the matching gateway URL into runtime config, and authorizes consumers only on the selected AI route.

--- a/manager/agent/skills/worker-management/SKILL.md
+++ b/manager/agent/skills/worker-management/SKILL.md
@@ -63,6 +63,7 @@ hiclaw create worker --name <NAME> --no-wait \
 - **Workers are stateless** — all state is in centralized storage. Reset = recreate config files
 - **Matrix accounts persist in Tuwunel** (cannot be deleted via API) — reuse same username on reset
 - **Changing a Worker's `--runtime` is a destructive operation** — the controller deletes the old container and creates a new one from the target runtime's image (openclaw/copaw/hermes/openhuman). Matrix account, room, gateway consumer, MinIO data and persisted credentials are preserved; container-local state (caches, in-memory session, current task progress) is lost. Always confirm with admin first, and avoid switching runtime while the Worker is mid-task.
+- **Delete Workers with the wrapper script** — never invent flags for `hiclaw delete worker`. The CLI syntax is positional: `hiclaw delete worker <name>`; `--name` is invalid. Use `scripts/delete-worker.sh` so failures are reported as failures and optional record cleanup is done with valid JSON operations.
 
 ## Operation Reference
 
@@ -77,7 +78,30 @@ Read the relevant doc **before** executing. Do not load all of them.
 | Open/close QwenPaw console | `references/console.md` | `scripts/enable-worker-console.sh` |
 | Enable direct @mentions between workers | `references/peer-mentions.md` | `scripts/enable-peer-mentions.sh` |
 | Reset a worker | `references/create-worker.md` | `hiclaw delete worker` + `hiclaw create worker` |
-| Delete a worker (remove container) | `references/lifecycle.md` | `scripts/lifecycle-worker.sh` |
+| Delete a worker permanently | `references/lifecycle.md` | `scripts/delete-worker.sh --worker <name>` |
+
+## Deleting a Worker
+
+When admin asks you to remove/delete a Worker, run the wrapper script:
+
+```bash
+bash /opt/hiclaw/agent/skills/worker-management/scripts/delete-worker.sh \
+  --worker <NAME>
+```
+
+If admin also asks to clean task/lifecycle records, or replies yes after you ask, run:
+
+```bash
+bash /opt/hiclaw/agent/skills/worker-management/scripts/delete-worker.sh \
+  --worker <NAME> \
+  --records-only
+```
+
+Rules:
+
+- Do not use `hiclaw delete worker --name <NAME>`; that flag does not exist.
+- Do not say the Worker was deleted unless the script returns JSON with `"deleted": true`.
+- Do not call `write_file` to clean records. The script updates `state.json`, `worker-lifecycle.json`, and `workers-registry.json` safely when record cleanup is requested.
 
 ## Switching Runtime
 

--- a/manager/agent/skills/worker-management/references/lifecycle.md
+++ b/manager/agent/skills/worker-management/references/lifecycle.md
@@ -18,8 +18,11 @@ bash /opt/hiclaw/agent/skills/worker-management/scripts/lifecycle-worker.sh --ac
 bash /opt/hiclaw/agent/skills/worker-management/scripts/lifecycle-worker.sh --action stop --worker <name>
 bash /opt/hiclaw/agent/skills/worker-management/scripts/lifecycle-worker.sh --action start --worker <name>
 
-# Delete a worker (stop + remove container + clean up lifecycle state)
-bash /opt/hiclaw/agent/skills/worker-management/scripts/lifecycle-worker.sh --action delete --worker <name>
+# Delete a Worker permanently through the controller
+bash /opt/hiclaw/agent/skills/worker-management/scripts/delete-worker.sh --worker <name>
+
+# Clean local task/lifecycle/registry records after deletion
+bash /opt/hiclaw/agent/skills/worker-management/scripts/delete-worker.sh --worker <name> --records-only
 ```
 
 ## start vs create
@@ -29,7 +32,9 @@ bash /opt/hiclaw/agent/skills/worker-management/scripts/lifecycle-worker.sh --ac
 | Container stopped | `lifecycle-worker.sh --action start` — restarts existing container |
 | Container not found | `create-worker.sh` — full registration flow |
 | Worker needs reset | `create-worker.sh` — removes old, rebuilds |
-| Worker permanently removed | `lifecycle-worker.sh --action delete` — stops, removes container, cleans lifecycle state |
+| Worker permanently removed | `delete-worker.sh --worker <name>` — deletes the Worker CR through `hiclaw delete worker <name>` |
+| Deleted Worker's local records need cleanup | `delete-worker.sh --worker <name> --records-only` — removes local `state.json`, `worker-lifecycle.json`, and `workers-registry.json` entries |
+| Remote worker | Admin runs install command on target machine |
 
 ## Changing Idle Timeout
 
@@ -37,6 +42,14 @@ Default: 720 minutes (12 hours). Change via:
 ```bash
 jq '.idle_timeout_minutes = 60' ~/worker-lifecycle.json > /tmp/lc.json && mv /tmp/lc.json ~/worker-lifecycle.json
 ```
+
+## Get Remote Worker Install Command
+
+```bash
+bash /opt/hiclaw/agent/skills/worker-management/scripts/get-worker-install-cmd.sh --worker <name>
+```
+
+Provide the `install_cmd` **verbatim in a code block** — do NOT redact any values.
 
 ## Heartbeat Check (automated every 15 minutes)
 

--- a/manager/agent/skills/worker-management/scripts/delete-worker.sh
+++ b/manager/agent/skills/worker-management/scripts/delete-worker.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# delete-worker.sh - Delete a Worker through the hiclaw CLI and clean local state.
+#
+# Usage:
+#   delete-worker.sh --worker <name> [--cleanup-records]
+#   delete-worker.sh --worker <name> --records-only
+
+set -euo pipefail
+
+WORKER_NAME=""
+CLEANUP_RECORDS=false
+RECORDS_ONLY=false
+
+usage() {
+    cat >&2 <<'EOF'
+Usage:
+  delete-worker.sh --worker <name> [--cleanup-records]
+  delete-worker.sh --worker <name> --records-only
+
+Options:
+  --worker, -w        Worker name to delete or clean up.
+  --cleanup-records   After successful delete, remove local state entries for this Worker.
+  --records-only      Do not call hiclaw delete; only remove local state entries.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --worker|-w)
+            WORKER_NAME="${2:-}"
+            shift 2
+            ;;
+        --cleanup-records)
+            CLEANUP_RECORDS=true
+            shift
+            ;;
+        --records-only)
+            RECORDS_ONLY=true
+            CLEANUP_RECORDS=true
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+if [ -z "${WORKER_NAME}" ]; then
+    echo "Missing required --worker <name>" >&2
+    usage
+    exit 2
+fi
+
+cleanup_records() {
+    local worker="$1"
+    local cleaned_state=false
+    local cleaned_lifecycle=false
+    local cleaned_registry=false
+    local tmp
+
+    if [ -f "${HOME}/state.json" ]; then
+        tmp=$(mktemp)
+        jq --arg w "${worker}" '
+          .active_tasks = [
+            (.active_tasks // [])[]
+            | select((.assigned_to // "") != $w and (.worker // "") != $w)
+          ]
+          | .updated_at = (now | strftime("%Y-%m-%dT%H:%M:%SZ"))
+        ' "${HOME}/state.json" > "${tmp}" && mv "${tmp}" "${HOME}/state.json"
+        cleaned_state=true
+    fi
+
+    if [ -f "${HOME}/worker-lifecycle.json" ]; then
+        tmp=$(mktemp)
+        jq --arg w "${worker}" '
+          if (.workers // null) != null then
+            del(.workers[$w]) | .updated_at = (now | strftime("%Y-%m-%dT%H:%M:%SZ"))
+          else . end
+        ' "${HOME}/worker-lifecycle.json" > "${tmp}" && mv "${tmp}" "${HOME}/worker-lifecycle.json"
+        cleaned_lifecycle=true
+    fi
+
+    if [ -f "${HOME}/workers-registry.json" ]; then
+        tmp=$(mktemp)
+        jq --arg w "${worker}" '
+          if (.workers // null) != null then
+            del(.workers[$w]) | .updated_at = (now | strftime("%Y-%m-%dT%H:%M:%SZ"))
+          else . end
+        ' "${HOME}/workers-registry.json" > "${tmp}" && mv "${tmp}" "${HOME}/workers-registry.json"
+        cleaned_registry=true
+    fi
+
+    jq -cn \
+      --argjson state "${cleaned_state}" \
+      --argjson lifecycle "${cleaned_lifecycle}" \
+      --argjson registry "${cleaned_registry}" \
+      '{state_json: $state, worker_lifecycle_json: $lifecycle, workers_registry_json: $registry}'
+}
+
+delete_output=""
+delete_status="skipped"
+delete_exit=0
+
+if [ "${RECORDS_ONLY}" != true ]; then
+    set +e
+    delete_output=$(hiclaw delete worker "${WORKER_NAME}" 2>&1)
+    delete_exit=$?
+    set -e
+    if [ "${delete_exit}" -ne 0 ]; then
+        jq -cn \
+          --arg worker "${WORKER_NAME}" \
+          --arg output "${delete_output}" \
+          --argjson exit_code "${delete_exit}" \
+          '{worker: $worker, status: "failed", deleted: false, exit_code: $exit_code, output: $output}'
+        exit "${delete_exit}"
+    fi
+    delete_status="deleted"
+fi
+
+cleanup_json='{}'
+if [ "${CLEANUP_RECORDS}" = true ]; then
+    cleanup_json=$(cleanup_records "${WORKER_NAME}")
+fi
+
+jq -cn \
+  --arg worker "${WORKER_NAME}" \
+  --arg status "${delete_status}" \
+  --arg output "${delete_output}" \
+  --argjson records "${cleanup_json}" \
+  '{worker: $worker, status: $status, deleted: ($status == "deleted"), output: $output, records: $records}'

--- a/manager/tests/test-delete-worker-script.sh
+++ b/manager/tests/test-delete-worker-script.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Regression tests for worker-management/scripts/delete-worker.sh.
+#
+# Usage: bash manager/tests/test-delete-worker-script.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+TMPDIR_ROOT=$(mktemp -d)
+trap 'rm -rf "${TMPDIR_ROOT}"' EXIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SCRIPT="${PROJECT_ROOT}/manager/agent/skills/worker-management/scripts/delete-worker.sh"
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "SKIP: jq not found; delete-worker.sh runs inside Manager images where jq is installed."
+    exit 0
+fi
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; echo "       expected: $2"; echo "       got:      $3"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "${expected}" = "${actual}" ]; then
+        pass "${desc}"
+    else
+        fail "${desc}" "${expected}" "${actual}"
+    fi
+}
+
+assert_json_eq() {
+    local desc="$1" expected="$2" json="$3" filter="$4"
+    local actual
+    actual=$(echo "${json}" | jq -r "${filter}")
+    assert_eq "${desc}" "${expected}" "${actual}"
+}
+
+new_home() {
+    mktemp -d "${TMPDIR_ROOT}/home-XXXXXX"
+}
+
+new_mockbin() {
+    local dir
+    dir=$(mktemp -d "${TMPDIR_ROOT}/bin-XXXXXX")
+    cat > "${dir}/hiclaw" <<'EOF'
+#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "${HICLAW_MOCK_LOG:?}"
+
+if [ "${HICLAW_MOCK_FAIL:-0}" = "1" ]; then
+    echo "mock delete failed" >&2
+    exit 17
+fi
+
+if [ "$#" -eq 3 ] && [ "$1" = "delete" ] && [ "$2" = "worker" ]; then
+    echo "worker/$3 deleted"
+    exit 0
+fi
+
+echo "unexpected args: $*" >&2
+exit 2
+EOF
+    chmod +x "${dir}/hiclaw"
+    echo "${dir}"
+}
+
+echo ""
+echo "=== TC1: delete uses positional hiclaw syntax ==="
+{
+    home=$(new_home)
+    mockbin=$(new_mockbin)
+    log="${TMPDIR_ROOT}/hiclaw.log"
+    output=$(HOME="${home}" PATH="${mockbin}:$PATH" HICLAW_MOCK_LOG="${log}" bash "${SCRIPT}" --worker zhao-yun)
+    assert_json_eq "delete status" "deleted" "${output}" ".status"
+    assert_json_eq "deleted true" "true" "${output}" ".deleted"
+    assert_eq "hiclaw called with positional worker name" "delete worker zhao-yun" "$(cat "${log}")"
+}
+
+echo ""
+echo "=== TC2: failed hiclaw delete is not reported as success ==="
+{
+    home=$(new_home)
+    mockbin=$(new_mockbin)
+    log="${TMPDIR_ROOT}/hiclaw-fail.log"
+    set +e
+    output=$(HOME="${home}" PATH="${mockbin}:$PATH" HICLAW_MOCK_LOG="${log}" HICLAW_MOCK_FAIL=1 bash "${SCRIPT}" --worker zhao-yun)
+    exit_code=$?
+    set -e
+    assert_eq "script exits with hiclaw failure" "17" "${exit_code}"
+    assert_json_eq "failure status" "failed" "${output}" ".status"
+    assert_json_eq "deleted false" "false" "${output}" ".deleted"
+}
+
+echo ""
+echo "=== TC3: records-only cleans local state ==="
+{
+    home=$(new_home)
+    cat > "${home}/state.json" <<'EOF'
+{"active_tasks":[
+  {"task_id":"keep","assigned_to":"other"},
+  {"task_id":"drop","assigned_to":"zhao-yun"},
+  {"task_id":"drop-legacy","worker":"zhao-yun"}
+]}
+EOF
+    cat > "${home}/worker-lifecycle.json" <<'EOF'
+{"workers":{"zhao-yun":{"container_status":"running"},"other":{"container_status":"running"}}}
+EOF
+    cat > "${home}/workers-registry.json" <<'EOF'
+{"workers":{"zhao-yun":{"runtime":"openclaw"},"other":{"runtime":"openclaw"}}}
+EOF
+
+    output=$(HOME="${home}" bash "${SCRIPT}" --worker zhao-yun --records-only)
+    assert_json_eq "records-only status" "skipped" "${output}" ".status"
+    assert_eq "only unrelated active task remains" "keep" "$(jq -r '.active_tasks[].task_id' "${home}/state.json")"
+    assert_eq "lifecycle entry removed" "false" "$(jq -r '.workers | has("zhao-yun")' "${home}/worker-lifecycle.json")"
+    assert_eq "registry entry removed" "false" "$(jq -r '.workers | has("zhao-yun")' "${home}/workers-registry.json")"
+}
+
+echo ""
+echo "=== Summary ==="
+echo "PASS: ${PASS}"
+echo "FAIL: ${FAIL}"
+
+if [ "${FAIL}" -ne 0 ]; then
+    exit 1
+fi

--- a/tests/test-06-multi-worker.sh
+++ b/tests/test-06-multi-worker.sh
@@ -35,53 +35,31 @@ wait_for_manager_agent_ready 300 "${DM_ROOM}" "${ADMIN_TOKEN}" || {
     exit 1
 }
 
-# test-05 can leave CoPaw Manager finishing heartbeat / pending-worker cleanup
-# replies in the admin DM. Let that prior turn go quiet before measuring Bob's
-# create-worker ack/provisioning SLA; the post-request waits below stay strict.
-if ! matrix_wait_for_sender_quiet "${ADMIN_TOKEN}" "${DM_ROOM}" "@manager" 20 180; then
-    log_fail "Manager DM did not become quiet before Bob create request"
-    test_teardown "06-multi-worker"
-    test_summary
-    exit 1
-fi
-
 # Alice is running from previous tests; bob will be created below (offset=0 is correct for new workers)
 wait_for_worker_container "alice" 60
 METRICS_BASELINE=$(snapshot_baseline "alice" "bob")
 TEST_WORKER_RUNTIME="${HICLAW_DEFAULT_WORKER_RUNTIME:-openclaw}"
-# worker-management/SKILL.md tells Manager to ask admin for FOUR inputs
-# (name / runtime / SOUL / skills) before running `hiclaw create worker`
-# and not to invent defaults. A vague prompt that only names the worker is
-# therefore a coin flip — sometimes Manager replies with a confirmation
-# request, never calls the CLI, and the consumer/SOUL.md polls below
-# silently time out. Spell out all four inputs and tell Manager to skip
-# confirmation so this test exercises actual Worker creation.
-#
-# The runtime is explicit because the CI matrix runtime is the source of truth;
-# rendered Manager workspace text may contain fallback defaults.
-matrix_send_message "${ADMIN_TOKEN}" "${DM_ROOM}" \
-    "Please create a new Worker now using these exact values — do not ask me to confirm any of them:
-- name: bob
-- runtime: ${TEST_WORKER_RUNTIME} (use this exact runtime; do not reinterpret it as the install default)
-- SOUL/role: Backend developer specializing in REST APIs, server-side logic, and data persistence
-- skills: github-operations (file-sync / task-progress / project-participation are auto-included, no need to ask)
-
-Proceed immediately and tell me when he is created."
-
-log_info "Waiting for Manager to create Worker Bob..."
-REPLY=$(matrix_wait_for_reply_matching "${ADMIN_TOKEN}" "${DM_ROOM}" "@manager" \
-    "bob.*(accepted|created|creating|pending|running|ready)" 300 \
-    "${ADMIN_TOKEN}" "${DM_ROOM}" "Please check if the request to create worker bob has been processed.")
-
-assert_not_empty "${REPLY}" "Manager replied to create bob request"
-assert_contains_i "${REPLY}" "bob" "Reply mentions worker name 'bob'"
+# This test verifies multi-worker collaboration after Alice and Bob exist. Bob
+# creation must be deterministic setup: asking the Manager to create him via DM
+# is flaky under CI because the Manager may still be processing heartbeat/task
+# follow-ups from earlier shard-A tests, or may hit a tool-guard prompt before
+# calling `hiclaw create worker`. Use the controller CLI directly here so the
+# collaboration assertions below measure the multi-worker flow, not LLM timing.
+BOB_SOUL="Backend developer specializing in REST APIs, server-side logic, and data persistence"
+log_info "Creating Worker Bob via hiclaw CLI (runtime: ${TEST_WORKER_RUNTIME})..."
+CREATE_OUTPUT=$(exec_in_agent hiclaw apply worker --name bob \
+    --runtime "${TEST_WORKER_RUNTIME}" \
+    --soul "${BOB_SOUL}" \
+    --skills github-operations 2>&1)
+if echo "${CREATE_OUTPUT}" | grep -qiE "worker/bob (created|configured)"; then
+    log_pass "hiclaw apply worker bob accepted"
+else
+    log_fail "hiclaw apply worker bob failed: ${CREATE_OUTPUT}"
+fi
 
 # Verify Bob's infrastructure. Worker creation is asynchronous, so wait on
 # persisted provisioning state and gateway side effects instead of sleeping.
-BOB_PROVISION_TIMEOUT=60
-if echo "${REPLY}" | grep -qiE "bob.*(accepted|creating|pending)" 2>/dev/null; then
-    BOB_PROVISION_TIMEOUT=180
-fi
+BOB_PROVISION_TIMEOUT=180
 if wait_worker_provisioned "bob" "${BOB_PROVISION_TIMEOUT}"; then
     log_pass "Worker Bob provisioned (roomID + matrixUserID populated)"
 else


### PR DESCRIPTION
## Summary

- add a worker-management delete wrapper that calls `hiclaw delete worker <name>` with the valid positional CLI syntax
- return structured JSON so you only report deletion after command success
- add a records-only cleanup path for `state.json`, `worker-lifecycle.json`, and `workers-registry.json`
- update Worker management guidance to use the wrapper while retaining the current remote-Worker install flow

Fixes #967.

## Verification

- `bash -n manager/agent/skills/worker-management/scripts/delete-worker.sh manager/tests/test-delete-worker-script.sh`
- `PATH=/tmp/AgentTeams-pr969-bin:$PATH bash manager/tests/test-delete-worker-script.sh` with jq 1.7.1 (10 passed, 0 failed)
- `git diff --check`

## Rebase note

Rebased onto current `main` (`6f0c7da`) and preserved the upstream remote-Worker lifecycle guidance. The changelog now adds only this PR's entry.

## CI note

The refreshed matrix has 18 passing checks and 2 skips. Its only failure is
the known SHARD_A `test-06-multi-worker` setup case where the Manager never
created bob; the deterministic bob setup is covered independently by #985.
No worker-deletion path from this PR is involved.

## Temporary dependency

- This branch is temporarily stacked on #985 (`78e9385`), whose full CI passed all 10 integration matrices.
- Relative to #985, this PR retains only its original scoped changes; the shared test fix disappears from the diff after #985 merges.
- Fresh checks on `f154dc72` passed every build and all 10 integration matrices.