### PR TITLE
fix(controller): surface pod container failures

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,6 +4,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 
 ---
 
+- fix(controller): surface Kubernetes Pod container failures in Worker backend status and status API responses.
 - feat(controller): expose low-cardinality AgentTeams controller metrics and optional Helm ServiceMonitor.
 - feat(controller): add Matrix AppService Human SSO identity provisioning with hash-derived Matrix IDs, AppService login, deletion deactivation, and Team admin/member identity resolution from Human status.
 - fix(agent): update file-sharing path guidance for CoPaw and Team Leader agents to use `/root/hiclaw-fs/agents/...` instead of the retired `/root/.hiclaw-worker/...` path.

--- a/hiclaw-controller/internal/backend/kubernetes.go
+++ b/hiclaw-controller/internal/backend/kubernetes.go
@@ -559,13 +559,76 @@ func (k *K8sBackend) Status(ctx context.Context, name string) (*WorkerResult, er
 	if err != nil {
 		return nil, fmt.Errorf("kubernetes get pod %s: %w", k.workerPodName(name), err)
 	}
+	status := normalizeK8sPodPhase(pod.Status.Phase)
+	rawStatus := rawK8sPhase(pod.Status.Phase)
+	var message string
+	if containerStatus, containerMessage, containerRaw, ok := podContainerFailureStatus(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses); ok {
+		status = containerStatus
+		message = containerMessage
+		rawStatus = containerRaw
+	}
 	return &WorkerResult{
 		Name:           name,
 		Backend:        "k8s",
 		DeploymentMode: DeployCloud,
-		Status:         normalizeK8sPodPhase(pod.Status.Phase),
-		RawStatus:      rawK8sPhase(pod.Status.Phase),
+		Status:         status,
+		Message:        message,
+		RawStatus:      rawStatus,
 	}, nil
+}
+
+func podContainerFailureStatus(statusGroups ...[]corev1.ContainerStatus) (WorkerStatus, string, string, bool) {
+	for _, statuses := range statusGroups {
+		for i := range statuses {
+			cs := statuses[i]
+			if waiting := cs.State.Waiting; waiting != nil {
+				reason := strings.TrimSpace(waiting.Reason)
+				if isK8sContainerFailureReason(reason) {
+					return StatusFailed, formatK8sContainerStateMessage(cs.Name, reason, waiting.Message), reason, true
+				}
+			}
+			if terminated := cs.State.Terminated; terminated != nil && terminated.ExitCode != 0 {
+				reason := strings.TrimSpace(terminated.Reason)
+				if reason == "" {
+					reason = fmt.Sprintf("ExitCode%d", terminated.ExitCode)
+				}
+				return StatusFailed, formatK8sContainerStateMessage(cs.Name, reason, terminated.Message), reason, true
+			}
+		}
+	}
+	return "", "", "", false
+}
+
+func isK8sContainerFailureReason(reason string) bool {
+	switch reason {
+	case "CrashLoopBackOff",
+		"CreateContainerConfigError",
+		"CreateContainerError",
+		"ErrImageNeverPull",
+		"ErrImagePull",
+		"ImageInspectError",
+		"ImagePullBackOff",
+		"InvalidImageName",
+		"RegistryUnavailable",
+		"RunContainerError":
+		return true
+	default:
+		return false
+	}
+}
+
+func formatK8sContainerStateMessage(containerName, reason, message string) string {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "container failed"
+	}
+	if containerName != "" {
+		reason = fmt.Sprintf("container %s: %s", containerName, reason)
+	}
+	if msg := strings.TrimSpace(message); msg != "" {
+		return reason + ": " + msg
+	}
+	return reason
 }
 
 func (k *K8sBackend) podName(prefix, name string) string {

--- a/hiclaw-controller/internal/backend/kubernetes_test.go
+++ b/hiclaw-controller/internal/backend/kubernetes_test.go
@@ -317,6 +317,96 @@ func TestK8sStatus(t *testing.T) {
 	}
 }
 
