### PR TITLE
feat(runtime): consume AgentTeams worker env

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -12,6 +12,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 - fix(worker): pass `X-HiClaw-Cluster-ID` when remote Workers refresh controller-issued STS credentials for OSS and Nacos AI registry access.
 - feat(hiclaw-controller): support a separate agent-pod-template for `deployMode: Remote` Workers via an optional `pod-template-remote.yaml` key on the controller-scoped pod-template ConfigMap; remote-mode Pod creation prefers this key and transparently falls back to `pod-template.yaml` when it is absent or empty, while non-remote/Sandbox paths keep ignoring it.
 - feat(controller): move Kubernetes resources to the `agentteams.io/v1beta1` API group and decouple Team membership through `spec.workerMembers` references to standalone Worker CRs.
+- feat(runtime): let Worker runtimes consume terminal `AGENTTEAMS_*` storage, controller, and auth environment variables while preserving existing `HICLAW_*` deployment compatibility.
 
 - **OpenHuman runtime**: OpenHuman added as the fourth Worker runtime with native Matrix support via `channel-matrix` feature flag; includes controller routing (K8s + Docker backends), Dockerfile, entrypoint script, agent template, Helm chart integration, and Makefile build targets.
 - **Multi model providers**: Worker, Team, and Manager specs can now select a Higress model provider via `spec.modelProvider`; the controller resolves the provider, injects the matching gateway URL into runtime config, and authorizes consumers only on the selected AI route.

--- a/copaw/scripts/copaw-worker-entrypoint.sh
+++ b/copaw/scripts/copaw-worker-entrypoint.sh
@@ -37,11 +37,11 @@ if [ -n "${TZ}" ] && [ -f "/usr/share/zoneinfo/${TZ}" ]; then
 fi
 
 # ── Credential setup ─────────────────────────────────────────────────────────
-# Controller-mediated OSS: STS credentials via MC_HOST_hiclaw.
+# Controller-mediated OSS: STS credentials via MC_HOST_${AGENTTEAMS_STORAGE_ALIAS:-agentteams}.
 # Local MinIO: explicit FS endpoint/key/secret passed via CLI args.
-if ensure_mc_credentials && [ -n "${MC_HOST_hiclaw:-}" ]; then
+if ensure_mc_credentials && agentteams_mc_host_configured; then
     log "Configuring OSS credentials via controller-issued STS..."
-    # CLI requires --fs/--fs-key/--fs-secret but they are unused when MC_HOST_hiclaw is set.
+    # CLI requires --fs/--fs-key/--fs-secret but they are unused when the mc host is set.
     FS_ENDPOINT="https://oss-placeholder.aliyuncs.com"
     FS_ACCESS_KEY="rrsa"
     FS_SECRET_KEY="rrsa"
@@ -49,7 +49,7 @@ if ensure_mc_credentials && [ -n "${MC_HOST_hiclaw:-}" ]; then
     log "  OSS bucket: ${FS_BUCKET}"
 else
     if [ "${AGENTTEAMS_STORAGE_PROVIDER:-minio}" = "oss" ]; then
-        log "ERROR: OSS storage requires controller-issued storage credentials, but MC_HOST_hiclaw is not configured"
+        log "ERROR: OSS storage requires controller-issued storage credentials, but $(agentteams_mc_host_var) is not configured"
         exit 1
     fi
     FS_ENDPOINT="${AGENTTEAMS_FS_ENDPOINT:-${HICLAW_FS_ENDPOINT:-}}"

--- a/copaw/src/copaw_worker/hooks/tools/taskflow.py
+++ b/copaw/src/copaw_worker/hooks/tools/taskflow.py
@@ -65,7 +65,11 @@ def _store() -> FileSystemTaskStore:
 
 
 def _current_actor() -> str | None:
-    configured = os.getenv("HICLAW_MATRIX_USER_ID") or os.getenv("COPAW_MATRIX_USER_ID")
+    configured = (
+        os.getenv("AGENTTEAMS_MATRIX_USER_ID")
+        or os.getenv("HICLAW_MATRIX_USER_ID")
+        or os.getenv("COPAW_MATRIX_USER_ID")
+    )
     if configured:
         return configured.strip()
 

--- a/copaw/tests/test_copaw_worker_entrypoint.py
+++ b/copaw/tests/test_copaw_worker_entrypoint.py
@@ -17,12 +17,24 @@ def _render_entrypoint(tmp_path: Path, *, mc_host: bool) -> Path:
 
     lib_dir = fake_root / "scripts" / "lib"
     lib_dir.mkdir(parents=True)
-    mc_line = 'export MC_HOST_hiclaw="https://ak:sk@oss.example.com"\n' if mc_host else ""
+    mc_line = (
+        'export "MC_HOST_${AGENTTEAMS_STORAGE_ALIAS:-agentteams}=https://ak:sk@oss.example.com"\n'
+        if mc_host
+        else ""
+    )
     (lib_dir / "hiclaw-env.sh").write_text(
         "#!/bin/sh\n"
+        "AGENTTEAMS_STORAGE_ALIAS=\"${AGENTTEAMS_STORAGE_ALIAS:-agentteams}\"\n"
         "ensure_mc_credentials() {\n"
         f"{mc_line}"
         "  return 0\n"
+        "}\n"
+        "agentteams_mc_host_var() {\n"
+        "  printf 'MC_HOST_%s' \"${AGENTTEAMS_STORAGE_ALIAS:-agentteams}\"\n"
+        "}\n"
+        "agentteams_mc_host_configured() {\n"
+        "  var=\"$(agentteams_mc_host_var)\"\n"
+        "  [ -n \"${!var:-}\" ]\n"
         "}\n"
     )
 
@@ -39,7 +51,7 @@ def _render_entrypoint(tmp_path: Path, *, mc_host: bool) -> Path:
     return rendered
 
 
