### PR TITLE
fix(copaw): retry prompt reads during worker startup

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,21 +4,8 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 
 ---
 
-- feat(qwenpaw): add the QwenPaw worker runtime Python package baseline with runtime config sync, storage sync, heartbeat reporting, Matrix channel overlay, and focused unit tests.
-- fix(controller): surface Kubernetes Pod container failures in Worker backend status and status API responses.
-- feat(controller): expose low-cardinality AgentTeams controller metrics and optional Helm ServiceMonitor.
-- feat(controller): add Matrix AppService Human SSO identity provisioning with hash-derived Matrix IDs, AppService login, deletion deactivation, and Team admin/member identity resolution from Human status.
 - fix(agent): update file-sharing path guidance for CoPaw and Team Leader agents to use `/root/hiclaw-fs/agents/...` instead of the retired `/root/.hiclaw-worker/...` path.
-- feat(helm): add a Helm LLM preflight hook and reusable `hiclaw llm-preflight` command to validate API key/base URL/model before controller startup.
-
-- fix(copaw): harden Matrix channel control-command handling, task-thread routing, NO_REPLY suppression, and cancellation noise handling.
-- feat(controller): add OpenKruise Sandbox backend support for Workers via `spec.backendRuntime=sandbox`, including SandboxClaim lifecycle, status watches, CRD schema, and Helm RBAC/env wiring.
-- fix(controller): materialize sandbox Worker runtime env/auth material into worker-deps storage before creating SandboxClaim deps and block legacy pod-to-sandbox runtime switches until the Worker is stopped.
 - feat(controller): add per-agent `spec.resources` support for Manager, Worker, Team Leader, and Team Worker CRDs.
-- fix(worker): pass `X-HiClaw-Cluster-ID` when remote Workers refresh controller-issued STS credentials for OSS and Nacos AI registry access.
-- feat(hiclaw-controller): support a separate agent-pod-template for `deployMode: Remote` Workers via an optional `pod-template-remote.yaml` key on the controller-scoped pod-template ConfigMap; remote-mode Pod creation prefers this key and transparently falls back to `pod-template.yaml` when it is absent or empty, while non-remote/Sandbox paths keep ignoring it.
-- feat(controller): move Kubernetes resources to the `agentteams.io/v1beta1` API group and decouple Team membership through `spec.workerMembers` references to standalone Worker CRs.
-- feat(runtime): let Worker runtimes consume terminal `AGENTTEAMS_*` storage, controller, and auth environment variables while preserving existing `HICLAW_*` deployment compatibility.
 
 - **OpenHuman runtime**: OpenHuman added as the fourth Worker runtime with native Matrix support via `channel-matrix` feature flag; includes controller routing (K8s + Docker backends), Dockerfile, entrypoint script, agent template, Helm chart integration, and Makefile build targets.
 - **Multi model providers**: Worker, Team, and Manager specs can now select a Higress model provider via `spec.modelProvider`; the controller resolves the provider, injects the matching gateway URL into runtime config, and authorizes consumers only on the selected AI route.
@@ -27,9 +14,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 
 **Bug Fixes**
 
-- **Legacy Team channel policy**: Legacy Team reconciliation now writes final Matrix channel allow-lists to member runtime config and re-adds the Team Leader to the Manager allow-list so controller integration tests observe durable policy state.
-- **Sandbox worker-deps hardening**: Sandbox-backed Workers now prepare controller-owned worker-deps env/token/data material before claim creation, recycle stale SandboxClaims and bound Sandboxes on runtime-affecting changes, and use bounded ServiceAccount token projection for built-in SandboxClaim mounts.
-- **CLI AgentTeams auth env**: The `hiclaw` CLI now discovers `AGENTTEAMS_CONTROLLER_URL`, `AGENTTEAMS_AUTH_TOKEN`, `AGENTTEAMS_AUTH_TOKEN_FILE`, and `AGENTTEAMS_CLUSTER_ID` while preserving legacy `HICLAW_*` fallbacks, so Manager and Worker containers can use the terminal env names for controller calls.
+- **CoPaw prompt materialization**: CoPaw workers now retry stable UTF-8 reads for `SOUL.md` / `AGENTS.md` before copying them into the runtime workspace, avoiding startup or re-bridge crashes when MinIO mirror exposes a transient partially-written prompt file.
 - **CoPaw worker runtime environment**: CoPaw workers now prefer AgentTeams storage/runtime environment variables while preserving legacy HiClaw fallbacks, and Qwen-style model health preflights disable thinking for lightweight readiness checks.
 - **CoPaw Worker heartbeat**: CoPaw worker templates now seed heartbeat at a 10-minute interval so Team Leader agents created from the worker template can run heartbeat turns without requiring an explicit Team CR heartbeat spec.
 - **Helm CRDs**: Removed unsupported `propertyNames` schema fields from Worker and Team CRDs so Kubernetes API servers accept the chart CRDs.