+func TestK8sStatus_ContainerFailureReasons(t *testing.T) {
+	cases := []struct {
+		name        string
+		podStatus   corev1.PodStatus
+		wantStatus  WorkerStatus
+		wantRaw     string
+		wantMessage string
+	}{
+		{
+			name: "pending image pull backoff fails worker",
+			podStatus: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: "worker",
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason:  "ImagePullBackOff",
+							Message: `failed to pull image "registry.example.com/worker:missing": not found`,
+						},
+					},
+				}},
+			},
+			wantStatus:  StatusFailed,
+			wantRaw:     "ImagePullBackOff",
+			wantMessage: `container worker: ImagePullBackOff: failed to pull image "registry.example.com/worker:missing": not found`,
+		},
+		{
+			name: "init container config error fails worker",
+			podStatus: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				InitContainerStatuses: []corev1.ContainerStatus{{
+					Name: "init",
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason:  "CreateContainerConfigError",
+							Message: "secret missing",
+						},
+					},
+				}},
+			},
+			wantStatus:  StatusFailed,
+			wantRaw:     "CreateContainerConfigError",
+			wantMessage: "container init: CreateContainerConfigError: secret missing",
+		},
+		{
+			name: "ordinary pending container creation still starts",
+			podStatus: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: "worker",
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: "ContainerCreating",
+						},
+					},
+				}},
+			},
+			wantStatus:  StatusStarting,
+			wantRaw:     "Pending",
+			wantMessage: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newFakeK8sCoreClient(&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "agentteams-worker-test",
+					Namespace: "agentteams",
+				},
+				Status: tc.podStatus,
+			})
+			b := NewK8sBackendWithClient(client, K8sConfig{Namespace: "agentteams"}, "agentteams-worker-", nil)
+
+			result, err := b.Status(context.Background(), "test")
+			if err != nil {
+				t.Fatalf("Status failed: %v", err)
+			}
+			if result.Status != tc.wantStatus {
+				t.Fatalf("Status = %s, want %s", result.Status, tc.wantStatus)
+			}
+			if result.RawStatus != tc.wantRaw {
+				t.Fatalf("RawStatus = %q, want %q", result.RawStatus, tc.wantRaw)
+			}
+			if result.Message != tc.wantMessage {
+				t.Fatalf("Message = %q, want %q", result.Message, tc.wantMessage)
+			}
+		})
+	}
+}
+
 func TestK8sStopAndDelete(t *testing.T) {
 	b := newTestK8sBackend(&corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/hiclaw-controller/internal/controller/pod_predicate_test.go
+++ b/hiclaw-controller/internal/controller/pod_predicate_test.go
@@ -132,3 +132,81 @@ func TestPodLifecyclePredicates_UpdateRequiresPhaseChange(t *testing.T) {
 		})
 	}
 }
+
+func TestPodLifecyclePredicates_UpdateRequiresStatusSignalChange(t *testing.T) {
+	const (
+		kindKey = "agentteams.io/worker"
+		ctlName = "ctl-a"
+	)
+
+	mine := map[string]string{kindKey: "alice", v1beta1.LabelController: ctlName}
+	other := map[string]string{kindKey: "alice", v1beta1.LabelController: "ctl-b"}
+
+	mk := func(labels map[string]string, phase corev1.PodPhase, ready corev1.ConditionStatus, waitingReason, waitingMessage string) *corev1.Pod {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels},
+			Status: corev1.PodStatus{
+				Phase: phase,
+				Conditions: []corev1.PodCondition{{
+					Type:   corev1.PodReady,
+					Status: ready,
+				}},
+			},
+		}
+		if waitingReason != "" || waitingMessage != "" {
+			pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+				Name: "worker",
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  waitingReason,
+						Message: waitingMessage,
+					},
+				},
+			}}
+		}
+		return pod
+	}
+
+	pred := podLifecyclePredicates(kindKey, ctlName)
+
+	tests := []struct {
+		name string
+		old  *corev1.Pod
+		new  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "mine, phase unchanged, waiting reason changed -> accept",
+			old:  mk(mine, corev1.PodPending, corev1.ConditionFalse, "ContainerCreating", ""),
+			new:  mk(mine, corev1.PodPending, corev1.ConditionFalse, "ImagePullBackOff", "image not found"),
+			want: true,
+		},
+		{
+			name: "mine, phase unchanged, Ready changed -> accept",
+			old:  mk(mine, corev1.PodRunning, corev1.ConditionTrue, "", ""),
+			new:  mk(mine, corev1.PodRunning, corev1.ConditionFalse, "", ""),
+			want: true,
+		},
+		{
+			name: "mine, status signal unchanged -> reject",
+			old:  mk(mine, corev1.PodPending, corev1.ConditionFalse, "ImagePullBackOff", "image not found"),
+			new:  mk(mine, corev1.PodPending, corev1.ConditionFalse, "ImagePullBackOff", "image not found"),
+			want: false,
+		},
+		{
+			name: "other controller, status signal changed -> reject",
+			old:  mk(other, corev1.PodPending, corev1.ConditionFalse, "ContainerCreating", ""),
+			new:  mk(other, corev1.PodPending, corev1.ConditionFalse, "ImagePullBackOff", "image not found"),
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pred.Update(event.UpdateEvent{ObjectOld: tc.old, ObjectNew: tc.new})
+			if got != tc.want {
+				t.Errorf("Update: got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/hiclaw-controller/internal/controller/worker_controller.go
+++ b/hiclaw-controller/internal/controller/worker_controller.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	v1beta1 "github.com/hiclaw/hiclaw-controller/api/v1beta1"
@@ -548,7 +550,7 @@ func workerPodRequests(obj client.Object, localNamespace string) []reconcile.Req
 }
 
 // podLifecyclePredicates filters Pod events to only trigger reconciliation on
-// create, delete, or phase transitions. A pod is considered "ours" only when
+// create, delete, or relevant status transitions. A pod is considered "ours" only when
 // it carries both:
 //
 //   - labelKey (one of "agentteams.io/worker" / "agentteams.io/team" /
@@ -583,12 +585,60 @@ func podLifecyclePredicates(labelKey, controllerName string) predicate.Predicate
 			if !ok1 || !ok2 {
 				return true
 			}
-			return oldPod.Status.Phase != newPod.Status.Phase
+			return podLifecycleSignal(oldPod) != podLifecycleSignal(newPod)
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
 			return false
 		},
 	}
