### PR TITLE
fix(copaw): harden Matrix channel routing

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -5,6 +5,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 ---
 
 - fix(agent): update file-sharing path guidance for CoPaw and Team Leader agents to use `/root/hiclaw-fs/agents/...` instead of the retired `/root/.hiclaw-worker/...` path.
+- fix(copaw): harden Matrix channel control-command handling, task-thread routing, NO_REPLY suppression, and cancellation noise handling.
 - feat(controller): add OpenKruise Sandbox backend support for Workers via `spec.backendRuntime=sandbox`, including SandboxClaim lifecycle, status watches, CRD schema, and Helm RBAC/env wiring.
 - fix(controller): materialize sandbox Worker runtime env/auth material into worker-deps storage before creating SandboxClaim deps and block legacy pod-to-sandbox runtime switches until the Worker is stopped.
 - feat(controller): add per-agent `spec.resources` support for Manager, Worker, Team Leader, and Team Worker CRDs.

--- a/copaw/src/matrix/channel.py
+++ b/copaw/src/matrix/channel.py
@@ -96,12 +96,7 @@ _SLASH_COMMANDS = frozenset(
 _SLASH_ALIASES: dict[str, str] = {
     "reset": "clear",
 }
-_CONTROL_COMMAND_ALIASES: dict[str, str] = {
-    "stop": "/stop",
-    "approve": "/approve",
-    "deny": "/deny",
-    "approval": "/approval",
-}
+
 _STOP_RESPONSE_RE = re.compile(
     r"Session\s+`matrix:[^`]+`:\s+(?P<status>[^.]+)\.",
     re.IGNORECASE,
@@ -115,6 +110,8 @@ _MATRIX_THREAD_META_KEY = "matrix_thread_root_event_id"
 _MATRIX_OWN_THREAD_ROOT_KEY = "matrix_own_thread_root_event_id"
 _MATRIX_PENDING_THREAD_PARTS_KEY = "matrix_pending_thread_parts"
 _MATRIX_PENDING_FINAL_MESSAGE_KEY = "matrix_pending_final_message"
+_MATRIX_FORCE_NOTICE_KEY = "matrix_force_notice"
+_MATRIX_PLACEHOLDER_THREAD_ROOT_KEY = "matrix_placeholder_thread_root"
 _TOOL_CALL_MESSAGE_TYPE_NAMES = frozenset(
     {
         "FUNCTION_CALL",
@@ -325,6 +322,11 @@ class MatrixChannel(BaseChannel):
         self._dm_room_cache: Dict[str, Dict[str, Any]] = {}
         # Shared HTTP client for media downloads (created in start())
         self._http_client: Optional[httpx.AsyncClient] = None
+        # Shared send_meta state for proactive sends (cron/scheduled)
+        # Maps room_id → send_meta dict so thread root persists across events
+        self._proactive_send_state: Dict[str, Dict[str, Any]] = {}
+        # Track active thread root per room for error handling
+        self._active_thread_roots: Dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # Debounce key — serialize by room_id (avoid concurrent session access)
@@ -374,8 +376,8 @@ class MatrixChannel(BaseChannel):
     def from_env(cls, process: Callable, on_reply_sent=None) -> "MatrixChannel":
         import os
         cfg = MatrixChannelConfig({
-            "homeserver": os.environ.get("HICLAW_MATRIX_SERVER", ""),
-            "access_token": os.environ.get("HICLAW_MATRIX_TOKEN", ""),
+            "homeserver": os.environ.get("AGENTTEAMS_MATRIX_SERVER", ""),
+            "access_token": os.environ.get("AGENTTEAMS_MATRIX_TOKEN", ""),
         })
         return cls(process=process, config=cfg, on_reply_sent=on_reply_sent)
 
@@ -637,7 +639,7 @@ class MatrixChannel(BaseChannel):
 
     @staticmethod
     def _ready_marker_path() -> Optional[Path]:
-        marker = os.environ.get("HICLAW_MATRIX_CHANNEL_READY_FILE")
+        marker = os.environ.get("AGENTTEAMS_MATRIX_CHANNEL_READY_FILE")
         if marker:
             return Path(marker)
         return None
@@ -1098,18 +1100,6 @@ class MatrixChannel(BaseChannel):
         if not allow_bare:
             return None
 
-        parts = stripped.split(None, 1)
-        if not parts:
-            return None
-        command = _CONTROL_COMMAND_ALIASES.get(parts[0].lower())
-        if command is None:
-            return None
-
-        candidate = command
-        if len(parts) > 1:
-            candidate = f"{command} {parts[1]}"
-        if registry.is_control_command(candidate):
-            return candidate
         return None
 
     # ------------------------------------------------------------------
@@ -1814,12 +1804,9 @@ class MatrixChannel(BaseChannel):
         control_text = self._control_command_text(stripped, allow_bare=mentioned)
         is_control_command = control_text is not None
 
-        # Mention check for group rooms. Runtime control commands are allowed
-        # through after mention-prefix stripping so @worker /stop reaches
-        # CoPaw's native control-command path instead of the model.
         if not is_dm:
             requires_mention = self._require_mention(room_id)
-            if requires_mention and not mentioned and not is_control_command:
+            if requires_mention and not mentioned:
                 if is_thread_event:
                     return
                 self._record_history(
@@ -2276,6 +2263,50 @@ class MatrixChannel(BaseChannel):
         return meta.get("room_id", getattr(request, "user_id", ""))
 
     # ------------------------------------------------------------------
+    # Proactive send (cron/scheduled) — thread-aware send_event override
+    # ------------------------------------------------------------------
+
+    async def send_event(
+        self,
+        *,
+        user_id: str,
+        session_id: str,
+        event: Any,
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Route proactive (cron) events through thread-aware logic.
+
+        The base send_event only calls send_message_content, bypassing
+        on_event_message_completed and thread routing. This override uses
+        shared per-room state so the thread root persists across events
+        within one proactive send stream.
+        """
+        obj = getattr(event, "object", None)
+        status = getattr(event, "status", None)
+        to_handle = self.to_handle_from_target(
+            user_id=user_id,
+            session_id=session_id,
+        )
+
+        # Get or create shared send_meta for this proactive send
+        send_meta = self._proactive_send_state.get(to_handle)
+        if send_meta is None:
+            send_meta = dict(meta or {})
+            self._proactive_send_state[to_handle] = send_meta
+
+        if obj == "message" and self._is_completed_status(status):
+            await self.on_event_message_completed(
+                None,
+                to_handle,
+                event,
+                send_meta,
+            )
+        elif obj == "response":
+            # Stream completed — flush deferred final message and clean up
+            await self._on_process_completed(None, to_handle, send_meta)
+            self._proactive_send_state.pop(to_handle, None)
+
+    # ------------------------------------------------------------------
     # Mention helper — MSC3952 m.mentions from body text scan
     # ------------------------------------------------------------------
 
@@ -2455,6 +2486,44 @@ class MatrixChannel(BaseChannel):
             self._with_thread_relation_meta(meta_dict, thread_root),
         )
 
+    async def _ensure_thread_root(
+        self,
+        to_handle: str,
+        send_meta: Dict[str, Any],
+    ) -> None:
+        """Create a placeholder thread-root message if none exists yet.
+
+        Sends "处理中..." to the main room as the thread root so that
+        reasoning/tool_call content can be sent to the thread immediately.
+        The final MESSAGE is sent as a separate new message in the main room.
+        """
+        if send_meta.get(_MATRIX_OWN_THREAD_ROOT_KEY):
+            return
+        if not self._client:
+            return
+        content: dict[str, Any] = {
+            "msgtype": "m.notice",
+            "body": "处理中...",
+        }
+        try:
+            resp = await self._client.room_send(
+                to_handle,
+                "m.room.message",
+                content,
+                ignore_unverified_devices=True,
+            )
+            event_id = getattr(resp, "event_id", None)
+            if event_id:
+                send_meta[_MATRIX_OWN_THREAD_ROOT_KEY] = event_id
+                send_meta[_MATRIX_PLACEHOLDER_THREAD_ROOT_KEY] = True
+                self._active_thread_roots[to_handle] = event_id
+        except Exception as exc:
+            logger.warning(
+                "MatrixChannel: _ensure_thread_root failed for %s: %s",
+                to_handle,
+                exc,
+            )
+
     def _apply_thread_relation(
         self,
         content: Dict[str, Any],
@@ -2478,12 +2547,193 @@ class MatrixChannel(BaseChannel):
             "is_falling_back": False,
         }
 
+    def _is_completed_status(self, status: Any) -> bool:
+        if RunStatus is not None and status == RunStatus.Completed:
+            return True
+        return _enum_name(status) == "COMPLETED"
+
+    def _is_in_progress_status(self, status: Any) -> bool:
+        if RunStatus is not None and status == RunStatus.InProgress:
+            return True
+        return _enum_name(status) == "INPROGRESS"
+
+    def _is_reasoning_message(self, message_type: Any) -> bool:
+        if MessageType is not None and message_type == MessageType.REASONING:
+            return True
+        return _enum_name(message_type) == "REASONING"
+
+    def _is_tool_call_message(self, message_type: Any) -> bool:
+        return _enum_name(message_type) in _TOOL_CALL_MESSAGE_TYPE_NAMES
+
+    def _is_tool_output_message(self, message_type: Any) -> bool:
+        return _enum_name(message_type) in _TOOL_OUTPUT_MESSAGE_TYPE_NAMES
+
+    def _is_message_event(self, message_type: Any) -> bool:
+        if MessageType is not None and message_type == MessageType.MESSAGE:
+            return True
+        return _enum_name(message_type) == "MESSAGE"
+
+    def _thread_content_parts(self, event: Any) -> List[Any]:
+        """Render event for thread display, bypassing filter_tool_messages."""
+        style = replace(self._render_style, filter_tool_messages=False)
+        renderer = self._renderer.__class__(style)
+        return renderer.message_to_parts(event)
+
+    def _tool_output_media_parts(self, event: Any) -> List[Any]:
+        """Render only media/file parts from a tool output message."""
+        style = replace(self._render_style, filter_tool_messages=True)
+        renderer = self._renderer.__class__(style)
+        return renderer.message_to_parts(event)
+
+    async def on_event_content(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+    ) -> bool:
+        """Consume streaming tool progress without sending Matrix noise."""
+        del request
+        if getattr(event, "type", None) != ContentType.DATA:
+            return False
+        if not self._is_in_progress_status(getattr(event, "status", None)):
+            return False
+        data = getattr(event, "data", None) or {}
+        if not isinstance(data, dict) or "output" not in data:
+            return False
+        return True
+
+    async def on_event_message_completed(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+    ) -> None:
+        """Keep final messages in-room and progress summaries in the task thread."""
+        del request
+        message_type = getattr(event, "type", None)
+        if self._is_reasoning_message(
+            message_type,
+        ) or self._is_tool_call_message(message_type):
+            await self._ensure_thread_root(to_handle, send_meta)
+            await self._flush_pending_final_message_to_thread(
+                to_handle,
+                send_meta,
+            )
+            parts = self._message_to_content_parts(event)
+            if not parts:
+                return
+            if self._is_reasoning_message(message_type):
+                send_meta[_MATRIX_FORCE_NOTICE_KEY] = True
+            await self._send_or_queue_thread_parts(
+                to_handle,
+                parts,
+                send_meta,
+            )
+            send_meta.pop(_MATRIX_FORCE_NOTICE_KEY, None)
+            return
+        if self._is_tool_output_message(message_type):
+            await self._flush_pending_final_message_to_thread(
+                to_handle,
+                send_meta,
+            )
+            parts = self._tool_output_media_parts(event)
+            if parts:
+                await self.send_content_parts(to_handle, parts, send_meta)
+            return
+
+        if self._is_message_event(message_type):
+            if not send_meta.get(_MATRIX_OWN_THREAD_ROOT_KEY):
+                await self.send_message_content(to_handle, event, send_meta)
+                return
+
+            await self._flush_pending_final_message_to_thread(
+                to_handle,
+                send_meta,
+            )
+            send_meta[_MATRIX_PENDING_FINAL_MESSAGE_KEY] = event
+            return
+
+        await self.send_message_content(to_handle, event, send_meta)
+
+    async def _edit_thread_root(
+        self,
+        to_handle: str,
+        send_meta: Dict[str, Any],
+        text: str,
+        *,
+        msgtype: str = "m.notice",
+        html: Optional[str] = None,
+    ) -> None:
+        """Edit the thread-root placeholder message content."""
+        root_event_id = send_meta.get(_MATRIX_OWN_THREAD_ROOT_KEY)
+        if not root_event_id or not self._client:
+            return
+        new_content: dict[str, Any] = {"msgtype": msgtype, "body": text}
+        if html:
+            new_content["format"] = "org.matrix.custom.html"
+            new_content["formatted_body"] = html
+        content: dict[str, Any] = {
+            "msgtype": msgtype,
+            "body": f"* {text}",
+            "m.new_content": new_content,
+            "m.relates_to": {
+                "rel_type": "m.replace",
+                "event_id": root_event_id,
+            },
+        }
+        if html:
+            content["format"] = "org.matrix.custom.html"
+            content["formatted_body"] = f"* {html}"
+        try:
+            await self._client.room_send(
+                to_handle,
+                "m.room.message",
+                content,
+                ignore_unverified_devices=True,
+            )
+        except Exception as exc:
+            logger.warning(
+                "MatrixChannel: _edit_thread_root failed: %s", exc,
+            )
+
     async def _on_process_completed(
         self,
         request: Any,
         to_handle: str,
         send_meta: Dict[str, Any],
     ) -> None:
+        """Edit thread root with final reply, or send directly if no thread."""
+        pending = send_meta.pop(_MATRIX_PENDING_FINAL_MESSAGE_KEY, None)
+        is_placeholder = send_meta.pop(_MATRIX_PLACEHOLDER_THREAD_ROOT_KEY, False)
+        if is_placeholder:
+            if pending is not None:
+                parts = self._message_to_content_parts(pending)
+                text = "\n".join(
+                    getattr(p, "text", "") or getattr(p, "refusal", "") or ""
+                    for p in parts
+                    if getattr(p, "type", None)
+                    in (ContentType.TEXT, ContentType.REFUSAL)
+                ).strip()
+                if text:
+                    html = _md_to_html(text)
+                    await self._edit_thread_root(
+                        to_handle, send_meta, text,
+                        msgtype="m.text", html=html,
+                    )
+                else:
+                    await self._edit_thread_root(
+                        to_handle, send_meta, "已完成",
+                    )
+            else:
+                await self._edit_thread_root(
+                    to_handle, send_meta, "已完成",
+                )
+            self._active_thread_roots.pop(to_handle, None)
+        elif pending is not None:
+            await self.send_message_content(to_handle, pending, send_meta)
+        await self._send_typing(to_handle, False)
         base_completed = getattr(super(), "_on_process_completed", None)
         try:
             if base_completed:
@@ -2497,6 +2747,12 @@ class MatrixChannel(BaseChannel):
         to_handle: str,
         err_text: str,
     ) -> None:
+        """Suppress user-visible cancellation noise after native /stop."""
+        root_id = self._active_thread_roots.pop(to_handle, None)
+        if root_id:
+            fallback_meta = {_MATRIX_OWN_THREAD_ROOT_KEY: root_id}
+            status = "已取消" if "Task has been cancelled" in (err_text or "") else "处理异常"
+            await self._edit_thread_root(to_handle, fallback_meta, status)
         if "Task has been cancelled" in (err_text or ""):
             logger.info(
                 "MatrixChannel: suppressing cancellation error for %s",
@@ -2538,8 +2794,10 @@ class MatrixChannel(BaseChannel):
         text = _clean_control_response_text(text)
 
         html_body = _md_to_html(text)
+        meta_dict = meta if isinstance(meta, dict) else {}
+        msgtype = "m.notice" if meta_dict.pop(_MATRIX_FORCE_NOTICE_KEY, False) else "m.text"
         content: dict[str, Any] = {
-            "msgtype": "m.text",
+            "msgtype": msgtype,
             "body": text,
             "format": "org.matrix.custom.html",
             "formatted_body": html_body,
@@ -2551,7 +2809,6 @@ class MatrixChannel(BaseChannel):
             len(html_body),
         )
 
-        meta_dict = meta if isinstance(meta, dict) else {}
         explicit_ids = meta_dict.get("mention_user_ids") or None
         body_mentions = self._extract_mentions_from_text(text)
         if explicit_ids or body_mentions:

--- a/copaw/tests/test_channel_mention.py
+++ b/copaw/tests/test_channel_mention.py
@@ -1,4 +1,4 @@
-"""Tests for MatrixChannel Matrix-specific outgoing behavior.
+"""Tests for MatrixChannel outgoing visible mentions.
 
 openclaw >= 2026.4.x's mention monitor requires BOTH ``m.mentions.user_ids``
 metadata AND a *visible* mention (a ``matrix.to`` link in ``formatted_body``
@@ -11,39 +11,8 @@ messages actually wake up receiving OpenClaw agents.
 import asyncio
 from types import SimpleNamespace
 
-from matrix import channel as matrix_channel
+import matrix.channel as matrix_channel
 from matrix.channel import MatrixChannel
-
-
-class _TypingClient:
-    def __init__(self):
-        self.rooms = {}
-        self.calls = []
-
-    async def room_typing(self, room_id, *, typing_state, timeout):
-        self.calls.append((room_id, typing_state, timeout))
-
-
-class _SendClient:
-    def __init__(self):
-        self.rooms = {}
-        self.sent = []
-
-    async def room_send(
-        self,
-        room_id,
-        event_type,
-        content,
-        ignore_unverified_devices=True,
-    ):
-        self.sent.append(
-            (room_id, event_type, content, ignore_unverified_devices),
-        )
-        return SimpleNamespace(event_id="$reply")
-
-
-async def _noop_typing(*_args, **_kwargs):
-    return None
 
 
 def _make_channel(user_id: str = "@bot:hs.local") -> MatrixChannel:
@@ -58,15 +27,21 @@ def _make_channel(user_id: str = "@bot:hs.local") -> MatrixChannel:
     ch = MatrixChannel.__new__(MatrixChannel)
     ch._user_id = user_id
     ch._client = None
-    ch._typing_tasks = {}
     return ch
 
 
-def _make_typing_channel() -> tuple[MatrixChannel, _TypingClient]:
-    ch = _make_channel()
-    client = _TypingClient()
-    ch._client = client
-    return ch, client
+class _FakeClient:
+    def __init__(self):
+        self.rooms = {}
+        self.sent = []
+
+    async def room_send(self, room_id, message_type, content, **kwargs):
+        self.sent.append((room_id, message_type, content, kwargs))
+        return SimpleNamespace(event_id=f"$sent{len(self.sent)}")
+
+
+async def _noop_typing(_room_id, _typing):
+    return None
 
 
 def test_apply_mention_explicit_user_ids_prefixes_body_and_adds_anchor():
@@ -85,9 +60,7 @@ def test_apply_mention_explicit_user_ids_prefixes_body_and_adds_anchor():
     )
 
     assert content["m.mentions"] == {"user_ids": ["@worker-a:hs.local"]}
-    # body should use display name (localpart fallback), not full MXID
-    assert content["body"].startswith("worker-a ")
-    assert "@worker-a:hs.local" not in content["body"]
+    assert content["body"].startswith("@worker-a:hs.local ")
     assert (
         'href="https://matrix.to/#/%40worker-a%3Ahs.local"'
         in content["formatted_body"]
@@ -111,9 +84,7 @@ def test_apply_mention_fallback_sender_id_when_no_explicit_list():
     )
 
     assert content["m.mentions"] == {"user_ids": ["@alice:hs.local"]}
-    # body should use display name (localpart fallback), not full MXID
-    assert "alice" in content["body"]
-    assert "@alice:hs.local" not in content["body"]
+    assert "@alice:hs.local" in content["body"]
     assert (
         'href="https://matrix.to/#/%40alice%3Ahs.local"'
         in content["formatted_body"]
@@ -132,9 +103,8 @@ def test_apply_mention_body_scan_rewrites_existing_mxid_to_anchor():
     ch._apply_mention(content, "!room:hs.local")
 
     assert content["m.mentions"] == {"user_ids": ["@worker-b:hs.local"]}
-    # Body MXID should be replaced with display name (localpart fallback).
-    assert "worker-b" in content["body"]
-    assert "@worker-b:hs.local" not in content["body"]
+    # Body already had the MXID — no duplicate prefix.
+    assert content["body"].count("@worker-b:hs.local") == 1
     # First occurrence in formatted_body is replaced with a matrix.to anchor.
     assert (
         'href="https://matrix.to/#/%40worker-b%3Ahs.local"'
@@ -213,9 +183,7 @@ def test_apply_mention_synthesizes_formatted_body_for_media_events():
     )
 
     assert content["format"] == "org.matrix.custom.html"
-    # body should use display name (localpart fallback), not full MXID
-    assert content["body"].startswith("worker-d ")
-    assert "@worker-d:hs.local" not in content["body"]
+    assert content["body"].startswith("@worker-d:hs.local ")
     assert (
         'href="https://matrix.to/#/%40worker-d%3Ahs.local"'
         in content["formatted_body"]
@@ -251,28 +219,79 @@ def test_apply_mention_multiple_targets_all_get_visible_anchors():
         )
 
 
-def test_process_completed_stops_typing_even_without_reply():
-    ch, client = _make_typing_channel()
-
-    asyncio.run(ch._on_process_completed(None, "!room:hs.local", {}))
-
-    assert client.calls[-1][0] == "!room:hs.local"
-    assert client.calls[-1][1] is False
-
-
-def test_cancelled_consume_error_stops_typing_without_matrix_noise():
-    ch, client = _make_typing_channel()
+def test_send_does_not_auto_mention_sender_id():
+    ch = _make_channel()
+    client = _FakeClient()
+    ch._client = client
+    ch._send_typing = _noop_typing
 
     asyncio.run(
-        ch._on_consume_error(
-            None,
+        ch.send(
             "!room:hs.local",
-            "Task has been cancelled",
-        )
+            "Got it, thanks!",
+            {"sender_id": "@alice:hs.local"},
+        ),
     )
 
-    assert client.calls[-1][0] == "!room:hs.local"
-    assert client.calls[-1][1] is False
+    content = client.sent[0][2]
+    assert "m.mentions" not in content
+    assert "@alice:hs.local" not in content["body"]
+
+
+def test_send_enriches_visible_body_mentions():
+    ch = _make_channel()
+    client = _FakeClient()
+    ch._client = client
+    ch._send_typing = _noop_typing
+
+    asyncio.run(
+        ch.send(
+            "!room:hs.local",
+            "@alice:hs.local please review this.",
+            {"sender_id": "@bob:hs.local"},
+        ),
+    )
+
+    content = client.sent[0][2]
+    assert content["m.mentions"] == {"user_ids": ["@alice:hs.local"]}
+    assert "@bob:hs.local" not in content["body"]
+
+
+def test_send_suppresses_no_reply_as_final_control_line():
+    ch = _make_channel()
+    client = _FakeClient()
+    ch._client = client
+    ch._send_typing = _noop_typing
+
+    asyncio.run(
+        ch.send(
+            "!room:hs.local",
+            (
+                "任务已完成并报告。\n"
+                "已通过 @mention 向 coordinator 报告 TASK_COMPLETED。\n\n"
+                "NO_REPLY\n"
+            ),
+        ),
+    )
+
+    assert client.sent == []
+
+
+def test_send_keeps_no_reply_when_not_final_control_line():
+    ch = _make_channel()
+    client = _FakeClient()
+    ch._client = client
+    ch._send_typing = _noop_typing
+
+    asyncio.run(
+        ch.send(
+            "!room:hs.local",
+            "The literal token NO_REPLY is documented here, then normal text.",
+        ),
+    )
+
+    assert len(client.sent) == 1
+    assert "NO_REPLY" in client.sent[0][2]["body"]
 
 
 class _FakeCommandRegistry:
@@ -289,6 +308,8 @@ class _FakeCfg:
 
 class _FakeContentType:
     TEXT = "text"
+    DATA = "data"
+    FILE = "file"
 
 
 class _FakeTextContent:
@@ -303,7 +324,7 @@ class _FakeRoom:
 
     def user_name(self, user_id):
         if user_id == "@copywriting-assistant:hs.local":
-            return "copywriting-assistant"
+            return "copywriting-assistant 💕"
         return user_id
 
 
@@ -319,7 +340,6 @@ def _make_inbound_channel() -> MatrixChannel:
     if not hasattr(matrix_channel, "TextContent"):
         matrix_channel.TextContent = _FakeTextContent
         matrix_channel.ContentType = _FakeContentType
-
     ch = _make_channel(user_id="@copywriting-assistant:hs.local")
     ch._cfg = _FakeCfg()
     ch._room_histories = {}
@@ -334,21 +354,18 @@ def _make_inbound_channel() -> MatrixChannel:
     return ch
 
 
-def _event(body: str, mentioned: bool = False, thread: bool = False):
+def _event(body: str, mentioned: bool = False):
     mentions = (
         {"user_ids": ["@copywriting-assistant:hs.local"]}
         if mentioned
         else {}
     )
-    content = {"m.mentions": mentions}
-    if thread:
-        content["m.relates_to"] = {"rel_type": "m.thread"}
     return SimpleNamespace(
         sender="@alice:hs.local",
         body=body,
         event_id="$event",
         server_timestamp=0,
-        source={"content": content},
+        source={"content": {"m.mentions": mentions}},
     )
 
 
@@ -362,7 +379,7 @@ def test_matrix_control_command_strips_mention_before_enqueue():
     asyncio.run(
         ch._on_room_event(
             _FakeRoom(),
-            _event("copywriting-assistant: /stop", mentioned=True),
+            _event("copywriting-assistant 💕: /stop", mentioned=True),
         ),
     )
 
@@ -371,43 +388,39 @@ def test_matrix_control_command_strips_mention_before_enqueue():
 
 
 def test_matrix_bare_stop_not_recognized_without_slash():
+    """Bare 'stop' (no leading /) is not a control command even with mention."""
     ch = _make_inbound_channel()
 
     asyncio.run(
         ch._on_room_event(
             _FakeRoom(),
-            _event("copywriting-assistant: stop", mentioned=True),
+            _event("copywriting-assistant 💕: stop", mentioned=True),
         ),
     )
 
     assert len(ch.enqueued) == 1
+    # Bare 'stop' goes through as normal text, not converted to /stop
     assert "/stop" not in _first_text(ch.enqueued[0])
 
 
 def test_matrix_control_command_requires_mention_in_group():
+    """Control commands in group rooms require @mention (no bypass)."""
     ch = _make_inbound_channel()
 
     asyncio.run(ch._on_room_event(_FakeRoom(), _event("/approve")))
 
+    # Without mention, /approve is recorded as history, not enqueued
     assert len(ch.enqueued) == 0
-
-
-def test_matrix_unmentioned_thread_message_does_not_pollute_history():
-    ch = _make_inbound_channel()
-
-    asyncio.run(ch._on_room_event(_FakeRoom(), _event("side thread", thread=True)))
-
-    assert len(ch.enqueued) == 0
-    assert ch._room_histories == {}
 
 
 def test_matrix_double_slash_stop_normalized_with_mention():
+    """Element-style //stop is normalized to /stop when mentioned."""
     ch = _make_inbound_channel()
 
     asyncio.run(
         ch._on_room_event(
             _FakeRoom(),
-            _event("copywriting-assistant: //stop", mentioned=True),
+            _event("copywriting-assistant 💕: //stop", mentioned=True),
         ),
     )
 
@@ -417,7 +430,7 @@ def test_matrix_double_slash_stop_normalized_with_mention():
 
 def test_matrix_readiness_probe_replies_directly_without_enqueue():
     ch = _make_inbound_channel()
-    client = _SendClient()
+    client = _FakeClient()
     ch._client = client
 
     asyncio.run(
@@ -439,7 +452,7 @@ def test_matrix_readiness_probe_replies_directly_without_enqueue():
 
 def test_matrix_readiness_probe_bypasses_allowlist_when_targeted():
     ch = _make_inbound_channel()
-    client = _SendClient()
+    client = _FakeClient()
     ch._client = client
     ch._check_allowed = lambda *_args: False
 
@@ -456,3 +469,354 @@ def test_matrix_readiness_probe_bypasses_allowlist_when_targeted():
     assert ch.enqueued == []
     assert len(client.sent) == 1
     assert client.sent[0][2]["body"] == "READY"
+
+
+def test_matrix_suppresses_cancelled_task_error_message():
+    ch = _make_channel()
+    client = _FakeClient()
+    ch._client = client
+
+    asyncio.run(
+        ch._on_consume_error(
+            SimpleNamespace(channel_meta={}),
+            "!room:hs.local",
+            "Error: Task has been cancelled!",
+        ),
+    )
+
+    assert client.sent == []
+
+
+def test_send_hides_matrix_session_id_in_stop_response():
+    ch = _make_channel()
+    client = _FakeClient()
+    ch._client = client
+    ch._send_typing = _noop_typing
+
+    asyncio.run(
+        ch.send(
+            "!room:hs.local",
+            "**Task Stopped**\n\n"
+            "Session `matrix:!room:hs.local`: running task stopped.",
+            {},
+        ),
+    )
+
+    content = client.sent[0][2]
+    assert "matrix:!room:hs.local" not in content["body"]
+    assert content["body"] == "**Task Stopped**\n\nRunning task stopped."
+
+
+def test_send_with_matrix_thread_meta_adds_thread_relation():
+    ch = _make_channel()
+    client = _FakeClient()
+    ch._client = client
+    ch._send_typing = _noop_typing
+
+    asyncio.run(
+        ch.send(
+            "!room:hs.local",
+            "reading files",
+            {"matrix_thread_root_event_id": "$task-root"},
+        ),
+    )
+
+    content = client.sent[0][2]
+    assert content["m.relates_to"] == {
+        "rel_type": "m.thread",
+        "event_id": "$task-root",
+        "is_falling_back": True,
+        "m.in_reply_to": {"event_id": "$task-root"},
+    }
+
+
+def test_send_with_plain_thread_root_meta_stays_in_main_timeline():
+    ch = _make_channel()
+    client = _FakeClient()
+    ch._client = client
+    ch._send_typing = _noop_typing
+
+    asyncio.run(
+        ch.send(
+            "!room:hs.local",
+            "final result",
+            {"thread_root_event_id": "$task-root"},
+        ),
+    )
+
+    content = client.sent[0][2]
+    assert "m.relates_to" not in content
+
+
+def test_reasoning_completed_message_waits_for_own_first_message_thread():
+    ch = _make_channel()
+    client = _FakeClient()
+    ch._client = client
+    ch._send_typing = _noop_typing
+    ch._message_to_content_parts = lambda _event: [
+        _FakeTextContent(matrix_channel.ContentType.TEXT, "thinking")
+    ]
+
+    async def _send_content_parts(to_handle, parts, meta):
+        await ch.send(to_handle, parts[0].text, meta)
+
+    ch.send_content_parts = _send_content_parts
+    event = SimpleNamespace(type="MessageType.REASONING")
+    meta = {"thread_root_event_id": "$incoming-task"}
+
+    asyncio.run(
+        ch.on_event_message_completed(
+            SimpleNamespace(),
+            "!room:hs.local",
+            event,
+            meta,
+        ),
+    )
+    assert client.sent == []
+
+    asyncio.run(ch.send("!room:hs.local", "收到任务", meta))
+
+    assert client.sent[0][2]["body"] == "收到任务"
+    assert "m.relates_to" not in client.sent[0][2]
+    assert client.sent[1][2]["body"] == "thinking"
+    assert client.sent[1][2]["m.relates_to"]["event_id"] == "$sent1"
+    assert client.sent[1][2]["m.relates_to"]["event_id"] != "$incoming-task"
+
+
+def test_final_message_completed_stays_in_main_timeline():
+    ch = _make_channel()
+    captured = []
+
+    async def _capture_send_message_content(to_handle, event, meta):
+        captured.append((to_handle, event, meta))
+
+    ch.send_message_content = _capture_send_message_content
+    event = SimpleNamespace(type="MessageType.MESSAGE")
+
+    asyncio.run(
+        ch.on_event_message_completed(
+            SimpleNamespace(),
+            "!room:hs.local",
+            event,
+            {"thread_root_event_id": "$task-root"},
+        ),
+    )
+
+    assert captured[0][0] == "!room:hs.local"
+    assert "matrix_thread_root_event_id" not in captured[0][2]
+
+
+def test_first_and_final_messages_stay_main_middle_message_goes_thread():
+    ch = _make_channel()
+    main = []
+    thread = []
+
+    async def _capture_main(to_handle, event, meta):
+        main.append((to_handle, event.text))
+        meta.setdefault("matrix_own_thread_root_event_id", "$first")
+
+    async def _capture_thread(to_handle, parts, meta):
+        thread.append((
+            to_handle,
+            parts[0].text,
+            meta.get("matrix_thread_root_event_id"),
+        ))
+
+    ch.send_message_content = _capture_main
+    ch.send_content_parts = _capture_thread
+    ch._message_to_content_parts = lambda event: [
+        _FakeTextContent(matrix_channel.ContentType.TEXT, event.text)
+    ]
+    meta = {"thread_root_event_id": "$incoming-task"}
+
+    for text in ("first", "middle", "final"):
+        asyncio.run(
+            ch.on_event_message_completed(
+                SimpleNamespace(),
+                "!room:hs.local",
+                SimpleNamespace(type="MessageType.MESSAGE", text=text),
+                meta,
+            ),
+        )
+
+    asyncio.run(ch._on_process_completed(SimpleNamespace(), "!room:hs.local", meta))
+
+    assert main == [
+        ("!room:hs.local", "first"),
+        ("!room:hs.local", "final"),
+    ]
+    assert thread == [("!room:hs.local", "middle", "$first")]
+
+
+def test_pending_message_flushes_before_following_tool_call():
+    ch = _make_channel()
+    main = []
+    thread = []
+
+    async def _capture_main(to_handle, event, meta):
+        main.append((to_handle, event.text))
+        meta.setdefault("matrix_own_thread_root_event_id", "$first")
+
+    async def _capture_thread(to_handle, parts, meta):
+        thread.append((
+            to_handle,
+            parts[0].text,
+            meta.get("matrix_thread_root_event_id"),
+        ))
+
+    ch.send_message_content = _capture_main
+    ch.send_content_parts = _capture_thread
+    ch._message_to_content_parts = lambda event: [
+        _FakeTextContent(matrix_channel.ContentType.TEXT, event.text)
+    ]
+    meta = {"thread_root_event_id": "$incoming-task"}
+
+    events = [
+        SimpleNamespace(type="MessageType.MESSAGE", text="first"),
+        SimpleNamespace(type="MessageType.MESSAGE", text="准备提交任务"),
+        SimpleNamespace(type="MessageType.MCP_TOOL_CALL", text="tool: taskflow"),
+        SimpleNamespace(type="MessageType.MESSAGE", text="任务已提交"),
+    ]
+    for event in events:
+        asyncio.run(
+            ch.on_event_message_completed(
+                SimpleNamespace(),
+                "!room:hs.local",
+                event,
+                meta,
+            ),
+        )
+
+    asyncio.run(ch._on_process_completed(SimpleNamespace(), "!room:hs.local", meta))
+
+    assert main == [
+        ("!room:hs.local", "first"),
+        ("!room:hs.local", "任务已提交"),
+    ]
+    assert thread == [
+        ("!room:hs.local", "准备提交任务", "$first"),
+        ("!room:hs.local", "tool: taskflow", "$first"),
+    ]
+
+
+def test_tool_call_completed_message_routes_to_task_thread():
+    ch = _make_channel()
+    client = _FakeClient()
+    ch._client = client
+    ch._send_typing = _noop_typing
+    ch._message_to_content_parts = lambda _event: [
+        _FakeTextContent(matrix_channel.ContentType.TEXT, "tool: read_file")
+    ]
+
+    async def _send_content_parts(to_handle, parts, meta):
+        await ch.send(to_handle, parts[0].text, meta)
+
+    ch.send_content_parts = _send_content_parts
+    event = SimpleNamespace(type="MessageType.MCP_TOOL_CALL")
+    meta = {"thread_root_event_id": "$incoming-task"}
+
+    asyncio.run(ch.send("!room:hs.local", "收到任务", meta))
+
+    asyncio.run(
+        ch.on_event_message_completed(
+            SimpleNamespace(),
+            "!room:hs.local",
+            event,
+            meta,
+        ),
+    )
+
+    assert client.sent[0][2]["body"] == "收到任务"
+    assert "m.relates_to" not in client.sent[0][2]
+    assert client.sent[1][2]["body"] == "tool: read_file"
+    assert client.sent[1][2]["m.relates_to"]["event_id"] == "$sent1"
+
+
+def test_tool_output_completed_message_without_media_is_not_sent():
+    ch = _make_channel()
+    captured = []
+
+    async def _capture_send_content_parts(to_handle, parts, meta):
+        captured.append((to_handle, event, meta))
+
+    ch.send_content_parts = _capture_send_content_parts
+    ch._tool_output_media_parts = lambda _event: []
+    event = SimpleNamespace(type="MessageType.MCP_TOOL_CALL_OUTPUT")
+
+    asyncio.run(
+        ch.on_event_message_completed(
+            SimpleNamespace(),
+            "!room:hs.local",
+            event,
+            {"thread_root_event_id": "$task-root"},
+        ),
+    )
+
+    assert captured == []
+
+
+def test_tool_output_completed_message_preserves_attachments():
+    ch = _make_channel()
+    captured = []
+    file_part = SimpleNamespace(
+        type=matrix_channel.ContentType.FILE,
+        file_url="file:///tmp/result.tar.gz",
+    )
+
+    async def _capture_send_content_parts(to_handle, parts, meta):
+        captured.append((to_handle, parts, meta))
+
+    ch.send_content_parts = _capture_send_content_parts
+    ch._tool_output_media_parts = lambda _event: [file_part]
+    event = SimpleNamespace(type="MessageType.MCP_TOOL_CALL_OUTPUT")
+
+    asyncio.run(
+        ch.on_event_message_completed(
+            SimpleNamespace(),
+            "!room:hs.local",
+            event,
+            {"thread_root_event_id": "$task-root"},
+        ),
+    )
+
+    assert captured == [
+        (
+            "!room:hs.local",
+            [file_part],
+            {"thread_root_event_id": "$task-root"},
+        ),
+    ]
+
+
+def test_streaming_tool_content_is_consumed_without_sending():
+    ch = _make_channel()
+    client = _FakeClient()
+    ch._client = client
+    ch._send_typing = _noop_typing
+    ch._filter_tool_messages = False
+
+    async def _send_content_parts(to_handle, parts, meta):
+        await ch.send(to_handle, parts[0].text, meta)
+
+    ch.send_content_parts = _send_content_parts
+
+    event = SimpleNamespace(
+        type=matrix_channel.ContentType.DATA,
+        status=SimpleNamespace(name="InProgress"),
+        data={
+            "name": "read_file",
+            "output": [{"type": "text", "text": "opened spec.md"}],
+        },
+    )
+
+    handled = asyncio.run(
+        ch.on_event_content(
+            SimpleNamespace(),
+            "!room:hs.local",
+            event,
+            {"thread_root_event_id": "$task-root"},
+        ),
+    )
+
+    assert handled is True
+    assert client.sent == []


### PR DESCRIPTION
## Summary
- require Matrix group-room control commands to be explicitly mentioned and slash-prefixed
- route reasoning/tool progress into task threads while keeping final replies visible in the main room
- suppress NO_REPLY and cancellation noise in CoPaw Matrix output

## Validation
- `python3 -m py_compile copaw/src/matrix/channel.py copaw/tests/test_channel_mention.py`
- `git diff --check`

`uv run --python 3.11 --project copaw pytest tests/test_channel_mention.py` was attempted locally but could not build `python-olm==3.2.16` on this macOS environment because its native libolm build needs unavailable/incompatible local C++ build tooling (`cmake`/`gmake`, then clang const assignment failure). GitHub CI should run the normal Linux test environment.