@@ -37,8 +22,4 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 - **CoPaw worker replies**: CoPaw's no-text debounce only recognized copaw `Content` objects, but the custom Matrix channel builds plain-dict content parts, so every message was buffered and the agent never replied. The channel now also recognizes dict-based text/audio parts; workers and team leaders reply as expected.
 - **Worker Matrix token refresh**: `POST /api/v1/credentials/matrix-token` was registered against the `credentials` resource kind, but the worker credentials branch only permitted `ActionSTS`, so the route was dead and workers could not self-refresh on a homeserver 401. The self-scoped credentials branch now also permits `ActionRefreshMatrixToken` (and the misplaced dead entry was removed).
 - **Helm AppService tokens**: The Helm `runtime-env` Secret now generates and preserves the AppService `as_token` / `hs_token` (values override -> existing Secret -> generated) so a default Helm/in-cluster install no longer crash-loops the controller, and a template comment trim-marker that broke `helm lint` YAML parsing was fixed.
-- **Remote Worker authentication boundary**: Remote Worker tokens are now bound to the matching local Worker CR's `deployMode: Remote`, target cluster ID, target namespace, and ServiceAccount name before authorization.
-- **Remote Worker applied target auth**: Remote Worker authentication now prefers the status-pinned deployment target and falls back to spec only before first provisioning, so spec target edits do not immediately break the running remote Worker or trust a target before it is applied.
-- **Remote Worker lifecycle boundary**: Workers now record the applied deployment target in status, reject running target changes until the Worker is Stopped, clean up using the applied target, and register remote Pod watches for Worker/Team status updates.
-- **Team Worker CR decoupling**: Worker identity enrichment and Worker REST APIs now resolve `spec.workerMembers` references, and Teams reject sharing the same referenced Worker CR before injecting coordination context.
-- **Matrix AppService integration**: SSO Human Team admins now resolve through the Human identity source, Matrix AppService transaction push routes are wired into the controller registration path, and registration keeps the homeserver-facing controller URL as the endpoint base.
+- **CoPaw prompt materialization**: CoPaw workers now retry stable UTF-8 reads for `SOUL.md` / `AGENTS.md` before copying them into the runtime workspace, avoiding startup or re-bridge crashes when MinIO mirror exposes a transient partially-written prompt file.

--- a/copaw/src/copaw_worker/worker.py
+++ b/copaw/src/copaw_worker/worker.py
@@ -15,6 +15,7 @@ import os
 import platform
 import shutil
 import stat
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -29,6 +30,41 @@ from copaw_worker.health import HealthState, check_matrix_service
 
 console = Console()
 logger = logging.getLogger(__name__)
+
+
+def _read_prompt_text_stable(path: Path, *, attempts: int = 6, delay: float = 0.2) -> str:
+    """Read a UTF-8 prompt file after transient mirror/write races settle."""
+    last_data = b""
+    last_error: Exception | None = None
+
+    for attempt in range(1, attempts + 1):
+        try:
+            before = path.stat()
+            data = path.read_bytes()
+            after = path.stat()
+            text = data.decode("utf-8")
+            if before.st_size == after.st_size and before.st_mtime_ns == after.st_mtime_ns:
+                return text
+            last_data = data
+            last_error = OSError(f"{path} changed while reading")
+        except (OSError, UnicodeDecodeError) as exc:
+            last_error = exc
+            try:
+                last_data = path.read_bytes()
+            except OSError:
+                pass
+
+        if attempt < attempts:
+            time.sleep(delay)
+
+    logger.warning(
+        "Prompt file %s did not become a stable UTF-8 file after %d attempts; "
+        "using replacement decoding. Last error: %s",
+        path,
+        attempts,
+        last_error,
+    )
+    return last_data.decode("utf-8", errors="replace")
 
 
 class Worker:
