### PR TITLE
fix(install): surface Higress gateway startup diagnostics

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -34,6 +34,7 @@ Record release-facing changes here before the next release.
 - **Install script model env passthrough**: Pass custom model override env vars to the Controller container so that `AGENTTEAMS_MODEL_VISION` and related settings actually reach the config generator.
 - **Bridge model capability propagation**: Propagate model `input` modalities from openclaw.json through `_write_providers_json()` so QwenPaw's `ModelInfo` receives `supports_image`/`supports_video`/`supports_multimodal` flags instead of relying on fail-open defaults.
 - **Manager diagnostic loops**: Manager prompts and Worker lifecycle guidance stop repeated no-op troubleshooting commands and treat a missing Worker in `agt get workers` as the deletion boundary instead of looping on Matrix room probes. ([#975](https://github.com/agentscope-ai/AgentTeams/pull/975))
+- **Higress startup diagnostics**: Report architecture, kernel limits, and the current gateway log when the embedded Higress Gateway fails to become ready, including ARM64 Wasm/V8 guidance. ([#984](https://github.com/agentscope-ai/AgentTeams/pull/984))
 
 ---
 
@@ -51,6 +52,7 @@ Record release-facing changes here before the next release.
 - **CoPaw Team 任务分配交接**：由 `taskflow(delegate_task)` 返回必须执行的 Team Room `message` 动作，根据 Team roster 规范化 Worker 别名，每分钟刷新 Controller 管理的运行时上下文，并将非 Team Room 中的任务分配回复重定向到 Team Room。([#1120](https://github.com/agentscope-ai/AgentTeams/pull/1120))
 - **Worker 端口暴露 CLI**：将 `--expose` 参数编码为数值端口，并在创建、更新或应用请求到达 Controller 前拒绝无效或越界输入。
 - **Manager 诊断循环**：Manager 提示和 Worker 生命周期指引会停止重复执行无效果的排障命令，并以 `agt get workers` 不再列出目标 Worker 作为删除完成边界，避免继续循环探测 Matrix Room。([#975](https://github.com/agentscope-ai/AgentTeams/pull/975))
+- **Higress 启动诊断**：嵌入式 Higress Gateway 未能 ready 时输出架构、内核限制和当前网关日志，并提供 ARM64 Wasm/V8 排查指引。([#984](https://github.com/agentscope-ai/AgentTeams/pull/984))
 
 ---
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -327,7 +327,26 @@ The controller starts the Manager container automatically. If the Manager contai
 
 Increase Docker VM memory to at least 4 GB: Docker Desktop → Settings → Resources → Memory. Then re-run the install command.
 
-**Case 3: Stale config data**
+**Case 3: Higress Gateway exits before it becomes ready**
+
+If installation stops at `Higress Gateway not ready after 120s` and the gateway log contains `Fatal error`, `Check failed: 12`, or `trace/breakpoint trap`, check Linux kernel limits used by the Docker VM or host:
+
+```bash
+docker exec agentteams-controller uname -m
+docker exec agentteams-controller cat /proc/sys/fs/inotify/max_user_instances
+docker exec agentteams-controller cat /proc/sys/vm/max_map_count
+docker exec agentteams-controller cat /proc/sys/vm/overcommit_memory
+```
+
+If `fs.inotify.max_user_instances` is lower than `1024`, raise it on the host and restart AgentTeams. This removes one possible file-watch limit, but does not guarantee that an Envoy/V8 crash is fixed:
+
+```bash
+sudo sysctl -w fs.inotify.max_user_instances=1024
+```
+
+On ARM64/aarch64 hosts, the same V8 assertion has been reported even with higher kernel limits. If disabling Wasm plugins makes the gateway start, treat that as evidence of a compatibility problem in the embedded Higress Wasm/V8 runtime, not as a supported workaround. AgentTeams relies on Higress Wasm plugins for gateway authentication and AI routing. Keep them enabled for normal use and include the architecture, kernel values, and gateway log when reporting the failure.
+
+**Case 4: Stale config data**
 
 Re-run the install command and choose **delete and reinstall**:
 
@@ -337,7 +356,7 @@ bash <(curl -sSL https://raw.githubusercontent.com/agentscope-ai/AgentTeams/main
 
 When the installer detects an existing installation, it will ask how to proceed. Choosing delete will wipe the stale data and start fresh.
 
-**Case 4: Mac with Apple Silicon and outdated Docker/Podman**
+**Case 5: Mac with Apple Silicon and outdated Docker/Podman**
 
 If you're using a Mac with Apple Silicon (M1/M2/M3/M4) and Docker Desktop is older than 4.39.0, Manager Agent may fail to start properly.
 
@@ -346,7 +365,7 @@ If you're using a Mac with Apple Silicon (M1/M2/M3/M4) and Docker Desktop is old
 - **Docker Desktop**: Upgrade to 4.39.0 or later
 - **Podman**: Ensure Podman Engine **Server version ≥ 5.7.1** (check with `podman version`)
 
-**Case 5: Linux host with SELinux volume denial**
+**Case 6: Linux host with SELinux volume denial**
 
 If the detailed log, especially `mc-mirror.log`, contains `permission denied`
 for files under the mounted workspace or host-share directory on an SELinux

--- a/docs/zh-cn/faq.md
+++ b/docs/zh-cn/faq.md
@@ -322,7 +322,28 @@ Controller 会自动启动 Manager 容器。如果 `docker ps` 中看不到 Mana
 
 建议将内存调整到 4GB 以上：Docker Desktop → Settings → Resources → Memory。调整后重新执行安装命令。
 
-**情况三：配置脏数据**
+**情况三：Higress Gateway 未 ready 前退出**
+
+如果安装停在 `Higress Gateway not ready after 120s`，并且 gateway 日志中出现
+`Fatal error`、`Check failed: 12` 或 `trace/breakpoint trap`，请检查 Docker VM
+或宿主机的 Linux 内核限制：
+
+```bash
+docker exec agentteams-controller uname -m
+docker exec agentteams-controller cat /proc/sys/fs/inotify/max_user_instances
+docker exec agentteams-controller cat /proc/sys/vm/max_map_count
+docker exec agentteams-controller cat /proc/sys/vm/overcommit_memory
+```
+
+如果 `fs.inotify.max_user_instances` 小于 `1024`，请在宿主机上调高后重启 AgentTeams。这可以排除一种文件监视资源限制，但不能保证修复 Envoy/V8 崩溃：
+
+```bash
+sudo sysctl -w fs.inotify.max_user_instances=1024
+```
+
+在 ARM64/aarch64 主机上，即使内核限制已经调高，也有报告出现相同的 V8 断言。如果禁用 Wasm 插件后 gateway 能启动，应将其视为嵌入式 Higress Wasm/V8 运行时兼容性问题的证据，而不是受支持的解决方式。AgentTeams 依赖 Higress Wasm 插件完成网关鉴权和 AI 路由；正常使用时请保持插件启用，并在报告问题时附上架构、内核参数和 gateway 日志。
+
+**情况四：配置脏数据**
 
 建议到原安装目录重新执行安装命令，选择**删除重装**：
 
@@ -332,7 +353,7 @@ bash <(curl -sSL https://raw.githubusercontent.com/agentscope-ai/AgentTeams/main
 
 安装脚本检测到已有安装时会询问处理方式，选择删除后重装即可清除脏数据。
 
-**情况四：Mac M 系列芯片 + 低版本 Docker/Podman**
+**情况五：Mac M 系列芯片 + 低版本 Docker/Podman**
 
 如果你使用的是搭载 Apple M 系列芯片（M1/M2/M3/M4）的 Mac，且 Docker Desktop 版本低于 4.39.0，Manager Agent 可能无法正常启动。
 
@@ -341,7 +362,7 @@ bash <(curl -sSL https://raw.githubusercontent.com/agentscope-ai/AgentTeams/main
 - **Docker Desktop**：升级到 4.39.0 或更高版本
 - **Podman**：确保 Podman Engine **Server 版本 ≥ 5.7.1**（可通过 `podman version` 查看）
 
-**情况五：Linux 主机 SELinux 拦截挂载目录**
+**情况六：Linux 主机 SELinux 拦截挂载目录**
 
 如果详细日志，尤其是 `mc-mirror.log`，在工作目录或共享目录下出现
 `permission denied`，且主机启用了 SELinux，可能是容器没有访问 bind mount 的

--- a/install/agentteams-install.ps1
+++ b/install/agentteams-install.ps1
@@ -3163,6 +3163,52 @@ function Install-Manager {
         Write-Log "Embedded controller started: agentteams-controller"
 
         # Wait for infra inside the controller container.
+        function Show-HigressGatewayTimeoutDiagnostics {
+            param([string]$Container)
+
+            Write-Log "Higress Gateway diagnostics:"
+            $architecture = docker exec $Container uname -m 2>$null
+            $inotifyInstances = docker exec $Container cat /proc/sys/fs/inotify/max_user_instances 2>$null
+            $maxMapCount = docker exec $Container cat /proc/sys/vm/max_map_count 2>$null
+            $overcommitMemory = docker exec $Container cat /proc/sys/vm/overcommit_memory 2>$null
+            if ($architecture) {
+                $architecture = $architecture | Select-Object -First 1
+                Write-Log "  architecture=$architecture"
+            }
+            if ($inotifyInstances) {
+                Write-Log "  fs.inotify.max_user_instances=$inotifyInstances"
+                $parsed = 0
+                if ([int]::TryParse(($inotifyInstances | Select-Object -First 1), [ref]$parsed) -and $parsed -lt 1024) {
+                    Write-Log "  WARNING: fs.inotify.max_user_instances is low and may exhaust file-watch resources."
+                    Write-Log "  Try on the host: sudo sysctl -w fs.inotify.max_user_instances=1024"
+                }
+            }
+            if ($maxMapCount) {
+                Write-Log "  vm.max_map_count=$($maxMapCount | Select-Object -First 1)"
+            }
+            if ($overcommitMemory) {
+                Write-Log "  vm.overcommit_memory=$($overcommitMemory | Select-Object -First 1)"
+            }
+
+            $gatewayTail = docker exec $Container sh -c "tail -80 /var/log/agentteams/higress-gateway.log 2>/dev/null" 2>$null
+            if ($LASTEXITCODE -eq 0 -and $gatewayTail) {
+                foreach ($line in $gatewayTail) {
+                    Write-Log "  gateway-log: $line"
+                }
+                $joined = ($gatewayTail -join "`n")
+                if ($joined -match "Fatal error|Check failed: 12|trace/breakpoint trap|core dumped") {
+                    Write-Log "  Detected Envoy/V8 fatal exit. Compare the architecture and kernel limits above when reporting this failure."
+                    if ($architecture -match "^(aarch64|arm64)$") {
+                        Write-Log "  WARNING: This failure has been reported on ARM64 even after raising the kernel limits."
+                        Write-Log "  If disabling Wasm makes the gateway start, treat that only as Higress Wasm/V8 compatibility evidence."
+                        Write-Log "  Keep Wasm enabled for normal use because AgentTeams relies on it for gateway authentication and AI routing."
+                    }
+                }
+            } else {
+                Write-Log "  No Higress Gateway log found at /var/log/agentteams/higress-gateway.log"
+            }
+        }
+
         function Wait-EmbeddedUrl {
             param([string]$Url, [string]$Container, [int]$MaxWait, [string]$Description)
             $elapsed = 0
@@ -3177,6 +3223,9 @@ function Install-Manager {
                 $elapsed += 2
             }
             Write-Host "$($script:ESC)[31m[AgentTeams ERROR]$($script:ESC)[0m $Description not ready after ${MaxWait}s" -ForegroundColor Red
+            if ($Description -eq "Higress Gateway") {
+                Show-HigressGatewayTimeoutDiagnostics -Container $Container
+            }
             return $false
         }
 

--- a/install/agentteams-install.sh
+++ b/install/agentteams-install.sh
@@ -4025,6 +4025,53 @@ CREDEOF
         log "Embedded controller started: agentteams-controller"
 
         # Wait for infrastructure inside the controller container
+        _report_higress_gateway_timeout() {
+            local ctr="$1"
+            local architecture=""
+            local inotify_instances=""
+            local max_map_count=""
+            local overcommit_memory=""
+            local gateway_tail=""
+
+            log "Higress Gateway diagnostics:"
+            architecture="$(${DOCKER_CMD} exec "${ctr}" uname -m 2>/dev/null || true)"
+            inotify_instances="$(${DOCKER_CMD} exec "${ctr}" cat /proc/sys/fs/inotify/max_user_instances 2>/dev/null || true)"
+            max_map_count="$(${DOCKER_CMD} exec "${ctr}" cat /proc/sys/vm/max_map_count 2>/dev/null || true)"
+            overcommit_memory="$(${DOCKER_CMD} exec "${ctr}" cat /proc/sys/vm/overcommit_memory 2>/dev/null || true)"
+            [ -n "${architecture}" ] && log "  architecture=${architecture}"
+            if [ -n "${inotify_instances}" ]; then
+                log "  fs.inotify.max_user_instances=${inotify_instances}"
+                case "${inotify_instances}" in
+                    ''|*[!0-9]*) ;;
+                    *)
+                        if [ "${inotify_instances}" -lt 1024 ]; then
+                            log "  WARNING: fs.inotify.max_user_instances is low and may exhaust file-watch resources."
+                            log "  Try on the host: sudo sysctl -w fs.inotify.max_user_instances=1024"
+                        fi
+                        ;;
+                esac
+            fi
+            [ -n "${max_map_count}" ] && log "  vm.max_map_count=${max_map_count}"
+            [ -n "${overcommit_memory}" ] && log "  vm.overcommit_memory=${overcommit_memory}"
+
+            gateway_tail="$(${DOCKER_CMD} exec "${ctr}" sh -c 'tail -80 /var/log/agentteams/higress-gateway.log 2>/dev/null' 2>/dev/null || true)"
+            if [ -n "${gateway_tail}" ]; then
+                printf '%s\n' "${gateway_tail}" | sed 's/^/[AgentTeams]   gateway-log: /'
+                if printf '%s\n' "${gateway_tail}" | grep -qiE 'Fatal error|Check failed: 12|trace/breakpoint trap|core dumped'; then
+                    log "  Detected Envoy/V8 fatal exit. Compare the architecture and kernel limits above when reporting this failure."
+                    case "${architecture}" in
+                        aarch64|arm64)
+                            log "  WARNING: This failure has been reported on ARM64 even after raising the kernel limits."
+                            log "  If disabling Wasm makes the gateway start, treat that only as Higress Wasm/V8 compatibility evidence."
+                            log "  Keep Wasm enabled for normal use because AgentTeams relies on it for gateway authentication and AI routing."
+                            ;;
+                    esac
+                fi
+            else
+                log "  No Higress Gateway log found at /var/log/agentteams/higress-gateway.log"
+            fi
+        }
+
         _wait_for_url() {
             local url="$1" ctr="$2" max_wait="${3:-120}" desc="${4:-service}"
             local elapsed=0
@@ -4038,6 +4085,9 @@ CREDEOF
                 elapsed=$((elapsed + 2))
             done
             log "ERROR: ${desc} not ready after ${max_wait}s"
+            if [ "${desc}" = "Higress Gateway" ]; then
+                _report_higress_gateway_timeout "${ctr}"
+            fi
             return 1
         }
 

--- a/install/tests/test-higress-timeout-diagnostics.sh
+++ b/install/tests/test-higress-timeout-diagnostics.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INSTALL_SCRIPT="${ROOT_DIR}/install/agentteams-install.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/agentteams-higress-diagnostics.XXXXXX")"
+trap 'rm -rf "${TEST_ROOT}"' EXIT
+
+HELPER="${TEST_ROOT}/helper.sh"
+OUTPUT="${TEST_ROOT}/output.log"
+
+sed -n '/^        _report_higress_gateway_timeout() {/,/^        }/p' \
+    "${INSTALL_SCRIPT}" >"${HELPER}"
+source "${HELPER}"
+
+cat >"${TEST_ROOT}/docker" <<'MOCK'
+#!/usr/bin/env bash
+set -e
+test "${1:-}" = exec
+shift 2
+case "$*" in
+    "uname -m") printf 'arm64\n' ;;
+    "cat /proc/sys/fs/inotify/max_user_instances") printf '128\n' ;;
+    "cat /proc/sys/vm/max_map_count") printf '65530\n' ;;
+    "cat /proc/sys/vm/overcommit_memory") printf '0\n' ;;
+    "sh -c tail -80 /var/log/agentteams/higress-gateway.log 2>/dev/null")
+        printf 'Fatal error: Check failed: 12\n'
+        ;;
+    *) echo "unexpected docker invocation: $*" >&2; exit 1 ;;
+esac
+MOCK
+chmod +x "${TEST_ROOT}/docker"
+
+DOCKER_CMD="${TEST_ROOT}/docker"
+log() { printf '%s\n' "$*" >>"${OUTPUT}"; }
+
+_report_higress_gateway_timeout agentteams-controller >>"${OUTPUT}"
+
+for expected in \
+    "architecture=arm64" \
+    "fs.inotify.max_user_instances=128" \
+    "vm.max_map_count=65530" \
+    "vm.overcommit_memory=0" \
+    "gateway-log: Fatal error: Check failed: 12" \
+    "Detected Envoy/V8 fatal exit" \
+    "reported on ARM64"; do
+    grep -Fq "${expected}" "${OUTPUT}" || {
+        echo "missing diagnostic: ${expected}" >&2
+        cat "${OUTPUT}" >&2
+        exit 1
+    }
+done
+
+grep -Fq '_report_higress_gateway_timeout "${ctr}"' "${INSTALL_SCRIPT}"
+echo "PASS: Higress timeout diagnostics include actionable evidence"


### PR DESCRIPTION
## Summary
- print architecture, relevant Linux kernel limits, and the Higress Gateway log tail when the embedded installer times out waiting for `/status`
- distinguish a low `fs.inotify.max_user_instances` limit from the ARM64 Envoy/V8 crash that can persist after sysctls are raised
- explain that disabling Wasm is useful diagnostic evidence, but is not a supported workaround because AgentTeams relies on Higress Wasm for gateway authentication and AI routing
- document the same troubleshooting guidance in the English and Chinese FAQ

Refs #888.

## Verification
- `bash -n install/hiclaw-install.sh`
- `git diff --check`
- extracted-function simulation verifies ARM64, all three kernel values, the
  fatal log tail, and the Wasm compatibility warning
- confirmed the branch is based on current `main` (`6f0c7da`)
- PowerShell parser not run locally because `pwsh` is not installed in this environment

## CI note

Both refreshed runs passed every build and 9/10 integration matrix jobs. The
only failures were two different pre-existing `test-06-multi-worker` setup
races in copaw/hermes SHARD_A:

- [run 29233390641](https://github.com/agentscope-ai/AgentTeams/actions/runs/29233390641): Bob was fully provisioned, but the collaborative-task message denied a pending Tool Guard approval instead of starting a new Manager turn
- [run 29236623909](https://github.com/agentscope-ai/AgentTeams/actions/runs/29236623909): the test aborted before Bob setup because the Manager DM did not become quiet within 180 seconds

This PR only changes installer diagnostics and FAQ text. #985 now removes both
Manager-conversation dependencies from Bob's deterministic test setup.

## Temporary dependency

- This branch is temporarily stacked on #985 (`78e9385`), whose full CI passed all 10 integration matrices.
- Relative to #985, this PR retains only its original scoped changes; the shared test fix disappears from the diff after #985 merges.
- Fresh checks on `b0d4f81d` passed every build and all 10 integration matrices.