### PR TITLE
feat(controller): expose AgentTeams metrics

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,6 +4,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 
 ---
 
+- feat(controller): expose low-cardinality AgentTeams controller metrics and optional Helm ServiceMonitor.
 - fix(agent): update file-sharing path guidance for CoPaw and Team Leader agents to use `/root/hiclaw-fs/agents/...` instead of the retired `/root/.hiclaw-worker/...` path.
 - fix(copaw): harden Matrix channel control-command handling, task-thread routing, NO_REPLY suppression, and cancellation noise handling.
 - feat(controller): add OpenKruise Sandbox backend support for Workers via `spec.backendRuntime=sandbox`, including SandboxClaim lifecycle, status watches, CRD schema, and Helm RBAC/env wiring.

--- a/helm/hiclaw/templates/controller/deployment.yaml
+++ b/helm/hiclaw/templates/controller/deployment.yaml
@@ -30,6 +30,11 @@ spec:
             - name: http
               containerPort: {{ .Values.controller.service.targetPort }}
               protocol: TCP
+            {{- if .Values.controller.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.controller.metrics.targetPort }}
+              protocol: TCP
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "hiclaw.secretName" . }}
@@ -38,6 +43,8 @@ spec:
               value: "incluster"
             - name: HICLAW_HTTP_ADDR
               value: {{ printf ":%v" .Values.controller.service.targetPort | quote }}