+}
+
+func podLifecycleSignal(pod *corev1.Pod) string {
+	if pod == nil {
+		return ""
+	}
+	return strings.Join([]string{
+		string(pod.Status.Phase),
+		podReadyConditionSignal(pod.Status.Conditions),
+		podContainerStatusesSignal(pod.Status.InitContainerStatuses),
+		podContainerStatusesSignal(pod.Status.ContainerStatuses),
+	}, "\n")
+}
+
+func podReadyConditionSignal(conditions []corev1.PodCondition) string {
+	for i := range conditions {
+		cond := conditions[i]
+		if cond.Type == corev1.PodReady {
+			return fmt.Sprintf("%s|%s|%s", cond.Status, cond.Reason, cond.Message)
+		}
+	}
+	return ""
+}
+
+func podContainerStatusesSignal(statuses []corev1.ContainerStatus) string {
+	if len(statuses) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(statuses))
+	for i := range statuses {
+		cs := statuses[i]
+		state, reason, message := "unknown", "", ""
+		switch {
+		case cs.State.Waiting != nil:
+			state = "waiting"
+			reason = cs.State.Waiting.Reason
+			message = cs.State.Waiting.Message
+		case cs.State.Running != nil:
+			state = "running"
+		case cs.State.Terminated != nil:
+			state = "terminated"
+			reason = cs.State.Terminated.Reason
+			message = cs.State.Terminated.Message
+		}
+		parts = append(parts, fmt.Sprintf("%s|%s|%s|%s|%t", cs.Name, state, reason, message, cs.Ready))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "\n")
 }
 
 // --- Package-level helpers ---

--- a/hiclaw-controller/internal/server/lifecycle_handler.go
+++ b/hiclaw-controller/internal/server/lifecycle_handler.go
@@ -194,6 +194,9 @@ func (h *LifecycleHandler) GetWorkerRuntimeStatus(w http.ResponseWriter, r *http
 		result, err := b.Status(r.Context(), name)
 		if err == nil && result != nil {
 			resp.Message = "backend=" + result.Backend + " status=" + string(result.Status)
+			if result.Message != "" {
+				resp.Message += " message=" + result.Message
+			}
 			resp.ContainerState = string(result.Status)
 			if result.Status == backend.StatusRunning && h.isReady(name) {
 				resp.Phase = "Ready"


### PR DESCRIPTION
## Summary
- mark Kubernetes backend status as failed when worker/init containers report image pull, config, crash-loop, or non-zero termination failures
- include backend failure messages in worker runtime status API responses
- reconcile matching worker Pods when Ready or container waiting status changes without a Pod phase transition

## Scope
This is a focused controller hardening slice from the confirmed Sandbox follow-up plan. It does not include QwenPaw, TeamHarness, Edge/local remote worker, or credential/JWT changes.

## Validation
- go test ./internal/backend ./internal/controller ./internal/server
- git diff --check
- added-line naming scan for final AgentTeams naming