### PR TITLE
docs: clarify Higress AI route matching

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -14,6 +14,7 @@
 - [Cannot connect to Matrix server locally](#cannot-connect-to-matrix-server-locally)
 - [How to talk to a Worker directly](#how-to-talk-to-a-worker-directly)
 - [How to connect third-party, local, or multi-provider models](#how-to-connect-third-party-local-or-multi-provider-models)
+- [Why does my custom Higress AI route never match](#why-does-my-custom-higress-ai-route-never-match)
 - [How to switch the Manager's model](#how-to-switch-the-managers-model)
 - [How to switch a Worker's model](#how-to-switch-a-workers-model)
 - [How to configure OpenRouter or another model provider with slashes in model names](#how-to-configure-openrouter-or-another-model-provider-with-slashes-in-model-names)
@@ -447,6 +448,23 @@ desired model explicitly to the Manager or a Worker. HiClaw can use different
 models for different Workers, but automatic model selection by task type is not
 a built-in policy; express that policy through Worker roles or switch the model
 explicitly.
+
+---
+
+## Why does my custom Higress AI route never match
+
+HiClaw creates a `default-ai-route` during setup. When that route has no
+`modelPredicates`, it can match all model requests, so a later custom route may
+look like it has lower priority.
+
+For multiple AI routes, make the model matching rules unambiguous:
+
+- Add `modelPredicates` to each custom route, such as a prefix match for
+  `deepseek` or a regex for `^openrouter/.*$`.
+- Also constrain `default-ai-route` to the models it should own, such as
+  `qwen*`, instead of leaving it without `modelPredicates`.
+- Use the same model id when switching Manager or Worker models; the route is
+  selected from the requested model name, not from the provider display name.
 
 ---
 

--- a/docs/zh-cn/faq.md
+++ b/docs/zh-cn/faq.md
@@ -14,6 +14,7 @@
 - [本地访问 Matrix 服务器不通](#本地访问-matrix-服务器不通)
 - [如何主动指挥 Worker](#如何主动指挥-worker)
 - [如何接入第三方、本地或多供应商模型](#如何接入第三方本地或多供应商模型)
+- [为什么自定义 Higress AI 路由总是匹配不到](#为什么自定义-higress-ai-路由总是匹配不到)
 - [如何切换 Manager 的模型](#如何切换-manager-的模型)
 - [如何切换 Worker 的模型](#如何切换-worker-的模型)
 - [如何配置 OpenRouter 或模型名带斜杠的供应商](#如何配置-openrouter-或模型名带斜杠的供应商)
@@ -430,6 +431,19 @@ Docker Desktop 下的 `http://host.docker.internal:<port>/v1`，或在 Linux/Pod
 `qwen*`，另一条匹配 `claude*`。然后明确给 Manager 或 Worker 指定目标模型。HiClaw
 可以让不同 Worker 使用不同模型，但不会内置按任务类型自动选择模型的策略；这类策略需要
 通过 Worker 角色设计或显式切换模型表达。
+
+---
+
+## 为什么自定义 Higress AI 路由总是匹配不到
+
+HiClaw 安装时会创建 `default-ai-route`。如果这条路由没有配置
+`modelPredicates`，它可能匹配所有模型请求，因此后添加的自定义路由看起来像是优先级更低。
+
+存在多条 AI route 时，需要让模型匹配规则不重叠：
+
+- 给每条自定义 route 配置 `modelPredicates`，例如用前缀匹配 `deepseek`，或用正则匹配 `^openrouter/.*$`。
+- 同时也要限制 `default-ai-route` 只匹配它负责的模型，例如 `qwen*`，不要让它保持空 `modelPredicates`。
+- 切换 Manager 或 Worker 模型时使用同一个 model id；路由是根据请求里的模型名选择的，不是根据供应商展示名选择的。
 
 ---
 


### PR DESCRIPTION
## Summary
- add English and Chinese FAQ entries for custom Higress AI routes that never match
- explain that an unconstrained default-ai-route can match all model requests
- document that multiple AI routes should each use explicit modelPredicates, including the default route

## Tests
- git diff --check

Addresses #867.