@@ -127,7 +163,7 @@ class Worker:
         for name in ("SOUL.md", "AGENTS.md"):
             src = self.sync.local_dir / name
             if src.exists():
-                (self._copaw_working_dir / name).write_text(src.read_text())
+                (self._copaw_working_dir / name).write_text(_read_prompt_text_stable(src), encoding="utf-8")
 
         # 5. Bridge openclaw.json -> CoPaw config.json + providers.json
         #    Infer gateway port from FS endpoint so bridge's _port_remap uses
@@ -624,13 +660,15 @@ class Worker:
         try:
             openclaw_cfg = self.sync.get_config()
             # Use local Worker-managed files; fallback to MinIO for initial bootstrap
-            soul = (self.sync.local_dir / "SOUL.md").read_text() if (self.sync.local_dir / "SOUL.md").exists() else self.sync.get_soul()
-            agents = (self.sync.local_dir / "AGENTS.md").read_text() if (self.sync.local_dir / "AGENTS.md").exists() else self.sync.get_agents_md()
+            soul_path = self.sync.local_dir / "SOUL.md"
+            agents_path = self.sync.local_dir / "AGENTS.md"
+            soul = _read_prompt_text_stable(soul_path) if soul_path.exists() else self.sync.get_soul()
+            agents = _read_prompt_text_stable(agents_path) if agents_path.exists() else self.sync.get_agents_md()
 
             if soul:
-                (self._copaw_working_dir / "SOUL.md").write_text(soul)
+                (self._copaw_working_dir / "SOUL.md").write_text(soul, encoding="utf-8")
             if agents:
-                (self._copaw_working_dir / "AGENTS.md").write_text(agents)
+                (self._copaw_working_dir / "AGENTS.md").write_text(agents, encoding="utf-8")
 
             bridge_openclaw_to_copaw(openclaw_cfg, self._copaw_working_dir)
             console.print("[green]Config re-bridged.[/green]")

--- a/copaw/tests/test_worker_health.py
+++ b/copaw/tests/test_worker_health.py
@@ -8,7 +8,7 @@ import pytest
 
 from copaw_worker.config import WorkerConfig
 from copaw_worker.health import ComponentHealth
-from copaw_worker.worker import Worker
+from copaw_worker.worker import Worker, _read_prompt_text_stable
 
 
 class _FakeWorkerAPIServer:
@@ -54,6 +54,26 @@ def _config(tmp_path):
 
 def _health_json(tmp_path):
     return json.loads((tmp_path / "alice" / ".copaw" / "health.json").read_text())
+
+
+def test_read_prompt_text_stable_retries_partial_utf8(tmp_path, monkeypatch):
+    prompt = tmp_path / "AGENTS.md"
+    prompt.write_bytes("hello ".encode("utf-8") + "中".encode("utf-8")[:2])
+
+    def finish_write(_delay):
+        prompt.write_text("hello 中", encoding="utf-8")
+
+    monkeypatch.setattr("copaw_worker.worker.time.sleep", finish_write)
+
+    assert _read_prompt_text_stable(prompt, attempts=2, delay=0.01) == "hello 中"
+
+
+def test_read_prompt_text_stable_falls_back_after_retries(tmp_path, monkeypatch):
+    prompt = tmp_path / "SOUL.md"
+    prompt.write_bytes(b"broken \xe4\xb8")
+    monkeypatch.setattr("copaw_worker.worker.time.sleep", lambda _delay: None)
+
+    assert _read_prompt_text_stable(prompt, attempts=2, delay=0.01) == "broken �"
 
 
 def test_worker_port_defaults_to_console_port_plus_one(tmp_path):


### PR DESCRIPTION
## Summary
- add a bounded stable UTF-8 prompt reader for CoPaw worker SOUL.md / AGENTS.md materialization
- use it during startup and config re-bridge so transient mc mirror/read races do not crash the worker
- add focused unit coverage and changelog entry

## Tests
- git diff --check
- python3 -m py_compile copaw/src/copaw_worker/worker.py copaw/tests/test_worker_health.py
- not run: python3 -m pytest copaw/tests/test_worker_health.py -q (pytest is not installed in this environment)

Fixes #711.
Also addresses #728.