+            - name: AGENTTEAMS_METRICS_BIND_ADDR
+              value: {{ ternary .Values.controller.metrics.bindAddress "0" .Values.controller.metrics.enabled | quote }}
             - name: HICLAW_CONTROLLER_URL
               value: {{ include "hiclaw.controller.internalURL" . | quote }}
             {{- /*

--- a/helm/hiclaw/templates/controller/service.yaml
+++ b/helm/hiclaw/templates/controller/service.yaml
@@ -15,3 +15,9 @@ spec:
       port: {{ .Values.controller.service.port }}
       targetPort: http
       protocol: TCP
+    {{- if .Values.controller.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.controller.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+    {{- end }}

--- a/helm/hiclaw/templates/controller/servicemonitor.yaml
+++ b/helm/hiclaw/templates/controller/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.controller.metrics.enabled .Values.controller.metrics.serviceMonitor.enabled }}
+{{- $comp := dict "root" . "component" "controller" }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "hiclaw.controller.fullname" . }}
+  namespace: {{ include "hiclaw.namespace" . }}
+  labels:
+    {{- include "hiclaw.component.labels" $comp | nindent 4 }}
+    {{- with .Values.controller.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "hiclaw.component.selectorLabels" $comp | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.controller.metrics.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.controller.metrics.serviceMonitor.scrapeTimeout | quote }}
+{{- end }}

--- a/helm/hiclaw/values.yaml
+++ b/helm/hiclaw/values.yaml
@@ -183,6 +183,16 @@ controller:
     type: ClusterIP
     port: 8090
     targetPort: 8090
+  metrics:
+    enabled: true
+    bindAddress: ":8080"
+    port: 8080
+    targetPort: 8080
+    serviceMonitor:
+      enabled: false
+      interval: 30s
+      scrapeTimeout: 10s
+      labels: {}
   resources:
     requests:
       cpu: 100m

--- a/hiclaw-controller/internal/app/app.go
+++ b/hiclaw-controller/internal/app/app.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hiclaw/hiclaw-controller/internal/gateway"
 	"github.com/hiclaw/hiclaw-controller/internal/initializer"
 	"github.com/hiclaw/hiclaw-controller/internal/matrix"
+	agentteamsmetrics "github.com/hiclaw/hiclaw-controller/internal/metrics"
 	"github.com/hiclaw/hiclaw-controller/internal/oss"
 	"github.com/hiclaw/hiclaw-controller/internal/remoteclient"
 	"github.com/hiclaw/hiclaw-controller/internal/server"
@@ -649,6 +650,14 @@ func (a *App) initReconcilers(_ context.Context) error {
 		return fmt.Errorf("setup ManagerReconciler: %w", err)
 	}
 
+	if err := a.mgr.Add(&agentteamsmetrics.CRCountCollector{
+		Client:       a.mgr.GetClient(),
+		Namespace:    a.namespace,
+		SkipManagers: !a.cfg.ManagerEnabled,
+	}); err != nil {
+		return fmt.Errorf("setup CR count collector: %w", err)
+	}
+
 	return nil
 }
 
@@ -703,7 +712,7 @@ func (a *App) startEmbedded(ctx context.Context) (*rest.Config, error) {
 	a.mgr, err = ctrl.NewManager(restCfg, ctrl.Options{
 		Scheme: a.scheme,
 		Metrics: metricsserver.Options{
-			BindAddress: "0",
+			BindAddress: a.cfg.MetricsBindAddr,
 		},
 	})
 	if err != nil {
@@ -742,7 +751,10 @@ func (a *App) startInCluster() (*rest.Config, error) {
 	restCfg := ctrl.GetConfigOrDie()
 	leaseID := a.cfg.ControllerName + "-leader"
 	opts := ctrl.Options{
-		Scheme:                        a.scheme,
+		Scheme: a.scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: a.cfg.MetricsBindAddr,
+		},
 		LeaderElection:                true,
 		LeaderElectionID:              leaseID,
 		LeaderElectionReleaseOnCancel: true,

--- a/hiclaw-controller/internal/config/config.go
+++ b/hiclaw-controller/internal/config/config.go
@@ -21,12 +21,13 @@ import (
 
 type Config struct {
 	// Controller core
-	KubeMode  string // "embedded" or "incluster"
-	DataDir   string
-	HTTPAddr  string
-	ConfigDir string
-	CRDDir    string
-	SkillsDir string
+	KubeMode        string // "embedded" or "incluster"
+	DataDir         string
+	HTTPAddr        string
+	MetricsBindAddr string
+	ConfigDir       string
+	CRDDir          string
+	SkillsDir       string
 
 	// ResourcePrefix is the tenant-level prefix used to derive Pod/SA/label/
 	// session names created by this controller. Default "hiclaw-". Set via
@@ -233,6 +234,16 @@ type managerSpecEnv struct {
 }
 
 func LoadConfig() *Config {
+	kubeMode := envOrDefault("HICLAW_KUBE_MODE", "embedded")
+	metricsBindAddr := os.Getenv("AGENTTEAMS_METRICS_BIND_ADDR")
+	if metricsBindAddr == "" {
+		if kubeMode == "embedded" {
+			metricsBindAddr = "0"
+		} else {
+			metricsBindAddr = ":8080"
+		}
+	}
+
 	dataDir := envOrDefault("HICLAW_DATA_DIR", "/data/hiclaw-controller")
 	if !filepath.IsAbs(dataDir) {
 		if wd, err := os.Getwd(); err == nil {
@@ -253,12 +264,13 @@ func LoadConfig() *Config {
 	}
 
 	cfg := &Config{
-		KubeMode:  envOrDefault("HICLAW_KUBE_MODE", "embedded"),
-		DataDir:   dataDir,
-		HTTPAddr:  envOrDefault("HICLAW_HTTP_ADDR", ":8090"),
-		ConfigDir: envOrDefault("HICLAW_CONFIG_DIR", "/root/hiclaw-fs/hiclaw-config"),
-		CRDDir:    envOrDefault("HICLAW_CRD_DIR", "/opt/hiclaw/config/crd"),
-		SkillsDir: envOrDefault("HICLAW_SKILLS_DIR", "/opt/hiclaw/agent/skills"),
+		KubeMode:        kubeMode,
+		DataDir:         dataDir,
+		HTTPAddr:        envOrDefault("HICLAW_HTTP_ADDR", ":8090"),
+		MetricsBindAddr: metricsBindAddr,
+		ConfigDir:       envOrDefault("HICLAW_CONFIG_DIR", "/root/hiclaw-fs/hiclaw-config"),
+		CRDDir:          envOrDefault("HICLAW_CRD_DIR", "/opt/hiclaw/config/crd"),
+		SkillsDir:       envOrDefault("HICLAW_SKILLS_DIR", "/opt/hiclaw/agent/skills"),
 
 		ResourcePrefix:     resourcePrefix,
 		ResourceAutoPrefix: resourceAutoPrefix,

--- a/hiclaw-controller/internal/config/config_test.go
+++ b/hiclaw-controller/internal/config/config_test.go
@@ -29,6 +29,47 @@ func TestNormalizeMinIOS3Endpoint(t *testing.T) {
 	}
 }
 
+func TestLoadConfigMetricsBindAddrDefaultsByMode(t *testing.T) {
+	t.Run("embedded", func(t *testing.T) {
+		t.Setenv("HICLAW_KUBE_MODE", "embedded")
+		t.Setenv("AGENTTEAMS_METRICS_BIND_ADDR", "")
+		cfg := LoadConfig()
+		if cfg.MetricsBindAddr != "0" {
+			t.Fatalf("MetricsBindAddr = %q, want disabled metrics in embedded mode", cfg.MetricsBindAddr)
+		}
+	})
+
+	t.Run("incluster", func(t *testing.T) {
+		t.Setenv("HICLAW_KUBE_MODE", "incluster")
+		t.Setenv("AGENTTEAMS_METRICS_BIND_ADDR", "")
+		cfg := LoadConfig()
+		if cfg.MetricsBindAddr != ":8080" {
+			t.Fatalf("MetricsBindAddr = %q, want :8080 in incluster mode", cfg.MetricsBindAddr)
+		}
+	})
+}
+
+func TestLoadConfigMetricsBindAddrPrefersAgentTeamsEnv(t *testing.T) {
+	t.Setenv("HICLAW_KUBE_MODE", "incluster")
+	t.Setenv("AGENTTEAMS_METRICS_BIND_ADDR", ":19090")
+
+	cfg := LoadConfig()
+	if cfg.MetricsBindAddr != ":19090" {
+		t.Fatalf("MetricsBindAddr = %q, want AGENTTEAMS_METRICS_BIND_ADDR", cfg.MetricsBindAddr)
+	}
+}
+
+func TestLoadConfigMetricsBindAddrIgnoresLegacyFallback(t *testing.T) {
+	t.Setenv("HICLAW_KUBE_MODE", "incluster")
+	t.Setenv("AGENTTEAMS_METRICS_BIND_ADDR", "")
+	t.Setenv("HICLAW_METRICS_BIND_ADDR", ":18080")
+
+	cfg := LoadConfig()
+	if cfg.MetricsBindAddr != ":8080" {
+		t.Fatalf("MetricsBindAddr = %q, want default :8080 without HICLAW fallback", cfg.MetricsBindAddr)
+	}
+}
+
 func TestLoadConfigAppliesManagerSpec(t *testing.T) {
 	t.Setenv("HICLAW_MANAGER_SPEC", `{
 		"model":"qwen-max",

--- a/hiclaw-controller/internal/controller/metrics_endpoint_test.go
+++ b/hiclaw-controller/internal/controller/metrics_endpoint_test.go
@@ -1,0 +1,85 @@
+package controller
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	appmetrics "github.com/hiclaw/hiclaw-controller/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+func TestMetricsEndpointIncludesAgentTeamsAndRuntimeMetrics(t *testing.T) {
+	appmetrics.ReconcileTotal.Reset()
+	appmetrics.ReconcileErrors.Reset()
+	appmetrics.ReconcileDuration.Reset()
+	appmetrics.ControllerCRCount.Reset()
+	appmetrics.ControllerHTTPRequestDuration.Reset()
+	appmetrics.ControllerHTTPRequests.Reset()
+	appmetrics.ControllerHTTPErrors.Reset()
+	appmetrics.UpstreamRequestDuration.Reset()
+	appmetrics.UpstreamRequests.Reset()
+	appmetrics.UpstreamRequestErrors.Reset()
+
+	appmetrics.Observe("worker", time.Now().Add(-25*time.Millisecond), nil)
+	appmetrics.Observe("team", time.Now().Add(-10*time.Millisecond), io.ErrUnexpectedEOF)
+	appmetrics.ControllerCRCount.WithLabelValues("worker", "Running").Set(2)
+	appmetrics.ObserveControllerHTTP(http.MethodGet, "/api/v1/workers/{name}", time.Now().Add(-3*time.Millisecond), http.StatusNotFound)
+	appmetrics.ObserveUpstream("matrix", "create_room", time.Now().Add(-5*time.Millisecond), http.StatusCreated, nil)
+
+	server := httptest.NewServer(promhttp.HandlerFor(crmetrics.Registry, promhttp.HandlerOpts{}))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/metrics")
+	if err != nil {
+		t.Fatalf("scrape metrics endpoint: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	body := string(bodyBytes)
+
+	for _, want := range []string{
+		"agentteams_reconcile_total",
+		"agentteams_reconcile_errors_total",
+		"agentteams_reconcile_duration_seconds_bucket",
+		"agentteams_controller_cr_count",
+		"status=\"Running\"",
+		"agentteams_controller_http_request_duration_seconds_bucket",
+		"agentteams_controller_http_requests_total",
+		"agentteams_controller_http_errors_total",
+		"route=\"/api/v1/workers/{name}\"",
+		"agentteams_upstream_request_duration_seconds_bucket",
+		"agentteams_upstream_requests_total",
+		"upstream=\"matrix\"",
+		"operation=\"create_room\"",
+		"go_goroutines",
+		"go_gc_duration_seconds",
+		"go_memstats_last_gc_time_seconds",
+		"process_resident_memory_bytes",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("metrics output missing %q", want)
+		}
+	}
+
+	for _, forbidden := range []string{
+		"hiclaw_reconcile_total",
+		"agentteams_team_migration_phase_total",
+		"agentteams_team_migration_failures_total",
+		"team=\"",
+	} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("metrics output contains forbidden text %q", forbidden)
+		}
+	}
+}

--- a/hiclaw-controller/internal/metrics/cr_count.go
+++ b/hiclaw-controller/internal/metrics/cr_count.go
@@ -1,0 +1,124 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const defaultCRCountRefreshInterval = 30 * time.Second
+
+// CRCountCollector periodically refreshes low-cardinality CR inventory gauges
+// from the controller cache.
+type CRCountCollector struct {
+	Client       client.Client
+	Namespace    string
+	Interval     time.Duration
+	SkipManagers bool
+}
+
+func (c *CRCountCollector) Start(ctx context.Context) error {
+	if c.Client == nil {
+		return fmt.Errorf("cr count collector requires a client")
+	}
+	interval := c.Interval
+	if interval <= 0 {
+		interval = defaultCRCountRefreshInterval
+	}
+	logger := log.FromContext(ctx).WithName("cr-count-collector")
+	if err := c.refresh(ctx); err != nil {
+		logger.Error(err, "refresh CR counts")
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := c.refresh(ctx); err != nil {
+				logger.Error(err, "refresh CR counts")
+			}
+		}
+	}
+}
+
+func (c *CRCountCollector) refresh(ctx context.Context) error {
+	counts := newCRCountSnapshot()
+	opts := c.listOptions()
+
+	var workers v1beta1.WorkerList
+	if err := c.Client.List(ctx, &workers, opts...); err != nil {
+		return fmt.Errorf("list workers: %w", err)
+	}
+	for i := range workers.Items {
+		counts["worker"][boundedCRStatus("worker", workers.Items[i].Status.Phase)]++
+	}
+
+	var teams v1beta1.TeamList
+	if err := c.Client.List(ctx, &teams, opts...); err != nil {
+		return fmt.Errorf("list teams: %w", err)
+	}
+	for i := range teams.Items {
+		counts["team"][boundedCRStatus("team", teams.Items[i].Status.Phase)]++
+	}
+
+	var humans v1beta1.HumanList
+	if err := c.Client.List(ctx, &humans, opts...); err != nil {
+		return fmt.Errorf("list humans: %w", err)
+	}
+	for i := range humans.Items {
+		counts["human"][boundedCRStatus("human", humans.Items[i].Status.Phase)]++
+	}
+
+	if !c.SkipManagers {
+		var managers v1beta1.ManagerList
+		if err := c.Client.List(ctx, &managers, opts...); err != nil {
+			return fmt.Errorf("list managers: %w", err)
+		}
+		for i := range managers.Items {
+			counts["manager"][boundedCRStatus("manager", managers.Items[i].Status.Phase)]++
+		}
+	}
+
+	for kind, statuses := range counts {
+		for status, count := range statuses {
+			ControllerCRCount.WithLabelValues(kind, status).Set(count)
+		}
+	}
+	return nil
+}
+
+func (c *CRCountCollector) listOptions() []client.ListOption {
+	if c.Namespace == "" {
+		return nil
+	}
+	return []client.ListOption{client.InNamespace(c.Namespace)}
+}
+
+func newCRCountSnapshot() map[string]map[string]float64 {
+	counts := make(map[string]map[string]float64, len(crStatusesByKind))
+	for kind, statuses := range crStatusesByKind {
+		counts[kind] = make(map[string]float64, len(statuses))
+		for _, status := range statuses {
+			counts[kind][status] = 0
+		}
+	}
+	return counts
+}
+
+func boundedCRStatus(kind, status string) string {
+	if status == "" {
+		return "unknown"
+	}
+	for _, allowed := range crStatusesByKind[kind] {
+		if status == allowed {
+			return status
+		}
+	}
+	return "unknown"
+}

--- a/hiclaw-controller/internal/metrics/cr_count_test.go
+++ b/hiclaw-controller/internal/metrics/cr_count_test.go
@@ -1,0 +1,116 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCRCountCollectorRefreshCountsByKindAndStatus(t *testing.T) {
+	ControllerCRCount.Reset()
+	initializeSeries()
+
+	scheme := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			&v1beta1.Worker{
+				ObjectMeta: metav1.ObjectMeta{Name: "w-running", Namespace: "ns1"},
+				Status:     v1beta1.WorkerStatus{Phase: "Running"},
+			},
+			&v1beta1.Worker{
+				ObjectMeta: metav1.ObjectMeta{Name: "w-empty", Namespace: "ns1"},
+			},
+			&v1beta1.Team{
+				ObjectMeta: metav1.ObjectMeta{Name: "t-active", Namespace: "ns1"},
+				Status:     v1beta1.TeamStatus{Phase: "Active"},
+			},
+			&v1beta1.Human{
+				ObjectMeta: metav1.ObjectMeta{Name: "h-custom", Namespace: "ns1"},
+				Status:     v1beta1.HumanStatus{Phase: "Custom"},
+			},
+			&v1beta1.Manager{
+				ObjectMeta: metav1.ObjectMeta{Name: "m-running", Namespace: "ns1"},
+				Status:     v1beta1.ManagerStatus{Phase: "Running"},
+			},
+			&v1beta1.Worker{
+				ObjectMeta: metav1.ObjectMeta{Name: "w-other", Namespace: "ns2"},
+				Status:     v1beta1.WorkerStatus{Phase: "Running"},
+			},
+		).
+		Build()
+
+	collector := &CRCountCollector{Client: cli, Namespace: "ns1"}
+	if err := collector.refresh(context.Background()); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	assertGauge(t, "worker", "Running", 1)
+	assertGauge(t, "worker", "unknown", 1)
+	assertGauge(t, "team", "Active", 1)
+	assertGauge(t, "human", "unknown", 1)
+	assertGauge(t, "manager", "Running", 1)
+}
+
+func TestCRCountCollectorCanSkipManagers(t *testing.T) {
+	ControllerCRCount.Reset()
+	initializeSeries()
+
+	scheme := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			&v1beta1.Worker{
+				ObjectMeta: metav1.ObjectMeta{Name: "w-running", Namespace: "ns1"},
+				Status:     v1beta1.WorkerStatus{Phase: "Running"},
+			},
+			&v1beta1.Manager{
+				ObjectMeta: metav1.ObjectMeta{Name: "m-running", Namespace: "ns1"},
+				Status:     v1beta1.ManagerStatus{Phase: "Running"},
+			},
+		).
+		Build()
+
+	collector := &CRCountCollector{Client: cli, Namespace: "ns1", SkipManagers: true}
+	if err := collector.refresh(context.Background()); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	assertGauge(t, "worker", "Running", 1)
+	assertGauge(t, "manager", "Running", 0)
+}
+
+func TestBoundedCRStatus(t *testing.T) {
+	tests := []struct {
+		kind   string
+		status string
+		want   string
+	}{
+		{kind: "worker", status: "Running", want: "Running"},
+		{kind: "worker", status: "Bogus", want: "unknown"},
+		{kind: "human", status: "", want: "unknown"},
+	}
+	for _, tt := range tests {
+		if got := boundedCRStatus(tt.kind, tt.status); got != tt.want {
+			t.Fatalf("boundedCRStatus(%q, %q) = %q, want %q", tt.kind, tt.status, got, tt.want)
+		}
+	}
+}
+
+func assertGauge(t *testing.T, kind, status string, want float64) {
+	t.Helper()
+	if got := testutil.ToFloat64(ControllerCRCount.WithLabelValues(kind, status)); got != want {
+		t.Fatalf("controller_cr_count{%s,%s} = %v, want %v", kind, status, got, want)
+	}
+}

--- a/hiclaw-controller/internal/metrics/metrics.go
+++ b/hiclaw-controller/internal/metrics/metrics.go
@@ -1,28 +1,153 @@
-// Package metrics defines hiclaw-specific Prometheus metrics and registers
-// them with the controller-runtime metrics registry, which exposes them on
-// the metrics endpoint configured by ctrl.Options.Metrics.BindAddress.
+// Package metrics defines AgentTeams-specific Prometheus metrics and registers
+// them with the controller-runtime metrics registry, which exposes them on the
+// metrics endpoint configured by ctrl.Options.Metrics.BindAddress.
 //
-// controller-runtime already exports generic reconcile metrics (controller_
-// runtime_reconcile_total etc.); these hiclaw_* metrics carry the CRD kind
-// as a label so we can dashboard per-CRD signals without parsing the
-// controller name.
+// controller-runtime already exports generic reconcile metrics. These
+// agentteams_* metrics carry bounded AgentTeams dimensions such as CRD kind and
+// outcome so dashboards do not need to parse controller names.
 package metrics
 
 import (
+	"context"
+	"errors"
+	"net"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-const subsystem = "hiclaw"
+const namespace = "agentteams"
+
+// ErrDecodeResponse lets upstream clients mark response decode failures for
+// error-class metrics without depending on error message text.
+var ErrDecodeResponse = errors.New("decode response")
+
+// ErrInvalidUpstreamResponse marks structurally valid responses that are
+// unusable for the caller, for example a credential-provider response missing
+// required credential fields.
+var ErrInvalidUpstreamResponse = errors.New("invalid upstream response")
+
+var (
+	reconcileKinds   = []string{"worker", "team", "human", "manager"}
+	reconcileResults = []string{"success", "error"}
+	crStatusesByKind = map[string][]string{
+		"human": {
+			"unknown",
+			"Pending",
+			"Active",
+			"Failed",
+		},
+		"manager": {
+			"unknown",
+			"Pending",
+			"Running",
+			"Updating",
+			"Failed",
+		},
+		"team": {
+			"unknown",
+			"Pending",
+			"Active",
+			"Degraded",
+			"Failed",
+		},
+		"worker": {
+			"unknown",
+			"Pending",
+			"Starting",
+			"Running",
+			"Stopping",
+			"Sleeping",
+			"Stopped",
+			"Failed",
+		},
+	}
+	httpRoutesByMethod = map[string][]string{
+		"DELETE": {
+			"/api/v1/gateway/consumers/{id}",
+			"/api/v1/humans/{name}",
+			"/api/v1/managers/{name}",
+			"/api/v1/teams/{name}",
+			"/api/v1/workers/{name}",
+		},
+		"GET": {
+			"/_matrix/app/v1/rooms/{roomAlias}",
+			"/_matrix/app/v1/users/{userId}",
+			"/api/v1/humans",
+			"/api/v1/humans/{name}",
+			"/api/v1/managers",
+			"/api/v1/managers/{name}",
+			"/api/v1/status",
+			"/api/v1/teams",
+			"/api/v1/teams/{name}",
+			"/api/v1/version",
+			"/api/v1/workers",
+			"/api/v1/workers/{name}",
+			"/api/v1/workers/{name}/status",
+			"/docker/",
+			"/healthz",
+			"unmatched",
+		},
+		"POST": {
+			"/api/v1/credentials/sts",
+			"/api/v1/gateway/consumers",
+			"/api/v1/gateway/consumers/{id}/bind",
+			"/api/v1/humans",
+			"/api/v1/managers",
+			"/api/v1/packages",
+			"/api/v1/teams",
+			"/api/v1/workers",
+			"/api/v1/workers/{name}/ensure-ready",
+			"/api/v1/workers/{name}/heartbeat",
+			"/api/v1/workers/{name}/ready",
+			"/api/v1/workers/{name}/sleep",
+			"/api/v1/workers/{name}/wake",
+			"unmatched",
+		},
+		"PUT": {
+			"/_matrix/app/v1/transactions/{txnId}",
+			"/api/v1/managers/{name}",
+			"/api/v1/teams/{name}",
+			"/api/v1/workers/{name}",
+			"unmatched",
+		},
+	}
+	upstreamOpsByTarget = map[string][]string{
+		"matrix": {
+			"create_room",
+			"delete_room_alias",
+			"invite",
+			"join_room",
+			"kick",
+			"leave_room",
+			"list_joined_rooms",
+			"list_room_members",
+			"login",
+			"register_user",
+			"resolve_room_alias",
+			"send_message",
+			"set_display_name",
+			"set_room_name",
+			"set_room_state",
+			"sync_messages",
+			"unknown",
+		},
+		"sts_provider": {
+			"get_kubeconfig",
+			"issue_token",
+		},
+	}
+	upstreamStatusClasses = []string{"none", "2xx", "3xx", "4xx", "5xx"}
+	upstreamErrorClasses  = []string{"canceled", "decode", "http", "invalid_response", "network", "timeout", "unknown"}
+)
 
 var (
 	// ReconcileDuration is a histogram of Reconcile latencies in seconds,
 	// partitioned by CRD kind and outcome ("success" or "error").
 	ReconcileDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: subsystem,
+			Namespace: namespace,
 			Name:      "reconcile_duration_seconds",
 			Help:      "Time spent in a single Reconcile call, partitioned by CRD kind and outcome.",
 			Buckets:   prometheus.ExponentialBuckets(0.01, 2, 12),
@@ -30,39 +155,171 @@ var (
 		[]string{"kind", "result"},
 	)
 
-	// ReconcileTotal counts Reconcile invocations, partitioned by CRD kind
-	// and outcome. The success counter doubles as a liveness signal — if it
-	// stops advancing for a kind that has live CRs, the controller is
-	// either deadlocked or starved.
+	// ReconcileTotal counts Reconcile invocations, partitioned by CRD kind and
+	// outcome. The success counter doubles as a liveness signal: if it stops
+	// advancing for a kind that has live CRs, the controller is either deadlocked
+	// or starved.
 	ReconcileTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: subsystem,
+			Namespace: namespace,
 			Name:      "reconcile_total",
 			Help:      "Number of Reconcile calls, partitioned by CRD kind and outcome.",
 		},
 		[]string{"kind", "result"},
 	)
 
-	// ReconcileErrors counts Reconcile invocations that returned a non-nil
-	// error. Redundant with ReconcileTotal{result="error"} but kept
-	// separate so alerts can be written against a single-label series.
+	// ReconcileErrors counts Reconcile invocations that returned a non-nil error.
+	// It is redundant with ReconcileTotal{result="error"} but kept separate so
+	// alerts can be written against a single-label series.
 	ReconcileErrors = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: subsystem,
+			Namespace: namespace,
 			Name:      "reconcile_errors_total",
 			Help:      "Number of Reconcile calls that returned an error.",
 		},
 		[]string{"kind"},
 	)
+
+	// ControllerCRCount reports the number of CRs currently visible to this
+	// controller's cache, grouped by CR kind and bounded status phase.
+	ControllerCRCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "controller_cr_count",
+			Help:      "Number of CRs currently visible to this controller, partitioned by kind and bounded status phase.",
+		},
+		[]string{"kind", "status"},
+	)
+
+	// ControllerHTTPRequestDuration records inbound controller HTTP API latency
+	// using normalized route patterns, never raw request paths.
+	ControllerHTTPRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "controller_http_request_duration_seconds",
+			Help:      "Time spent serving controller HTTP API requests, partitioned by method, route, and result.",
+			Buckets:   prometheus.ExponentialBuckets(0.005, 2, 13),
+		},
+		[]string{"method", "route", "result"},
+	)
+
+	// ControllerHTTPRequests counts inbound controller HTTP API requests.
+	ControllerHTTPRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "controller_http_requests_total",
+			Help:      "Number of controller HTTP API requests, partitioned by method, route, result, and HTTP status class.",
+		},
+		[]string{"method", "route", "result", "status_class"},
+	)
+
+	// ControllerHTTPErrors counts inbound controller HTTP API requests that
+	// completed with HTTP status >= 400.
+	ControllerHTTPErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "controller_http_errors_total",
+			Help:      "Number of failed controller HTTP API requests, partitioned by method, route, and HTTP status class.",
+		},
+		[]string{"method", "route", "status_class"},
+	)
+
+	// UpstreamRequestDuration records controller outbound call latency with
+	// bounded labels only. The operation label must be a stable enum, not a raw
+	// URL path or resource name.
+	UpstreamRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "upstream_request_duration_seconds",
+			Help:      "Time spent on controller outbound upstream calls, partitioned by upstream, operation, and result.",
+			Buckets:   prometheus.ExponentialBuckets(0.01, 2, 12),
+		},
+		[]string{"upstream", "operation", "result"},
+	)
+
+	// UpstreamRequests counts controller outbound upstream calls and their HTTP
+	// status class. status_class is "none" when no HTTP response was received.
+	UpstreamRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "upstream_requests_total",
+			Help:      "Number of controller outbound upstream calls, partitioned by upstream, operation, result, and HTTP status class.",
+		},
+		[]string{"upstream", "operation", "result", "status_class"},
+	)
+
+	// UpstreamRequestErrors counts outbound upstream calls that failed at the
+	// HTTP status, network, timeout, cancellation, or response decoding layer.
+	UpstreamRequestErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "upstream_request_errors_total",
+			Help:      "Number of failed controller outbound upstream calls, partitioned by upstream, operation, and error class.",
+		},
+		[]string{"upstream", "operation", "error_class"},
+	)
 )
 
 func init() {
-	metrics.Registry.MustRegister(ReconcileDuration, ReconcileTotal, ReconcileErrors)
+	metrics.Registry.MustRegister(
+		ReconcileDuration,
+		ReconcileTotal,
+		ReconcileErrors,
+		ControllerCRCount,
+		ControllerHTTPRequestDuration,
+		ControllerHTTPRequests,
+		ControllerHTTPErrors,
+		UpstreamRequestDuration,
+		UpstreamRequests,
+		UpstreamRequestErrors,
+	)
+	initializeSeries()
 }
 
-// Observe records duration and outcome for a single Reconcile call. Intended
-// to be invoked from a deferred closure so it sees the final value of the
-// named error return.
+func initializeSeries() {
+	for _, kind := range reconcileKinds {
+		ReconcileErrors.WithLabelValues(kind)
+		for _, result := range reconcileResults {
+			ReconcileDuration.WithLabelValues(kind, result)
+			ReconcileTotal.WithLabelValues(kind, result)
+		}
+	}
+	for kind, statuses := range crStatusesByKind {
+		for _, status := range statuses {
+			ControllerCRCount.WithLabelValues(kind, status)
+		}
+	}
+	for method, routes := range httpRoutesByMethod {
+		for _, route := range routes {
+			for _, result := range reconcileResults {
+				ControllerHTTPRequestDuration.WithLabelValues(method, route, result)
+				for _, statusClass := range upstreamStatusClasses {
+					ControllerHTTPRequests.WithLabelValues(method, route, result, statusClass)
+				}
+			}
+			for _, statusClass := range upstreamStatusClasses {
+				ControllerHTTPErrors.WithLabelValues(method, route, statusClass)
+			}
+		}
+	}
+	for upstream, operations := range upstreamOpsByTarget {
+		for _, operation := range operations {
+			for _, result := range reconcileResults {
+				UpstreamRequestDuration.WithLabelValues(upstream, operation, result)
+				for _, statusClass := range upstreamStatusClasses {
+					UpstreamRequests.WithLabelValues(upstream, operation, result, statusClass)
+				}
+			}
+			for _, errorClass := range upstreamErrorClasses {
+				UpstreamRequestErrors.WithLabelValues(upstream, operation, errorClass)
+			}
+		}
+	}
+}
+
+// Observe records duration and outcome for a single Reconcile call. Intended to
+// be invoked from a deferred closure so it sees the final value of the named
+// error return.
 func Observe(kind string, start time.Time, err error) {
 	result := "success"
 	if err != nil {
@@ -71,4 +328,82 @@ func Observe(kind string, start time.Time, err error) {
 	}
 	ReconcileDuration.WithLabelValues(kind, result).Observe(time.Since(start).Seconds())
 	ReconcileTotal.WithLabelValues(kind, result).Inc()
+}
+
+// ObserveControllerHTTP records latency and outcome for an inbound controller
+// HTTP request. The route argument must be a normalized route pattern.
+func ObserveControllerHTTP(method, route string, start time.Time, statusCode int) {
+	if method == "" {
+		method = "UNKNOWN"
+	}
+	if route == "" {
+		route = "unmatched"
+	}
+	result := "success"
+	statusClass := upstreamStatusClass(statusCode)
+	if statusCode >= 400 {
+		result = "error"
+	}
+	ControllerHTTPRequestDuration.WithLabelValues(method, route, result).Observe(time.Since(start).Seconds())
+	ControllerHTTPRequests.WithLabelValues(method, route, result, statusClass).Inc()
+	if result == "error" {
+		ControllerHTTPErrors.WithLabelValues(method, route, statusClass).Inc()
+	}
+}
+
+// ObserveUpstream records latency and outcome for a controller outbound call.
+func ObserveUpstream(upstream, operation string, start time.Time, statusCode int, err error) {
+	result := "success"
+	statusClass := upstreamStatusClass(statusCode)
+	errorClass := ""
+	if err != nil {
+		result = "error"
+		errorClass = classifyUpstreamError(err)
+	} else if statusCode >= 400 {
+		result = "error"
+		errorClass = "http"
+	}
+	UpstreamRequestDuration.WithLabelValues(upstream, operation, result).Observe(time.Since(start).Seconds())
+	UpstreamRequests.WithLabelValues(upstream, operation, result, statusClass).Inc()
+	if errorClass != "" {
+		UpstreamRequestErrors.WithLabelValues(upstream, operation, errorClass).Inc()
+	}
+}
+
+func upstreamStatusClass(statusCode int) string {
+	switch {
+	case statusCode >= 200 && statusCode < 300:
+		return "2xx"
+	case statusCode >= 300 && statusCode < 400:
+		return "3xx"
+	case statusCode >= 400 && statusCode < 500:
+		return "4xx"
+	case statusCode >= 500:
+		return "5xx"
+	default:
+		return "none"
+	}
+}
+
+func classifyUpstreamError(err error) string {
+	if errors.Is(err, context.Canceled) {
+		return "canceled"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		if netErr.Timeout() {
+			return "timeout"
+		}
+		return "network"
+	}
+	if errors.Is(err, ErrDecodeResponse) {
+		return "decode"
+	}
+	if errors.Is(err, ErrInvalidUpstreamResponse) {
+		return "invalid_response"
+	}
+	return "unknown"
 }

--- a/hiclaw-controller/internal/metrics/metrics_test.go
+++ b/hiclaw-controller/internal/metrics/metrics_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -39,6 +40,66 @@ func TestObserve_ErrorIncrementsBothErrorSeries(t *testing.T) {
 	}
 }
 
+func TestObserveUpstream_HTTPErrorIncrementsErrorSeries(t *testing.T) {
+	UpstreamRequestDuration.Reset()
+	UpstreamRequests.Reset()
+	UpstreamRequestErrors.Reset()
+
+	ObserveUpstream("matrix", "create_room", time.Now(), 500, nil)
+
+	if got := testutil.ToFloat64(UpstreamRequests.WithLabelValues("matrix", "create_room", "error", "5xx")); got != 1 {
+		t.Errorf("upstream_requests_total = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(UpstreamRequestErrors.WithLabelValues("matrix", "create_room", "http")); got != 1 {
+		t.Errorf("upstream_request_errors_total = %v, want 1", got)
+	}
+	if got := testutil.CollectAndCount(UpstreamRequestDuration, "agentteams_upstream_request_duration_seconds"); got == 0 {
+		t.Error("UpstreamRequestDuration histogram recorded no samples")
+	}
+}
+
+func TestObserveControllerHTTP_RecordsRouteAndStatusClass(t *testing.T) {
+	ControllerHTTPRequests.Reset()
+	ControllerHTTPErrors.Reset()
+	ControllerHTTPRequestDuration.Reset()
+
+	ObserveControllerHTTP("GET", "/api/v1/workers/{name}", time.Now(), 404)
+
+	if got := testutil.ToFloat64(ControllerHTTPRequests.WithLabelValues("GET", "/api/v1/workers/{name}", "error", "4xx")); got != 1 {
+		t.Errorf("controller_http_requests_total = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(ControllerHTTPErrors.WithLabelValues("GET", "/api/v1/workers/{name}", "4xx")); got != 1 {
+		t.Errorf("controller_http_errors_total = %v, want 1", got)
+	}
+	if got := testutil.CollectAndCount(ControllerHTTPRequestDuration, "agentteams_controller_http_request_duration_seconds"); got == 0 {
+		t.Error("ControllerHTTPRequestDuration histogram recorded no samples")
+	}
+}
+
+func TestObserveUpstream_ClassifiesTimeout(t *testing.T) {
+	UpstreamRequests.Reset()
+	UpstreamRequestErrors.Reset()
+
+	ObserveUpstream("matrix", "login", time.Now(), 0, context.DeadlineExceeded)
+
+	if got := testutil.ToFloat64(UpstreamRequests.WithLabelValues("matrix", "login", "error", "none")); got != 1 {
+		t.Errorf("upstream_requests_total = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(UpstreamRequestErrors.WithLabelValues("matrix", "login", "timeout")); got != 1 {
+		t.Errorf("upstream_request_errors_total = %v, want 1", got)
+	}
+}
+
+func TestObserveUpstream_ClassifiesInvalidResponse(t *testing.T) {
+	UpstreamRequestErrors.Reset()
+
+	ObserveUpstream("sts_provider", "issue_token", time.Now(), 200, ErrInvalidUpstreamResponse)
+
+	if got := testutil.ToFloat64(UpstreamRequestErrors.WithLabelValues("sts_provider", "issue_token", "invalid_response")); got != 1 {
+		t.Errorf("upstream_request_errors_total = %v, want 1", got)
+	}
+}
+
 func TestObserve_RecordsDuration(t *testing.T) {
 	ReconcileDuration.Reset()
 	start := time.Now().Add(-50 * time.Millisecond)
@@ -47,4 +108,72 @@ func TestObserve_RecordsDuration(t *testing.T) {
 	if got := testutil.CollectAndCount(ReconcileDuration); got == 0 {
 		t.Error("ReconcileDuration histogram recorded no samples")
 	}
+}
+
+func TestMetricsUseAgentTeamsNamespace(t *testing.T) {
+	if got := testutil.CollectAndCount(ReconcileTotal, "agentteams_reconcile_total"); got == 0 {
+		t.Fatal("agentteams_reconcile_total was not collected")
+	}
+}
+
+func TestInitializeSeriesPublishesZeroValueMetrics(t *testing.T) {
+	ReconcileTotal.Reset()
+	ReconcileErrors.Reset()
+	ReconcileDuration.Reset()
+	initializeSeries()
+
+	if got, want := testutil.CollectAndCount(ReconcileTotal, "agentteams_reconcile_total"), len(reconcileKinds)*len(reconcileResults); got != want {
+		t.Fatalf("reconcile_total series count = %v, want %v", got, want)
+	}
+	if got, want := testutil.CollectAndCount(ReconcileErrors, "agentteams_reconcile_errors_total"), len(reconcileKinds); got != want {
+		t.Fatalf("reconcile_errors_total series count = %v, want %v", got, want)
+	}
+	if got, want := testutil.CollectAndCount(ReconcileDuration, "agentteams_reconcile_duration_seconds"), len(reconcileKinds)*len(reconcileResults); got != want {
+		t.Fatalf("reconcile_duration_seconds series count = %v, want %v", got, want)
+	}
+	if got, want := testutil.CollectAndCount(ControllerCRCount, "agentteams_controller_cr_count"), crStatusCount(); got != want {
+		t.Fatalf("controller_cr_count series count = %v, want %v", got, want)
+	}
+	if got, want := testutil.CollectAndCount(ControllerHTTPRequestDuration, "agentteams_controller_http_request_duration_seconds"), httpRouteCount()*len(reconcileResults); got != want {
+		t.Fatalf("controller_http_request_duration_seconds series count = %v, want %v", got, want)
+	}
+	if got, want := testutil.CollectAndCount(ControllerHTTPRequests, "agentteams_controller_http_requests_total"), httpRouteCount()*len(reconcileResults)*len(upstreamStatusClasses); got != want {
+		t.Fatalf("controller_http_requests_total series count = %v, want %v", got, want)
+	}
+	if got, want := testutil.CollectAndCount(ControllerHTTPErrors, "agentteams_controller_http_errors_total"), httpRouteCount()*len(upstreamStatusClasses); got != want {
+		t.Fatalf("controller_http_errors_total series count = %v, want %v", got, want)
+	}
+	if got, want := testutil.CollectAndCount(UpstreamRequestDuration, "agentteams_upstream_request_duration_seconds"), upstreamOperationCount()*len(reconcileResults); got != want {
+		t.Fatalf("upstream_request_duration_seconds series count = %v, want %v", got, want)
+	}
+	if got, want := testutil.CollectAndCount(UpstreamRequests, "agentteams_upstream_requests_total"), upstreamOperationCount()*len(reconcileResults)*len(upstreamStatusClasses); got != want {
+		t.Fatalf("upstream_requests_total series count = %v, want %v", got, want)
+	}
+	if got, want := testutil.CollectAndCount(UpstreamRequestErrors, "agentteams_upstream_request_errors_total"), upstreamOperationCount()*len(upstreamErrorClasses); got != want {
+		t.Fatalf("upstream_request_errors_total series count = %v, want %v", got, want)
+	}
+}
+
+func crStatusCount() int {
+	count := 0
+	for _, statuses := range crStatusesByKind {
+		count += len(statuses)
+	}
+	return count
+}
+
+func httpRouteCount() int {
+	count := 0
+	for _, routes := range httpRoutesByMethod {
+		count += len(routes)
+	}
+	return count
+}
+
+func upstreamOperationCount() int {
+	count := 0
+	for _, operations := range upstreamOpsByTarget {
+		count += len(operations)
+	}
+	return count
 }

--- a/hiclaw-controller/internal/server/http.go
+++ b/hiclaw-controller/internal/server/http.go
@@ -27,9 +27,9 @@ type ServerDeps struct {
 	AuthMw         *authpkg.Middleware
 	KubeMode       string
 	Namespace      string
-	ControllerName string // HICLAW_CONTROLLER_NAME; empty in embedded mode
-	SocketPath     string       // Docker proxy (embedded only)
-	MatrixConfig   matrix.Config       // for AppService rotation endpoint
+	ControllerName string               // HICLAW_CONTROLLER_NAME; empty in embedded mode
+	SocketPath     string               // Docker proxy (embedded only)
+	MatrixConfig   matrix.Config        // for AppService rotation endpoint
 	Provisioner    *service.Provisioner // for Matrix token refresh
 }
 
@@ -47,7 +47,7 @@ func NewHTTPServer(addr string, deps ServerDeps) *HTTPServer {
 		Mux:  mux,
 		server: &http.Server{
 			Addr:    addr,
-			Handler: mux,
+			Handler: withControllerHTTPMetrics(mux),
 		},
 	}
 

--- a/hiclaw-controller/internal/server/http_metrics.go
+++ b/hiclaw-controller/internal/server/http_metrics.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hiclaw/hiclaw-controller/internal/metrics"
+)
+
+func withControllerHTTPMetrics(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := &statusRecorder{ResponseWriter: w, statusCode: http.StatusOK}
+		start := time.Now()
+		next.ServeHTTP(rec, r)
+		metrics.ObserveControllerHTTP(r.Method, routePattern(r), start, rec.statusCode)
+	})
+}
+
+func routePattern(r *http.Request) string {
+	pattern := r.Pattern
+	if pattern == "" {
+		return "unmatched"
+	}
+	prefix := r.Method + " "
+	if strings.HasPrefix(pattern, prefix) {
+		return strings.TrimPrefix(pattern, prefix)
+	}
+	return pattern
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (r *statusRecorder) WriteHeader(statusCode int) {
+	r.statusCode = statusCode
+	r.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (r *statusRecorder) Unwrap() http.ResponseWriter {
+	return r.ResponseWriter
+}

--- a/hiclaw-controller/internal/server/http_metrics_test.go
+++ b/hiclaw-controller/internal/server/http_metrics_test.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	appmetrics "github.com/hiclaw/hiclaw-controller/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestControllerHTTPMetricsUseMuxRoutePattern(t *testing.T) {
+	appmetrics.ControllerHTTPRequests.Reset()
+	appmetrics.ControllerHTTPErrors.Reset()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/workers/{name}", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "missing", http.StatusNotFound)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workers/alpha-dev", nil)
+	rec := httptest.NewRecorder()
+	withControllerHTTPMetrics(mux).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	if got := testutil.ToFloat64(appmetrics.ControllerHTTPRequests.WithLabelValues("GET", "/api/v1/workers/{name}", "error", "4xx")); got != 1 {
+		t.Fatalf("controller_http_requests_total = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(appmetrics.ControllerHTTPErrors.WithLabelValues("GET", "/api/v1/workers/{name}", "4xx")); got != 1 {
+		t.Fatalf("controller_http_errors_total = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(appmetrics.ControllerHTTPRequests.WithLabelValues("GET", "/api/v1/workers/alpha-dev", "error", "4xx")); got != 0 {
+		t.Fatalf("raw path label must not be used, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- expose controller-runtime metrics with low-cardinality `agentteams_*` controller metrics
- add CR count collection and HTTP API route/status metrics
- add Helm metrics port plus optional ServiceMonitor, configured by `AGENTTEAMS_METRICS_BIND_ADDR`

## Scope
- Controller metrics and Helm observability wiring only.
- Does not include AppService identity changes, Sandbox runtime changes, QwenPaw runtime, TeamHarness plugin runtime, or broad controller/Helm environment rename.

## Validation
- `go test ./internal/metrics ./internal/server ./internal/config ./internal/controller ./internal/app` from `hiclaw-controller`
- `git diff --cached --check`

Local `helm lint` was not run because `helm` is not installed in this environment.