-def test_entrypoint_uses_hiclaw_mc_host_and_bucket_contract(tmp_path):
+def test_entrypoint_uses_agentteams_mc_host_and_legacy_bucket_contract(tmp_path):
     script = _render_entrypoint(tmp_path, mc_host=True)
     capture = tmp_path / "args.txt"
     env = {
@@ -58,7 +70,7 @@ def test_entrypoint_uses_hiclaw_mc_host_and_bucket_contract(tmp_path):
     assert args[args.index("--fs-bucket") + 1] == "custom-bucket"
 
 
-def test_entrypoint_reports_missing_hiclaw_mc_host_for_oss(tmp_path):
+def test_entrypoint_reports_missing_agentteams_mc_host_for_oss(tmp_path):
     script = _render_entrypoint(tmp_path, mc_host=False)
     env = {
         **os.environ,
@@ -71,4 +83,4 @@ def test_entrypoint_reports_missing_hiclaw_mc_host_for_oss(tmp_path):
     result = subprocess.run([str(script)], env=env, text=True, capture_output=True)
 
     assert result.returncode == 1
-    assert "MC_HOST_hiclaw is not configured" in result.stdout
+    assert "MC_HOST_agentteams is not configured" in result.stdout

--- a/copaw/tests/test_taskflow_tool.py
+++ b/copaw/tests/test_taskflow_tool.py
@@ -24,7 +24,7 @@ def _response_json(response):
 
 
 def _set_actor(monkeypatch, actor: str) -> None:
-    monkeypatch.setenv("HICLAW_MATRIX_USER_ID", actor)
+    monkeypatch.setenv("AGENTTEAMS_MATRIX_USER_ID", actor)
 
 
 def _mock_sync(monkeypatch) -> MagicMock:

--- a/copaw/tests/test_worker_sync.py
+++ b/copaw/tests/test_worker_sync.py
@@ -10,7 +10,7 @@ from copaw_worker.sync import FileSync
 def test_ensure_alias_skips_static_alias_in_k8s_mode(monkeypatch, tmp_path):
     calls = []
 
-    monkeypatch.setenv("HICLAW_RUNTIME", "k8s")
+    monkeypatch.setenv("AGENTTEAMS_RUNTIME", "k8s")
     monkeypatch.setattr(sync, "_mc", lambda *args, **_kwargs: calls.append(args))
 
     fs = FileSync(

--- a/shared/lib/hiclaw-env.sh
+++ b/shared/lib/hiclaw-env.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
-# hiclaw-env.sh - Unified environment bootstrap for HiClaw scripts
+# hiclaw-env.sh - Unified environment bootstrap for AgentTeams scripts
 #
 # Single source of truth for both Manager and Worker containers.
 # Source this file instead of manually setting up Matrix/storage variables.
 #
 # Provides:
-#   HICLAW_RUNTIME         — "aliyun" | "k8s" | "docker" | "none"
-#   HICLAW_MATRIX_URL      — Matrix server URL (works in both local and cloud)
-#   HICLAW_AI_GATEWAY_URL  — AI Gateway base URL
-#   HICLAW_FS_BUCKET       — bucket name for mc commands
-#   HICLAW_STORAGE_PREFIX  — "hiclaw/<bucket>" ready for mc paths
+#   AGENTTEAMS_RUNTIME         — "aliyun" | "k8s" | "docker" | "none"
+#   AGENTTEAMS_MATRIX_URL      — Matrix server URL (works in both local and cloud)
+#   AGENTTEAMS_AI_GATEWAY_URL  — AI Gateway base URL
+#   AGENTTEAMS_FS_BUCKET       — bucket name for mc commands
+#   AGENTTEAMS_STORAGE_ALIAS   — mc alias name used in AGENTTEAMS_STORAGE_PREFIX
+#   AGENTTEAMS_STORAGE_PREFIX  — "<mc-alias>/<bucket>" ready for mc paths
 #   ensure_mc_credentials  — callable function (no-op in local mode)
 #
 # Usage:
@@ -20,32 +21,229 @@
 # Worker images don't ship base.sh; the silent fallback is intentional.
 source /opt/hiclaw/scripts/lib/base.sh 2>/dev/null || true
 
+_agentteams_env_or_legacy() {
+    local primary_name="$1"
+    local legacy_name="$2"
+    local default_value="${3-}"
+    local primary_value="${!primary_name:-}"
+    local legacy_value="${!legacy_name:-}"
+
+    if [ -n "${primary_value}" ]; then
+        printf '%s' "${primary_value}"
+    elif [ -n "${legacy_value}" ]; then
+        printf '%s' "${legacy_value}"
+    else
+        printf '%s' "${default_value}"
+    fi
+}
+
+# Compatibility bridge for existing open-source controller/Helm releases.
+# Runtime code below consumes AGENTTEAMS_* only; these assignments preserve
+# already-deployed HICLAW_* inputs until controller injection is renamed.
+AGENTTEAMS_WORKER_NAME="$(_agentteams_env_or_legacy AGENTTEAMS_WORKER_NAME HICLAW_WORKER_NAME)"
+AGENTTEAMS_WORKER_CR_NAME="$(_agentteams_env_or_legacy AGENTTEAMS_WORKER_CR_NAME HICLAW_WORKER_CR_NAME)"
+AGENTTEAMS_WORKER_GATEWAY_KEY="$(_agentteams_env_or_legacy AGENTTEAMS_WORKER_GATEWAY_KEY HICLAW_WORKER_GATEWAY_KEY)"
+AGENTTEAMS_WORKER_MATRIX_TOKEN="$(_agentteams_env_or_legacy AGENTTEAMS_WORKER_MATRIX_TOKEN HICLAW_WORKER_MATRIX_TOKEN)"
+AGENTTEAMS_AUTH_TOKEN="$(_agentteams_env_or_legacy AGENTTEAMS_AUTH_TOKEN HICLAW_AUTH_TOKEN "${HICLAW_WORKER_API_KEY:-}")"
+AGENTTEAMS_AUTH_TOKEN_FILE="$(_agentteams_env_or_legacy AGENTTEAMS_AUTH_TOKEN_FILE HICLAW_AUTH_TOKEN_FILE)"
+AGENTTEAMS_CLUSTER_ID="$(_agentteams_env_or_legacy AGENTTEAMS_CLUSTER_ID HICLAW_CLUSTER_ID)"
+AGENTTEAMS_CONSOLE_PORT="$(_agentteams_env_or_legacy AGENTTEAMS_CONSOLE_PORT HICLAW_CONSOLE_PORT)"
+AGENTTEAMS_WORKER_ENV_MOUNT_DIR="$(_agentteams_env_or_legacy AGENTTEAMS_WORKER_ENV_MOUNT_DIR HICLAW_WORKER_ENV_MOUNT_DIR)"
+AGENTTEAMS_WORKER_ENV_MOUNT_REQUIRED="$(_agentteams_env_or_legacy AGENTTEAMS_WORKER_ENV_MOUNT_REQUIRED HICLAW_WORKER_ENV_MOUNT_REQUIRED)"
+
+# ── Worker deps env projection ────────────────────────────────────────────────
+# SandboxSet pool workers start from identityless warm instances. The claim-time
+# dynamic mount projects Worker-specific env into this directory. In the sandbox
+# pool path, AGENTTEAMS_WORKER_ENV_MOUNT_REQUIRED=1 makes this file a startup
+# prerequisite.
+_agentteams_truthy() {
+    case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+        1|true|yes|on) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+_agentteams_fail_source() {
+    echo "[hiclaw-env] ERROR: $1" >&2
+    exit 1
+}
+
+_agentteams_wait_for_file() {
+    local file="$1"
+    local label="$2"
+    local timeout="${AGENTTEAMS_WORKER_ENV_MOUNT_TIMEOUT_SECONDS:-300}"
+    local elapsed=0
+
+    while [ ! -f "${file}" ]; do
+        if [ "${elapsed}" -ge "${timeout}" ]; then
+            _agentteams_fail_source "timed out waiting for ${label}: ${file}"
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+}
+
+_agentteams_source_env_file() {
+    local file="$1"
+    local had_errexit=false
+
+    case "$-" in
+        *e*)
+            had_errexit=true
+            set +e
+            ;;
+    esac
+
+    set -a
+    # The file is controller-generated shell export syntax.
+    # shellcheck disable=SC1090
+    . "${file}"
+    local rc=$?
+    set +a
+
+    if [ "${had_errexit}" = "true" ]; then
+        set -e
+    fi
+
+    return "${rc}"
+}
+
+_agentteams_required_worker_env_ready() {
+    [ -n "${AGENTTEAMS_WORKER_NAME:-}" ] && [ -n "${AGENTTEAMS_AUTH_TOKEN_FILE:-}" ]
+}
+
+_agentteams_wait_for_worker_env_ready() {
+    local file="$1"
+    local timeout="${AGENTTEAMS_WORKER_ENV_MOUNT_TIMEOUT_SECONDS:-300}"
+    local elapsed=0
+    local last_error="worker env file not found"
+
+    while true; do
+        if [ -f "${file}" ]; then
+            if _agentteams_source_env_file "${file}"; then
+                if _agentteams_required_worker_env_ready; then
+                    return 0
+                fi
+                last_error="missing AGENTTEAMS_WORKER_NAME or AGENTTEAMS_AUTH_TOKEN_FILE"
+            else
+                last_error="failed to source worker env file"
+            fi
+        fi
+
+        if [ "${elapsed}" -ge "${timeout}" ]; then
+            _agentteams_fail_source "timed out waiting for worker env values in ${file}: ${last_error}"
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+}
+
+_agentteams_env_mount_required=false
+if _agentteams_truthy "${AGENTTEAMS_WORKER_ENV_MOUNT_REQUIRED:-}"; then
+    _agentteams_env_mount_required=true
+fi
+
+if [ "${_agentteams_env_mount_required}" = "true" ] && [ -z "${AGENTTEAMS_WORKER_ENV_MOUNT_DIR:-}" ]; then
+    _agentteams_fail_source "AGENTTEAMS_WORKER_ENV_MOUNT_DIR is required when AGENTTEAMS_WORKER_ENV_MOUNT_REQUIRED=1"
+fi
+
+if [ -n "${AGENTTEAMS_WORKER_ENV_MOUNT_DIR:-}" ]; then
+    _agentteams_env_file="${AGENTTEAMS_WORKER_ENV_MOUNT_DIR%/}/env"
+    if [ "${_agentteams_env_mount_required}" = "true" ]; then
+        _agentteams_wait_for_worker_env_ready "${_agentteams_env_file}"
+    elif [ -f "${_agentteams_env_file}" ]; then
+        if ! _agentteams_source_env_file "${_agentteams_env_file}"; then
+            _agentteams_fail_source "failed to source worker env file: ${_agentteams_env_file}"
+        fi
+    fi
+    unset _agentteams_env_file
+fi
+
+if [ "${_agentteams_env_mount_required}" = "true" ]; then
+    if [ -z "${AGENTTEAMS_AUTH_TOKEN_FILE:-}" ]; then
+        _agentteams_fail_source "AGENTTEAMS_AUTH_TOKEN_FILE is required after loading worker env"
+    fi
+    _agentteams_wait_for_file "${AGENTTEAMS_AUTH_TOKEN_FILE}" "worker auth token file"
+fi
+unset _agentteams_env_mount_required
+
 # ── Runtime detection ─────────────────────────────────────────────────────────
-# HICLAW_RUNTIME is normally pre-set by the deployment (Helm sets "k8s",
+# AGENTTEAMS_RUNTIME is normally pre-set by the deployment (Helm sets "k8s",
 # Dockerfile.aliyun sets "aliyun", local scripts leave it unset).
 # Only a minimal fallback is done here; cloud mode must be set explicitly.
-if [ -z "${HICLAW_RUNTIME:-}" ]; then
-    if [ -S "${HICLAW_CONTAINER_SOCKET:-/var/run/docker.sock}" ]; then
-        HICLAW_RUNTIME="docker"
+AGENTTEAMS_RUNTIME="$(_agentteams_env_or_legacy AGENTTEAMS_RUNTIME HICLAW_RUNTIME)"
+AGENTTEAMS_CONTAINER_SOCKET="$(_agentteams_env_or_legacy AGENTTEAMS_CONTAINER_SOCKET HICLAW_CONTAINER_SOCKET)"
+
+if [ -z "${AGENTTEAMS_RUNTIME:-}" ]; then
+    if [ -S "${AGENTTEAMS_CONTAINER_SOCKET:-/var/run/docker.sock}" ]; then
+        AGENTTEAMS_RUNTIME="docker"
     else
-        HICLAW_RUNTIME="none"
+        AGENTTEAMS_RUNTIME="none"
     fi
 fi
 
 # ── Normalized variables ──────────────────────────────────────────────────────
-# Runtime-neutral infra contract with local defaults.
-HICLAW_MATRIX_URL="${HICLAW_MATRIX_URL:-http://127.0.0.1:6167}"
-HICLAW_AI_GATEWAY_URL="${HICLAW_AI_GATEWAY_URL:-http://${HICLAW_AI_GATEWAY_DOMAIN:-aigw-local.hiclaw.io}:8080}"
-HICLAW_FS_BUCKET="${HICLAW_FS_BUCKET:-hiclaw-storage}"
-HICLAW_STORAGE_PREFIX="${HICLAW_STORAGE_PREFIX:-hiclaw/${HICLAW_FS_BUCKET}}"
+# AgentTeams runtime contract with local defaults.
+AGENTTEAMS_MATRIX_URL="$(_agentteams_env_or_legacy AGENTTEAMS_MATRIX_URL HICLAW_MATRIX_URL "http://127.0.0.1:6167")"
+AGENTTEAMS_MATRIX_DOMAIN="$(_agentteams_env_or_legacy AGENTTEAMS_MATRIX_DOMAIN HICLAW_MATRIX_DOMAIN "matrix-local.agentteams.io:8080")"
+AGENTTEAMS_AI_GATEWAY_DOMAIN="$(_agentteams_env_or_legacy AGENTTEAMS_AI_GATEWAY_DOMAIN HICLAW_AI_GATEWAY_DOMAIN "aigw-local.agentteams.io")"
+AGENTTEAMS_AI_GATEWAY_URL="$(_agentteams_env_or_legacy AGENTTEAMS_AI_GATEWAY_URL HICLAW_AI_GATEWAY_URL "http://${AGENTTEAMS_AI_GATEWAY_DOMAIN}:8080")"
+AGENTTEAMS_FS_DOMAIN="$(_agentteams_env_or_legacy AGENTTEAMS_FS_DOMAIN HICLAW_FS_DOMAIN "fs-local.agentteams.io")"
+AGENTTEAMS_FS_ENDPOINT="$(_agentteams_env_or_legacy AGENTTEAMS_FS_ENDPOINT HICLAW_FS_ENDPOINT)"
+AGENTTEAMS_FS_ACCESS_KEY="$(_agentteams_env_or_legacy AGENTTEAMS_FS_ACCESS_KEY HICLAW_FS_ACCESS_KEY)"
+AGENTTEAMS_FS_SECRET_KEY="$(_agentteams_env_or_legacy AGENTTEAMS_FS_SECRET_KEY HICLAW_FS_SECRET_KEY)"
+AGENTTEAMS_FS_BUCKET="$(_agentteams_env_or_legacy AGENTTEAMS_FS_BUCKET HICLAW_FS_BUCKET "${HICLAW_OSS_BUCKET:-agentteams-storage}")"
+_AGENTTEAMS_STORAGE_ALIAS_ENV="${AGENTTEAMS_STORAGE_ALIAS:-}"
+_AGENTTEAMS_STORAGE_PREFIX_ENV="$(_agentteams_env_or_legacy AGENTTEAMS_STORAGE_PREFIX HICLAW_STORAGE_PREFIX)"
+AGENTTEAMS_STORAGE_ALIAS="${_AGENTTEAMS_STORAGE_ALIAS_ENV:-agentteams}"
+AGENTTEAMS_STORAGE_PREFIX="${_AGENTTEAMS_STORAGE_PREFIX_ENV:-${AGENTTEAMS_STORAGE_ALIAS}/${AGENTTEAMS_FS_BUCKET}}"
+if [ -z "${_AGENTTEAMS_STORAGE_ALIAS_ENV}" ]; then
+    case "${AGENTTEAMS_STORAGE_PREFIX}" in
+        */*) AGENTTEAMS_STORAGE_ALIAS="${AGENTTEAMS_STORAGE_PREFIX%%/*}" ;;
+    esac
+fi
+AGENTTEAMS_STORAGE_PROVIDER="$(_agentteams_env_or_legacy AGENTTEAMS_STORAGE_PROVIDER HICLAW_STORAGE_PROVIDER)"
+AGENTTEAMS_CONTROLLER_URL="$(_agentteams_env_or_legacy AGENTTEAMS_CONTROLLER_URL HICLAW_CONTROLLER_URL)"
+AGENTTEAMS_YOLO="$(_agentteams_env_or_legacy AGENTTEAMS_YOLO HICLAW_YOLO)"
+AGENTTEAMS_MATRIX_DEBUG="$(_agentteams_env_or_legacy AGENTTEAMS_MATRIX_DEBUG HICLAW_MATRIX_DEBUG)"
+AGENTTEAMS_CMS_TRACES_ENABLED="$(_agentteams_env_or_legacy AGENTTEAMS_CMS_TRACES_ENABLED HICLAW_CMS_TRACES_ENABLED)"
+AGENTTEAMS_CMS_METRICS_ENABLED="$(_agentteams_env_or_legacy AGENTTEAMS_CMS_METRICS_ENABLED HICLAW_CMS_METRICS_ENABLED)"
+AGENTTEAMS_CMS_ENDPOINT="$(_agentteams_env_or_legacy AGENTTEAMS_CMS_ENDPOINT HICLAW_CMS_ENDPOINT)"
+AGENTTEAMS_CMS_LICENSE_KEY="$(_agentteams_env_or_legacy AGENTTEAMS_CMS_LICENSE_KEY HICLAW_CMS_LICENSE_KEY)"
+AGENTTEAMS_CMS_PROJECT="$(_agentteams_env_or_legacy AGENTTEAMS_CMS_PROJECT HICLAW_CMS_PROJECT)"
+AGENTTEAMS_CMS_WORKSPACE="$(_agentteams_env_or_legacy AGENTTEAMS_CMS_WORKSPACE HICLAW_CMS_WORKSPACE)"
+AGENTTEAMS_CMS_SERVICE_NAME="$(_agentteams_env_or_legacy AGENTTEAMS_CMS_SERVICE_NAME HICLAW_CMS_SERVICE_NAME)"
 
 # ── Credential management ────────────────────────────────────────────────────
 # In cloud mode, provides ensure_mc_credentials() for STS token refresh.
 # In local mode, ensure_mc_credentials() is a no-op.
 source /opt/hiclaw/scripts/lib/oss-credentials.sh 2>/dev/null || true
 
-# Embedding model: default to Qwen3-Embedding (text-embedding-v4), overridable via env.
-# Use - (not :-) so HICLAW_EMBEDDING_MODEL="" in env file means "disabled" instead of falling back to default.
-HICLAW_EMBEDDING_MODEL="${HICLAW_EMBEDDING_MODEL-text-embedding-v4}"
+agentteams_mc_host_var() {
+    printf 'MC_HOST_%s' "${AGENTTEAMS_STORAGE_ALIAS:-agentteams}"
+}
 
-export HICLAW_RUNTIME HICLAW_MATRIX_URL HICLAW_AI_GATEWAY_URL HICLAW_FS_BUCKET HICLAW_STORAGE_PREFIX HICLAW_EMBEDDING_MODEL
+agentteams_mc_host_configured() {
+    local var
+    var="$(agentteams_mc_host_var)"
+    [ -n "${!var:-}" ]
+}
+
+# Embedding model: default to Qwen3-Embedding (text-embedding-v4), overridable via env.
+# Use - (not :-) so AGENTTEAMS_EMBEDDING_MODEL="" means "disabled" instead of falling back to default.
+AGENTTEAMS_EMBEDDING_MODEL="${AGENTTEAMS_EMBEDDING_MODEL-${HICLAW_EMBEDDING_MODEL-text-embedding-v4}}"
+
+export AGENTTEAMS_RUNTIME AGENTTEAMS_CONTAINER_SOCKET
+export AGENTTEAMS_WORKER_NAME AGENTTEAMS_WORKER_CR_NAME
+export AGENTTEAMS_WORKER_GATEWAY_KEY AGENTTEAMS_WORKER_MATRIX_TOKEN
+export AGENTTEAMS_FS_ENDPOINT AGENTTEAMS_FS_ACCESS_KEY AGENTTEAMS_FS_SECRET_KEY AGENTTEAMS_FS_BUCKET
+export AGENTTEAMS_STORAGE_ALIAS AGENTTEAMS_STORAGE_PREFIX AGENTTEAMS_STORAGE_PROVIDER AGENTTEAMS_CONTROLLER_URL
+export AGENTTEAMS_AUTH_TOKEN AGENTTEAMS_AUTH_TOKEN_FILE AGENTTEAMS_CLUSTER_ID AGENTTEAMS_CONSOLE_PORT
+export AGENTTEAMS_WORKER_ENV_MOUNT_DIR AGENTTEAMS_WORKER_ENV_MOUNT_REQUIRED
+export AGENTTEAMS_MATRIX_URL AGENTTEAMS_MATRIX_DOMAIN AGENTTEAMS_AI_GATEWAY_URL AGENTTEAMS_AI_GATEWAY_DOMAIN
+export AGENTTEAMS_FS_DOMAIN AGENTTEAMS_EMBEDDING_MODEL
+export AGENTTEAMS_YOLO AGENTTEAMS_MATRIX_DEBUG
+export AGENTTEAMS_CMS_TRACES_ENABLED AGENTTEAMS_CMS_METRICS_ENABLED AGENTTEAMS_CMS_ENDPOINT
+export AGENTTEAMS_CMS_LICENSE_KEY AGENTTEAMS_CMS_PROJECT AGENTTEAMS_CMS_WORKSPACE AGENTTEAMS_CMS_SERVICE_NAME
+
+unset _AGENTTEAMS_STORAGE_ALIAS_ENV _AGENTTEAMS_STORAGE_PREFIX_ENV

--- a/shared/lib/oss-credentials.sh
+++ b/shared/lib/oss-credentials.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 # oss-credentials.sh - STS credential management for mc (MinIO Client)
 #
-# Two credential paths (checked in priority order):
-#
-# 1. Controller-mediated STS (cloud mode):
-#    HICLAW_CONTROLLER_URL + bearer token (HICLAW_AUTH_TOKEN or token file
-#    at HICLAW_AUTH_TOKEN_FILE, legacy fallback HICLAW_WORKER_API_KEY) →
+# Controller-mediated STS (cloud mode):
+#    AGENTTEAMS_CONTROLLER_URL + bearer token (AGENTTEAMS_AUTH_TOKEN or token
+#    file at AGENTTEAMS_AUTH_TOKEN_FILE; legacy HICLAW_* envs are accepted) →
 #    call controller /api/v1/credentials/sts. The controller obtains STS
 #    tokens from its hiclaw-credential-provider sidecar.
 #
@@ -26,22 +24,72 @@ _OSS_CRED_REFRESH_MARGIN=600  # refresh if less than 10 minutes remaining
 # --------------------------------------------------------------------------
 
 # Resolve the bearer token used to authenticate against the controller.
-# Priority: HICLAW_AUTH_TOKEN > HICLAW_AUTH_TOKEN_FILE > HICLAW_WORKER_API_KEY.
+# Priority: active contract AUTH_TOKEN > active contract AUTH_TOKEN_FILE.
 # Emits the token on stdout; empty string if none found.
 _oss_resolve_bearer() {
-    if [ -n "${HICLAW_AUTH_TOKEN:-}" ]; then
-        printf '%s' "${HICLAW_AUTH_TOKEN}"
+    if [ -n "${AGENTTEAMS_AUTH_TOKEN:-}" ]; then
+        printf '%s' "${AGENTTEAMS_AUTH_TOKEN}"
         return 0
     fi
-    if [ -n "${HICLAW_AUTH_TOKEN_FILE:-}" ] && [ -f "${HICLAW_AUTH_TOKEN_FILE}" ]; then
-        cat "${HICLAW_AUTH_TOKEN_FILE}"
+    if [ -n "${HICLAW_AUTH_TOKEN:-}" ]; then
+        printf '%s' "${HICLAW_AUTH_TOKEN}"
         return 0
     fi
     if [ -n "${HICLAW_WORKER_API_KEY:-}" ]; then
         printf '%s' "${HICLAW_WORKER_API_KEY}"
         return 0
     fi
+    if [ -n "${AGENTTEAMS_AUTH_TOKEN_FILE:-}" ] && [ -f "${AGENTTEAMS_AUTH_TOKEN_FILE}" ]; then
+        cat "${AGENTTEAMS_AUTH_TOKEN_FILE}"
+        return 0
+    fi
+    if [ -n "${HICLAW_AUTH_TOKEN_FILE:-}" ] && [ -f "${HICLAW_AUTH_TOKEN_FILE}" ]; then
+        cat "${HICLAW_AUTH_TOKEN_FILE}"
+        return 0
+    fi
     return 0
+}
+
+_oss_use_agentteams_env() {
+    [ -n "${AGENTTEAMS_WORKER_NAME:-}" ] || [ -n "${AGENTTEAMS_CONTROLLER_URL:-}" ] || \
+        [ -n "${AGENTTEAMS_AUTH_TOKEN:-}" ] || [ -n "${AGENTTEAMS_AUTH_TOKEN_FILE:-}" ]
+}
+
+_oss_controller_url() {
+    printf '%s' "${AGENTTEAMS_CONTROLLER_URL:-${HICLAW_CONTROLLER_URL:-}}"
+}
+
+_oss_auth_cluster_id() {
+    printf '%s' "${AGENTTEAMS_CLUSTER_ID:-${HICLAW_CLUSTER_ID:-}}"
+}
+
+_oss_storage_alias() {
+    local prefix
+    if [ -n "${AGENTTEAMS_STORAGE_ALIAS:-}" ]; then
+        printf '%s' "${AGENTTEAMS_STORAGE_ALIAS}"
+        return
+    fi
+    prefix="${AGENTTEAMS_STORAGE_PREFIX:-${HICLAW_STORAGE_PREFIX:-}}"
+    case "${prefix}" in
+        */*) printf '%s' "${prefix%%/*}" ;;
+        *) printf '%s' "agentteams" ;;
+    esac
+}
+
+_oss_auth_error_vars() {
+    printf '%s' "AGENTTEAMS_AUTH_TOKEN / AGENTTEAMS_AUTH_TOKEN_FILE / HICLAW_AUTH_TOKEN / HICLAW_AUTH_TOKEN_FILE"
+}
+
+_oss_export_mc_host() {
+    export "MC_HOST_$(_oss_storage_alias)"
+}
+
+_oss_mc_host_var() {
+    printf 'MC_HOST_%s' "$(_oss_storage_alias)"
+}
+
+_oss_has_controller_url() {
+    [ -n "$(_oss_controller_url)" ]
 }
 
 # --------------------------------------------------------------------------
