### PR TITLE
fix(worker): keep live OpenClaw token out of bulk file sync

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -19,6 +19,7 @@ Record release-facing changes here before the next release.
 
 **Bug Fixes**
 
+- **OpenClaw Worker file-sync token safety**: Fetch remote `openclaw.json` separately, exclude the live file from bulk mirrors, and merge Manager-owned fields afterward so a stale MinIO Matrix token is never exposed to the running Worker. ([#983](https://github.com/agentscope-ai/AgentTeams/pull/983))
 - **QwenPaw MCP policy startup convergence**: Persist built-in plugin MCP policies before runtime desired-state reloads so a replacement QwenPaw workspace cannot retain the pre-policy interactive approval handler.
 - **QwenPaw Team policy and runtime-aware acceptance**: Merge Team and Worker channel-policy overrides into QwenPaw `runtime.yaml`, wait for public plugin/API state before integration assertions, and verify prompt/config files from the runtime location that consumes them.
 - **QwenPaw 2.0 tool execution**: Preserve QwenPaw's asynchronous tool-result stream while sanitizing output, and allow only the built-in TeamHarness and Workerflow MCP drivers to run without an unavailable interactive approval prompt.
@@ -48,6 +49,7 @@ Record release-facing changes here before the next release.
 
 **Bug 修复**
 
+- **OpenClaw Worker 文件同步 Token 安全**：单独拉取远端 `openclaw.json`，在批量 mirror 中排除运行中的配置文件，再合并 Manager 管理字段，避免 MinIO 中的旧 Matrix Token 暂时暴露给运行中的 Worker。([#983](https://github.com/agentscope-ai/AgentTeams/pull/983))
 - **Worker 存储同步 I/O 放大**：基于成功 watermark 只上传变化文件，保持 jq 1.7 fallback pull 存活，并将 embedded Controller mirror 限定为控制面配置。并发创建 Worker 和未知工作目录仍保持原有持久化语义，不再反复执行全量 workspace mirror。([#1110](https://github.com/agentscope-ai/AgentTeams/pull/1110))
 - **Manager 诊断循环**：Manager 提示和 Worker 生命周期指引会停止重复执行无效果的排障命令，并以 `agt get workers` 不再列出目标 Worker 作为删除完成边界，避免继续循环探测 Matrix Room。([#975](https://github.com/agentscope-ai/AgentTeams/pull/975))
 - **CoPaw Team 路由与 workspace 投影**：将 Team Leader 分配（包括 localpart mention）路由到 Team Room，并把 Worker prompt、skills、工具配置和 Matrix 设置投影到 CoPaw 默认 workspace。([#1060](https://github.com/agentscope-ai/AgentTeams/pull/1060), [9074def](https://github.com/agentscope-ai/AgentTeams/commit/9074def3), [973e291](https://github.com/agentscope-ai/AgentTeams/commit/973e291), [92c8145](https://github.com/agentscope-ai/AgentTeams/commit/92c8145))

--- a/manager/agent/worker-agent/skills/file-sync/scripts/agentteams-sync.sh
+++ b/manager/agent/worker-agent/skills/file-sync/scripts/agentteams-sync.sh
@@ -3,46 +3,52 @@
 # Called by the Worker agent when coordinator notifies of config updates.
 # Uses /root/agentteams-fs/ layout — same absolute path as the Manager's MinIO mirror.
 
-# Bootstrap env: provides AGENTTEAMS_STORAGE_PREFIX and ensure_mc_credentials
-if [ -f /opt/agentteams/scripts/lib/agentteams-env.sh ]; then
-    . /opt/agentteams/scripts/lib/agentteams-env.sh
+# Bootstrap env: provides AGENTTEAMS_STORAGE_PREFIX and ensure_mc_credentials.
+# Library overrides keep the sync behavior testable without changing runtime
+# defaults inside the Worker image.
+AGENTTEAMS_LIB_DIR="${AGENTTEAMS_LIB_DIR:-/opt/agentteams/scripts/lib}"
+if [ -f "${AGENTTEAMS_LIB_DIR}/agentteams-env.sh" ]; then
+    . "${AGENTTEAMS_LIB_DIR}/agentteams-env.sh"
 else
-    . /opt/agentteams/scripts/lib/oss-credentials.sh 2>/dev/null || true
+    . "${AGENTTEAMS_LIB_DIR}/oss-credentials.sh" 2>/dev/null || true
     ensure_mc_credentials 2>/dev/null || true
     AGENTTEAMS_FS_BUCKET="${AGENTTEAMS_FS_BUCKET:-agentteams-storage}"
     AGENTTEAMS_STORAGE_PREFIX="${AGENTTEAMS_STORAGE_PREFIX:-agentteams/${AGENTTEAMS_FS_BUCKET}}"
 fi
 
 # Merge helper for openclaw.json (local-first: MinIO overlays models/gateway/channels + plugins rules)
-. /opt/agentteams/scripts/lib/merge-openclaw-config.sh
-. /opt/agentteams/scripts/lib/worker-file-sync.sh
+. "${AGENTTEAMS_LIB_DIR}/merge-openclaw-config.sh"
+. "${AGENTTEAMS_LIB_DIR}/worker-file-sync.sh"
 
 WORKER_NAME="${AGENTTEAMS_WORKER_NAME:?AGENTTEAMS_WORKER_NAME is required}"
-AGENTTEAMS_ROOT="/root/agentteams-fs"
+AGENTTEAMS_ROOT="${AGENTTEAMS_ROOT:-/root/agentteams-fs}"
 WORKSPACE="${AGENTTEAMS_ROOT}/agents/${WORKER_NAME}"
 
 ensure_mc_credentials 2>/dev/null || true
 
-# Save local openclaw.json before mirror overwrites it
+# Fetch Manager-owned config separately. The bulk mirror must never replace
+# the live file, even briefly, because OpenClaw watches it and may reconnect
+# with the stale Matrix token stored in MinIO.
 LOCAL_OPENCLAW="${WORKSPACE}/openclaw.json"
-SAVED_LOCAL="/tmp/openclaw-local-sync.json"
-if [ -f "${LOCAL_OPENCLAW}" ]; then
-    cp "${LOCAL_OPENCLAW}" "${SAVED_LOCAL}"
-fi
+REMOTE_OPENCLAW="${AGENTTEAMS_REMOTE_OPENCLAW_TMP:-/tmp/openclaw-remote-sync-${WORKER_NAME}.json}"
+rm -f "${REMOTE_OPENCLAW}"
+mc cp "${AGENTTEAMS_STORAGE_PREFIX}/agents/${WORKER_NAME}/openclaw.json" "${REMOTE_OPENCLAW}" 2>/dev/null || true
 
 mc mirror "${AGENTTEAMS_STORAGE_PREFIX}/agents/${WORKER_NAME}/" "${WORKSPACE}/" --overwrite \
+    --exclude "openclaw.json" \
     --exclude ".openclaw/matrix/**" --exclude ".openclaw/canvas/**" 2>&1
 mc mirror "${AGENTTEAMS_STORAGE_PREFIX}/shared/" "${AGENTTEAMS_ROOT}/shared/" --overwrite 2>/dev/null || true
 
 # Update pull marker so the local→remote sync loop doesn't push back freshly-pulled files
 touch "${WORKSPACE}/.last-pull"
 
-# Merge openclaw.json: local-first (pre-mirror copy) with MinIO overlay (arg1=remote, arg2=local, arg3=out)
-if [ -f "${SAVED_LOCAL}" ] && [ -f "${LOCAL_OPENCLAW}" ]; then
-    if ! merge_openclaw_config "${LOCAL_OPENCLAW}" "${SAVED_LOCAL}" "${LOCAL_OPENCLAW}"; then
+# Merge openclaw.json after the bulk mirror: local token and Worker-owned
+# settings remain authoritative while Manager-owned slices are refreshed.
+if [ -f "${REMOTE_OPENCLAW}" ]; then
+    if ! merge_openclaw_config "${REMOTE_OPENCLAW}" "${LOCAL_OPENCLAW}" "${LOCAL_OPENCLAW}"; then
         echo "WARNING: failed to merge remote openclaw.json; keeping local config" >&2
     fi
-    rm -f "${SAVED_LOCAL}"
+    rm -f "${REMOTE_OPENCLAW}"
 fi
 
 # Restore +x on scripts (MinIO does not preserve Unix permission bits)

--- a/manager/tests/test-agentteams-sync.sh
+++ b/manager/tests/test-agentteams-sync.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SYNC_SCRIPT="${REPO_ROOT}/manager/agent/worker-agent/skills/file-sync/scripts/agentteams-sync.sh"
+MERGE_LIB="${REPO_ROOT}/shared/lib/merge-openclaw-config.sh"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+WORKER_NAME="alice"
+LOCAL_ROOT="${TMP_DIR}/local"
+REMOTE_ROOT="${TMP_DIR}/remote"
+LIB_DIR="${TMP_DIR}/lib"
+BIN_DIR="${TMP_DIR}/bin"
+OBSERVATION="${TMP_DIR}/mirror-observation"
+REMOTE_TMP="${TMP_DIR}/openclaw-remote.json"
+
+mkdir -p \
+    "${LOCAL_ROOT}/agents/${WORKER_NAME}/skills" \
+    "${LOCAL_ROOT}/shared" \
+    "${REMOTE_ROOT}/agents/${WORKER_NAME}" \
+    "${REMOTE_ROOT}/shared" \
+    "${LIB_DIR}" \
+    "${BIN_DIR}"
+
+cat > "${LOCAL_ROOT}/agents/${WORKER_NAME}/openclaw.json" <<'EOF'
+{
+  "channels": {
+    "matrix": {
+      "accessToken": "fresh-token",
+      "homeserver": "https://local.example"
+    }
+  },
+  "tools": {
+    "workerOwned": true
+  }
+}
+EOF
+
+cat > "${REMOTE_ROOT}/agents/${WORKER_NAME}/openclaw.json" <<'EOF'
+{
+  "models": {
+    "default": "manager-model"
+  },
+  "channels": {
+    "matrix": {
+      "accessToken": "stale-token",
+      "homeserver": "https://manager.example"
+    }
+  }
+}
+EOF
+
+printf '%s\n' "updated instructions" > "${REMOTE_ROOT}/agents/${WORKER_NAME}/AGENTS.md"
+
+cat > "${LIB_DIR}/agentteams-env.sh" <<'EOF'
+ensure_mc_credentials() {
+    :
+}
+EOF
+
+cat > "${LIB_DIR}/worker-file-sync.sh" <<'EOF'
+worker_sync_mark_remote_pull() {
+    :
+}
+EOF
+cp "${MERGE_LIB}" "${LIB_DIR}/merge-openclaw-config.sh"
+
+cat > "${BIN_DIR}/mc" <<'EOF'
+#!/bin/sh
+set -eu
+
+operation="$1"
+shift
+
+case "${operation}" in
+    cp)
+        source_path="$1"
+        destination="$2"
+        case "${source_path}" in
+            */agents/"${AGENTTEAMS_WORKER_NAME}"/openclaw.json)
+                cp "${FAKE_REMOTE_ROOT}/agents/${AGENTTEAMS_WORKER_NAME}/openclaw.json" "${destination}"
+                ;;
+            *)
+                echo "unexpected mc cp source: ${source_path}" >&2
+                exit 1
+                ;;
+        esac
+        ;;
+    mirror)
+        source_path="$1"
+        destination="$2"
+        shift 2
+        case "${source_path}" in
+            */agents/"${AGENTTEAMS_WORKER_NAME}"/)
+                excluded=false
+                previous=""
+                for argument in "$@"; do
+                    if [ "${previous}" = "--exclude" ] && [ "${argument}" = "openclaw.json" ]; then
+                        excluded=true
+                    fi
+                    previous="${argument}"
+                done
+
+                mkdir -p "${destination}"
+                if [ "${excluded}" != "true" ]; then
+                    cp "${FAKE_REMOTE_ROOT}/agents/${AGENTTEAMS_WORKER_NAME}/openclaw.json" \
+                        "${destination}/openclaw.json"
+                fi
+
+                token="$(jq -r '.channels.matrix.accessToken' "${destination}/openclaw.json")"
+                {
+                    echo "excluded=${excluded}"
+                    echo "mirror-token=${token}"
+                } > "${FAKE_OBSERVATION}"
+                cp "${FAKE_REMOTE_ROOT}/agents/${AGENTTEAMS_WORKER_NAME}/AGENTS.md" \
+                    "${destination}/AGENTS.md"
+                ;;
+            */shared/)
+                mkdir -p "${destination}"
+                ;;
+            *)
+                echo "unexpected mc mirror source: ${source_path}" >&2
+                exit 1
+                ;;
+        esac
+        ;;
+    *)
+        echo "unexpected mc operation: ${operation}" >&2
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "${BIN_DIR}/mc"
+
+PATH="${BIN_DIR}:${PATH}" \
+AGENTTEAMS_WORKER_NAME="${WORKER_NAME}" \
+AGENTTEAMS_STORAGE_PREFIX="fake/agentteams-storage" \
+AGENTTEAMS_ROOT="${LOCAL_ROOT}" \
+AGENTTEAMS_LIB_DIR="${LIB_DIR}" \
+AGENTTEAMS_REMOTE_OPENCLAW_TMP="${REMOTE_TMP}" \
+FAKE_REMOTE_ROOT="${REMOTE_ROOT}" \
+FAKE_OBSERVATION="${OBSERVATION}" \
+    /bin/sh "${SYNC_SCRIPT}" >/dev/null
+
+grep -qx 'excluded=true' "${OBSERVATION}"
+grep -qx 'mirror-token=fresh-token' "${OBSERVATION}"
+
+LOCAL_OPENCLAW="${LOCAL_ROOT}/agents/${WORKER_NAME}/openclaw.json"
+test "$(jq -r '.channels.matrix.accessToken' "${LOCAL_OPENCLAW}")" = "fresh-token"
+test "$(jq -r '.channels.matrix.homeserver' "${LOCAL_OPENCLAW}")" = "https://manager.example"
+test "$(jq -r '.models.default' "${LOCAL_OPENCLAW}")" = "manager-model"
+test "$(jq -r '.tools.workerOwned' "${LOCAL_OPENCLAW}")" = "true"
+test "$(cat "${LOCAL_ROOT}/agents/${WORKER_NAME}/AGENTS.md")" = "updated instructions"
+test ! -e "${REMOTE_TMP}"
+
+echo "agentteams-sync token safety test: PASS"


### PR DESCRIPTION
## Summary

Fixes #809 by preventing the manual OpenClaw Worker file-sync path from ever replacing the live `openclaw.json` with the stale MinIO copy, even briefly.

The previous flow copied the live file aside, bulk-mirrored the remote workspace over it, and merged the saved local copy afterward. OpenClaw watches this file, so the stale Matrix token could be observed during that overwrite window and used on reconnect.

## Changes

- fetch remote `openclaw.json` into a Worker-specific temporary file;
- exclude the live `openclaw.json` from the bulk `mc mirror`;
- merge Manager-owned remote fields into the untouched local config after the mirror;
- preserve the existing local-first merge contract, including the local Matrix `accessToken`;
- add a focused behavior test with a mock `mc` implementation.

The behavior test reads the live token *inside* the mocked bulk-mirror operation. It fails if `openclaw.json` was not excluded or if the stale remote token became visible. It also verifies that Manager-owned model/channel fields are updated, Worker-owned fields remain, other workspace files are pulled, and the temporary remote config is removed.

## Scope

This PR contains only:

- `manager/agent/worker-agent/skills/file-sync/scripts/agentteams-sync.sh`
- `manager/tests/test-agentteams-sync.sh`
- the required bilingual changelog entry

The previously stacked integration-test commits are no longer part of the branch.

## Verification

- [x] `bash -n manager/agent/worker-agent/skills/file-sync/scripts/agentteams-sync.sh manager/tests/test-agentteams-sync.sh`
- [x] `bash manager/tests/test-agentteams-sync.sh`
- [x] `git diff --check`

## Impact

- Breaking change: no
- Affected runtime: OpenClaw Worker manual/on-demand file sync
- Performance: one object `mc cp` replaces the previous local backup copy; bulk mirror scope is reduced by one file