@@ -49,20 +97,23 @@ _oss_resolve_bearer() {
 # --------------------------------------------------------------------------
 
 _oss_refresh_sts_via_controller() {
-    local _controller_url="${HICLAW_CONTROLLER_URL:-}"
+    local _controller_url="$(_oss_controller_url)"
     local bearer resp http_code
-    local sts_ak sts_sk sts_token oss_endpoint mc_host_value
+    local sts_ak sts_sk sts_token oss_endpoint mc_host_value mc_host_var
 
     bearer=$(_oss_resolve_bearer)
     if [ -z "${bearer}" ]; then
-        echo "[oss-credentials] ERROR: no bearer token available (HICLAW_AUTH_TOKEN / HICLAW_AUTH_TOKEN_FILE / HICLAW_WORKER_API_KEY all empty)" >&2
+        echo "[oss-credentials] ERROR: no bearer token available ($(_oss_auth_error_vars) both empty)" >&2
         return 1
     fi
 
-    if [ -n "${HICLAW_CLUSTER_ID:-}" ]; then
+    local auth_cluster_id
+    auth_cluster_id="$(_oss_auth_cluster_id)"
+    if [ -n "${auth_cluster_id:-}" ]; then
         resp=$(curl -s -w "\n%{http_code}" -X POST "${_controller_url}/api/v1/credentials/sts" \
             -H "Authorization: Bearer ${bearer}" \
-            -H "X-HiClaw-Cluster-ID: ${HICLAW_CLUSTER_ID}" \
+            -H "X-AgentTeams-Cluster-ID: ${auth_cluster_id}" \
+            -H "X-HiClaw-Cluster-ID: ${auth_cluster_id}" \
             --connect-timeout 10 --max-time 30 2>&1)
     else
         resp=$(curl -s -w "\n%{http_code}" -X POST "${_controller_url}/api/v1/credentials/sts" \
@@ -113,8 +164,9 @@ _oss_refresh_sts_via_controller() {
     local expires_at
     expires_at=$(( $(date +%s) + 3600 ))
 
+    mc_host_var="$(_oss_mc_host_var)"
     cat > "${_OSS_CRED_FILE}" <<EOF
-MC_HOST_hiclaw="${mc_host_value}"
+${mc_host_var}="${mc_host_value}"
 _OSS_CRED_EXPIRES_AT=${expires_at}
 EOF
     chmod 600 "${_OSS_CRED_FILE}"
@@ -128,7 +180,7 @@ EOF
 
 ensure_mc_credentials() {
     # Cloud mode: Controller URL + any resolvable bearer token → controller-mediated STS
-    if [ -n "${HICLAW_CONTROLLER_URL:-}" ]; then
+    if _oss_has_controller_url; then
         local bearer
         bearer=$(_oss_resolve_bearer)
         if [ -n "${bearer}" ]; then
@@ -161,5 +213,5 @@ _oss_ensure_refresh() {
         . "${_OSS_CRED_FILE}"
     fi
 
-    export MC_HOST_hiclaw
+    _oss_export_mc_host
 }

--- a/shared/tests/test-hiclaw-env.sh
+++ b/shared/tests/test-hiclaw-env.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Unit checks for shared/lib/hiclaw-env.sh sandbox worker env loading.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+run_env_source() {
+    env -i \
+        PATH="${PATH}" \
+        AGENTTEAMS_WORKER_ENV_MOUNT_REQUIRED=1 \
+        AGENTTEAMS_WORKER_ENV_MOUNT_DIR="$1" \
+        AGENTTEAMS_WORKER_ENV_MOUNT_TIMEOUT_SECONDS="$2" \
+        bash -c ". '${REPO_ROOT}/shared/lib/hiclaw-env.sh'; printf 'worker=%s token=%s\n' \"\${AGENTTEAMS_WORKER_NAME:-}\" \"\${AGENTTEAMS_AUTH_TOKEN_FILE:-}\""
+}
+
+test_waits_for_required_worker_env_values() {
+    local tmpdir mount token output updater_pid
+    tmpdir="$(mktemp -d)"
+    mount="${tmpdir}/env"
+    token="${tmpdir}/token"
+    mkdir -p "${mount}"
+    printf 'token\n' > "${token}"
+    printf "export AGENTTEAMS_AUTH_TOKEN_FILE='%s'\n" "${token}" > "${mount}/env"
+
+    (
+        sleep 1
+        {
+            printf "export AGENTTEAMS_AUTH_TOKEN_FILE='%s'\n" "${token}"
+            printf "export AGENTTEAMS_WORKER_NAME='alice'\n"
+        } > "${mount}/env"
+    ) &
+    updater_pid=$!
+
+    output="$(run_env_source "${mount}" 4)"
+    wait "${updater_pid}"
+
+    rm -rf "${tmpdir}"
+    [ "${output}" = "worker=alice token=${token}" ] || fail "unexpected delayed env output: ${output}"
+}
+
+test_times_out_when_required_worker_env_values_never_arrive() {
+    local tmpdir mount token output rc
+    tmpdir="$(mktemp -d)"
+    mount="${tmpdir}/env"
+    token="${tmpdir}/token"
+    mkdir -p "${mount}"
+    printf 'token\n' > "${token}"
+    printf "export AGENTTEAMS_AUTH_TOKEN_FILE='%s'\n" "${token}" > "${mount}/env"
+
+    set +e
+    output="$(run_env_source "${mount}" 1 2>&1)"
+    rc=$?
+    set -e
+
+    rm -rf "${tmpdir}"
+    [ "${rc}" -ne 0 ] || fail "expected timeout failure"
+    grep -q "\[hiclaw-env\] ERROR" <<<"${output}" || fail "timeout did not include hiclaw-env error: ${output}"
+    grep -q "AGENTTEAMS_WORKER_NAME" <<<"${output}" || fail "timeout did not name missing worker env: ${output}"
+}
+
+test_legacy_hiclaw_env_maps_to_agentteams_contract() {
+    local output
+    output="$(
+        env -i \
+            PATH="${PATH}" \
+            HICLAW_WORKER_NAME=legacy-worker \
+            HICLAW_AUTH_TOKEN_FILE=/var/run/secrets/hiclaw/token \
+            HICLAW_CONTROLLER_URL=http://controller:8090 \
+            HICLAW_FS_BUCKET=hiclaw-storage \
+            HICLAW_STORAGE_PREFIX=hiclaw/hiclaw-storage \
+            bash -c ". '${REPO_ROOT}/shared/lib/hiclaw-env.sh'; printf 'worker=%s token=%s controller=%s alias=%s prefix=%s\n' \"\${AGENTTEAMS_WORKER_NAME:-}\" \"\${AGENTTEAMS_AUTH_TOKEN_FILE:-}\" \"\${AGENTTEAMS_CONTROLLER_URL:-}\" \"\${AGENTTEAMS_STORAGE_ALIAS:-}\" \"\${AGENTTEAMS_STORAGE_PREFIX:-}\""
+    )"
+
+    [ "${output}" = "worker=legacy-worker token=/var/run/secrets/hiclaw/token controller=http://controller:8090 alias=hiclaw prefix=hiclaw/hiclaw-storage" ] || \
+        fail "legacy HICLAW env did not map to AgentTeams contract: ${output}"
+}
+
+test_waits_for_required_worker_env_values
+test_times_out_when_required_worker_env_values_never_arrive
+test_legacy_hiclaw_env_maps_to_agentteams_contract
+
+echo "PASS: hiclaw-env sandbox worker env loading"

--- a/shared/tests/test-oss-credentials.sh
+++ b/shared/tests/test-oss-credentials.sh
@@ -96,10 +96,12 @@ echo "=== oss credentials STS controller request ==="
 
 with_cluster="$(run_refresh with-cluster remote-cluster-a)"
 assert_contains "cluster id should be sent as controller header" "X-HiClaw-Cluster-ID: remote-cluster-a" "${with_cluster}"
+assert_contains "AgentTeams cluster header should also be sent" "X-AgentTeams-Cluster-ID: remote-cluster-a" "${with_cluster}"
 assert_contains "bearer token should still be sent" "Authorization: Bearer controller-token" "${with_cluster}"
 
 without_cluster="$(run_refresh without-cluster)"
 assert_not_contains "cluster header should be omitted when HICLAW_CLUSTER_ID is empty" "X-HiClaw-Cluster-ID:" "${without_cluster}"
+assert_not_contains "AgentTeams cluster header should be omitted when cluster id is empty" "X-AgentTeams-Cluster-ID:" "${without_cluster}"
 assert_contains "bearer token should be sent without cluster id" "Authorization: Bearer controller-token" "${without_cluster}"
 
 echo "All oss-credentials tests passed"

--- a/worker/README.md
+++ b/worker/README.md
@@ -51,12 +51,12 @@ worker/
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `HICLAW_WORKER_NAME` | Yes | Worker name (e.g., `alice`) |
-| `HICLAW_MATRIX_URL` | No | Matrix Homeserver URL injected by controller-managed deployments |
-| `HICLAW_AI_GATEWAY_URL` | No | AI Gateway URL injected by controller-managed deployments |
-| `HICLAW_FS_ENDPOINT` | Yes | MinIO/HTTP file system URL |
-| `HICLAW_FS_BUCKET` | No | Bucket name for CoPaw or non-default storage layouts |
-| `HICLAW_FS_ACCESS_KEY` | Yes | MinIO access key |
-| `HICLAW_FS_SECRET_KEY` | Yes | MinIO secret key |
+| `AGENTTEAMS_WORKER_NAME` | Yes | Worker name (e.g., `alice`) |
+| `AGENTTEAMS_MATRIX_URL` | No | Matrix Homeserver URL injected by controller-managed deployments |
+| `AGENTTEAMS_AI_GATEWAY_URL` | No | AI Gateway URL injected by controller-managed deployments |
+| `AGENTTEAMS_FS_ENDPOINT` | Yes | MinIO/HTTP file system URL |
+| `AGENTTEAMS_FS_BUCKET` | No | Bucket name for CoPaw or non-default storage layouts |
+| `AGENTTEAMS_FS_ACCESS_KEY` | Yes | MinIO access key |
+| `AGENTTEAMS_FS_SECRET_KEY` | Yes | MinIO secret key |
 
-Runtime scripts now consume `HICLAW_MATRIX_URL` and `HICLAW_AI_GATEWAY_URL` directly; legacy aliases are no longer part of the main contract.
+Runtime scripts use `AGENTTEAMS_MATRIX_URL` and `AGENTTEAMS_AI_GATEWAY_URL` as the main contract. Existing `HICLAW_*` inputs are still accepted by the shared bootstrap for compatibility with older controller/Helm releases.

--- a/worker/scripts/worker-entrypoint.sh
+++ b/worker/scripts/worker-entrypoint.sh
@@ -10,10 +10,10 @@ set -e
 source /opt/hiclaw/scripts/lib/hiclaw-env.sh
 source /opt/hiclaw/scripts/lib/merge-openclaw-config.sh
 
-WORKER_NAME="${HICLAW_WORKER_NAME:?HICLAW_WORKER_NAME is required}"
-FS_ENDPOINT="${HICLAW_FS_ENDPOINT:-}"
-FS_ACCESS_KEY="${HICLAW_FS_ACCESS_KEY:-}"
-FS_SECRET_KEY="${HICLAW_FS_SECRET_KEY:-}"
+WORKER_NAME="${AGENTTEAMS_WORKER_NAME:?AGENTTEAMS_WORKER_NAME is required}"
+FS_ENDPOINT="${AGENTTEAMS_FS_ENDPOINT:-}"
+FS_ACCESS_KEY="${AGENTTEAMS_FS_ACCESS_KEY:-}"
+FS_SECRET_KEY="${AGENTTEAMS_FS_SECRET_KEY:-}"
 
 log() {
     echo "[hiclaw-worker $(date '+%Y-%m-%d %H:%M:%S')] $1"
@@ -29,32 +29,35 @@ if [ -n "${TZ}" ] && [ -f "/usr/share/zoneinfo/${TZ}" ]; then
 fi
 
 # Use absolute path because HOME is set to the workspace directory via docker run
-HICLAW_ROOT="/root/hiclaw-fs"
-WORKSPACE="${HICLAW_ROOT}/agents/${WORKER_NAME}"
+AGENTTEAMS_ROOT="/root/hiclaw-fs"
+WORKSPACE="${AGENTTEAMS_ROOT}/agents/${WORKER_NAME}"
 
 # ============================================================
 # Step 1: Configure mc alias for centralized file system
 # ============================================================
-if [ "${HICLAW_RUNTIME}" = "aliyun" ]; then
-    log "Configuring mc alias for cloud (RRSA OIDC)..."
-    ensure_mc_credentials
+if ensure_mc_credentials && agentteams_mc_host_configured; then
+    log "Configuring mc alias via controller-issued storage credentials (${AGENTTEAMS_STORAGE_ALIAS})..."
 else
-    log "Configuring mc alias for local MinIO..."
-    mc alias set hiclaw "${FS_ENDPOINT:?HICLAW_FS_ENDPOINT is required}" \
-        "${FS_ACCESS_KEY:?HICLAW_FS_ACCESS_KEY is required}" \
-        "${FS_SECRET_KEY:?HICLAW_FS_SECRET_KEY is required}"
+    if [ "${AGENTTEAMS_STORAGE_PROVIDER:-minio}" = "oss" ]; then
+        log "ERROR: OSS storage requires controller-issued storage credentials, but $(agentteams_mc_host_var) is not configured"
+        exit 1
+    fi
+    log "Configuring mc alias for static storage credentials (${AGENTTEAMS_STORAGE_ALIAS})..."
+    mc alias set "${AGENTTEAMS_STORAGE_ALIAS}" "${FS_ENDPOINT:?AGENTTEAMS_FS_ENDPOINT is required}" \
+        "${FS_ACCESS_KEY:?AGENTTEAMS_FS_ACCESS_KEY is required}" \
+        "${FS_SECRET_KEY:?AGENTTEAMS_FS_SECRET_KEY is required}"
 fi
 
 # ============================================================
 # Step 2: Pull Worker config and shared data from centralized storage
 # ============================================================
-mkdir -p "${WORKSPACE}" "${HICLAW_ROOT}/shared"
+mkdir -p "${WORKSPACE}" "${AGENTTEAMS_ROOT}/shared"
 
 log "Pulling Worker config from centralized storage..."
 ensure_mc_credentials 2>/dev/null || true
-mc mirror "${HICLAW_STORAGE_PREFIX}/agents/${WORKER_NAME}/" "${WORKSPACE}/" --overwrite \
+mc mirror "${AGENTTEAMS_STORAGE_PREFIX}/agents/${WORKER_NAME}/" "${WORKSPACE}/" --overwrite \
     --exclude ".openclaw/matrix/**" --exclude ".openclaw/canvas/**" --exclude "credentials/**"
-mc mirror "${HICLAW_STORAGE_PREFIX}/shared/" "${HICLAW_ROOT}/shared/" --overwrite 2>/dev/null || true
+mc mirror "${AGENTTEAMS_STORAGE_PREFIX}/shared/" "${AGENTTEAMS_ROOT}/shared/" --overwrite 2>/dev/null || true
 
 # Mark pull completion — the local→remote sync loop uses this marker to avoid
 # pushing back files that were just pulled (their mtime is fresh from the pull).
@@ -72,7 +75,7 @@ while [ ! -f "${WORKSPACE}/openclaw.json" ] || [ ! -f "${WORKSPACE}/SOUL.md" ] \
     fi
     log "Waiting for config files to appear in MinIO (attempt ${RETRY}/6)..."
     sleep 5
-    mc mirror "${HICLAW_STORAGE_PREFIX}/agents/${WORKER_NAME}/" "${WORKSPACE}/" --overwrite \
+    mc mirror "${AGENTTEAMS_STORAGE_PREFIX}/agents/${WORKER_NAME}/" "${WORKSPACE}/" --overwrite \
         --exclude ".openclaw/matrix/**" --exclude ".openclaw/canvas/**" --exclude "credentials/**" 2>/dev/null || true
     touch "${PULL_MARKER}"
 done
@@ -177,7 +180,7 @@ log "HOME set to ${HOME} (workspace files will be synced to MinIO)"
         CHANGED=$(find "${WORKSPACE}/" -type f -newer "${PULL_MARKER}" 2>/dev/null | head -1)
         if [ -n "${CHANGED}" ]; then
             ensure_mc_credentials 2>/dev/null || true
-            if ! mc mirror "${WORKSPACE}/" "${HICLAW_STORAGE_PREFIX}/agents/${WORKER_NAME}/" --overwrite \
+            if ! mc mirror "${WORKSPACE}/" "${AGENTTEAMS_STORAGE_PREFIX}/agents/${WORKER_NAME}/" --overwrite \
                 --exclude "openclaw.json" \
                 --exclude "config/mcporter.json" --exclude "mcporter-servers.json" --exclude ".agents/**" \
                 --exclude "credentials/**" \
@@ -192,7 +195,7 @@ log "HOME set to ${HOME} (workspace files will be synced to MinIO)"
             # modified after the last pull. See block comment above for design.
             for _mf in SOUL.md AGENTS.md HEARTBEAT.md; do
                 if [ -f "${WORKSPACE}/${_mf}" ] && [ "${WORKSPACE}/${_mf}" -nt "${PULL_MARKER}" ]; then
-                    mc cp "${WORKSPACE}/${_mf}" "${HICLAW_STORAGE_PREFIX}/agents/${WORKER_NAME}/${_mf}" 2>/dev/null || true
+                    mc cp "${WORKSPACE}/${_mf}" "${AGENTTEAMS_STORAGE_PREFIX}/agents/${WORKER_NAME}/${_mf}" 2>/dev/null || true
                 fi
             done
         fi
@@ -209,13 +212,13 @@ log "Local->Remote change-triggered sync started (PID: $!)"
     while true; do
         sleep 300
         ensure_mc_credentials 2>/dev/null || true
-        mc cp "${HICLAW_STORAGE_PREFIX}/agents/${WORKER_NAME}/openclaw.json" /tmp/openclaw-remote.json 2>/dev/null || true
+        mc cp "${AGENTTEAMS_STORAGE_PREFIX}/agents/${WORKER_NAME}/openclaw.json" /tmp/openclaw-remote.json 2>/dev/null || true
         merge_openclaw_config /tmp/openclaw-remote.json "${WORKSPACE}/openclaw.json"
         rm -f /tmp/openclaw-remote.json
-        mc cp "${HICLAW_STORAGE_PREFIX}/agents/${WORKER_NAME}/config/mcporter.json" "${WORKSPACE}/config/mcporter.json" 2>/dev/null || true
-        mc mirror "${HICLAW_STORAGE_PREFIX}/agents/${WORKER_NAME}/skills/" "${WORKSPACE}/skills/" --overwrite 2>/dev/null || true
+        mc cp "${AGENTTEAMS_STORAGE_PREFIX}/agents/${WORKER_NAME}/config/mcporter.json" "${WORKSPACE}/config/mcporter.json" 2>/dev/null || true
+        mc mirror "${AGENTTEAMS_STORAGE_PREFIX}/agents/${WORKER_NAME}/skills/" "${WORKSPACE}/skills/" --overwrite 2>/dev/null || true
         find "${WORKSPACE}/skills" -name '*.sh' -exec chmod +x {} + 2>/dev/null || true
-        mc mirror "${HICLAW_STORAGE_PREFIX}/shared/" "${HICLAW_ROOT}/shared/" --overwrite --newer-than "5m" 2>/dev/null || true
+        mc mirror "${AGENTTEAMS_STORAGE_PREFIX}/shared/" "${AGENTTEAMS_ROOT}/shared/" --overwrite --newer-than "5m" 2>/dev/null || true
         # Refresh PULL_MARKER so the change-triggered push loop doesn't
         # re-trigger forever on freshly-pulled openclaw.json/skills mtimes,
         # and so the per-file -nt guard correctly classifies post-pull edits.
@@ -272,7 +275,7 @@ log "Cleaned Matrix crypto storage (will re-establish E2EE sessions)"
 # identity key (crypto storage was just wiped) causes other clients to
 # reject key distribution. Re-login creates a new device_id, matching
 # the Manager's behavior and allowing clean E2EE session establishment.
-MATRIX_PASSWORD_FILE="${HICLAW_STORAGE_PREFIX}/agents/${WORKER_NAME}/credentials/matrix/password"
+MATRIX_PASSWORD_FILE="${AGENTTEAMS_STORAGE_PREFIX}/agents/${WORKER_NAME}/credentials/matrix/password"
 MATRIX_PASSWORD=$(mc cat "${MATRIX_PASSWORD_FILE}" 2>/dev/null) || true
 if [ -n "${MATRIX_PASSWORD}" ]; then
     # Read homeserver URL from openclaw.json (already pulled from MinIO)
@@ -314,22 +317,22 @@ fi
 # Without this, config reload spawns a detached child and exits, killing the container.
 export OPENCLAW_NO_RESPAWN=1
 
-# Optional matrix-plugin trace logging — when HICLAW_MATRIX_DEBUG=1 is set in
+# Optional matrix-plugin trace logging — when AGENTTEAMS_MATRIX_DEBUG=1 is set in
 # the worker environment (propagated by the controller / install script), turn
 # on OPENCLAW_MATRIX_DEBUG so the matrix plugin emits structured INFO-level
 # lifecycle traces (sync.state transitions, room.invite/join, message handler
 # arrival + filter outcomes). Useful when diagnosing "worker never joined the
 # room" / "manager never replied" hangs without rebuilding the image.
-if [ "${HICLAW_MATRIX_DEBUG:-}" = "1" ] && [ -z "${OPENCLAW_MATRIX_DEBUG:-}" ]; then
+if [ "${AGENTTEAMS_MATRIX_DEBUG:-}" = "1" ] && [ -z "${OPENCLAW_MATRIX_DEBUG:-}" ]; then
     export OPENCLAW_MATRIX_DEBUG=1
-    log "HICLAW_MATRIX_DEBUG=1 detected; OPENCLAW_MATRIX_DEBUG=1 exported for matrix plugin tracing"
+    log "AGENTTEAMS_MATRIX_DEBUG=1 detected; OPENCLAW_MATRIX_DEBUG=1 exported for matrix plugin tracing"
 fi
 
 # ============================================================
 # Step 5c: Background readiness reporter
 # ============================================================
 # Wait for local gateway health, then report ready via hiclaw CLI.
-if [ -n "${HICLAW_CONTROLLER_URL:-}" ]; then
+if [ -n "${AGENTTEAMS_CONTROLLER_URL:-}" ]; then
 (
         # Phase 1: Wait for gateway to be healthy (with timeout)
         TIMEOUT=120; ELAPSED=0
@@ -346,7 +349,7 @@ if [ -n "${HICLAW_CONTROLLER_URL:-}" ]; then
         fi
 
         # Report ready to controller via hiclaw CLI
-        hiclaw worker report-ready --name "${HICLAW_WORKER_CR_NAME:-${WORKER_NAME}}"
+        hiclaw worker report-ready --name "${AGENTTEAMS_WORKER_CR_NAME:-${WORKER_NAME}}"
     ) &
     log "Background readiness reporter started (PID: $!)"
 fi


### PR DESCRIPTION
## Summary
- make shared runtime bootstrap normalize AGENTTEAMS_* worker, storage, controller, auth, CMS, and Matrix env vars
- keep existing HICLAW_* deployment inputs as compatibility fallbacks while runtime scripts consume AGENTTEAMS_* as the primary contract
- update OpenClaw Worker and CoPaw Worker storage/STS paths plus focused shell and CoPaw tests

## Scope
This PR is intentionally limited to runtime env/storage consumption. It does not switch controller or Helm env injection, and it does not include QwenPaw, TeamHarness, AppService, Sandbox pool follow-ups, or Edge/local worker credential work.

## Validation
- bash shared/tests/test-hiclaw-env.sh
- bash shared/tests/test-oss-credentials.sh
- bash -n shared/lib/hiclaw-env.sh shared/lib/oss-credentials.sh worker/scripts/worker-entrypoint.sh copaw/scripts/copaw-worker-entrypoint.sh shared/tests/test-hiclaw-env.sh shared/tests/test-oss-credentials.sh
- python3 -m py_compile copaw/src/copaw_worker/hooks/tools/taskflow.py
- git diff --cached --check

Note: local CoPaw pytest via uv is still blocked by python-olm==3.2.16 native libolm build on this macOS toolchain (missing cmake/gmake path then clang const assignment failure), so full pytest is left to Linux CI.