### PR TITLE
feat(qwenpaw): add runtime package baseline

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,6 +4,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 
 ---
 
+- feat(qwenpaw): add the QwenPaw worker runtime Python package baseline with runtime config sync, storage sync, heartbeat reporting, Matrix channel overlay, and focused unit tests.
 - feat(controller): expose low-cardinality AgentTeams controller metrics and optional Helm ServiceMonitor.
 - feat(controller): add Matrix AppService Human SSO identity provisioning with hash-derived Matrix IDs, AppService login, deletion deactivation, and Team admin/member identity resolution from Human status.
 - fix(agent): update file-sharing path guidance for CoPaw and Team Leader agents to use `/root/hiclaw-fs/agents/...` instead of the retired `/root/.hiclaw-worker/...` path.

--- a/qwenpaw/README.md
+++ b/qwenpaw/README.md
@@ -1,0 +1,24 @@
+# AgentTeams QwenPaw Worker Runtime
+
+This package contains the QwenPaw worker runtime baseline for AgentTeams.
+
+The package owns the local runtime lifecycle:
+
+- prepare the QwenPaw working directory and default workspace
+- restore and persist eligible worker files through object storage
+- apply `runtime.yaml` model, MCP, Matrix, DingTalk, and AgentSpec package changes
+- maintain local QwenPaw health state and controller readiness/heartbeat reports
+- overlay QwenPaw Matrix behavior for AgentTeams startup readiness, first-sync stability, invite auto-join, and mention compatibility
+
+The package intentionally does not wire the runtime into controller/Helm
+selection, build the worker image, package TeamHarness/WorkerFlow adapter
+artifacts, or implement remote-worker credential/JWT flows. Those integration
+surfaces are separate PR scopes.
+
+## Development
+
+Run the focused unit suite with:
+
+```bash
+PYTHONPATH=qwenpaw/src python -m pytest qwenpaw/tests -q
+```

--- a/qwenpaw/pyproject.toml
+++ b/qwenpaw/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "qwenpaw-worker"
+version = "0.1.0"
+description = "AgentTeams Worker runtime based on QwenPaw"
+readme = "README.md"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.10"
+dependencies = [
+    "qwenpaw==1.1.11",
+    "markdown-it-py>=3.0",
+    "linkify-it-py>=2.0",
+    "pyyaml>=6.0",
+    "typer>=0.9",
+]
+
+[project.urls]
+Homepage = "https://github.com/agentscope-ai/AgentTeams"
+Repository = "https://github.com/agentscope-ai/AgentTeams"
+
+[project.scripts]
+qwenpaw-worker = "qwenpaw_worker.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/qwenpaw/src/matrix/channel.py
+++ b/qwenpaw/src/matrix/channel.py
@@ -1,0 +1,4597 @@
+# -*- coding: utf-8 -*-
+"""
+AgentTeams overlay for QwenPaw MatrixChannel.
+
+The base implementation comes from QwenPaw. AgentTeams keeps a small overlay for
+runtime behavior that is not a TeamHarness concern: startup readiness, first
+sync stability, and Matrix mention compatibility.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import importlib
+import inspect
+import io
+import json
+import logging
+import mimetypes
+import os
+import random
+import re
+import time
+import urllib.parse
+from uuid import uuid4
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+import httpx
+
+from nio import (
+    AsyncClient,
+    AsyncClientConfig,
+    KeysUploadResponse,
+    LoginResponse,
+    KeyVerificationCancel,
+    KeyVerificationEvent,
+    KeyVerificationKey,
+    KeyVerificationMac,
+    KeyVerificationStart,
+    LocalProtocolError,
+    MatrixRoom,
+    MegolmEvent,
+    RoomEncryptedAudio,
+    RoomEncryptedFile,
+    RoomEncryptedImage,
+    RoomEncryptedVideo,
+    RoomMessageAudio,
+    RoomMessageFile,
+    RoomMessageImage,
+    RoomMessageText,
+    RoomMessageVideo,
+    SyncResponse,
+    ToDeviceEvent,
+    ToDeviceError,
+    UploadResponse,
+)
+from nio.event_builders.direct_messages import ToDeviceMessage
+from nio.events.to_device import RoomKeyRequest, RoomKeyRequestCancellation
+from nio.responses import (
+    JoinedMembersResponse,
+    RoomGetStateEventResponse,
+    RoomSendError,
+    SyncError,
+    WhoamiResponse,
+)
+
+from agentscope_runtime.engine.schemas.agent_schemas import (
+    AudioContent,
+    ContentType,
+    FileContent,
+    ImageContent,
+    MessageType,
+    RunStatus,
+    TextContent,
+    VideoContent,
+)
+
+from ....app.channels.base import BaseChannel
+from ....app.channels.utils import file_url_to_local_path
+from ....constant import WORKING_DIR
+
+logger = logging.getLogger("qwenpaw.channels.matrix")
+
+
+CHANNEL_KEY = "matrix"
+
+# Tunables: sync / typing / DM membership cache TTL
+SYNC_TIMEOUT_MS = 30000
+TYPING_SERVER_TIMEOUT_MS = 30000
+TYPING_RENEWAL_INTERVAL_S = 25
+TYPING_MAX_DURATION_S = 120
+DM_CACHE_TTL_MS = 30_000
+TASK_ROOM_CACHE_TTL_MS = 30_000
+MATRIX_EVENT_PROTOCOL_LIMIT_BYTES = 64 * 1024
+MATRIX_TEXT_EVENT_SAFE_BYTES = (MATRIX_EVENT_PROTOCOL_LIMIT_BYTES * 3) // 4
+MATRIX_TEXT_EVENT_FALLBACK_BUDGET_BYTES = MATRIX_TEXT_EVENT_SAFE_BYTES - 1024
+MATRIX_LONG_MESSAGE_METADATA_KEY = "com.agentteams.long_message"
+TEAMHARNESS_TRIGGER_CONTENT_KEY = "m.teamharness.trigger"
+TEAMHARNESS_SELF_TRIGGER_TYPES = frozenset({"PROJECT_REQUESTED"})
+TEAMHARNESS_TOOL_DISPLAY_RE = re.compile(
+    r"^\s*(?:[^\n:]{1,80}:\s*)?🔧\s+(?:\*\*)?[A-Za-z0-9_.-]+(?:\*\*)?",
+)
+MATRIX_LONG_MESSAGE_MIMETYPE = "text/markdown; charset=utf-8"
+MATRIX_ATTACHMENT_REL_TYPE = "com.agentteams.attachment"
+MATRIX_ATTACHMENT_CONTEXT_FILE = "teamharness-matrix-context.json"
+ATTACHMENT_PARENT_EVENT_KEYS = (
+    "parentEventId",
+    "parent_event_id",
+    "attachmentParentEventId",
+    "attachment_parent_event_id",
+    "matrixAttachmentParentEventId",
+    "matrix_attachment_parent_event_id",
+)
+
+# Known QwenPaw slash commands — used to decide whether to strip
+# @mention prefix
+_SLASH_COMMANDS = frozenset(
+    {
+        "message",
+        "history",
+        "compact_str",
+        "compact",
+        "new",
+        "stop",
+        "clear",
+        "reset",
+    },
+)
+
+# Aliases: map alternative command names to their canonical form.
+_SLASH_ALIASES: dict[str, str] = {
+    "reset": "clear",
+}
+
+# --- Thread / readiness / control constants (ported from CoPaw overlay) ---
+
+_STOP_RESPONSE_RE = re.compile(
+    r"Session\s+`matrix:[^`]+`:\s+(?P<status>[^.]+)\.",
+    re.IGNORECASE,
+)
+_READINESS_REPLY_RE = re.compile(
+    r"\breadiness\s+check\b.*\breply\s+with\s+the\s+exact\s+text\s+READY\b",
+    re.IGNORECASE | re.DOTALL,
+)
+
+_THREAD_META_ROOT_KEY = "thread_root_event_id"
+_MATRIX_THREAD_META_KEY = "matrix_thread_root_event_id"
+_MATRIX_OWN_THREAD_ROOT_KEY = "matrix_own_thread_root_event_id"
+_MATRIX_PENDING_THREAD_PARTS_KEY = "matrix_pending_thread_parts"
+_MATRIX_PENDING_FINAL_MESSAGE_KEY = "matrix_pending_final_message"
+_MATRIX_STREAMING_FINAL_TEXT_KEY = "matrix_streaming_final_text"
+_MATRIX_FORCE_NOTICE_KEY = "matrix_force_notice"
+_MATRIX_PLACEHOLDER_THREAD_ROOT_KEY = "matrix_placeholder_thread_root"
+
+_TOOL_CALL_MESSAGE_TYPE_NAMES = frozenset(
+    {"FUNCTION_CALL", "PLUGIN_CALL", "MCP_TOOL_CALL"},
+)
+_TOOL_OUTPUT_MESSAGE_TYPE_NAMES = frozenset(
+    {"FUNCTION_CALL_OUTPUT", "PLUGIN_CALL_OUTPUT", "MCP_TOOL_CALL_OUTPUT"},
+)
+_MATRIX_STREAMING_REASONING_EVENT_ID_KEY = "matrix_streaming_reasoning_event_id"
+_MATRIX_STREAMING_REASONING_LAST_EDIT_KEY = "matrix_streaming_reasoning_last_edit_at"
+_MATRIX_STREAMING_REASONING_STREAM_ID_KEY = "matrix_streaming_reasoning_stream_id"
+
+
+def _clean_control_response_text(text: str) -> str:
+    """Hide channel-internal session ids from user-facing control replies."""
+    if not text:
+        return text
+    match = _STOP_RESPONSE_RE.search(text)
+    if not match:
+        return text
+    status = match.group("status").strip()
+    status = status[:1].upper() + status[1:] if status else "Task stopped"
+    return _STOP_RESPONSE_RE.sub(status + ".", text)
+
+
+def _ends_with_no_reply_control(text: str) -> bool:
+    """Return true when the final non-empty output line is NO_REPLY."""
+    return bool(text) and text.rstrip().splitlines()[-1].strip() == "NO_REPLY"
+
+
+def _is_teamharness_tool_display(text: str) -> bool:
+    return bool(text and TEAMHARNESS_TOOL_DISPLAY_RE.match(text))
+
+
+def _readiness_probe_reply(text: str) -> str | None:
+    """Return the direct reply for the Matrix runtime readiness probe."""
+    return "READY" if _READINESS_REPLY_RE.search(text or "") else None
+
+
+def _enum_name(value: Any) -> str:
+    """Return a stable enum-like name for runtime schemas."""
+    name = getattr(value, "name", None)
+    if name:
+        return str(name).upper()
+    return str(value).rsplit(".", 1)[-1].upper() if value is not None else ""
+
+
+def _dedupe_nonempty(values: List[str]) -> List[str]:
+    result = []
+    seen = set()
+    for value in values:
+        text = str(value).strip()
+        if text and text not in seen:
+            result.append(text)
+            seen.add(text)
+    return result
+
+
+def _md_to_html(text: str) -> str:
+    """Convert Markdown text to HTML for Matrix ``formatted_body``.
+
+    Uses ``markdown-it-py`` (the Python port of markdown-it) with the same
+    configuration as OpenClaw's Matrix extension so rendering is consistent
+    across both runtimes:
+
+    - html disabled (raw HTML is escaped)
+    - linkify enabled (bare URLs become clickable links)
+    - breaks enabled (single newlines become ``<br>``)
+    - strikethrough enabled (``~~text~~``)
+
+    Falls back to simple HTML-escape + ``<br>`` if the library is missing.
+    """
+    try:
+        from markdown_it import MarkdownIt
+
+        md = MarkdownIt(
+            "commonmark",
+            {
+                "html": False,
+                "linkify": True,
+                "breaks": True,
+                "typographer": False,
+            },
+        )
+        md.enable("strikethrough")
+        md.enable("table")
+
+        # linkify support requires linkify-it-py
+        try:
+            from linkify_it import LinkifyIt
+
+            md.linkify = LinkifyIt()
+        except ImportError:
+            logger.debug(
+                "linkify-it-py not installed; bare URLs may not be linkified",
+            )
+
+        return md.render(text).rstrip("\n")
+    except ImportError:
+        logger.warning(
+            "markdown-it-py not installed; formatted_body will be plain text",
+        )
+        return html.escape(text).replace("\n", "<br>\n")
+
+
+def _edit_fallback_html(text: str) -> str:
+    escaped = html.escape(text).replace("\n", "<br>\n")
+    return f"<p>* {escaped}</p>"
+
+
+def _matrix_event_payload_size(content: Dict[str, Any]) -> int:
+    return len(
+        json.dumps(
+            content,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8"),
+    )
+
+
+def _long_message_metadata(
+    path: Path,
+    media_uri: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    if not media_uri:
+        return None
+    return {
+        "version": 1,
+        "url": media_uri,
+        "filename": path.name,
+        "mimetype": MATRIX_LONG_MESSAGE_MIMETYPE,
+    }
+
+
+def _attach_long_message_metadata(
+    content: Dict[str, Any],
+    metadata: Optional[Dict[str, Any]],
+) -> None:
+    if metadata:
+        content[MATRIX_LONG_MESSAGE_METADATA_KEY] = dict(metadata)
+
+
+# Markers that separate accumulated history from the triggering message,
+# matching the convention used by OpenClaw so agents can parse uniformly.
+HISTORY_CONTEXT_MARKER = "[Chat messages since your last reply - for context]"
+CURRENT_MESSAGE_MARKER = "[Current message - respond to this]"
+DEFAULT_HISTORY_LIMIT = 50
+
+
+class QwenPawMatrixClient(AsyncClient):
+    """Keep query-token auth for homeservers/proxies that drop auth headers."""
+
+    async def send(
+        self,
+        method: str,
+        path: str,
+        data: Any = None,
+        headers: Optional[Dict[str, str]] = None,
+        trace_context: Optional[Any] = None,
+        timeout: Optional[float] = None,
+    ) -> Any:
+        if self.access_token and "access_token=" not in path:
+            url = urllib.parse.urlparse(path)
+            query = urllib.parse.parse_qs(url.query)
+            query["access_token"] = [self.access_token]
+            path = urllib.parse.urlunparse(
+                url._replace(
+                    query=urllib.parse.urlencode(query, doseq=True),
+                ),
+            )
+        return await super().send(
+            method,
+            path,
+            data,
+            headers,
+            trace_context,
+            timeout,
+        )
+
+
+@dataclass
+class HistoryEntry:
+    """A buffered room message that didn't mention the bot."""
+
+    sender: str
+    body: str
+    timestamp: Optional[int] = None
+    message_id: Optional[str] = None
+    # Optional structured media parts (e.g. downloaded images for vision
+    # models) to be included alongside the text history when the mention
+    # arrives.
+    media_parts: Optional[List[Any]] = None
+
+
+class MatrixChannel(BaseChannel):
+    """QwenPaw channel that connects to a Matrix homeserver via matrix-nio."""
+
+    channel = CHANNEL_KEY  # type: ignore[assignment]
+    uses_manager_queue: bool = True
+
+    def __init__(
+        self,
+        process: Callable,
+        homeserver: str = "",
+        matrix_user_id: str = "",
+        access_token: str = "",
+        password: str = "",
+        device_name: str = "qwenpaw-worker",
+        device_id: str = "",
+        encryption: bool = False,
+        dm_disabled: bool = False,
+        group_disabled: bool = False,
+        groups: Optional[Dict[str, Any]] = None,
+        vision_enabled: bool = False,
+        history_limit: int = DEFAULT_HISTORY_LIMIT,
+        sync_timeout_ms: int = 30000,
+        on_reply_sent: Optional[Callable] = None,
+        show_tool_details: bool = True,
+        filter_tool_messages: bool = False,
+        filter_thinking: bool = False,
+        streaming_enabled: bool = True,
+        workspace_dir: Path | None = None,
+        access_control_dm: bool = False,
+        access_control_group: bool = False,
+        enabled: bool = True,
+        **_kwargs: Any,
+    ) -> None:
+        super().__init__(
+            process=process,
+            on_reply_sent=on_reply_sent,
+            show_tool_details=show_tool_details,
+            filter_tool_messages=filter_tool_messages,
+            filter_thinking=filter_thinking,
+            streaming_enabled=streaming_enabled,
+            access_control_dm=access_control_dm,
+            access_control_group=access_control_group,
+        )
+        # Matrix connection
+        self.homeserver: str = homeserver.rstrip("/")
+        self.matrix_user_id: str = matrix_user_id
+        self.access_token: str = access_token
+        self.password: str = password
+        self.device_name: str = device_name
+        self.device_id: str = device_id
+        self.encryption: bool = encryption
+        self.enabled: bool = enabled
+        # Channel-level mute
+        self.dm_disabled: bool = dm_disabled
+        self.group_disabled: bool = group_disabled
+        # Per-room overrides
+        self.groups: Dict[str, Any] = groups or {}
+        # Media / history
+        self.vision_enabled: bool = vision_enabled
+        self.history_limit: int = max(0, history_limit)
+        self.sync_timeout_ms: int = sync_timeout_ms
+
+        self._workspace_dir = (
+            Path(workspace_dir).expanduser() if workspace_dir else None
+        )
+        self._client: Optional[AsyncClient] = None
+        self._user_id: Optional[str] = None
+        self._sync_task: Optional[asyncio.Task] = None
+        self._typing_tasks: Dict[str, asyncio.Task] = {}
+        self._room_histories: Dict[str, List[HistoryEntry]] = {}
+        self._dm_room_cache: Dict[str, Dict[str, Any]] = {}
+        self._teamharness_task_room_cache: Dict[str, Dict[str, Any]] = {}
+        self._http_client: Optional[httpx.AsyncClient] = None
+        self._handled_verification_requests: set[str] = set()
+        self._verification_tx_peers: dict[str, tuple[str, str]] = {}
+        self._sent_verification_done: set[str] = set()
+        # Thread tracking (ported from CoPaw overlay)
+        self._active_thread_roots: Dict[str, str] = {}
+        self._proactive_send_state: Dict[str, Dict[str, Any]] = {}
+
+    # ------------------------------------------------------------------
+    # Debounce key — serialize by room_id (avoid concurrent session access)
+    # ------------------------------------------------------------------
+
+    def get_debounce_key(self, payload: Any) -> str:
+        if isinstance(payload, dict):
+            meta = payload.get("meta") or {}
+            room_id = meta.get("room_id")
+            if room_id:
+                return f"matrix:{room_id}"
+            return payload.get("sender_id") or ""
+        return getattr(payload, "session_id", "") or ""
+
+    # ------------------------------------------------------------------
+    # Factory — from_config / from_env
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_config(
+        cls,
+        process: Callable,
+        config: Any,
+        on_reply_sent: Optional[Callable] = None,
+        show_tool_details: bool = True,
+        filter_tool_messages: bool = False,
+        filter_thinking: bool = False,
+        workspace_dir: Path | None = None,
+    ) -> "MatrixChannel":
+        # Support pydantic model, dict, or SimpleNamespace
+        if isinstance(config, dict):
+            raw = config
+        else:
+            raw = (
+                config.model_dump()
+                if hasattr(config, "model_dump")
+                else vars(config)
+            )
+        return cls(
+            process=process,
+            homeserver=raw.get("homeserver", ""),
+            matrix_user_id=raw.get("user_id", ""),
+            access_token=raw.get("access_token", ""),
+            password=raw.get("password", ""),
+            device_name=raw.get("device_name", "qwenpaw-worker"),
+            device_id=raw.get("device_id", ""),
+            encryption=raw.get("encryption", False),
+            dm_disabled=raw.get("dm_disabled", False),
+            group_disabled=raw.get("group_disabled", False),
+            groups=raw.get("groups"),
+            vision_enabled=raw.get("vision_enabled", False),
+            history_limit=raw.get("history_limit", DEFAULT_HISTORY_LIMIT),
+            sync_timeout_ms=raw.get("sync_timeout_ms", 30000),
+            on_reply_sent=on_reply_sent,
+            show_tool_details=show_tool_details,
+            filter_tool_messages=(
+                filter_tool_messages or raw.get("filter_tool_messages", False)
+            ),
+            filter_thinking=(
+                filter_thinking or raw.get("filter_thinking", False)
+            ),
+            streaming_enabled=bool(raw.get("streaming_enabled", True)),
+            workspace_dir=workspace_dir,
+            access_control_dm=bool(raw.get("access_control_dm", False)),
+            access_control_group=bool(raw.get("access_control_group", False)),
+            enabled=raw.get("enabled", True),
+        )
+
+    @classmethod
+    def from_env(
+        cls,
+        process: Callable,
+        on_reply_sent=None,
+    ) -> "MatrixChannel":
+        return cls(
+            process=process,
+            homeserver=os.environ.get("AGENTTEAMS_MATRIX_SERVER", ""),
+            access_token=os.environ.get("AGENTTEAMS_MATRIX_TOKEN", ""),
+            on_reply_sent=on_reply_sent,
+        )
+
+    # ------------------------------------------------------------------
+    # Lifecycle — client, login, event callbacks, _sync_loop
+    # token + user_id/password login (§2); optional
+    # E2EE client config + store; cleartext + encrypted event callbacks;
+    # starts _sync_loop (§3).
+    # ------------------------------------------------------------------
+
+    def _build_client_config(
+        self,
+        encryption: bool = False,
+    ) -> AsyncClientConfig:
+        """Build an AsyncClientConfig with proper request timeout.
+
+        The HTTP request timeout must exceed the sync long-poll timeout
+        so the HTTP layer doesn't kill the connection while the
+        homeserver is legitimately waiting for new events.
+        """
+        sync_s = self.sync_timeout_ms / 1000
+        request_timeout = max(sync_s + 30, 60)
+        return AsyncClientConfig(
+            store_sync_tokens=False,
+            encryption_enabled=encryption,
+            request_timeout=request_timeout,
+        )
+
+    @staticmethod
+    def _derive_device_id_from_name(device_name: str) -> str:
+        """Use configured device_name directly as fallback device_id."""
+        return (device_name or "").strip()
+
+    async def health_check(self) -> Dict[str, Any]:
+        """Check Matrix client connection status."""
+        if not getattr(self, "enabled", True) or not self.homeserver:
+            return {
+                "channel": self.channel,
+                "status": "disabled",
+                "detail": "Matrix homeserver not configured.",
+            }
+        if self._client is None:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "Matrix client not initialized.",
+            }
+        has_token = bool(self._client.access_token)
+        if not has_token:
+            return {
+                "channel": self.channel,
+                "status": "unhealthy",
+                "detail": "Matrix client has no access token (not logged in).",
+            }
+        return {
+            "channel": self.channel,
+            "status": "healthy",
+            "detail": "Matrix client is connected.",
+        }
+
+    def _restore_auth_state_before_start(
+        self,
+        *,
+        has_password_creds: bool,
+        has_token_cred: bool,
+    ) -> None:
+        # Auth source priority:
+        # 1) Explicit user_id/password from config/UI
+        # 2) Explicit access_token from config/UI
+        # 3) Cached auth_state fallback
+        #
+        # When token or user_id/password is explicitly configured, do not
+        # restore cached token, otherwise we may accidentally bypass the
+        # intended auth path.
+        has_explicit_identity = (
+            has_password_creds or has_token_cred or self.matrix_user_id
+        )
+        self._load_auth_state(
+            restore_token=False,
+            restore_identity=not has_explicit_identity,
+        )
+
+    def _preflight_e2ee_dependencies(self) -> None:
+        """Probe olm before creating AsyncClientConfig;
+        disable E2EE if absent."""
+        if not self.encryption:
+            return
+        try:
+            importlib.import_module("olm")
+        except ImportError:
+            logger.error(
+                "MatrixChannel: olm not installed — falling back to "
+                "non-encrypted mode. "
+                "To enable E2EE: pip install matrix-nio[e2e] && "
+                "apt/dnf install libolm-dev",
+            )
+            self.encryption = False
+
+    def _init_async_client(self, resolved_device_id: str) -> None:
+        # E2EE: when encryption is enabled, provide store_path so matrix-nio
+        # persists Olm/Megolm keys, and set config to auto-trust all devices
+        # (appropriate for bot use cases where interactive verification is
+        # impractical).
+        store_path = None
+        if self.encryption:
+            store_path = self._e2ee_store_path()
+            store_path.mkdir(parents=True, exist_ok=True)
+        client_config = self._build_client_config(
+            encryption=self.encryption,
+        )
+        self._client = QwenPawMatrixClient(
+            self.homeserver,
+            # Keep user neutral before auth; token/whoami or login response
+            # will set the canonical MXID.
+            user="",
+            store_path=str(store_path) if store_path else "",
+            config=client_config,
+        )
+        if resolved_device_id:
+            self._client.device_id = resolved_device_id
+
+    def _password_login_kwargs_for_nio(
+        self,
+        login_user: str,
+        resolved_device_id: str,
+    ) -> dict[str, Any]:
+        # matrix-nio login() signature differs across versions. Build
+        # kwargs from runtime signature to avoid argument collisions.
+        login_sig = inspect.signature(self._client.login)
+        login_kwargs: dict[str, Any] = {}
+        login_params = login_sig.parameters
+        if "user" in login_params:
+            login_kwargs["user"] = login_user
+        elif "user_id" in login_params:
+            login_kwargs["user_id"] = login_user
+        if "password" in login_params:
+            login_kwargs["password"] = self.password
+        if "device_name" in login_params and self.device_name:
+            login_kwargs["device_name"] = self.device_name
+        if "device_id" in login_params:
+            stable_device_id = (
+                self._client.device_id or resolved_device_id or ""
+            )
+            if stable_device_id:
+                login_kwargs["device_id"] = stable_device_id
+        # For nio versions that derive username from client.user.
+        if "user" not in login_params and "user_id" not in login_params:
+            self._client.user = login_user
+        return login_kwargs
+
+    def _password_login_attempts(
+        self,
+        login_user: str,
+        login_kwargs: dict[str, Any],
+        resolved_device_id: str,
+    ) -> list[tuple[tuple[Any, ...], dict[str, Any]]]:
+        login_attempts: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+        if login_kwargs:
+            login_attempts.append(((), login_kwargs))
+        login_attempts.append(
+            (
+                (self.password,),
+                {
+                    "device_name": self.device_name,
+                    **(
+                        {"device_id": resolved_device_id}
+                        if resolved_device_id
+                        else {}
+                    ),
+                },
+            ),
+        )
+        login_attempts.append(
+            (
+                (login_user, self.password),
+                {
+                    "device_name": self.device_name,
+                    **(
+                        {"device_id": resolved_device_id}
+                        if resolved_device_id
+                        else {}
+                    ),
+                },
+            ),
+        )
+        return login_attempts
+
+    async def _try_password_login_variants(
+        self,
+        login_attempts: list[tuple[tuple[Any, ...], dict[str, Any]]],
+    ) -> tuple[Any, Optional[TypeError]]:
+        last_exc: Optional[TypeError] = None
+        for args, kwargs in login_attempts:
+            try:
+                resp = await self._client.login(*args, **kwargs)
+                return resp, None
+            except TypeError as exc:
+                last_exc = exc
+        return None, last_exc
+
+    def _handle_password_login_success(self, resp: LoginResponse) -> None:
+        self._user_id = resp.user_id
+        self._client.user_id = resp.user_id
+        self._client.user = resp.user_id
+        if getattr(resp, "device_id", None):
+            self._client.device_id = resp.device_id
+        if getattr(resp, "access_token", None):
+            self._client.access_token = resp.access_token
+        logger.info(
+            "MatrixChannel: logged in component=matrix user_id=%s method=password device=%s "
+            "device_name=%s",
+            self._user_id,
+            getattr(self._client, "device_id", ""),
+            self.device_name,
+        )
+        self._save_auth_state()
+        if self.encryption and self._client.store_path:
+            if self._client.device_id:
+                self._client.load_store()
+                logger.info(
+                    "MatrixChannel: crypto store loaded component=matrix store_path=%s",
+                    self._client.store_path,
+                )
+            else:
+                logger.warning(
+                    "MatrixChannel: password login returned no device_id component=matrix; "
+                    "E2EE store may not be reusable",
+                )
+
+    async def _login_with_password(
+        self,
+        login_user: str,
+        resolved_device_id: str,
+    ) -> bool:
+        login_kwargs = self._password_login_kwargs_for_nio(
+            login_user,
+            resolved_device_id,
+        )
+        attempts = self._password_login_attempts(
+            login_user,
+            login_kwargs,
+            resolved_device_id,
+        )
+        resp, last_exc = await self._try_password_login_variants(attempts)
+        if last_exc is not None:
+            raise last_exc
+        if isinstance(resp, LoginResponse):
+            self._handle_password_login_success(resp)
+            return True
+        logger.error("MatrixChannel: password login failed component=matrix response_type=%s", type(resp).__name__)
+        return False
+
+    async def _login_with_access_token(self) -> bool:
+        self._client.access_token = self.access_token
+        whoami = await self._client.whoami()
+        if isinstance(whoami, WhoamiResponse):
+            if self.matrix_user_id and self.matrix_user_id != whoami.user_id:
+                logger.error(
+                    "MatrixChannel: configured user_id mismatch component=matrix configured_user_id=%s "
+                    "token_owner=%s; refusing stale credentials",
+                    self.matrix_user_id,
+                    whoami.user_id,
+                )
+                return False
+            self._user_id = whoami.user_id
+            self._client.user_id = whoami.user_id
+            self._client.user = whoami.user_id
+            # E2EE requires device_id to associate Olm keys with this
+            # device
+            if whoami.device_id:
+                self._client.device_id = whoami.device_id
+            logger.info(
+                "MatrixChannel: logged in component=matrix user_id=%s method=token device=%s",
+                self._user_id,
+                whoami.device_id,
+            )
+            self._save_auth_state()
+            # Load crypto store after user_id and device_id are set
+            if self.encryption and self._client.store_path:
+                if self._client.device_id:
+                    self._client.load_store()
+                    logger.info(
+                        "MatrixChannel: crypto store loaded component=matrix store_path=%s",
+                        self._client.store_path,
+                    )
+                else:
+                    logger.error(
+                        "MatrixChannel: E2EE enabled but whoami returned no device_id component=matrix "
+                        "encryption disabled; token may lack device scope",
+                    )
+                    self.encryption = False
+            return True
+        logger.error("MatrixChannel: token login failed component=matrix response_type=%s", type(whoami).__name__)
+        return False
+
+    def _register_plain_room_callbacks(self) -> None:
+        self._client.add_event_callback(
+            self._on_room_event,
+            (RoomMessageText,),
+        )
+        self._client.add_event_callback(
+            self._on_room_media_event,
+            (
+                RoomMessageImage,
+                RoomMessageFile,
+                RoomMessageAudio,
+                RoomMessageVideo,
+            ),
+        )
+
+    async def _setup_e2ee_after_login(self) -> bool:
+        if not self.encryption:
+            return True
+        if self._client.should_upload_keys:
+            resp = await self._client.keys_upload()
+            if not isinstance(resp, KeysUploadResponse):
+                logger.error(
+                    "MatrixChannel: E2E keys upload failed after login component=matrix response_type=%s",
+                    type(resp).__name__,
+                )
+                return False
+            logger.info("MatrixChannel: E2E keys uploaded component=matrix")
+        # Encrypted media events (decrypted by nio, delivered as
+        # RoomEncrypted* types)
+        self._client.add_event_callback(
+            self._on_room_encrypted_media_event,
+            (
+                RoomEncryptedImage,
+                RoomEncryptedAudio,
+                RoomEncryptedVideo,
+                RoomEncryptedFile,
+            ),
+        )
+        # Undecryptable events (missing session key)
+        self._client.add_event_callback(
+            self._on_megolm_event,
+            (MegolmEvent,),
+        )
+        self._client.add_to_device_callback(
+            self._on_key_verification_event,
+            (KeyVerificationEvent,),
+        )
+        self._client.add_to_device_callback(
+            self._on_to_device_probe_event,
+            (ToDeviceEvent,),
+        )
+        self._client.add_to_device_callback(
+            self._on_room_key_request_event,
+            (
+                RoomKeyRequest,
+                RoomKeyRequestCancellation,
+            ),
+        )
+        logger.info(
+            "MatrixChannel: key verification to-device callback registered component=matrix",
+        )
+        logger.info(
+            "MatrixChannel: E2EE enabled, encrypted event handlers registered component=matrix",
+        )
+        return True
+
+    async def start(self) -> None:
+        if not self.homeserver:
+            logger.warning(
+                "MatrixChannel: homeserver not configured, skipping component=matrix",
+            )
+            return
+        self._preflight_e2ee_dependencies()
+        login_user = (self.matrix_user_id or "").strip()
+        has_password_creds = bool(login_user and self.password)
+        has_token_cred = bool(self.access_token)
+        self._restore_auth_state_before_start(
+            has_password_creds=has_password_creds,
+            has_token_cred=has_token_cred,
+        )
+        resolved_device_id = (
+            self.device_id
+            or self._derive_device_id_from_name(self.device_name)
+        )
+        self._init_async_client(resolved_device_id)
+
+        if has_password_creds:
+            if not await self._login_with_password(
+                login_user,
+                resolved_device_id,
+            ):
+                return
+        elif self.access_token:
+            if not await self._login_with_access_token():
+                return
+        else:
+            logger.error("MatrixChannel: no credentials configured component=matrix")
+            return
+
+        self._register_plain_room_callbacks()
+        if not await self._setup_e2ee_after_login():
+            return
+
+        self._http_client = httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=60,
+        )
+
+        self._sync_task = asyncio.create_task(self._sync_loop())
+        logger.info("MatrixChannel: sync loop started component=matrix")
+
+    async def stop(self) -> None:
+        if self._sync_task:
+            self._sync_task.cancel()
+            try:
+                await self._sync_task
+            except asyncio.CancelledError:
+                logger.debug("MatrixChannel: sync task cancelled during stop component=matrix")
+        if self._http_client:
+            await self._http_client.aclose()
+            self._http_client = None
+        if self._client:
+            await self._client.close()
+        logger.info("MatrixChannel: stopped component=matrix")
+
+    # ------------------------------------------------------------------
+    # Sync loop — token persistence, catch-up, incremental sync, E2EE
+    # maintenance
+    # catch-up sync suppresses replay; incremental sync; E2EE maintenance
+    # between syncs when encryption on.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _sync_token_path() -> Optional[Path]:
+        """Return the file path for persisting the Matrix sync token."""
+        return WORKING_DIR / "matrix_sync_token"
+
+    @staticmethod
+    def _auth_state_path() -> Path:
+        """Return the file path for persisted Matrix auth state."""
+        return WORKING_DIR / "matrix_auth_state.json"
+
+    @staticmethod
+    def _ready_marker_path() -> Optional[Path]:
+        marker = os.environ.get("AGENTTEAMS_MATRIX_CHANNEL_READY_FILE", "").strip()
+        return Path(marker) if marker else None
+
+    def _mark_channel_ready(self) -> None:
+        """Mark Matrix sync ready for worker-level readiness probes."""
+        path = self._ready_marker_path()
+        if not path:
+            return
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("ready\n", encoding="utf-8")
+        except Exception as exc:
+            logger.warning(
+                "MatrixChannel: failed to write ready marker: %s",
+                exc,
+            )
+
+    def _load_auth_state(
+        self,
+        restore_token: bool = True,
+        restore_identity: bool = True,
+    ) -> None:
+        """Best-effort load persisted access_token/user_id/device_id."""
+        path = self._auth_state_path()
+        if not path.exists():
+            return
+        try:
+            import json
+
+            payload = json.loads(path.read_text())
+            restored_any = False
+            if restore_token and not self.access_token:
+                self.access_token = str(payload.get("access_token", ""))
+                restored_any = bool(self.access_token)
+            if restore_identity:
+                if not self.matrix_user_id:
+                    self.matrix_user_id = str(payload.get("user_id", ""))
+                    restored_any = restored_any or bool(self.matrix_user_id)
+                if not self.device_id:
+                    self.device_id = str(payload.get("device_id", ""))
+                    restored_any = restored_any or bool(self.device_id)
+            if restored_any:
+                logger.info(
+                    "MatrixChannel: restored auth state from %s "
+                    "(token=%s, user=%s, device=%s)",
+                    path,
+                    bool(self.access_token),
+                    self.matrix_user_id or "<unknown>",
+                    self.device_id or "<unknown>",
+                )
+            else:
+                logger.debug(
+                    "MatrixChannel: auth state present at %s but not applied "
+                    "(restore_token=%s restore_identity=%s)",
+                    path,
+                    restore_token,
+                    restore_identity,
+                )
+        except Exception as exc:
+            logger.warning(
+                "MatrixChannel: failed to load auth state from %s: %s",
+                path,
+                exc,
+            )
+
+    def _save_auth_state(self) -> None:
+        """Persist access_token/user_id/device_id for stable restarts."""
+        if not self._client:
+            return
+        token = getattr(self._client, "access_token", "") or ""
+        user_id = getattr(self._client, "user_id", "") or self._user_id or ""
+        device_id = getattr(self._client, "device_id", "") or ""
+        if not token or not user_id:
+            return
+        try:
+            import json
+
+            payload = {
+                "access_token": token,
+                "user_id": user_id,
+                "device_id": device_id,
+            }
+            path = self._auth_state_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps(payload))
+            self.access_token = token
+            self.matrix_user_id = user_id
+            if device_id:
+                self.device_id = device_id
+        except Exception as exc:
+            logger.warning(
+                "MatrixChannel: failed to persist auth state: %s",
+                exc,
+            )
+
+    def _load_sync_token(self) -> Optional[str]:
+        """Load persisted next_batch token from disk, or None.
+
+        The token file is pulled from MinIO by FileSync.pull_all() during
+        startup, so it's already on disk when this runs — even on a fresh
+        container after destroy/recreate.
+        """
+        path = self._sync_token_path()
+        if path and path.exists():
+            try:
+                token = path.read_text().strip()
+                if token:
+                    logger.info(
+                        "MatrixChannel: restored sync token from %s",
+                        path,
+                    )
+                    return token
+            except Exception as exc:
+                logger.warning(
+                    "MatrixChannel: failed to read sync token: %s",
+                    exc,
+                )
+        return None
+
+    def _save_sync_token(self, token: str) -> None:
+        """Persist next_batch token to disk (push_loop uploads it to MinIO)."""
+        path = self._sync_token_path()
+        if path:
+            try:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(token)
+            except Exception as exc:
+                logger.warning(
+                    "MatrixChannel: failed to save sync token: %s",
+                    exc,
+                )
+
+    async def _e2ee_maintenance(self) -> None:
+        """Perform E2EE key maintenance tasks after each sync.
+
+        Mirrors what nio's sync_forever() does between syncs:
+        - Upload device keys when needed
+        - Query device keys for new/changed users
+        - Claim one-time keys to establish Olm sessions
+        - Send outgoing to-device messages (key shares, key requests)
+        """
+        if not self.encryption or not self._client or not self._client.olm:
+            return
+        try:
+            if self._client.should_upload_keys:
+                await self._client.keys_upload()
+            if self._client.should_query_keys:
+                await self._client.keys_query()
+            if self._client.should_claim_keys:
+                await self._client.keys_claim(
+                    self._client.get_users_for_key_claiming(),
+                )
+            await self._client.send_to_device_messages()
+        except Exception as exc:
+            logger.warning("MatrixChannel: E2EE maintenance error: %s", exc)
+
+    async def _on_key_verification_event(
+        self,
+        event: KeyVerificationEvent,
+    ) -> None:
+        """Complete the bot side of an Element SAS verification challenge."""
+        if not self._client or not self._client.olm:
+            logger.info(
+                "MatrixChannel: verification event received "
+                "but olm is not ready (event=%s, tx=%s, sender=%s)",
+                type(event).__name__,
+                getattr(event, "transaction_id", ""),
+                getattr(event, "sender", ""),
+            )
+            return
+
+        try:
+            logger.info(
+                "MatrixChannel: verification event received "
+                "(event=%s, tx=%s, sender=%s, from_device=%s)",
+                type(event).__name__,
+                getattr(event, "transaction_id", ""),
+                getattr(event, "sender", ""),
+                getattr(event, "from_device", ""),
+            )
+            if isinstance(event, KeyVerificationStart):
+                await self._handle_key_verification_start(event)
+            elif isinstance(event, KeyVerificationKey):
+                await self._handle_key_verification_key(event)
+            elif isinstance(event, KeyVerificationMac):
+                sas = self._client.key_verifications.get(event.transaction_id)
+                logger.info(
+                    "MatrixChannel: key verification MAC received "
+                    "(tx=%s, verified=%s, verified_devices=%s)",
+                    event.transaction_id,
+                    getattr(sas, "verified", False),
+                    getattr(sas, "verified_devices", []),
+                )
+                if getattr(sas, "verified", False):
+                    await self._send_verification_done(event.transaction_id)
+            elif isinstance(event, KeyVerificationCancel):
+                known_tx = event.transaction_id in getattr(
+                    self._client,
+                    "key_verifications",
+                    {},
+                )
+                if known_tx:
+                    logger.info(
+                        "MatrixChannel: key verification cancelled by %s "
+                        "(tx=%s, reason=%s)",
+                        event.sender,
+                        event.transaction_id,
+                        getattr(event, "reason", ""),
+                    )
+                else:
+                    logger.info(
+                        "MatrixChannel: key verification cancelled for "
+                        "unknown key verification tx=%s from %s (reason=%s)",
+                        event.transaction_id,
+                        event.sender,
+                        getattr(event, "reason", ""),
+                    )
+            else:
+                logger.info(
+                    "MatrixChannel: unhandled verification event type=%s "
+                    "(tx=%s, sender=%s)",
+                    type(event).__name__,
+                    getattr(event, "transaction_id", ""),
+                    getattr(event, "sender", ""),
+                )
+        except Exception as exc:
+            logger.warning(
+                "MatrixChannel: key verification handling failed: %s",
+                exc,
+            )
+
+    async def _on_to_device_probe_event(
+        self,
+        event: ToDeviceEvent,
+    ) -> None:
+        """Probe raw to-device verification event types for troubleshooting."""
+        raw_type = getattr(event, "type", "")
+        if not raw_type:
+            raw_type = getattr(event, "source", {}).get("type", "")
+        if not isinstance(raw_type, str) or not raw_type.startswith(
+            "m.key.verification.",
+        ):
+            return
+        logger.info(
+            "MatrixChannel: raw to-device verification event "
+            "(type=%s, parsed=%s, sender=%s)",
+            raw_type,
+            type(event).__name__,
+            getattr(event, "sender", ""),
+        )
+        if raw_type in (
+            "m.key.verification.request",
+            "m.key.verification.ready",
+        ):
+            logger.warning(
+                "MatrixChannel: homeserver sent %s but current matrix-nio "
+                "cannot parse it into KeyVerificationEvent; handling via "
+                "raw to-device compatibility path",
+                raw_type,
+            )
+        if raw_type == "m.key.verification.request":
+            await self._handle_unknown_key_verification_request(event)
+        elif raw_type == "m.key.verification.done":
+            await self._handle_unknown_key_verification_done(event)
+
+    async def _on_room_key_request_event(
+        self,
+        event: RoomKeyRequest | RoomKeyRequestCancellation,
+    ) -> None:
+        """Log room-key request events that often require manual review."""
+        if isinstance(event, RoomKeyRequest):
+            logger.warning(
+                "MatrixChannel: room key request received; other device may "
+                "show 'Review' until trust decision is made "
+                "(sender=%s device=%s request_id=%s room_id=%s session_id=%s)",
+                event.sender,
+                event.requesting_device_id,
+                event.request_id,
+                getattr(event, "room_id", ""),
+                getattr(event, "session_id", ""),
+            )
+        else:
+            logger.info(
+                "MatrixChannel: room key request cancelled "
+                "(sender=%s device=%s request_id=%s)",
+                event.sender,
+                event.requesting_device_id,
+                event.request_id,
+            )
+
+    async def _handle_unknown_key_verification_request(
+        self,
+        event: ToDeviceEvent,
+    ) -> None:
+        """Compat path for m.key.verification.request on older matrix-nio."""
+        if not self._client or not self._client.olm:
+            return
+
+        source = getattr(event, "source", {}) or {}
+        content = source.get("content", {}) or {}
+        sender = getattr(event, "sender", "")
+        from_device = str(content.get("from_device", "") or "")
+        transaction_id = str(content.get("transaction_id", "") or "")
+        methods = content.get("methods", []) or []
+
+        request_key = f"{sender}|{from_device}|{transaction_id}"
+        if request_key in self._handled_verification_requests:
+            logger.debug(
+                "MatrixChannel: verification request already handled "
+                "(sender=%s, device=%s, tx=%s)",
+                sender,
+                from_device,
+                transaction_id,
+            )
+            return
+        self._handled_verification_requests.add(request_key)
+
+        if not sender or not from_device:
+            logger.warning(
+                "MatrixChannel: cannot handle verification request without "
+                "sender/device (sender=%s, device=%s, tx=%s)",
+                sender,
+                from_device,
+                transaction_id,
+            )
+            return
+
+        self._verification_tx_peers[transaction_id] = (sender, from_device)
+
+        our_device = getattr(self._client, "device_id", "") or ""
+        if not our_device:
+            logger.warning(
+                "MatrixChannel: cannot reply verification request without "
+                "local device_id (sender=%s, device=%s, tx=%s)",
+                sender,
+                from_device,
+                transaction_id,
+            )
+            return
+
+        ready_content = {
+            "from_device": our_device,
+            "methods": ["m.sas.v1"],
+            "transaction_id": transaction_id,
+        }
+        ready_message = ToDeviceMessage(
+            "m.key.verification.ready",
+            sender,
+            from_device,
+            ready_content,
+        )
+        try:
+            resp = await self._client.to_device(ready_message)
+        except Exception as exc:
+            logger.warning(
+                "MatrixChannel: failed to send verification ready "
+                "(sender=%s, device=%s, tx=%s): %s",
+                sender,
+                from_device,
+                transaction_id,
+                exc,
+            )
+            return
+
+        if isinstance(resp, ToDeviceError):
+            logger.warning(
+                "MatrixChannel: homeserver rejected verification ready "
+                "(sender=%s, device=%s, tx=%s): %s",
+                sender,
+                from_device,
+                transaction_id,
+                resp,
+            )
+            return
+
+        logger.info(
+            "MatrixChannel: sent verification ready for request "
+            "(sender=%s, device=%s, tx=%s, methods=%s)",
+            sender,
+            from_device,
+            transaction_id,
+            methods,
+        )
+
+    async def _handle_unknown_key_verification_done(
+        self,
+        event: ToDeviceEvent,
+    ) -> None:
+        """Handle done event emitted as UnknownToDeviceEvent on older nio."""
+        source = getattr(event, "source", {}) or {}
+        content = source.get("content", {}) or {}
+        tx = str(content.get("transaction_id", "") or "")
+        if not tx:
+            return
+        logger.info(
+            "MatrixChannel: received verification done from %s (tx=%s)",
+            getattr(event, "sender", ""),
+            tx,
+        )
+        if tx not in self._sent_verification_done:
+            await self._send_verification_done(tx)
+
+    async def _handle_key_verification_start(
+        self,
+        event: KeyVerificationStart,
+    ) -> None:
+        """Accept Element's SAS start, querying device keys if needed."""
+        if not self._client or not self._client.olm:
+            return
+        self._verification_tx_peers[event.transaction_id] = (
+            event.sender,
+            event.from_device,
+        )
+
+        if event.transaction_id not in self._client.key_verifications:
+            await self._recover_key_verification_start(event)
+
+        if event.transaction_id not in self._client.key_verifications:
+            logger.warning(
+                "MatrixChannel: cannot accept key verification from %s "
+                "(device=%s, tx=%s) because no SAS state exists yet; "
+                "retry verification after the next sync",
+                event.sender,
+                event.from_device,
+                event.transaction_id,
+            )
+            return
+
+        try:
+            resp = await self._client.accept_key_verification(
+                event.transaction_id,
+            )
+        except LocalProtocolError as exc:
+            logger.warning(
+                "MatrixChannel: accept_key_verification failed for tx=%s: %s",
+                event.transaction_id,
+                exc,
+            )
+            return
+
+        if isinstance(resp, ToDeviceError):
+            logger.warning(
+                "MatrixChannel: accept_key_verification failed for tx=%s: %s",
+                event.transaction_id,
+                resp,
+            )
+            return
+
+        logger.info(
+            "MatrixChannel: accepted key verification from %s "
+            "(device=%s, tx=%s)",
+            event.sender,
+            event.from_device,
+            event.transaction_id,
+        )
+
+    async def _send_verification_done(self, transaction_id: str) -> None:
+        """Send m.key.verification.done for runtimes lacking done helpers."""
+        if (
+            not self._client
+            or not transaction_id
+            or transaction_id in self._sent_verification_done
+        ):
+            return
+
+        peer = self._verification_tx_peers.get(transaction_id)
+        if not peer:
+            logger.warning(
+                "MatrixChannel: cannot send verification done for tx=%s "
+                "because peer device is unknown",
+                transaction_id,
+            )
+            return
+
+        sender, device_id = peer
+        done_message = ToDeviceMessage(
+            "m.key.verification.done",
+            sender,
+            device_id,
+            {"transaction_id": transaction_id},
+        )
+        try:
+            resp = await self._client.to_device(done_message)
+        except Exception as exc:
+            logger.warning(
+                "MatrixChannel: failed to send verification done "
+                "(tx=%s, sender=%s, device=%s): %s",
+                transaction_id,
+                sender,
+                device_id,
+                exc,
+            )
+            return
+
+        if isinstance(resp, ToDeviceError):
+            logger.warning(
+                "MatrixChannel: homeserver rejected verification done "
+                "(tx=%s, sender=%s, device=%s): %s",
+                transaction_id,
+                sender,
+                device_id,
+                resp,
+            )
+            return
+
+        self._sent_verification_done.add(transaction_id)
+        logger.info(
+            "MatrixChannel: sent verification done "
+            "(tx=%s, sender=%s, device=%s)",
+            transaction_id,
+            sender,
+            device_id,
+        )
+
+    async def _recover_key_verification_start(
+        self,
+        event: KeyVerificationStart,
+    ) -> None:
+        """Re-process start event after matrix-nio queried unknown devices."""
+        assert self._client is not None
+        assert self._client.olm is not None
+
+        try:
+            if self._client.should_query_keys:
+                await self._client.keys_query()
+        except Exception as exc:
+            logger.warning(
+                "MatrixChannel: failed to query keys for verification "
+                "from %s: %s",
+                event.sender,
+                exc,
+            )
+            return
+
+        try:
+            self._client.olm.handle_key_verification(event)
+        except Exception as exc:
+            logger.warning(
+                "MatrixChannel: failed to rebuild key verification state "
+                "for tx=%s: %s",
+                event.transaction_id,
+                exc,
+            )
+
+    async def _handle_key_verification_key(
+        self,
+        event: KeyVerificationKey,
+    ) -> None:
+        """Log the SAS challenge and confirm the bot side."""
+        if not self._client:
+            return
+
+        sas = self._client.key_verifications.get(event.transaction_id)
+        if sas is None:
+            logger.warning(
+                "MatrixChannel: key verification key for unknown tx=%s "
+                "from %s; ask Element to restart verification",
+                event.transaction_id,
+                event.sender,
+            )
+            return
+
+        logger.warning(
+            "MatrixChannel: Element key verification challenge from %s "
+            "(tx=%s): %s",
+            event.sender,
+            event.transaction_id,
+            self._format_sas_challenge(sas),
+        )
+
+        # Receiving Key queues share_key in nio; flush it before sending MAC.
+        await self._client.send_to_device_messages()
+        try:
+            resp = await self._client.confirm_short_auth_string(
+                event.transaction_id,
+            )
+        except LocalProtocolError as exc:
+            logger.warning(
+                "MatrixChannel: confirm_short_auth_string failed "
+                "for tx=%s: %s",
+                event.transaction_id,
+                exc,
+            )
+            return
+
+        if isinstance(resp, ToDeviceError):
+            logger.warning(
+                "MatrixChannel: confirm_short_auth_string failed "
+                "for tx=%s: %s",
+                event.transaction_id,
+                resp,
+            )
+            return
+
+        logger.info(
+            "MatrixChannel: confirmed local SAS side for tx=%s; "
+            "compare the challenge in Element and accept there if it matches",
+            event.transaction_id,
+        )
+
+    @staticmethod
+    def _format_sas_challenge(sas: Any) -> str:
+        """Return a human-readable SAS challenge for logs."""
+        parts: list[str] = []
+
+        get_emoji = getattr(sas, "get_emoji", None)
+        if callable(get_emoji):
+            try:
+                emojis = get_emoji()
+                if emojis:
+                    parts.append(
+                        "emoji="
+                        + " ".join(
+                            f"{symbol}({description})"
+                            for symbol, description in emojis
+                        ),
+                    )
+            except Exception as exc:
+                logger.debug("MatrixChannel: get_emoji failed: %s", exc)
+
+        get_decimal = getattr(sas, "get_decimal", None)
+        if callable(get_decimal):
+            try:
+                decimals = get_decimal()
+                if decimals:
+                    parts.append(
+                        "decimal=" + " ".join(str(n) for n in decimals),
+                    )
+            except Exception as exc:
+                logger.debug("MatrixChannel: get_decimal failed: %s", exc)
+
+        return "; ".join(parts) if parts else "unavailable"
+
+    # pylint: disable=too-many-branches,too-many-statements
+    async def _sync_loop(self) -> None:
+        next_batch: Optional[str] = self._load_sync_token()
+
+        # When no persisted token exists (old version upgrade or first
+        # deploy), do an initial sync with callbacks suppressed — only capture
+        # next_batch so subsequent syncs are incremental.  This prevents
+        # replaying old messages when the token file doesn't exist yet.
+        #
+        # Use timeout=0 so startup does not long-poll while callbacks are
+        # temporarily suppressed. A long-poll here can swallow fresh messages
+        # sent during worker boot.
+        #
+        # To truly suppress callbacks, temporarily remove event callbacks
+        # before the sync and restore them after, because nio's sync()
+        # internally calls receive_response() which fires callbacks.
+        if next_batch is None:
+            logger.info(
+                "MatrixChannel: no sync token found, "
+                "performing catch-up sync component=matrix messages_suppressed=True",
+            )
+            try:
+                saved_cbs = self._client.event_callbacks[:]
+                self._client.event_callbacks.clear()
+                try:
+                    resp = await self._client.sync(
+                        timeout=0,
+                        full_state=True,
+                    )
+                finally:
+                    self._client.event_callbacks.extend(saved_cbs)
+                if isinstance(resp, SyncResponse):
+                    next_batch = resp.next_batch
+                    if next_batch is not None:
+                        self._save_sync_token(next_batch)
+                    # Still auto-join invited rooms during catch-up
+                    for room_id in resp.rooms.invite:
+                        logger.info("MatrixChannel: auto-joining component=matrix room_id=%s", room_id)
+                        await self._client.join(room_id)
+                    await self._e2ee_maintenance()
+                    logger.info(
+                        "MatrixChannel: catch-up sync done, "
+                        "will process messages from next sync component=matrix",
+                    )
+                else:
+                    logger.warning(
+                        "MatrixChannel: catch-up sync error component=matrix response_type=%s",
+                        type(resp).__name__,
+                    )
+            except Exception as exc:
+                logger.exception(
+                    "MatrixChannel: catch-up sync exception component=matrix error_type=%s",
+                    type(exc).__name__,
+                )
+        else:
+            # Restored from token — do a full_state sync to populate room
+            # member display names (nio needs full state for user_name()).
+            # Event callbacks are already registered so any messages received
+            # during the offline window will be processed normally.
+            logger.info(
+                "MatrixChannel: restored token, "
+                "performing full-state sync component=matrix",
+            )
+            try:
+                resp = await self._client.sync(
+                    timeout=self.sync_timeout_ms,
+                    since=next_batch,
+                    full_state=True,
+                )
+                if isinstance(resp, SyncResponse):
+                    next_batch = resp.next_batch
+                    if next_batch is not None:
+                        self._save_sync_token(next_batch)
+                    for room_id in resp.rooms.invite:
+                        logger.info("MatrixChannel: auto-joining component=matrix room_id=%s", room_id)
+                        await self._client.join(room_id)
+                    await self._e2ee_maintenance()
+                else:
+                    logger.warning(
+                        "MatrixChannel: full-state sync error component=matrix response_type=%s",
+                        type(resp).__name__,
+                    )
+            except Exception as exc:
+                logger.exception(
+                    "MatrixChannel: full-state sync exception component=matrix error_type=%s",
+                    type(exc).__name__,
+                )
+
+        self._mark_channel_ready()
+
+        while True:
+            try:
+                resp = await self._client.sync(
+                    timeout=self.sync_timeout_ms,
+                    since=next_batch,
+                    full_state=False,
+                )
+                if isinstance(resp, SyncResponse):
+                    next_batch = resp.next_batch
+                    if next_batch is not None:
+                        self._save_sync_token(next_batch)
+                    # Auto-join invited rooms
+                    for room_id in resp.rooms.invite:
+                        logger.info("MatrixChannel: auto-joining component=matrix room_id=%s", room_id)
+                        await self._client.join(room_id)
+                    # E2EE: full key maintenance (upload, query, claim,
+                    # to-device)
+                    await self._e2ee_maintenance()
+                else:
+                    if isinstance(resp, SyncError) and getattr(
+                        resp,
+                        "status_code",
+                        None,
+                    ) in {"M_UNKNOWN_TOKEN", "M_MISSING_TOKEN"}:
+                        logger.error(
+                            "MatrixChannel: sync stopped due to "
+                            "invalid/missing access token; please re-login "
+                            "(password or fresh token) component=matrix",
+                        )
+                        if self._client:
+                            self._client.access_token = ""
+                        self.access_token = ""
+                        return
+                    logger.warning("MatrixChannel: sync error component=matrix response_type=%s", type(resp).__name__)
+                    await asyncio.sleep(5)
+            except asyncio.CancelledError:
+                logger.debug("MatrixChannel: sync loop cancelled component=matrix")
+                raise
+            except Exception as exc:
+                logger.exception("MatrixChannel: sync exception component=matrix error_type=%s", type(exc).__name__)
+                await asyncio.sleep(5)
+
+    # ------------------------------------------------------------------
+    # Channel-level mute, per-room requireMention, strip @mention prefix
+    # ------------------------------------------------------------------
+
+    def _is_channel_disabled(
+        self,
+        sender_id: str,
+        room_id: str,
+        is_dm: bool,
+    ) -> bool:
+        """Return True if chat type is muted at channel level."""
+        if is_dm and self.dm_disabled:
+            logger.warning(
+                "MatrixChannel: dropping DM message (dm_disabled) "
+                "sender=%s room=%s",
+                sender_id,
+                room_id,
+            )
+            return True
+        if not is_dm and self.group_disabled:
+            logger.warning(
+                "MatrixChannel: dropping group message (group_disabled) "
+                "sender=%s room=%s",
+                sender_id,
+                room_id,
+            )
+            return True
+        return False
+
+    def _require_mention(self, room_id: str) -> bool:
+        """Per-room config; default is require mention in group rooms."""
+        room_cfg = self.groups.get(room_id) or self.groups.get("*")
+        if room_cfg:
+            if room_cfg.get("autoReply") is True:
+                return False
+            if "requireMention" in room_cfg:
+                return bool(room_cfg["requireMention"])
+        return True  # default: require mention in group rooms
+
+    # pylint: disable=too-many-return-statements
+    def _was_mentioned(self, event: Any, text: str) -> bool:
+        if not self._user_id:
+            return False
+        # 1. Check m.mentions (structured mention from Matrix spec)
+        content = event.source.get("content", {})
+        mentions = content.get("m.mentions", {})
+        if self._user_id in mentions.get("user_ids", []):
+            return True
+        if mentions.get("room"):
+            return True
+        # 2. formatted_body: matrix.to mention links (Element HTML format)
+        formatted_body = content.get("formatted_body", "")
+        if formatted_body and self._user_id:
+            escaped_uid = re.escape(self._user_id)
+            if re.search(
+                rf'href=["\']https://matrix\.to/#/{escaped_uid}["\']',
+                formatted_body,
+                re.IGNORECASE,
+            ):
+                return True
+            encoded_uid = re.escape(urllib.parse.quote(self._user_id))
+            if re.search(
+                rf'href=["\']https://matrix\.to/#/{encoded_uid}["\']',
+                formatted_body,
+                re.IGNORECASE,
+            ):
+                return True
+        # 3. Fallback: match full MXID in plain text
+        if self._user_id and re.search(
+            re.escape(self._user_id),
+            text,
+            re.IGNORECASE,
+        ):
+            return True
+        return False
+
+    def _teamharness_self_trigger(self, room_id: str, event: Any) -> dict[str, Any] | None:
+        content = getattr(event, "source", {}).get("content", {})
+        if not isinstance(content, dict):
+            return None
+        trigger = content.get(TEAMHARNESS_TRIGGER_CONTENT_KEY)
+        if not isinstance(trigger, dict):
+            return None
+        if trigger.get("kind") != "self_cross_session":
+            return None
+        if trigger.get("type") not in TEAMHARNESS_SELF_TRIGGER_TYPES:
+            return None
+        target_room_id = str(trigger.get("targetRoomId") or "").strip()
+        target_session = str(trigger.get("targetSession") or "").strip()
+        if target_session.startswith("matrix:"):
+            target_session = target_session[len("matrix:") :]
+        if target_session.startswith("room:"):
+            target_session = target_session[len("room:") :]
+        if room_id not in {target_room_id, target_session}:
+            return None
+        return trigger
+
+    def _strip_mention_prefix(self, text: str, room: Any = None) -> str:
+        """Strip leading @mention prefix so slash commands can be detected.
+
+        Handles MXID format (@user:server), room display name, and localpart.
+        E.g. ``"@worker:hs.example /new"`` → ``"/new"``
+             ``"math 💕: /clear"`` → ``"/clear"``.
+        """
+        if not self._user_id:
+            return text
+        # 1. Strip MXID (@user:server) at start
+        escaped = re.escape(self._user_id)
+        result = re.sub(rf"^{escaped}\s*:?\s*", "", text, flags=re.IGNORECASE)
+        if result != text:
+            return result.strip()
+        # 2. Strip room display name (e.g. "math 💕") at start — try before
+        #    localpart so that "math 💕: /clear" is not partially matched by
+        #    the shorter localpart "math".
+        if room and self._user_id:
+            display_name = self._get_display_name(room, self._user_id)
+            logger.debug(
+                "strip_mention_prefix: user_id=%s display_name=%r "
+                "room_users=%d",
+                self._user_id,
+                display_name,
+                len(getattr(room, "users", {})),
+            )
+            if display_name and display_name != self._user_id:
+                result = re.sub(
+                    rf"^{re.escape(display_name)}\s*:?\s*",
+                    "",
+                    text,
+                    flags=re.IGNORECASE,
+                )
+                if result != text:
+                    # Clean leftover decoration (e.g. emoji suffix) between
+                    # the display name and the actual message content.
+                    result = re.sub(r"^[^\w/]+", "", result)
+                    return result.strip()
+        # 3. Strip localpart (e.g. "math") at start — only if display name
+        #    didn't match.
+        localpart = self._user_id.split(":")[0].lstrip("@")
+        if localpart:
+            result = re.sub(
+                rf"^{re.escape(localpart)}\s*:?\s*",
+                "",
+                text,
+                flags=re.IGNORECASE,
+            )
+            if result != text:
+                # After stripping localpart, there may be leftover decoration
+                # from the display name (e.g. emoji suffix "💕: " from
+                # "math 💕: /clear").  Strip non-alphanumeric prefix so the
+                # slash command is exposed.
+                result = re.sub(r"^[^\w/]+", "", result)
+                return result.strip()
+        return text
+
+    def _control_command_text(self, text: str) -> str | None:
+        """Return normalized runtime control command text, if any."""
+        registry = getattr(self, "_command_registry", None)
+        if registry is None:
+            return None
+
+        stripped = (text or "").strip()
+        if registry.is_control_command(stripped):
+            return stripped
+
+        if stripped.startswith("/"):
+            normalized = "/" + stripped.lstrip("/")
+            if normalized != stripped and registry.is_control_command(normalized):
+                return normalized
+
+        return None
+
+    # ------------------------------------------------------------------
+    # Display names & group history buffer (requireMention context)
+    # display names from room / client.rooms (§5–§6);
+    # per-room history buffer + history_limit; media_parts in buffer when
+    # applicable; prefix merged into AgentRequest on mention (§6).
+    # ------------------------------------------------------------------
+
+    def _get_display_name(self, room: Any, user_id: str) -> str:
+        """Best-effort human-readable name for a Matrix user in *room*.
+
+        Tries the room object passed by nio first, then falls back to
+        looking up the room in the nio client's rooms dict (which is
+        populated by full_state sync at startup).
+        """
+        # 1. Try the room object directly (passed by nio callback)
+        try:
+            name = room.user_name(user_id)
+            if name:
+                return name
+        except Exception as exc:
+            logger.debug(
+                "MatrixChannel: user_name failed for %s: %s",
+                user_id,
+                exc,
+            )
+        # 2. Fallback: look up from nio client's rooms dict
+        if self._client:
+            room_id = getattr(room, "room_id", None)
+            if room_id:
+                client_room = self._client.rooms.get(room_id)
+                if client_room and client_room is not room:
+                    try:
+                        name = client_room.user_name(user_id)
+                        if name:
+                            logger.debug(
+                                "display_name resolved via client.rooms "
+                                "fallback: %s -> %r",
+                                user_id,
+                                name,
+                            )
+                            return name
+                    except Exception as exc:
+                        logger.debug(
+                            "MatrixChannel: client_room user_name failed "
+                            "for %s: %s",
+                            user_id,
+                            exc,
+                        )
+        # 3. Fallback: localpart of MXID (e.g. "@alice:hs" → "alice")
+        logger.debug(
+            "display_name fallback to localpart for %s "
+            "(room.users=%d, client_rooms=%d)",
+            user_id,
+            len(getattr(room, "users", {})),
+            len(self._client.rooms) if self._client else 0,
+        )
+        return user_id.split(":")[0].lstrip("@") or user_id
+
+    def _record_history(self, room_id: str, entry: HistoryEntry) -> None:
+        """Append *entry* to the per-room history buffer (respect limit)."""
+        limit = self.history_limit
+        if limit <= 0:
+            return
+        history = self._room_histories.setdefault(room_id, [])
+        history.append(entry)
+        while len(history) > limit:
+            history.pop(0)
+
+    def _build_history_prefix(self, room_id: str) -> str:
+        """Format buffered history entries as a multi-line text block."""
+        entries = self._room_histories.get(room_id, [])
+        if not entries:
+            return ""
+        lines: list[str] = []
+        for e in entries:
+            line = f"{e.sender}: {e.body}"
+            if e.message_id:
+                line += f" [id:{e.message_id}]"
+            lines.append(line)
+        return "\n".join(lines)
+
+    def _apply_history_to_parts(
+        self,
+        room_id: str,
+        content_parts: list[Any],
+    ) -> list[Any]:
+        """Prepend accumulated history context to *content_parts*.
+
+        If the first part is text, the history block is merged into it;
+        otherwise a new text part is prepended.  Any media parts stored
+        in history entries (e.g. downloaded images) are inserted between
+        the history text block and the current message parts so that
+        vision models can see them.
+
+        Returns a (possibly new) list — the original is not mutated.
+        """
+        if self.history_limit <= 0:
+            return content_parts
+        history_text = self._build_history_prefix(room_id)
+        if not history_text:
+            return content_parts
+
+        # Collect media content parts carried by history entries
+        history_media: list[Any] = []
+        for entry in self._room_histories.get(room_id, []):
+            if entry.media_parts:
+                history_media.extend(entry.media_parts)
+
+        # Merge into the leading text part when possible
+        first = content_parts[0] if content_parts else None
+        if first and getattr(first, "type", None) == ContentType.TEXT:
+            current_text = first.text or ""
+            combined = (
+                f"{HISTORY_CONTEXT_MARKER}\n{history_text}\n\n"
+                f"{CURRENT_MESSAGE_MARKER}\n{current_text}"
+            )
+            return (
+                [TextContent(type=ContentType.TEXT, text=combined)]
+                + history_media
+                + content_parts[1:]
+            )
+        # No leading text part (e.g. pure media) — prepend a dedicated block
+        prefix_part = TextContent(
+            type=ContentType.TEXT,
+            text=(
+                f"{HISTORY_CONTEXT_MARKER}\n{history_text}\n\n"
+                f"{CURRENT_MESSAGE_MARKER}"
+            ),
+        )
+        return [prefix_part] + history_media + content_parts
+
+    def _clear_history(self, room_id: str) -> None:
+        """Drop the buffered history for *room_id*."""
+        self._room_histories.pop(room_id, None)
+
+    async def _record_media_history(
+        self,
+        room: Any,
+        event: Any,
+        sender_id: str,
+        room_id: str,
+    ) -> None:
+        """Record a non-mentioned media message as a history entry.
+
+        Produces a typed text description (e.g. ``[sent an image: photo.jpg]``)
+        and, for images when vision is enabled, downloads the actual file so it
+        can be included as an image content part later.
+        """
+        body = event.body or ""
+        media_parts: list[Any] = []
+
+        if isinstance(event, RoomMessageImage):
+            body_desc = (
+                f"[sent an image: {body}]" if body else "[sent an image]"
+            )
+            if self.vision_enabled:
+                mxc_url: str = getattr(event, "url", "") or ""
+                if mxc_url:
+                    eid = event.event_id[:8].lstrip("$")
+                    filename = body or f"matrix_media_{eid}"
+                    filename = f"{eid}_{filename}"
+                    local_path = await self._download_mxc(mxc_url, filename)
+                    if local_path:
+                        media_parts.append(
+                            ImageContent(
+                                type=ContentType.IMAGE,
+                                image_url=Path(local_path).as_uri(),
+                            ),
+                        )
+        elif isinstance(event, RoomMessageFile):
+            body_desc = f"[sent a file: {body}]" if body else "[sent a file]"
+            mxc_url = getattr(event, "url", "") or ""
+            if mxc_url:
+                eid = event.event_id[:8].lstrip("$")
+                filename = body or f"matrix_media_{eid}"
+                filename = f"{eid}_{filename}"
+                local_path = await self._download_mxc(mxc_url, filename)
+                if local_path:
+                    media_parts.append(
+                        FileContent(
+                            type=ContentType.FILE,
+                            file_url=Path(local_path).as_uri(),
+                            filename=body or filename,
+                        ),
+                    )
+        elif isinstance(event, RoomMessageAudio):
+            body_desc = f"[sent audio: {body}]" if body else "[sent audio]"
+        elif isinstance(event, RoomMessageVideo):
+            body_desc = f"[sent a video: {body}]" if body else "[sent a video]"
+        else:
+            body_desc = body or "[media]"
+
+        self._record_history(
+            room_id,
+            HistoryEntry(
+                sender=self._get_display_name(room, sender_id),
+                body=body_desc,
+                timestamp=getattr(event, "server_timestamp", None),
+                message_id=event.event_id,
+                media_parts=media_parts or None,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Media — local dirs, mxc download, E2EE decrypt, inbound handlers
+    # local media dir; mxc fetch; AES decrypt for
+    # encrypted attachments; cleartext + RoomEncrypted* inbound paths (§7).
+    # ------------------------------------------------------------------
+
+    def _media_dir(self) -> Path:
+        """Return (and create) the local media storage directory."""
+        if self._workspace_dir:
+            return self._workspace_dir / "media"
+        return WORKING_DIR / "media"
+
+    def _mxc_to_http(self, mxc_url: str) -> str:
+        """Convert an mxc:// URL to an HTTP download URL.
+
+        Returns the original URL unchanged if it is not an mxc:// URL or if
+        the format is invalid.
+        """
+        if not mxc_url:
+            return mxc_url
+        if not mxc_url.startswith("mxc://"):
+            return mxc_url
+        rest = mxc_url[6:]  # strip "mxc://"
+        if "/" not in rest:
+            return mxc_url
+        server, media_id = rest.split("/", 1)
+        return (
+            f"{self.homeserver}/_matrix/media/v3/download"
+            f"/{server}/{media_id}"
+        )
+
+    async def _download_mxc(
+        self,
+        mxc_url: str,
+        filename: str,
+    ) -> Optional[str]:
+        """Download mxc:// to a local file; return path or None."""
+        if not mxc_url.startswith("mxc://"):
+            return None
+        try:
+            rest = mxc_url[6:]  # strip "mxc://"
+            server, media_id = rest.split("/", 1)
+            url = (
+                f"{self.homeserver}/_matrix/media/v3/download"
+                f"/{server}/{media_id}"
+            )
+            headers = {"Authorization": f"Bearer {self.access_token}"}
+            if not self._http_client:
+                logger.warning("MatrixChannel: HTTP client not initialized")
+                return None
+            resp = await self._http_client.get(url, headers=headers)
+            resp.raise_for_status()
+            dest = self._media_dir() / filename
+            dest.write_bytes(resp.content)
+            logger.debug("MatrixChannel: downloaded %s → %s", mxc_url, dest)
+            return str(dest)
+        except Exception as exc:
+            logger.warning(
+                "MatrixChannel: failed to download %s: %s",
+                mxc_url,
+                exc,
+            )
+            return None
+
+    def _e2ee_store_path(self) -> Path:
+        """Return the directory for persisting Olm/Megolm crypto state."""
+        return WORKING_DIR / "matrix_crypto_store"
+
+    async def _download_encrypted_mxc(
+        self,
+        mxc_url: str,
+        filename: str,
+        key: dict,
+        hashes: dict,
+        iv: str,
+    ) -> Optional[str]:
+        """Download an encrypted mxc:// URI, decrypt it, and save locally."""
+        if not mxc_url.startswith("mxc://") or not self._client:
+            return None
+        try:
+            rest = mxc_url[6:]
+            server, media_id = rest.split("/", 1)
+            url = (
+                f"{self.homeserver}/_matrix/media/v3/download"
+                f"/{server}/{media_id}"
+            )
+            headers = {"Authorization": f"Bearer {self.access_token}"}
+            if not self._http_client:
+                logger.warning("MatrixChannel: HTTP client not initialized")
+                return None
+            resp = await self._http_client.get(url, headers=headers)
+            resp.raise_for_status()
+
+            from nio.crypto.attachments import decrypt_attachment
+
+            jwk_key = key.get("k", "")
+            sha256_hash = hashes.get("sha256", "")
+            plaintext = decrypt_attachment(
+                resp.content,
+                jwk_key,
+                sha256_hash,
+                iv,
+            )
+
+            dest = self._media_dir() / filename
+            dest.write_bytes(plaintext)
+            logger.debug(
+                "MatrixChannel: downloaded+decrypted %s → %s",
+                mxc_url,
+                dest,
+            )
+            return str(dest)
+        except Exception as exc:
+            logger.warning(
+                "MatrixChannel: failed to download encrypted %s: %s",
+                mxc_url,
+                exc,
+            )
+            return None
+
+    # ------------------------------------------------------------------
+    # Incoming E2EE — undecryptable log + decrypted media (§7)
+    # MegolmEvent warning; RoomEncrypted* same allow/
+    # history/vision path as cleartext media when nio decrypts (optional E2EE).
+    # ------------------------------------------------------------------
+
+    async def _on_megolm_event(
+        self,
+        room: MatrixRoom,
+        event: MegolmEvent,
+    ) -> None:
+        """Handle undecryptable encrypted events (missing session key)."""
+        logger.warning(
+            "MatrixChannel: could not decrypt event %s in %s (session_id=%s)",
+            event.event_id,
+            room.room_id,
+            getattr(event, "session_id", "?"),
+        )
+
+    # pylint: disable=too-many-branches,too-many-statements
+    async def _on_room_encrypted_media_event(
+        self,
+        room: MatrixRoom,
+        event: Any,
+    ) -> None:
+        """Handle decrypted encrypted media (RoomEncryptedImage, etc.).
+
+        Delivered by matrix-nio after Megolm decrypt. File bytes are still
+        AES-encrypted; download + decrypt with key/iv/hashes from the event.
+        """
+        if event.sender == self._user_id:
+            return
+
+        sender_id = event.sender
+        room_id = room.room_id
+        # Use Matrix API for reliable DM detection (room.users unreliable
+        # after token restore)
+        is_dm = await self._is_dm_room(room_id, sender_id, room)
+
+        if self._is_channel_disabled(sender_id, room_id, is_dm):
+            return
+
+        if not is_dm:
+            if self._require_mention(room_id) and not self._was_mentioned(
+                event,
+                "",
+            ):
+                # Record as history (text description only)
+                body = event.body or ""
+                if isinstance(event, RoomEncryptedImage):
+                    desc = (
+                        f"[sent an encrypted image: {body}]"
+                        if body
+                        else "[sent an encrypted image]"
+                    )
+                elif isinstance(event, RoomEncryptedAudio):
+                    desc = (
+                        f"[sent encrypted audio: {body}]"
+                        if body
+                        else "[sent encrypted audio]"
+                    )
+                elif isinstance(event, RoomEncryptedVideo):
+                    desc = (
+                        f"[sent an encrypted video: {body}]"
+                        if body
+                        else "[sent an encrypted video]"
+                    )
+                else:
+                    desc = (
+                        f"[sent an encrypted file: {body}]"
+                        if body
+                        else "[sent an encrypted file]"
+                    )
+                self._record_history(
+                    room_id,
+                    HistoryEntry(
+                        sender=self._get_display_name(room, sender_id),
+                        body=desc,
+                        timestamp=getattr(event, "server_timestamp", None),
+                        message_id=event.event_id,
+                    ),
+                )
+                return
+
+        await self._send_read_receipt(room_id, event.event_id)
+        await self._send_typing(room_id, True)
+
+        body = event.body or ""
+        mxc_url = getattr(event, "url", "") or ""
+        key = getattr(event, "key", {}) or {}
+        hashes = getattr(event, "hashes", {}) or {}
+        iv = getattr(event, "iv", "") or ""
+
+        content_parts: list[Any] = []
+
+        if mxc_url and key and iv:
+            eid = event.event_id[:8].lstrip("$")
+            filename = body or f"matrix_media_{eid}"
+            filename = f"{eid}_{filename}"
+            local_path = await self._download_encrypted_mxc(
+                mxc_url,
+                filename,
+                key,
+                hashes,
+                iv,
+            )
+            if local_path:
+                file_uri = Path(local_path).as_uri()
+                if isinstance(event, RoomEncryptedImage):
+                    if self.vision_enabled:
+                        content_parts.append(
+                            ImageContent(
+                                type=ContentType.IMAGE,
+                                image_url=file_uri,
+                            ),
+                        )
+                    else:
+                        _no_vis = (
+                            "[User sent an image (current model does not "
+                            f"support image input): {body or filename}]"
+                        )
+                        content_parts.append(
+                            TextContent(
+                                type=ContentType.TEXT,
+                                text=_no_vis,
+                            ),
+                        )
+                elif isinstance(event, RoomEncryptedAudio):
+                    content_parts.append(
+                        AudioContent(
+                            type=ContentType.AUDIO,
+                            data=file_uri,
+                        ),
+                    )
+                elif isinstance(event, RoomEncryptedVideo):
+                    content_parts.append(
+                        VideoContent(
+                            type=ContentType.VIDEO,
+                            video_url=file_uri,
+                        ),
+                    )
+                else:
+                    content_parts.append(
+                        FileContent(
+                            type=ContentType.FILE,
+                            file_url=file_uri,
+                            filename=body or filename,
+                        ),
+                    )
+            else:
+                content_parts.append(
+                    TextContent(
+                        type=ContentType.TEXT,
+                        text=f"[Encrypted media unavailable: {body}]",
+                    ),
+                )
+
+        if not content_parts:
+            return
+
+        if not is_dm:
+            # Prefix sender identity so the LLM can distinguish participants
+            sender_name = self._get_display_name(room, sender_id)
+            first = content_parts[0] if content_parts else None
+            if first and getattr(first, "type", None) == ContentType.TEXT:
+                content_parts[0] = TextContent(
+                    type=ContentType.TEXT,
+                    text=f"{sender_name}: {first.text}",
+                )
+            else:
+                content_parts.insert(
+                    0,
+                    TextContent(
+                        type=ContentType.TEXT,
+                        text=f"{sender_name}:",
+                    ),
+                )
+            content_parts = self._apply_history_to_parts(
+                room_id,
+                content_parts,
+            )
+
+        worker_name = (self._user_id or "").split(":")[0].lstrip("@")
+        payload = {
+            "channel_id": CHANNEL_KEY,
+            "sender_id": sender_id,
+            "content_parts": content_parts,
+            "acl_sender_id": sender_id,
+            "meta": {
+                "room_id": room_id,
+                "is_dm": is_dm,
+                "is_group": not is_dm,
+                "worker_name": worker_name,
+                "event_id": event.event_id,
+                "sender_id": sender_id,
+            },
+        }
+
+        if self._enqueue:
+            self._enqueue(payload)
+            if not is_dm:
+                self._clear_history(room_id)
+
+    # ------------------------------------------------------------------
+    # Media upload (local file → mxc://)
+    # upload to homeserver media repo; shared by
+    # send_media outbound path (same role as worker _upload_file).
+    # ------------------------------------------------------------------
+
+    async def _upload_file(self, file_ref: str) -> Optional[str]:
+        """Upload a local file to Matrix; return mxc:// URI or None."""
+        if not self._client:
+            return None
+        try:
+            # file_ref may be a file:// URI or a plain path
+            path = Path(file_url_to_local_path(file_ref) or file_ref)
+            if not path.exists():
+                logger.warning(
+                    "MatrixChannel: upload source not found: %s",
+                    file_ref,
+                )
+                return None
+            mime_type, _ = mimetypes.guess_type(str(path))
+            mime_type = mime_type or "application/octet-stream"
+            data = path.read_bytes()
+            resp, _ = await self._client.upload(
+                io.BytesIO(data),
+                content_type=mime_type,
+                filename=path.name,
+                filesize=len(data),
+            )
+            if isinstance(resp, UploadResponse):
+                logger.debug(
+                    "MatrixChannel: uploaded %s → %s",
+                    path.name,
+                    resp.content_uri,
+                )
+                return resp.content_uri
+            logger.warning("MatrixChannel: upload failed: %s", resp)
+            return None
+        except Exception as exc:
+            logger.warning(
+                "MatrixChannel: upload error for %s: %s",
+                file_ref,
+                exc,
+            )
+            return None
+
+    # ------------------------------------------------------------------
+    # DM room detection (joined_members API + short-lived cache)
+    # reliable DM vs group after token restore (§8);
+    # feeds allowlist / requireMention / history behavior.
+    # ------------------------------------------------------------------
+
+    def _is_dm_room_fallback(
+        self,
+        room: Optional[MatrixRoom],
+        sender_id: str,
+    ) -> bool:
+        """Best-effort DM check when joined_members API is unavailable."""
+        room_id = str(getattr(room, "room_id", "") or "")
+        if self._looks_like_teamharness_task_room(room_id, room):
+            return False
+        if not room or not self._user_id:
+            return False
+        try:
+            users = list(getattr(room, "users", {}).keys())
+            if users:
+                return (
+                    len(users) == 2
+                    and self._user_id in users
+                    and sender_id in users
+                )
+            member_count = int(getattr(room, "member_count", 0) or 0)
+            return member_count == 2
+        except Exception:
+            return False
+
+    def _room_has_teamharness_task_marker(
+        self,
+        room: Optional[MatrixRoom],
+    ) -> bool:
+        """Return True when room state looks like a TeamHarness task room."""
+        if not room:
+            return False
+        for attr in ("topic", "name", "display_name"):
+            value = getattr(room, attr, "")
+            if callable(value):
+                continue
+            text = str(value or "").strip()
+            if text.startswith("Task room for ") or "Task room for " in text:
+                return True
+        return False
+
+    def _is_known_teamharness_task_room(self, room_id: str) -> bool:
+        """Check local TeamHarness task metadata for an assignment room id."""
+        if not room_id:
+            return False
+        now = int(time.time() * 1000)
+        cache = getattr(self, "_teamharness_task_room_cache", None)
+        if cache is None:
+            cache = {}
+            self._teamharness_task_room_cache = cache
+        cached = cache.get(room_id)
+        if cached and (now - cached["ts"]) < TASK_ROOM_CACHE_TTL_MS:
+            return bool(cached["is_task_room"])
+
+        is_task_room = False
+        root = getattr(self, "_workspace_dir", None)
+        workspace_dir = Path(root).expanduser() if root else Path(WORKING_DIR)
+        tasks_dir = workspace_dir / "shared" / "tasks"
+        if tasks_dir.is_dir():
+            for meta_path in tasks_dir.glob("*/meta.json"):
+                try:
+                    task = json.loads(meta_path.read_text(encoding="utf-8"))
+                except (OSError, json.JSONDecodeError) as exc:
+                    logger.debug(
+                        "MatrixChannel: failed to read task room metadata "
+                        "%s: %s",
+                        meta_path,
+                        exc,
+                    )
+                    continue
+                task_room_id = str(
+                    task.get("room_id") or task.get("roomId") or "",
+                ).strip()
+                if task_room_id == room_id:
+                    is_task_room = True
+                    break
+
+        cache[room_id] = {"is_task_room": is_task_room, "ts": now}
+        return is_task_room
+
+    def _looks_like_teamharness_task_room(
+        self,
+        room_id: str,
+        room: Optional[MatrixRoom] = None,
+    ) -> bool:
+        if self._room_has_teamharness_task_marker(room):
+            return True
+        return self._is_known_teamharness_task_room(room_id)
+
+    async def _is_dm_room(
+        self,
+        room_id: str,
+        sender_id: str,
+        room: Optional[MatrixRoom] = None,
+    ) -> bool:
+        """Check if a room is a DM (direct message) between self and sender.
+
+        Uses Matrix API to get actual joined members, because nio's room.users
+        can be unreliable after token restore.
+
+        Args:
+            room_id: The Matrix room ID
+            sender_id: The sender's user ID
+
+        Returns:
+            True if the room has exactly 2 members (self and sender)
+        """
+        if not self._client or not self._user_id:
+            return False
+
+        if self._looks_like_teamharness_task_room(room_id, room):
+            logger.debug(
+                "MatrixChannel: room=%s is a TeamHarness task room; "
+                "treating as group semantics",
+                room_id,
+            )
+            return False
+
+        now = int(time.time() * 1000)
+
+        # Check cache
+        cached = self._dm_room_cache.get(room_id)
+        if cached and (now - cached["ts"]) < DM_CACHE_TTL_MS:
+            members = cached["members"]
+            is_dm = (
+                len(members) == 2
+                and self._user_id in members
+                and sender_id in members
+            )
+            logger.debug(
+                "MatrixChannel: DM check (cached) room=%s members=%d is_dm=%s",
+                room_id,
+                len(members),
+                is_dm,
+            )
+            return is_dm
+
+        # Fetch from Matrix API
+        try:
+            resp = await self._client.joined_members(room_id)
+            if isinstance(resp, JoinedMembersResponse):
+                members = [m.user_id for m in resp.members]
+                # Update cache
+                self._dm_room_cache[room_id] = {"members": members, "ts": now}
+
+                is_dm = (
+                    len(members) == 2
+                    and self._user_id in members
+                    and sender_id in members
+                )
+                logger.debug(
+                    "MatrixChannel: DM check (API) room=%s members=%d "
+                    "is_dm=%s members=%s",
+                    room_id,
+                    len(members),
+                    is_dm,
+                    members,
+                )
+                return is_dm
+            else:
+                logger.warning(
+                    "MatrixChannel: joined_members failed for %s: %s",
+                    room_id,
+                    resp,
+                )
+                fallback = self._is_dm_room_fallback(room, sender_id)
+                logger.warning(
+                    "MatrixChannel: joined_members fallback for %s "
+                    "-> is_dm=%s",
+                    room_id,
+                    fallback,
+                )
+                return fallback
+        except Exception as exc:
+            fallback = self._is_dm_room_fallback(room, sender_id)
+            logger.warning(
+                "MatrixChannel: joined_members error for %s: %s; "
+                "fallback is_dm=%s",
+                room_id,
+                exc,
+                fallback,
+            )
+            return fallback
+
+    # ------------------------------------------------------------------
+    # Incoming message handling — text
+    # text receive; allowlist + per-room rules +
+    # mention gating; history buffer when no mention; enqueue AgentRequest
+    # (§9).
+    # ------------------------------------------------------------------
+
+    async def _on_room_event(
+        self,
+        room: MatrixRoom,
+        event: RoomMessageText,
+    ) -> None:
+        room_id = room.room_id
+        sender_id = event.sender
+        teamharness_self_trigger = None
+        if sender_id == self._user_id:
+            teamharness_self_trigger = self._teamharness_self_trigger(room_id, event)
+
+        # Skip own messages early
+        if sender_id == self._user_id and teamharness_self_trigger is None:
+            return
+
+        text = event.body or ""
+
+        # Use Matrix API to reliably detect DM rooms
+        # (nio's room.users is unreliable after token restore)
+        is_dm = await self._is_dm_room(room_id, sender_id, room)
+
+        logger.info(
+            "_on_room_event: sender=%s room=%s body=%r is_dm=%s",
+            event.sender,
+            room_id,
+            (event.body or "")[:80],
+            is_dm,
+        )
+
+        if self._is_channel_disabled(sender_id, room_id, is_dm):
+            return
+
+        if teamharness_self_trigger is None and _is_teamharness_tool_display(text):
+            logger.info(
+                "MatrixChannel: skipping TeamHarness tool display event "
+                "(room=%s sender=%s event_id=%s)",
+                room_id,
+                sender_id,
+                event.event_id,
+            )
+            return
+
+        is_thread_event = self._is_thread_event(event)
+
+        # Readiness probe: reply directly without enqueuing to the agent
+        readiness_reply = self._targeted_readiness_probe_reply(event, text)
+        if readiness_reply:
+            await self._send_plain_text(room_id, readiness_reply)
+            return
+
+        # Mention check for group rooms
+        if not is_dm:
+            if teamharness_self_trigger is None and self._require_mention(room_id) and not self._was_mentioned(
+                event,
+                text,
+            ):
+                # Thread events that don't mention us are silently ignored
+                if is_thread_event:
+                    return
+                logger.info(
+                    "MatrixChannel: group text not mentioned, cached to "
+                    "history (room=%s sender=%s event_id=%s)",
+                    room_id,
+                    sender_id,
+                    event.event_id,
+                )
+                self._record_history(
+                    room_id,
+                    HistoryEntry(
+                        sender=self._get_display_name(room, sender_id),
+                        body=text,
+                        timestamp=getattr(event, "server_timestamp", None),
+                        message_id=event.event_id,
+                    ),
+                )
+                return
+
+        # Mark as read + start typing immediately so the sender sees feedback
+        await self._send_read_receipt(room_id, event.event_id)
+        await self._send_typing(room_id, True)
+
+        # Strip leading @mention so slash commands and NO_REPLY are detected
+        # regardless of room type (group or DM).
+        command_text = text
+        stripped = self._strip_mention_prefix(text, room)
+
+        # NO_REPLY protocol: the sender explicitly signals "nothing to say".
+        # Drop it silently to prevent infinite ping-pong between agents.
+        if stripped.strip() == "NO_REPLY":
+            logger.info(
+                "MatrixChannel: received NO_REPLY from %s in %s, ignoring",
+                sender_id,
+                room_id,
+            )
+            await self._send_typing(room_id, False)
+            return
+
+        control_text = self._control_command_text(stripped)
+        cmd = ""
+        if control_text is not None:
+            command_text = control_text
+        elif stripped.startswith("/"):
+            command_text = "/" + stripped.lstrip("/")
+            cmd = command_text.lstrip("/").split()[0]
+        if control_text is None and cmd in _SLASH_COMMANDS:
+            # Apply alias (e.g. /reset -> /clear)
+            if cmd in _SLASH_ALIASES:
+                canonical = _SLASH_ALIASES[cmd]
+                command_text = command_text.replace(
+                    f"/{cmd}",
+                    f"/{canonical}",
+                    1,
+                )
+            if stripped != text:
+                logger.info(
+                    "Stripped mention prefix for slash command: %r -> %r",
+                    text,
+                    command_text,
+                )
+
+        # Build content parts, prepending accumulated history for group rooms.
+        # Skip history prepend for slash commands — QwenPaw's command parser
+        # requires the message to start with "/" to recognise it.
+        content_parts: list[Any] = [
+            TextContent(type=ContentType.TEXT, text=command_text),
+        ]
+        is_slash_cmd = command_text.startswith("/")
+        if not is_dm and not is_slash_cmd:
+            # Prefix sender identity so the LLM can distinguish participants
+            sender_name = self._get_display_name(room, sender_id)
+            content_parts[0] = TextContent(
+                type=ContentType.TEXT,
+                text=f"{sender_name}: {command_text}",
+            )
+            if not is_thread_event:
+                content_parts = self._apply_history_to_parts(
+                    room_id,
+                    content_parts,
+                )
+
+        worker_name = (self._user_id or "").split(":")[0].lstrip("@")
+        payload = {
+            "channel_id": CHANNEL_KEY,
+            "sender_id": sender_id,
+            "content_parts": content_parts,
+            "acl_sender_id": sender_id,
+            "meta": {
+                "room_id": room_id,
+                "is_dm": is_dm,
+                "is_group": not is_dm,
+                "worker_name": worker_name,
+                "event_id": event.event_id,
+                "thread_root_event_id": event.event_id,
+                "sender_id": sender_id,
+            },
+        }
+        if teamharness_self_trigger is not None:
+            payload["meta"].update(
+                {
+                    "teamharness_trigger": True,
+                    "teamharness_trigger_type": str(teamharness_self_trigger.get("type") or ""),
+                    "teamharness_trigger_kind": str(teamharness_self_trigger.get("kind") or ""),
+                },
+            )
+
+        if self._enqueue:
+            self._enqueue(payload)
+            if not is_dm and not is_thread_event:
+                self._clear_history(room_id)
+
+    # ------------------------------------------------------------------
+    # Incoming message handling — media (image / file / audio / video)
+    # media receive + mxc download; vision_enabled
+    # gates image→model vs text downgrade; same allow/history path as text
+    # (§9–§11).
+    # ------------------------------------------------------------------
+
+    # pylint: disable=too-many-branches,too-many-statements
+    async def _on_room_media_event(self, room: MatrixRoom, event: Any) -> None:
+        """Handle incoming media messages (image, file, audio, video)."""
+        if event.sender == self._user_id:
+            return
+
+        sender_id = event.sender
+        room_id = room.room_id
+        # Use Matrix API for reliable DM detection (room.users unreliable
+        # after token restore)
+        is_dm = await self._is_dm_room(room_id, sender_id, room)
+
+        if self._is_channel_disabled(sender_id, room_id, is_dm):
+            return
+
+        is_thread_event = self._is_thread_event(event)
+
+        # For group rooms, apply the same mention policy as text messages.
+        if not is_dm:
+            if self._require_mention(room_id) and not self._was_mentioned(
+                event,
+                "",
+            ):
+                if is_thread_event:
+                    return
+                logger.info(
+                    "MatrixChannel: group media not mentioned, cached to "
+                    "history (room=%s sender=%s event_id=%s)",
+                    room_id,
+                    sender_id,
+                    event.event_id,
+                )
+                await self._record_media_history(
+                    room,
+                    event,
+                    sender_id,
+                    room_id,
+                )
+                return
+
+        await self._send_read_receipt(room_id, event.event_id)
+        await self._send_typing(room_id, True)
+
+        mxc_url: str = getattr(event, "url", "") or ""
+        body: str = event.body or ""  # filename or caption
+
+        content_parts: list[Any] = []
+
+        if mxc_url:
+            # Use the body as filename, fall back to a safe default.
+            # Strip leading '$' from Matrix event IDs to avoid URI encoding
+            # issues ($→%24 breaks agentscope's image extension check).
+            eid = event.event_id[:8].lstrip("$")
+            filename = body or f"matrix_media_{eid}"
+            filename = f"{eid}_{filename}"
+            local_path = await self._download_mxc(mxc_url, filename)
+            if local_path:
+                file_uri = Path(local_path).as_uri()
+                if isinstance(event, RoomMessageImage):
+                    if self.vision_enabled:
+                        content_parts.append(
+                            ImageContent(
+                                type=ContentType.IMAGE,
+                                image_url=file_uri,
+                            ),
+                        )
+                    else:
+                        # No vision: downgrade image to text
+                        _no_vis = (
+                            "[User sent an image (current model does not "
+                            f"support image input): {body or filename}]"
+                        )
+                        content_parts.append(
+                            TextContent(
+                                type=ContentType.TEXT,
+                                text=_no_vis,
+                            ),
+                        )
+                elif isinstance(event, RoomMessageAudio):
+                    content_parts.append(
+                        AudioContent(
+                            type=ContentType.AUDIO,
+                            data=file_uri,
+                        ),
+                    )
+                elif isinstance(event, RoomMessageVideo):
+                    content_parts.append(
+                        VideoContent(
+                            type=ContentType.VIDEO,
+                            video_url=file_uri,
+                        ),
+                    )
+                else:  # RoomMessageFile
+                    content_parts.append(
+                        FileContent(
+                            type=ContentType.FILE,
+                            file_url=file_uri,
+                            filename=body or filename,
+                        ),
+                    )
+            else:
+                content_parts.append(
+                    TextContent(
+                        type=ContentType.TEXT,
+                        text=f"[Media unavailable: {body}]",
+                    ),
+                )
+
+        if not content_parts:
+            return
+
+        # Prepend accumulated history for group rooms
+        if not is_dm:
+            # Prefix sender identity so the LLM can distinguish participants
+            sender_name = self._get_display_name(room, sender_id)
+            first = content_parts[0] if content_parts else None
+            if first and getattr(first, "type", None) == ContentType.TEXT:
+                content_parts[0] = TextContent(
+                    type=ContentType.TEXT,
+                    text=f"{sender_name}: {first.text}",
+                )
+            else:
+                content_parts.insert(
+                    0,
+                    TextContent(
+                        type=ContentType.TEXT,
+                        text=f"{sender_name}:",
+                    ),
+                )
+            if not is_thread_event:
+                content_parts = self._apply_history_to_parts(
+                    room_id,
+                    content_parts,
+                )
+
+        worker_name = (self._user_id or "").split(":")[0].lstrip("@")
+        payload = {
+            "channel_id": CHANNEL_KEY,
+            "sender_id": sender_id,
+            "content_parts": content_parts,
+            "acl_sender_id": sender_id,
+            "meta": {
+                "room_id": room_id,
+                "is_dm": is_dm,
+                "is_group": not is_dm,
+                "worker_name": worker_name,
+                "event_id": event.event_id,
+                "thread_root_event_id": event.event_id,
+                "sender_id": sender_id,
+            },
+        }
+
+        if self._enqueue:
+            self._enqueue(payload)
+            if not is_dm and not is_thread_event:
+                self._clear_history(room_id)
+
+    # ------------------------------------------------------------------
+    # Read receipt & typing indicator
+    # read markers on handled messages; typing on/off
+    # + renewal until cap (optional UX; §10).
+    # ------------------------------------------------------------------
+
+    async def _send_read_receipt(self, room_id: str, event_id: str) -> None:
+        """Mark a message as read (sends both read receipt and read marker)."""
+        if not self._client or not event_id:
+            return
+        try:
+            await self._client.room_read_markers(
+                room_id,
+                fully_read_event=event_id,
+                read_event=event_id,
+            )
+        except Exception as exc:
+            logger.debug(
+                "MatrixChannel: read receipt failed for %s: %s",
+                event_id,
+                exc,
+            )
+
+    async def _send_typing(
+        self,
+        room_id: str,
+        typing: bool,
+        timeout: int = TYPING_SERVER_TIMEOUT_MS,
+    ) -> None:
+        """Set typing indicator on/off for a room.
+
+        When turning on, starts a background renewal task that re-sends the
+        typing indicator periodically (see ``TYPING_RENEWAL_INTERVAL_S``)
+        before the server timeout, up to ``TYPING_MAX_DURATION_S``.
+        When turning off, cancels the renewal task.
+        """
+        if not self._client:
+            return
+        # Cancel any existing renewal task for this room
+        existing = self._typing_tasks.pop(room_id, None)
+        if existing and not existing.done():
+            existing.cancel()
+        try:
+            await self._client.room_typing(
+                room_id,
+                typing_state=typing,
+                timeout=timeout,
+            )
+        except Exception as exc:
+            logger.debug(
+                "MatrixChannel: typing indicator failed for %s: %s",
+                room_id,
+                exc,
+            )
+        # Start renewal loop if turning on
+        if typing:
+            self._typing_tasks[room_id] = asyncio.create_task(
+                self._typing_renewal_loop(room_id, timeout),
+            )
+
+    async def _typing_renewal_loop(
+        self,
+        room_id: str,
+        timeout: int = TYPING_SERVER_TIMEOUT_MS,
+    ) -> None:
+        """Re-send typing=true until cap or cancellation."""
+        elapsed = 0
+        try:
+            while elapsed < TYPING_MAX_DURATION_S:
+                await asyncio.sleep(TYPING_RENEWAL_INTERVAL_S)
+                elapsed += TYPING_RENEWAL_INTERVAL_S
+                if not self._client:
+                    break
+                await self._client.room_typing(
+                    room_id,
+                    typing_state=True,
+                    timeout=timeout,
+                )
+        except asyncio.CancelledError:
+            logger.debug(
+                "MatrixChannel: typing renewal cancelled for %s",
+                room_id,
+            )
+            raise
+        except Exception as exc:
+            logger.debug(
+                "MatrixChannel: typing renewal failed for %s: %s",
+                room_id,
+                exc,
+            )
+        finally:
+            # If we hit the cap, explicitly stop typing
+            if elapsed >= TYPING_MAX_DURATION_S and self._client:
+                try:
+                    await self._client.room_typing(room_id, typing_state=False)
+                except Exception as exc:
+                    logger.debug(
+                        "MatrixChannel: typing stop after cap failed "
+                        "for %s: %s",
+                        room_id,
+                        exc,
+                    )
+            self._typing_tasks.pop(room_id, None)
+
+    # ------------------------------------------------------------------
+    # build_agent_request_from_native (BaseChannel protocol)
+    # native content_parts → QwenPaw Content; same
+    # vision_enabled guard as inbound media for image parts (§11).
+    # ------------------------------------------------------------------
+
+    # pylint: disable=too-many-return-statements
+    def _build_content_part(self, p: dict[str, Any]) -> Any:
+        """Convert a native content-part dict to a QwenPaw Content object."""
+        t = p.get("type")
+        if t == "text" and p.get("text"):
+            return TextContent(type=ContentType.TEXT, text=p["text"])
+        if t == "image" and p.get("image_url"):
+            if not self.vision_enabled:
+                # Downgrade silently; _on_room_media_event should have already
+                # converted this, but guard here for any code path that builds
+                # content_parts directly.
+                return TextContent(
+                    type=ContentType.TEXT,
+                    text=(
+                        "[Image omitted: current model does not support "
+                        "image input]"
+                    ),
+                )
+            return ImageContent(
+                type=ContentType.IMAGE,
+                image_url=p["image_url"],
+            )
+        if t == "file":
+            return FileContent(
+                type=ContentType.FILE,
+                file_url=p.get("file_url", ""),
+            )
+        if t == "audio" and p.get("data"):
+            return AudioContent(type=ContentType.AUDIO, data=p["data"])
+        if t == "video" and p.get("video_url"):
+            return VideoContent(
+                type=ContentType.VIDEO,
+                video_url=p["video_url"],
+            )
+        return None
+
+    def build_agent_request_from_native(self, native_payload: Any) -> Any:
+        parts = native_payload.get("content_parts", [])
+        meta = native_payload.get("meta", {})
+        sender_id = native_payload.get("sender_id", "")
+        room_id = meta.get("room_id", sender_id)
+        session_id = f"matrix:{room_id}"
+
+        # content_parts are already ContentType objects (from both
+        # _on_room_event and _on_room_media_event); filter out None.
+        content = [p for p in parts if p is not None]
+        if not content:
+            content = [TextContent(type=ContentType.TEXT, text="")]
+
+        # Use room_id as the AgentRequest user_id so that all participants
+        # in the same room share one session (QwenPaw keys session state on
+        # both session_id AND user_id).  The real sender is preserved in
+        # meta["sender_id"] for reply mentions.
+        req = self.build_agent_request_from_user_content(
+            channel_id=CHANNEL_KEY,
+            sender_id=room_id,
+            session_id=session_id,
+            content_parts=content,
+            channel_meta=meta,
+        )
+        req.channel_meta = meta  # type: ignore[attr-defined]
+        return req
+
+    def resolve_session_id(self, sender_id: str, channel_meta=None) -> str:
+        room_id = (channel_meta or {}).get("room_id", sender_id)
+        return f"matrix:{room_id}"
+
+    def to_handle_from_target(self, *, user_id: str, session_id: str) -> str:
+        """For Matrix, return room_id (session_id), not user_id.
+
+        Matrix requires room_id to send messages, not user_id.
+        Override BaseChannel's default implementation which returns user_id.
+        The session_id carries a ``matrix:`` prefix added by
+        :meth:`resolve_session_id`; strip it so the value is a raw
+        Matrix room_id that can be passed directly to ``room_send``.
+        """
+        if session_id.startswith("matrix:"):
+            return session_id[len("matrix:") :]
+        return session_id
+
+    def get_to_handle_from_request(self, request: Any) -> str:
+        meta = getattr(request, "channel_meta", {}) or {}
+        return meta.get("room_id", getattr(request, "user_id", ""))
+
+    # ------------------------------------------------------------------
+    # Mention helper — MSC3952 m.mentions from body text scan
+    # ------------------------------------------------------------------
+
+    # Regex to match Matrix user IDs: @localpart:domain (with optional port)
+    _MATRIX_USER_ID_RE = re.compile(
+        r"@[a-zA-Z0-9._=+/\-]+:[a-zA-Z0-9.\-]+(?::\d+)?",
+    )
+
+    def _extract_mentions_from_text(self, text: str) -> list[str]:
+        """Extract all @user:domain Matrix IDs from message text."""
+        matches = self._MATRIX_USER_ID_RE.findall(text)
+        return list(dict.fromkeys(matches))  # dedupe, preserve order
+
+    def _apply_mention(
+        self,
+        content: dict[str, Any],
+        user_id: str,
+        room_id: str,
+        *,
+        explicit_user_ids: Optional[List[str]] = None,
+        fallback_user_id: Optional[str] = None,
+    ) -> None:
+        """Attach Matrix mentions in both visible and structured forms."""
+        body = content.get("body", "") or ""
+        if isinstance(explicit_user_ids, str):
+            targets = [explicit_user_ids]
+        elif explicit_user_ids:
+            targets = list(explicit_user_ids)
+        else:
+            targets = self._extract_mentions_from_text(body)
+            if not targets and fallback_user_id:
+                targets = [fallback_user_id]
+        targets = [
+            target
+            for target in _dedupe_nonempty(targets)
+            if target != self._user_id
+        ]
+        if not targets:
+            return
+
+        html_body = content.get("formatted_body", "") or ""
+        if not html_body:
+            html_body = html.escape(body).replace("\n", "<br>\n")
+
+        for mxid in targets:
+            display = self._resolve_display_name(mxid, room_id) or mxid
+            if mxid in body:
+                body = body.replace(mxid, display, 1)
+            elif display not in body:
+                body = f"{display} {body}" if body else display
+
+            mxid_enc = urllib.parse.quote(mxid, safe="")
+            anchor = (
+                f'<a href="https://matrix.to/#/{mxid_enc}">'
+                f"{html.escape(display)}</a>"
+            )
+            if mxid in html_body:
+                html_body = html_body.replace(mxid, anchor, 1)
+            elif anchor not in html_body:
+                html_body = f"{anchor} {html_body}" if html_body else anchor
+
+        content["body"] = body
+        content["format"] = "org.matrix.custom.html"
+        content["formatted_body"] = html_body
+        content["m.mentions"] = {"user_ids": targets}
+
+    def _resolve_display_name(self, user_id: str, room_id: str) -> str:
+        """Best-effort display name for *user_id* in *room_id*."""
+        if self._client:
+            room = self._client.rooms.get(room_id)
+            if room:
+                try:
+                    name = room.user_name(user_id)
+                    if name:
+                        return name
+                except Exception as exc:
+                    logger.debug(
+                        "MatrixChannel: resolve_display_name user_name failed "
+                        "for %s: %s",
+                        user_id,
+                        exc,
+                    )
+        return user_id.split(":")[0].lstrip("@") or user_id
+
+    def _mark_room_encrypted(
+        self,
+        room_id: str,
+        room: Optional[MatrixRoom] = None,
+    ) -> None:
+        """Keep nio's encrypted room state consistent for outbound sends."""
+        if not self._client:
+            return
+        encrypted_rooms = getattr(self._client, "encrypted_rooms", None)
+        if encrypted_rooms is not None:
+            encrypted_rooms.add(room_id)
+        target_room = room
+        if target_room is None:
+            rooms = getattr(self._client, "rooms", {})
+            target_room = rooms.get(room_id) if rooms else None
+        if target_room is not None:
+            try:
+                target_room.encrypted = True
+            except Exception as exc:
+                logger.debug(
+                    "MatrixChannel: failed to mark %s encrypted: %s",
+                    room_id,
+                    exc,
+                )
+
+    def _room_will_encrypt(self, room_id: str) -> bool:
+        """Return whether matrix-nio will encrypt room_send for this room."""
+        if not self._client or not getattr(self._client, "olm", None):
+            return False
+        rooms = getattr(self._client, "rooms", {})
+        room = rooms.get(room_id) if rooms else None
+        if room is not None and getattr(room, "encrypted", False) is True:
+            return True
+        encrypted_rooms = (
+            getattr(self._client, "encrypted_rooms", set()) or set()
+        )
+        if room_id in encrypted_rooms:
+            self._mark_room_encrypted(room_id, room)
+            return True
+        return False
+
+    async def _prepare_room_send(self, room_id: str) -> None:
+        """Align local encryption flags with the homeserver before
+        ``room_send``.
+
+        matrix-nio only wraps ``room_send`` as ``m.room.encrypted`` when
+        ``client.rooms[room_id].encrypted`` is true. If incremental sync never
+        applied ``m.room.encryption`` to that object (common after restoring
+        tokens or partial state), sends are still plaintext and Element shows
+        "not encrypted". Fetch room state once per send attempt when needed.
+        """
+        if not self.encryption:
+            return
+        if not self._client or not getattr(self._client, "olm", None):
+            logger.warning(
+                "MatrixChannel: E2EE configured but Olm is not ready; "
+                "outbound message to %s will not be encrypted",
+                room_id,
+            )
+            return
+        await self._e2ee_maintenance()
+        if self._room_will_encrypt(room_id):
+            return
+        if room_id not in getattr(self._client, "rooms", {}):
+            logger.warning(
+                "MatrixChannel: room %s not in client cache; "
+                "cannot confirm E2EE before send (wait for sync / join)",
+                room_id,
+            )
+            return
+        try:
+            enc_state = await self._client.room_get_state_event(
+                room_id,
+                "m.room.encryption",
+                "",
+            )
+        except Exception as exc:
+            logger.warning(
+                "MatrixChannel: failed to get m.room.encryption for %s: %s",
+                room_id,
+                exc,
+            )
+            enc_state = None
+
+        if isinstance(enc_state, RoomGetStateEventResponse):
+            algo = (enc_state.content or {}).get("algorithm")
+            if algo:
+                self._mark_room_encrypted(room_id)
+                logger.debug(
+                    "MatrixChannel: marked %s encrypted from server (%s)",
+                    room_id,
+                    algo,
+                )
+
+        if not self._room_will_encrypt(room_id):
+            logger.warning(
+                "MatrixChannel: E2EE on but room %s is not encrypted in "
+                "client after state check; outbound send may be plaintext",
+                room_id,
+            )
+
+    # ------------------------------------------------------------------
+    # Thread detection and readiness (ported from CoPaw overlay)
+    # ------------------------------------------------------------------
+
+    def _is_thread_event(self, event: Any) -> bool:
+        """Return True when an inbound Matrix event belongs to a thread."""
+        source = getattr(event, "source", {}) or {}
+        if not isinstance(source, dict):
+            return False
+        content = source.get("content", {}) or {}
+        if not isinstance(content, dict):
+            return False
+        relates_to = content.get("m.relates_to", {}) or {}
+        if not isinstance(relates_to, dict):
+            return False
+        return relates_to.get("rel_type") == "m.thread"
+
+    def _targeted_readiness_probe_reply(self, event: Any, text: str) -> str | None:
+        """Return a direct readiness reply if this event explicitly targets us."""
+        reply = _readiness_probe_reply(text)
+        if not reply or not self._user_id:
+            return None
+        content = getattr(event, "source", {}).get("content", {}) or {}
+        mentions = content.get("m.mentions", {}) or {}
+        if self._user_id in mentions.get("user_ids", []):
+            return reply
+        if re.search(re.escape(self._user_id), text, re.IGNORECASE):
+            return reply
+        return None
+
+    async def _send_plain_text(self, room_id: str, text: str) -> None:
+        """Send a plain Matrix text event without invoking the agent path."""
+        if not self._client:
+            logger.error("MatrixChannel: direct send called but client not ready")
+            return
+        try:
+            await self._room_send_with_retry(
+                room_id,
+                "m.room.message",
+                {"msgtype": "m.text", "body": text},
+            )
+        except Exception as exc:
+            logger.exception(
+                "MatrixChannel: direct send failed to %s: %s",
+                room_id,
+                exc,
+            )
+
+    # ------------------------------------------------------------------
+    # Thread relation helpers (ported from CoPaw overlay)
+    # ------------------------------------------------------------------
+
+    def _with_thread_relation_meta(
+        self,
+        meta: Optional[Dict[str, Any]],
+        thread_root_event_id: str,
+    ) -> Dict[str, Any]:
+        """Return send metadata pinned to a Matrix thread root."""
+        meta_dict = dict(meta or {})
+        if thread_root_event_id:
+            meta_dict[_MATRIX_THREAD_META_KEY] = thread_root_event_id
+            meta_dict.setdefault(_THREAD_META_ROOT_KEY, thread_root_event_id)
+        return meta_dict
+
+    async def _send_or_queue_thread_parts(
+        self,
+        room_id: str,
+        parts: List[Any],
+        meta: Optional[Dict[str, Any]],
+    ) -> bool:
+        """Send follow-up parts in the current thread, or queue until rooted."""
+        meta_dict = meta if isinstance(meta, dict) else {}
+        thread_root = (
+            meta_dict.get(_MATRIX_THREAD_META_KEY)
+            or meta_dict.get(_MATRIX_OWN_THREAD_ROOT_KEY)
+            or meta_dict.get(_THREAD_META_ROOT_KEY)
+        )
+        if not thread_root:
+            meta_dict.setdefault(_MATRIX_PENDING_THREAD_PARTS_KEY, []).extend(
+                parts,
+            )
+            return True
+        thread_meta = self._with_thread_relation_meta(meta_dict, thread_root)
+        await self.send_content_parts(room_id, parts, thread_meta)
+        return True
+
+    async def _flush_pending_thread_parts(
+        self,
+        room_id: str,
+        meta: Optional[Dict[str, Any]],
+    ) -> None:
+        """Flush queued follow-up parts after the first event becomes root."""
+        meta_dict = meta if isinstance(meta, dict) else {}
+        pending = meta_dict.pop(_MATRIX_PENDING_THREAD_PARTS_KEY, []) or []
+        if pending:
+            await self._send_or_queue_thread_parts(room_id, pending, meta_dict)
+        await self._flush_pending_final_message_to_thread(room_id, meta_dict)
+
+    async def _flush_pending_final_message_to_thread(
+        self,
+        room_id: str,
+        meta: Optional[Dict[str, Any]],
+    ) -> None:
+        """Flush a queued final message event into the established thread."""
+        meta_dict = meta if isinstance(meta, dict) else {}
+        pending = meta_dict.pop(_MATRIX_PENDING_FINAL_MESSAGE_KEY, None)
+        if not pending:
+            return
+        thread_root = (
+            meta_dict.get(_MATRIX_THREAD_META_KEY)
+            or meta_dict.get(_MATRIX_OWN_THREAD_ROOT_KEY)
+            or meta_dict.get(_THREAD_META_ROOT_KEY)
+        )
+        if not thread_root:
+            meta_dict[_MATRIX_PENDING_FINAL_MESSAGE_KEY] = pending
+            return
+        thread_meta = self._with_thread_relation_meta(meta_dict, thread_root)
+        # pending is the event object — use send_message_content to properly
+        # render it through the renderer, not str() which produces repr.
+        if isinstance(pending, str):
+            await self.send(room_id, pending, thread_meta)
+        else:
+            await self.send_message_content(room_id, pending, thread_meta)
+
+    async def _ensure_thread_root(
+        self,
+        to_handle: str,
+        send_meta: Dict[str, Any],
+    ) -> None:
+        """Create a placeholder thread-root message if none exists yet."""
+        if send_meta.get(_MATRIX_OWN_THREAD_ROOT_KEY):
+            return
+        if not self._client:
+            return
+        content: dict[str, Any] = {
+            "msgtype": "m.notice",
+            "body": "处理中...",
+        }
+        try:
+            resp = await self._room_send_with_retry(
+                to_handle,
+                "m.room.message",
+                content,
+            )
+            event_id = getattr(resp, "event_id", None)
+            if event_id:
+                send_meta[_MATRIX_OWN_THREAD_ROOT_KEY] = event_id
+                send_meta[_THREAD_META_ROOT_KEY] = event_id
+                send_meta[_MATRIX_PLACEHOLDER_THREAD_ROOT_KEY] = True
+                self._active_thread_roots[to_handle] = event_id
+                self._write_attachment_context(to_handle, event_id)
+        except Exception as exc:
+            logger.warning(
+                "MatrixChannel: _ensure_thread_root failed for %s: %s",
+                to_handle,
+                exc,
+            )
+
+    async def _send_streaming_thread_text(
+        self,
+        to_handle: str,
+        send_meta: Dict[str, Any],
+        text: str,
+    ) -> Optional[str]:
+        thread_root = (
+            send_meta.get(_MATRIX_THREAD_META_KEY)
+            or send_meta.get(_MATRIX_OWN_THREAD_ROOT_KEY)
+            or send_meta.get(_THREAD_META_ROOT_KEY)
+        )
+        if not thread_root or not self._client:
+            return None
+        content: dict[str, Any] = {
+            "msgtype": "m.notice",
+            "body": text,
+            "format": "org.matrix.custom.html",
+            "formatted_body": _md_to_html(text),
+        }
+        self._apply_thread_relation(
+            content,
+            self._with_thread_relation_meta(send_meta, thread_root),
+        )
+        try:
+            resp = await self._room_send_with_retry(
+                to_handle,
+                "m.room.message",
+                content,
+            )
+            return getattr(resp, "event_id", None)
+        except Exception as exc:
+            logger.warning(
+                "MatrixChannel: streaming thread send failed for %s: %s",
+                to_handle,
+                exc,
+            )
+            return None
+
+    async def _edit_matrix_event(
+        self,
+        to_handle: str,
+        event_id: str,
+        text: str,
+        *,
+        msgtype: str = "m.notice",
+        html: Optional[str] = None,
+    ) -> None:
+        if not event_id or not self._client:
+            return
+        new_content: dict[str, Any] = {"msgtype": msgtype, "body": text}
+        if html:
+            new_content["format"] = "org.matrix.custom.html"
+            new_content["formatted_body"] = html
+        content: dict[str, Any] = {
+            "msgtype": msgtype,
+            "body": f"* {text}",
+            "m.new_content": new_content,
+            "m.relates_to": {"rel_type": "m.replace", "event_id": event_id},
+        }
+        if html:
+            content["format"] = "org.matrix.custom.html"
+            content["formatted_body"] = _edit_fallback_html(text)
+        try:
+            if _matrix_event_payload_size(content) > MATRIX_TEXT_EVENT_SAFE_BYTES:
+                await self._send_long_text_fallback(
+                    to_handle,
+                    text,
+                    {_MATRIX_OWN_THREAD_ROOT_KEY: event_id},
+                    msgtype,
+                    edit_event_id=event_id,
+                )
+                return
+            await self._room_send_with_retry(
+                to_handle,
+                "m.room.message",
+                content,
+            )
+        except Exception as exc:
+            logger.warning(
+                "MatrixChannel: event edit failed for %s: %s",
+                to_handle,
+                exc,
+            )
+
+    def _apply_thread_relation(
+        self,
+        content: Dict[str, Any],
+        meta: Optional[Dict[str, Any]],
+    ) -> None:
+        """Attach Matrix thread relation metadata to an outgoing event.
+
+        Only applies when an explicit thread context has been established
+        (by _with_thread_relation_meta or _ensure_thread_root). The inbound
+        _THREAD_META_ROOT_KEY alone is NOT sufficient — it is always present
+        from the original sender's event_id and would incorrectly thread
+        every reply under the sender's message.
+        """
+        if not isinstance(content, dict) or not isinstance(meta, dict):
+            return
+        thread_root = (
+            meta.get(_MATRIX_THREAD_META_KEY)
+            or meta.get(_MATRIX_OWN_THREAD_ROOT_KEY)
+        )
+        if not thread_root:
+            return
+        content["m.relates_to"] = {
+            "rel_type": "m.thread",
+            "event_id": thread_root,
+            "is_falling_back": False,
+        }
+
+    def _attachment_parent_event_id(self, meta: Optional[Dict[str, Any]]) -> str:
+        if not isinstance(meta, dict):
+            return ""
+        for key in ATTACHMENT_PARENT_EVENT_KEYS:
+            value = str(meta.get(key) or "").strip()
+            if value:
+                return value
+        return ""
+
+    def _apply_attachment_relation(
+        self,
+        content: Dict[str, Any],
+        meta: Optional[Dict[str, Any]],
+    ) -> None:
+        parent_event_id = self._attachment_parent_event_id(meta)
+        if not parent_event_id:
+            return
+        content["m.relates_to"] = {
+            "rel_type": MATRIX_ATTACHMENT_REL_TYPE,
+            "event_id": parent_event_id,
+        }
+
+    def _matrix_attachment_context_path(self) -> Optional[Path]:
+        raw = os.environ.get("TEAMHARNESS_MATRIX_CONTEXT_FILE", "").strip()
+        if raw:
+            return Path(raw)
+        qwenpaw_dir = os.environ.get("QWENPAW_WORKING_DIR", "").strip()
+        if qwenpaw_dir:
+            return Path(qwenpaw_dir) / MATRIX_ATTACHMENT_CONTEXT_FILE
+        try:
+            return Path(WORKING_DIR) / MATRIX_ATTACHMENT_CONTEXT_FILE
+        except TypeError:
+            return None
+
+    def _write_attachment_context(self, room_id: str, event_id: str) -> None:
+        if not room_id or not event_id:
+            return
+        path = self._matrix_attachment_context_path()
+        if not path:
+            return
+        data: Dict[str, Any] = {}
+        try:
+            if path.is_file():
+                loaded = json.loads(path.read_text(encoding="utf-8"))
+                if isinstance(loaded, dict):
+                    data = loaded
+        except (OSError, json.JSONDecodeError):
+            data = {}
+        rooms = data.get("rooms")
+        if not isinstance(rooms, dict):
+            rooms = {}
+            data["rooms"] = rooms
+        rooms[room_id] = {
+            "attachmentParentEventId": event_id,
+            "eventId": event_id,
+            "updatedAt": time.time(),
+        }
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+            tmp.write_text(
+                json.dumps(data, ensure_ascii=False, sort_keys=True),
+                encoding="utf-8",
+            )
+            tmp.replace(path)
+        except OSError as exc:
+            logger.debug(
+                "MatrixChannel: attachment context write failed for %s: %s",
+                room_id,
+                exc,
+            )
+
+    def _matrix_media_event_content(
+        self,
+        file_ref: str,
+        matrix_msgtype: str,
+        mxc_uri: str,
+    ) -> Dict[str, Any]:
+        path_str = file_url_to_local_path(file_ref) or file_ref
+        filename = os.path.basename(path_str) or "file"
+        mime_type, _ = mimetypes.guess_type(path_str)
+        mime_type = mime_type or "application/octet-stream"
+        try:
+            file_size = os.path.getsize(path_str)
+        except OSError:
+            file_size = 0
+        return {
+            "msgtype": matrix_msgtype,
+            "body": filename,
+            "url": mxc_uri,
+            "info": {
+                "mimetype": mime_type,
+                "size": file_size,
+            },
+        }
+
+    async def _send_uploaded_media_event(
+        self,
+        room_id: str,
+        file_ref: str,
+        matrix_msgtype: str,
+        mxc_uri: str,
+        meta: Optional[Dict[str, Any]],
+    ) -> Optional[str]:
+        event_content = self._matrix_media_event_content(
+            file_ref,
+            matrix_msgtype,
+            mxc_uri,
+        )
+        meta_dict = meta or {}
+        sender_id = meta_dict.get("sender_id") or meta_dict.get("user_id")
+        explicit_ids = meta_dict.get("mention_user_ids") or None
+        if explicit_ids:
+            self._apply_mention(
+                event_content,
+                sender_id or "",
+                room_id,
+                explicit_user_ids=explicit_ids,
+            )
+        self._apply_attachment_relation(event_content, meta_dict)
+
+        resp = await self._room_send_with_retry(
+            room_id,
+            "m.room.message",
+            event_content,
+        )
+        return getattr(resp, "event_id", None)
+
+    def _matrix_text_content(
+        self,
+        room_id: str,
+        text: str,
+        meta: Optional[Dict[str, Any]],
+        msgtype: str,
+        *,
+        html_body: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        content: dict[str, Any] = {
+            "msgtype": msgtype,
+            "body": text,
+            "format": "org.matrix.custom.html",
+            "formatted_body": html_body if html_body is not None else _md_to_html(text),
+        }
+        meta_dict = meta if isinstance(meta, dict) else {}
+        sender_id = meta_dict.get("sender_id") or meta_dict.get("user_id")
+        explicit_ids = meta_dict.get("mention_user_ids") or None
+        if explicit_ids or self._extract_mentions_from_text(text):
+            self._apply_mention(
+                content,
+                sender_id or "",
+                room_id,
+                explicit_user_ids=explicit_ids,
+            )
+        self._apply_thread_relation(content, meta_dict)
+        return content
+
+    def _write_long_message_file(self, text: str) -> Path:
+        directory = self._media_dir() / "long-messages"
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / f"matrix-long-message-{time.time_ns()}.md"
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def _long_message_summary(
+        self,
+        text: str,
+        path: Path,
+        media_uri: Optional[str],
+        preview_chars: int,
+    ) -> str:
+        size = path.stat().st_size
+        if media_uri:
+            notice = (
+                f"<单条 Matrix 消息已按安全长度截断，完整内容已缓存为 Matrix 附件："
+                f"{path.name}，附件地址：{media_uri}。>"
+            )
+        else:
+            notice = (
+                f"<单条 Matrix 消息已按安全长度截断，完整内容已缓存为本地文件："
+                f"{path.name}（{size} bytes），Matrix 附件上传失败。>"
+            )
+        prefix = (text or "")[:preview_chars].rstrip()
+        if not prefix:
+            return notice
+        return f"{prefix}\n\n{notice}"
+
+    def _bounded_long_message_content(
+        self,
+        text: str,
+        path: Path,
+        media_uri: Optional[str],
+        build_content: Callable[[str], Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        low = 0
+        high = len(text or "")
+        best_content: Optional[Dict[str, Any]] = None
+        while low <= high:
+            preview_chars = (low + high) // 2
+            summary = self._long_message_summary(
+                text,
+                path,
+                media_uri,
+                preview_chars,
+            )
+            content = build_content(summary)
+            if _matrix_event_payload_size(content) <= MATRIX_TEXT_EVENT_FALLBACK_BUDGET_BYTES:
+                best_content = content
+                low = preview_chars + 1
+            else:
+                high = preview_chars - 1
+        if best_content is not None:
+            return best_content
+        return build_content(self._long_message_summary(text, path, media_uri, 0))
+
+    async def _send_long_text_fallback(
+        self,
+        room_id: str,
+        text: str,
+        meta: Optional[Dict[str, Any]],
+        msgtype: str,
+        *,
+        edit_event_id: str = "",
+    ) -> Optional[str]:
+        if not self._client:
+            return None
+        path = self._write_long_message_file(text)
+        file_ref = str(path)
+        media_uri = await self._upload_file(file_ref)
+        if not media_uri:
+            logger.warning(
+                "MatrixChannel: long text fallback upload failed for %s",
+                file_ref,
+            )
+        long_message_metadata = _long_message_metadata(path, media_uri)
+
+        def build_content(summary: str) -> Dict[str, Any]:
+            if edit_event_id:
+                html_body = _md_to_html(summary)
+                new_content: dict[str, Any] = {
+                    "msgtype": msgtype,
+                    "body": summary,
+                    "format": "org.matrix.custom.html",
+                    "formatted_body": html_body,
+                }
+                _attach_long_message_metadata(new_content, long_message_metadata)
+                content: Dict[str, Any] = {
+                    "msgtype": msgtype,
+                    "body": f"* {summary}",
+                    "m.new_content": new_content,
+                    "m.relates_to": {
+                        "rel_type": "m.replace",
+                        "event_id": edit_event_id,
+                    },
+                    "format": "org.matrix.custom.html",
+                    "formatted_body": _edit_fallback_html(summary),
+                }
+                _attach_long_message_metadata(content, long_message_metadata)
+                return content
+            content = self._matrix_text_content(room_id, summary, meta, msgtype)
+            _attach_long_message_metadata(content, long_message_metadata)
+            return content
+
+        content = self._bounded_long_message_content(
+            text,
+            path,
+            media_uri,
+            build_content,
+        )
+        resp = await self._room_send_with_retry(
+            room_id,
+            "m.room.message",
+            content,
+        )
+        event_id = getattr(resp, "event_id", None)
+        parent_event_id = edit_event_id or event_id
+        if media_uri and parent_event_id:
+            file_meta = dict(meta or {})
+            file_meta["matrixAttachmentParentEventId"] = parent_event_id
+            try:
+                await self._send_uploaded_media_event(
+                    room_id,
+                    file_ref,
+                    "m.file",
+                    media_uri,
+                    file_meta,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "MatrixChannel: long text fallback media event failed "
+                    "for %s: %s",
+                    room_id,
+                    exc,
+                )
+        return event_id
+
+    async def _edit_thread_root(
+        self,
+        to_handle: str,
+        send_meta: Dict[str, Any],
+        text: str,
+        *,
+        msgtype: str = "m.notice",
+        html: Optional[str] = None,
+    ) -> None:
+        """Edit the thread-root placeholder message content."""
+        root_id = send_meta.get(_MATRIX_OWN_THREAD_ROOT_KEY)
+        await self._edit_matrix_event(
+            to_handle,
+            root_id,
+            text,
+            msgtype=msgtype,
+            html=html,
+        )
+
+    # ------------------------------------------------------------------
+    # Agent run lifecycle overrides (ported from CoPaw overlay)
+    # ------------------------------------------------------------------
+
+    def _is_completed_status(self, status: Any) -> bool:
+        if RunStatus is not None and status == RunStatus.Completed:
+            return True
+        return _enum_name(status) == "COMPLETED"
+
+    def _is_in_progress_status(self, status: Any) -> bool:
+        if RunStatus is not None and status == RunStatus.InProgress:
+            return True
+        return _enum_name(status) == "INPROGRESS"
+
+    def _is_reasoning_message(self, message_type: Any) -> bool:
+        if MessageType is not None and message_type == MessageType.REASONING:
+            return True
+        return _enum_name(message_type) == "REASONING"
+
+    def _is_tool_call_message(self, message_type: Any) -> bool:
+        return _enum_name(message_type) in _TOOL_CALL_MESSAGE_TYPE_NAMES
+
+    def _is_tool_output_message(self, message_type: Any) -> bool:
+        return _enum_name(message_type) in _TOOL_OUTPUT_MESSAGE_TYPE_NAMES
+
+    def _is_message_event(self, message_type: Any) -> bool:
+        if MessageType is not None and message_type == MessageType.MESSAGE:
+            return True
+        return _enum_name(message_type) == "MESSAGE"
+
+    def _thread_content_parts(self, event: Any) -> List[Any]:
+        """Render event for thread display, bypassing filter_tool_messages."""
+        from dataclasses import replace as dc_replace
+        style = dc_replace(self._render_style, filter_tool_messages=False)
+        renderer = self._renderer.__class__(style)
+        return renderer.message_to_parts(event)
+
+    def _text_from_message_event(self, event: Any) -> str:
+        parts = self._message_to_content_parts(event)
+        return "\n".join(
+            getattr(p, "text", "") or getattr(p, "refusal", "") or ""
+            for p in parts
+            if getattr(p, "type", None)
+            in (ContentType.TEXT, ContentType.REFUSAL)
+        ).strip()
+
+    def _visible_final_text(self, text: str) -> str:
+        text = (text or "").strip()
+        if not text:
+            return ""
+        return _clean_control_response_text(text).strip()
+
+    def _tool_output_media_parts(self, event: Any) -> List[Any]:
+        """Extract media-only parts from a tool output event."""
+        from dataclasses import replace as dc_replace
+        style = dc_replace(self._render_style, filter_tool_messages=True)
+        renderer = self._renderer.__class__(style)
+        parts = renderer.message_to_parts(event)
+        return [p for p in parts if getattr(p, "type", None) != ContentType.TEXT]
+
+    async def on_event_content(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+    ) -> bool:
+        """Consume streaming tool progress without sending Matrix noise."""
+        del request
+        if getattr(event, "type", None) != ContentType.DATA:
+            return False
+        if not self._is_in_progress_status(getattr(event, "status", None)):
+            return False
+        data = getattr(event, "data", None) or {}
+        if not isinstance(data, dict) or "output" not in data:
+            return False
+        # Silently consume — return True so BaseChannel skips default send.
+        # Tool output details are too noisy for Matrix; the completed
+        # TOOL_CALL / TOOL_OUTPUT events carry the useful summary.
+        return True
+
+    async def on_event_message_completed(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+    ) -> None:
+        """Route completed messages behind a processing root."""
+        del request
+        message_type = getattr(event, "type", None)
+        if self._is_reasoning_message(
+            message_type,
+        ) or self._is_tool_call_message(message_type):
+            await self._ensure_thread_root(to_handle, send_meta)
+            await self._flush_pending_final_message_to_thread(
+                to_handle,
+                send_meta,
+            )
+            parts = self._message_to_content_parts(event)
+            if not parts:
+                return
+            if self._is_reasoning_message(message_type):
+                send_meta[_MATRIX_FORCE_NOTICE_KEY] = True
+            await self._send_or_queue_thread_parts(
+                to_handle,
+                parts,
+                send_meta,
+            )
+            send_meta.pop(_MATRIX_FORCE_NOTICE_KEY, None)
+            return
+        if self._is_tool_output_message(message_type):
+            await self._flush_pending_final_message_to_thread(
+                to_handle,
+                send_meta,
+            )
+            parts = self._tool_output_media_parts(event)
+            if parts:
+                await self.send_content_parts(to_handle, parts, send_meta)
+            return
+
+        if self._is_message_event(message_type):
+            await self._ensure_thread_root(to_handle, send_meta)
+            await self._flush_pending_final_message_to_thread(
+                to_handle,
+                send_meta,
+            )
+            send_meta[_MATRIX_PENDING_FINAL_MESSAGE_KEY] = event
+            return
+
+        await self.send_message_content(to_handle, event, send_meta)
+
+    async def on_streaming_start(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+        stream_type: str,
+        accumulated_text: str = "",
+    ) -> None:
+        del request, accumulated_text
+        if stream_type == "reasoning":
+            send_meta.pop(_MATRIX_STREAMING_REASONING_EVENT_ID_KEY, None)
+            send_meta.pop(_MATRIX_STREAMING_REASONING_LAST_EDIT_KEY, None)
+            stream_id = getattr(event, "id", None)
+            if stream_id:
+                send_meta[_MATRIX_STREAMING_REASONING_STREAM_ID_KEY] = stream_id
+            await self._ensure_thread_root(to_handle, send_meta)
+            return
+        if stream_type == "message":
+            await self._ensure_thread_root(to_handle, send_meta)
+
+    async def on_streaming_delta(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+        stream_type: str,
+        accumulated_text: str = "",
+    ) -> None:
+        del request, to_handle, event, send_meta, stream_type, accumulated_text
+        return
+
+    async def on_streaming_end(
+        self,
+        request: Any,
+        to_handle: str,
+        event: Any,
+        send_meta: Dict[str, Any],
+        stream_type: str,
+        accumulated_text: str = "",
+    ) -> None:
+        del request
+        text = (accumulated_text or "").strip()
+        if stream_type == "reasoning":
+            await self._ensure_thread_root(to_handle, send_meta)
+            if not text:
+                text = self._text_from_message_event(event)
+            if text:
+                text = f"Thinking:\n\n{text}"
+                await self._send_streaming_thread_text(
+                    to_handle,
+                    send_meta,
+                    text,
+                )
+            send_meta.pop(_MATRIX_STREAMING_REASONING_EVENT_ID_KEY, None)
+            send_meta.pop(_MATRIX_STREAMING_REASONING_LAST_EDIT_KEY, None)
+            send_meta.pop(_MATRIX_STREAMING_REASONING_STREAM_ID_KEY, None)
+            return
+
+        if not text:
+            text = self._text_from_message_event(event)
+        if not text:
+            return
+
+        if stream_type == "message":
+            send_meta[_MATRIX_STREAMING_FINAL_TEXT_KEY] = text
+
+    async def send_event(
+        self,
+        *,
+        user_id: str,
+        session_id: str,
+        event: Any,
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Route proactive (cron) events through thread-aware logic.
+
+        Uses shared per-room state so the thread root persists across events
+        within one proactive send stream.
+        """
+        obj = getattr(event, "object", None)
+        status = getattr(event, "status", None)
+        to_handle = self.to_handle_from_target(
+            user_id=user_id,
+            session_id=session_id,
+        )
+
+        # Get or create shared send_meta for this proactive send
+        send_meta = self._proactive_send_state.get(to_handle)
+        if send_meta is None:
+            send_meta = dict(meta or {})
+            self._proactive_send_state[to_handle] = send_meta
+
+        if obj == "message" and self._is_completed_status(status):
+            await self.on_event_message_completed(
+                None, to_handle, event, send_meta,
+            )
+        elif obj == "response":
+            # Stream completed — flush deferred final message and clean up
+            await self._on_process_completed(None, to_handle, send_meta)
+            self._proactive_send_state.pop(to_handle, None)
+
+    async def _on_process_completed(
+        self,
+        request: Any,
+        to_handle: str,
+        send_meta: Dict[str, Any],
+    ) -> None:
+        """Edit thread root with final reply, or send directly if no thread."""
+        pending = send_meta.pop(_MATRIX_PENDING_FINAL_MESSAGE_KEY, None)
+        streaming_final_text = send_meta.pop(
+            _MATRIX_STREAMING_FINAL_TEXT_KEY,
+            None,
+        )
+        is_placeholder = send_meta.pop(_MATRIX_PLACEHOLDER_THREAD_ROOT_KEY, False)
+        if is_placeholder:
+            if streaming_final_text:
+                raw_text = streaming_final_text.strip()
+                if _ends_with_no_reply_control(raw_text):
+                    await self._edit_thread_root(
+                        to_handle, send_meta, "已处理",
+                    )
+                else:
+                    text = self._visible_final_text(raw_text)
+                    if not text:
+                        await self._edit_thread_root(
+                            to_handle, send_meta, "已完成",
+                        )
+                    else:
+                        html_body = _md_to_html(text)
+                        await self._edit_thread_root(
+                            to_handle, send_meta, text,
+                            msgtype="m.text", html=html_body,
+                        )
+            elif pending is not None:
+                raw_text = self._text_from_message_event(pending)
+                if _ends_with_no_reply_control(raw_text):
+                    await self._edit_thread_root(
+                        to_handle, send_meta, "已处理",
+                    )
+                else:
+                    text = self._visible_final_text(raw_text)
+                    if text:
+                        html_body = _md_to_html(text)
+                        await self._edit_thread_root(
+                            to_handle, send_meta, text,
+                            msgtype="m.text", html=html_body,
+                        )
+                    else:
+                        await self._edit_thread_root(
+                            to_handle, send_meta, "已完成",
+                        )
+            else:
+                await self._edit_thread_root(
+                    to_handle, send_meta, "已完成",
+                )
+            self._active_thread_roots.pop(to_handle, None)
+        elif streaming_final_text:
+            await self.send(to_handle, streaming_final_text.strip(), send_meta)
+        elif pending is not None:
+            await self.send_message_content(to_handle, pending, send_meta)
+        await self._send_typing(to_handle, False)
+        base_completed = getattr(super(), "_on_process_completed", None)
+        try:
+            if base_completed:
+                await base_completed(request, to_handle, send_meta)
+        finally:
+            await self._send_typing(to_handle, False)
+
+    async def _on_consume_error(
+        self,
+        request: Any,
+        to_handle: str,
+        err_text: str,
+    ) -> None:
+        """Edit thread root on error; suppress user-visible cancellation noise."""
+        root_id = self._active_thread_roots.pop(to_handle, None)
+        if root_id:
+            fallback_meta = {_MATRIX_OWN_THREAD_ROOT_KEY: root_id}
+            status = "已取消" if "Task has been cancelled" in (err_text or "") else "处理异常"
+            await self._edit_thread_root(to_handle, fallback_meta, status)
+        if "Task has been cancelled" in (err_text or ""):
+            logger.info(
+                "MatrixChannel: suppressing cancellation error component=matrix handle=%s",
+                to_handle,
+            )
+            await self._send_typing(to_handle, False)
+            return
+        await super()._on_consume_error(request, to_handle, err_text)
+
+    # ------------------------------------------------------------------
+    # Outgoing send — retry helper
+    # Exponential backoff for transient room_send failures (5xx, 429,
+    # network errors).  Deterministic errors (4xx except 429) are raised
+    # immediately so callers can log without retry.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _is_retryable_send_error(exc: Exception) -> bool:
+        """Return True if *exc* is a transient error worth retrying."""
+        # Network / transport layer errors — always retry
+        if isinstance(exc, (ConnectionError, TimeoutError, OSError)):
+            return True
+        if isinstance(exc, asyncio.TimeoutError):
+            return True
+        # httpx transport errors (httpx is already imported)
+        if isinstance(exc, httpx.TransportError):
+            return True
+        return False
+
+    # Matrix errcode strings that indicate a transient / retryable condition.
+    _RETRYABLE_MATRIX_ERRCODES = frozenset({
+        "M_LIMIT_EXCEEDED",       # 429 rate-limited
+        "M_UNKNOWN",              # generic server-side error
+    })
+
+    @staticmethod
+    def _is_retryable_room_send_response(resp: Any) -> bool:
+        """Return True if a nio ``RoomSendError`` is transient.
+
+        nio's ``ErrorResponse.status_code`` is a **Matrix errcode string**
+        (e.g. ``"M_LIMIT_EXCEEDED"``), not an HTTP integer.  We therefore
+        match on the errcode string for Matrix-level classification and
+        fall back to the HTTP status code carried inside
+        ``transport_response`` when available.
+        """
+        if not isinstance(resp, RoomSendError):
+            return False
+
+        # 1. Check Matrix errcode (string)
+        errcode = getattr(resp, "status_code", None)
+        if errcode in MatrixChannel._RETRYABLE_MATRIX_ERRCODES:
+            return True
+
+        # 2. Fall back to HTTP status via transport_response
+        tr = getattr(resp, "transport_response", None)
+        if tr is not None:
+            http_status = getattr(tr, "status_code", None)
+            if isinstance(http_status, int):
+                if http_status == 429 or 500 <= http_status < 600:
+                    return True
+
+        # 3. No errcode and no transport info — assume transient
+        if errcode is None and tr is None:
+            return True
+
+        return False
+
+    async def _room_send_with_retry(
+        self,
+        room_id: str,
+        message_type: str,
+        content: dict,
+        *,
+        max_retries: int = 3,
+        base_delay: float = 1.0,
+    ) -> Any:
+        """Wrap ``_prepare_room_send`` + ``room_send`` with limited retries.
+
+        Retryable errors (5xx, 429, network) trigger exponential back-off
+        with a small random jitter.  Non-retryable errors propagate
+        immediately.
+
+        A single ``tx_id`` is generated for the entire retry sequence so that
+        the Matrix homeserver can de-duplicate if a request was actually
+        processed but the response was lost in transit (idempotency).
+
+        Returns the successful ``RoomSendResponse``.
+        """
+        tx_id = str(uuid4())
+        last_exc: Optional[Exception] = None
+        last_err_resp: Any = None
+
+        for attempt in range(max_retries + 1):  # 0 = first try, 1-3 = retries
+            try:
+                await self._prepare_room_send(room_id)
+                resp = await self._client.room_send(
+                    room_id,
+                    message_type,
+                    content,
+                    tx_id=tx_id,
+                    ignore_unverified_devices=True,
+                )
+
+                # nio returns RoomSendError on failure instead of raising
+                if isinstance(resp, RoomSendError):
+                    if self._is_retryable_room_send_response(resp) and attempt < max_retries:
+                        # Prefer server-suggested delay for rate-limiting
+                        retry_ms = getattr(resp, "retry_after_ms", None)
+                        if retry_ms and isinstance(retry_ms, (int, float)) and retry_ms > 0:
+                            delay = retry_ms / 1000.0 + random.uniform(0, 0.5)
+                        else:
+                            delay = base_delay * (2 ** attempt) + random.uniform(0, 0.5)
+                        logger.warning(
+                            "MatrixChannel: room_send returned retryable error "
+                            "(attempt %d/%d) room_id=%s status=%s message=%s — "
+                            "retrying in %.1fs component=matrix",
+                            attempt + 1,
+                            max_retries,
+                            room_id,
+                            getattr(resp, "status_code", "?"),
+                            getattr(resp, "message", ""),
+                            delay,
+                        )
+                        last_err_resp = resp
+                        await asyncio.sleep(delay)
+                        continue
+                    # Non-retryable or retries exhausted — let caller handle
+                    if attempt >= max_retries and self._is_retryable_room_send_response(resp):
+                        logger.error(
+                            "MatrixChannel: room_send retries exhausted "
+                            "(attempts=%d) room_id=%s status=%s message=%s "
+                            "component=matrix",
+                            max_retries,
+                            room_id,
+                            getattr(resp, "status_code", "?"),
+                            getattr(resp, "message", ""),
+                        )
+                    return resp
+
+                # Success
+                if attempt > 0:
+                    logger.info(
+                        "MatrixChannel: room_send succeeded after %d "
+                        "retry(ies) room_id=%s component=matrix",
+                        attempt,
+                        room_id,
+                    )
+                return resp
+
+            except Exception as exc:
+                if self._is_retryable_send_error(exc) and attempt < max_retries:
+                    delay = base_delay * (2 ** attempt) + random.uniform(0, 0.5)
+                    logger.warning(
+                        "MatrixChannel: room_send raised retryable exception "
+                        "(attempt %d/%d) room_id=%s error=%s — "
+                        "retrying in %.1fs component=matrix",
+                        attempt + 1,
+                        max_retries,
+                        room_id,
+                        exc,
+                        delay,
+                    )
+                    last_exc = exc
+                    await asyncio.sleep(delay)
+                    continue
+                # Non-retryable or retries exhausted
+                if attempt >= max_retries and self._is_retryable_send_error(exc):
+                    logger.error(
+                        "MatrixChannel: room_send retries exhausted "
+                        "(attempts=%d) room_id=%s last_error=%s "
+                        "component=matrix",
+                        max_retries,
+                        room_id,
+                        exc,
+                    )
+                raise
+
+        # Should not reach here, but guard against it
+        if last_exc is not None:
+            raise last_exc
+        return last_err_resp
+
+    # ------------------------------------------------------------------
+    # Outgoing send — text
+    # Markdown→HTML (formatted_body); m.mentions when meta has sender_id.
+    # ------------------------------------------------------------------
+
+    async def send(
+        self,
+        to_handle: str,
+        text: str,
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if not self._client:
+            logger.error("MatrixChannel: send called but client not ready component=matrix")
+            return
+
+        room_id = (meta or {}).get("room_id") or to_handle
+
+        # NO_REPLY protocol: agent decided it has nothing to say.
+        if _ends_with_no_reply_control(text):
+            logger.info(
+                "MatrixChannel: suppressing NO_REPLY send component=matrix room_id=%s",
+                room_id,
+            )
+            await self._send_typing(room_id, False)
+            return
+
+        text = _clean_control_response_text(text)
+
+        html_body = _md_to_html(text)
+        meta_dict = meta if isinstance(meta, dict) else {}
+        msgtype = "m.notice" if meta_dict.pop(_MATRIX_FORCE_NOTICE_KEY, False) else "m.text"
+        content = self._matrix_text_content(
+            room_id,
+            text,
+            meta_dict,
+            msgtype,
+            html_body=html_body,
+        )
+        logger.debug(
+            "MatrixChannel (custom): sending message component=matrix with formatted_body "
+            "text_len=%d html_len=%d",
+            len(text),
+            len(html_body),
+        )
+
+        try:
+            if _matrix_event_payload_size(content) > MATRIX_TEXT_EVENT_SAFE_BYTES:
+                event_id = await self._send_long_text_fallback(
+                    room_id,
+                    text,
+                    meta_dict,
+                    msgtype,
+                )
+                if (
+                    event_id
+                    and not meta_dict.get(_MATRIX_THREAD_META_KEY)
+                    and not meta_dict.get(_MATRIX_OWN_THREAD_ROOT_KEY)
+                ):
+                    meta_dict[_MATRIX_OWN_THREAD_ROOT_KEY] = event_id
+                    self._write_attachment_context(room_id, event_id)
+                    await self._flush_pending_thread_parts(room_id, meta_dict)
+                return
+            resp = await self._room_send_with_retry(
+                room_id, "m.room.message", content,
+            )
+            event_id = getattr(resp, "event_id", None)
+            if (
+                event_id
+                and not meta_dict.get(_MATRIX_THREAD_META_KEY)
+                and not meta_dict.get(_MATRIX_OWN_THREAD_ROOT_KEY)
+                and not self._attachment_parent_event_id(meta_dict)
+            ):
+                meta_dict[_MATRIX_OWN_THREAD_ROOT_KEY] = event_id
+                self._write_attachment_context(room_id, event_id)
+                await self._flush_pending_thread_parts(room_id, meta_dict)
+        except Exception as exc:
+            logger.exception(
+                "MatrixChannel: send failed to %s: %s",
+                room_id,
+                exc,
+            )
+        finally:
+            await self._send_typing(room_id, False)
+
+    # ------------------------------------------------------------------
+    # Outgoing send — media
+    # ------------------------------------------------------------------
+
+    async def send_media(
+        self,
+        to_handle: str,
+        part: Any,
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Upload a local file to Matrix and send as m.image / m.file / etc."""
+        if not self._client:
+            return None
+
+        room_id = (meta or {}).get("room_id") or to_handle
+        t = getattr(part, "type", None)
+
+        # Extract the local file reference from the content part
+        if t == ContentType.IMAGE:
+            file_ref = getattr(part, "image_url", "")
+            matrix_msgtype = "m.image"
+        elif t == ContentType.VIDEO:
+            file_ref = getattr(part, "video_url", "")
+            matrix_msgtype = "m.video"
+        elif t == ContentType.AUDIO:
+            file_ref = getattr(part, "data", "")
+            matrix_msgtype = "m.audio"
+        elif t == ContentType.FILE:
+            file_ref = getattr(part, "file_url", "") or getattr(
+                part,
+                "file_id",
+                "",
+            )
+            matrix_msgtype = "m.file"
+        else:
+            return None
+
+        if not file_ref:
+            return None
+
+        # Upload to Matrix media repository
+        mxc_uri = await self._upload_file(file_ref)
+        if not mxc_uri:
+            logger.warning(
+                "MatrixChannel: send_media upload failed for %s",
+                file_ref,
+            )
+            return None
+
+        # Build and send the Matrix room event
+        try:
+            await self._send_uploaded_media_event(
+                room_id,
+                file_ref,
+                matrix_msgtype,
+                mxc_uri,
+                meta,
+            )
+            logger.debug(
+                "MatrixChannel: sent %s %s to %s",
+                matrix_msgtype,
+                os.path.basename(file_url_to_local_path(file_ref) or file_ref)
+                or "file",
+                room_id,
+            )
+            return mxc_uri
+        except Exception as exc:
+            logger.exception(
+                "MatrixChannel: send_media failed for %s: %s",
+                room_id,
+                exc,
+            )
+            return None

--- a/qwenpaw/src/qwenpaw_worker/__init__.py
+++ b/qwenpaw/src/qwenpaw_worker/__init__.py
@@ -1,0 +1,3 @@
+"""AgentTeams QwenPaw worker runtime."""
+
+__version__ = "0.1.0"

--- a/qwenpaw/src/qwenpaw_worker/cli.py
+++ b/qwenpaw/src/qwenpaw_worker/cli.py
@@ -1,0 +1,69 @@
+"""CLI entry point: qwenpaw-worker."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+import signal
+from typing import Optional
+
+import typer
+
+from qwenpaw_worker.config import WorkerConfig
+from qwenpaw_worker.log import configure_worker_logging
+from qwenpaw_worker.worker import Worker
+
+
+def main() -> None:
+    """Entry point registered in pyproject.toml."""
+
+    def _run(
+        name: str = typer.Option(..., "--name", help="Worker name"),
+        cr_name: Optional[str] = typer.Option(None, "--cr-name", help="Worker CR name"),
+        fs: str = typer.Option(..., "--fs", help="MinIO/OSS endpoint"),
+        fs_key: str = typer.Option(..., "--fs-key", help="MinIO/OSS access key"),
+        fs_secret: str = typer.Option(..., "--fs-secret", help="MinIO/OSS secret key"),
+        fs_bucket: str = typer.Option("agentteams-storage", "--fs-bucket", help="Storage bucket"),
+        install_dir: Optional[str] = typer.Option(None, "--install-dir", help="Base install dir"),
+        storage_prefix: Optional[str] = typer.Option(None, "--storage-prefix", help="Storage prefix"),
+        shared_prefix: Optional[str] = typer.Option(None, "--shared-prefix", help="Shared storage prefix"),
+        runtime_config: Optional[str] = typer.Option(None, "--runtime-config", help="Local runtime.yaml path"),
+        console_port: int = typer.Option(8088, "--console-port", help="QwenPaw API port"),
+    ) -> None:
+        """Start the QwenPaw Worker."""
+        config = WorkerConfig(
+            worker_name=name,
+            worker_cr_name=cr_name,
+            fs_endpoint=fs,
+            fs_access_key=fs_key,
+            fs_secret_key=fs_secret,
+            fs_bucket=fs_bucket,
+            install_dir=Path(install_dir) if install_dir else None,
+            storage_prefix=storage_prefix,
+            shared_prefix=shared_prefix,
+            runtime_config_path=Path(runtime_config) if runtime_config else None,
+            console_port=console_port,
+        )
+        configure_worker_logging(config.qwenpaw_working_dir)
+        worker = Worker(config)
+
+        async def _async_run() -> None:
+            loop = asyncio.get_running_loop()
+
+            def _shutdown() -> None:
+                asyncio.create_task(worker.stop())
+
+            try:
+                for sig in (signal.SIGINT, signal.SIGTERM):
+                    loop.add_signal_handler(sig, _shutdown)
+            except NotImplementedError:
+                pass
+
+            await worker.run()
+
+        try:
+            asyncio.run(_async_run())
+        except KeyboardInterrupt:
+            pass
+
+    typer.run(_run)

--- a/qwenpaw/src/qwenpaw_worker/config.py
+++ b/qwenpaw/src/qwenpaw_worker/config.py
@@ -1,0 +1,107 @@
+"""WorkerConfig parsed from CLI args and AgentTeams env."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+
+def _clean_prefix(value: str) -> str:
+    return value.strip().strip("/")
+
+
+def _relative_storage_prefix(value: str, bucket: str) -> str:
+    prefix = _clean_prefix(value)
+    if not prefix:
+        return ""
+    parts = prefix.split("/")
+    if parts[0] == bucket:
+        return "/".join(parts[1:])
+    if len(parts) >= 2 and parts[1] == bucket:
+        return "/".join(parts[2:])
+    return prefix
+
+
+def _join_prefix(root: str, suffix: str) -> str:
+    root = _clean_prefix(root)
+    suffix = _clean_prefix(suffix)
+    return f"{root}/{suffix}" if root else suffix
+
+
+class WorkerConfig:
+    def __init__(
+        self,
+        worker_name: str,
+        fs_endpoint: str,
+        fs_access_key: str,
+        fs_secret_key: str,
+        fs_bucket: str = "agentteams-storage",
+        install_dir: Optional[Path] = None,
+        console_port: int = 8088,
+        worker_cr_name: Optional[str] = None,
+        shared_dir: Optional[Path] = None,
+        storage_prefix: Optional[str] = None,
+        shared_prefix: Optional[str] = None,
+        runtime_config_path: Optional[Path] = None,
+        runtime_config_poll_interval: float = 5,
+    ) -> None:
+        self.worker_name = worker_name
+        self.worker_cr_name = worker_cr_name or worker_name
+        self.agent_role = os.environ.get("AGENTTEAMS_WORKER_ROLE") or os.environ.get("AGENTTEAMS_AGENT_ROLE") or "worker"
+        self.agent_name = worker_name
+        self.fs_endpoint = fs_endpoint
+        self.fs_access_key = fs_access_key
+        self.fs_secret_key = fs_secret_key
+        self.fs_bucket = fs_bucket
+        self.install_dir = install_dir or Path(
+            os.environ.get("QWENPAW_INSTALL_DIR", "/root/agentteams-fs/agents"),
+        )
+        self.shared_dir_override = shared_dir
+        storage_root = _relative_storage_prefix(
+            os.environ.get("AGENTTEAMS_STORAGE_PREFIX", ""),
+            self.fs_bucket,
+        )
+        self.storage_prefix = _relative_storage_prefix(
+            storage_prefix,
+            self.fs_bucket,
+        ) if storage_prefix else _join_prefix(storage_root, f"agents/{self.worker_name}")
+        configured_shared_prefix = os.environ.get("AGENTTEAMS_SHARED_STORAGE_PREFIX", "")
+        self.shared_prefix = _relative_storage_prefix(
+            shared_prefix,
+            self.fs_bucket,
+        ) if shared_prefix else (
+            _relative_storage_prefix(configured_shared_prefix, self.fs_bucket)
+            if configured_shared_prefix
+            else _join_prefix(storage_root, "shared")
+        )
+        self.console_port = console_port
+        self.runtime_config_path_override = runtime_config_path
+        self.runtime_config_poll_interval = runtime_config_poll_interval
+
+    @property
+    def worker_home(self) -> Path:
+        return self.install_dir / self.worker_name
+
+    @property
+    def qwenpaw_working_dir(self) -> Path:
+        return self.worker_home / ".qwenpaw"
+
+    @property
+    def default_workspace_dir(self) -> Path:
+        return self.qwenpaw_working_dir / "workspaces" / "default"
+
+    @property
+    def shared_dir(self) -> Path:
+        if self.shared_dir_override is not None:
+            return self.shared_dir_override
+        return self.install_dir.parent / "shared"
+
+    @property
+    def runtime_config_path(self) -> Path:
+        if self.runtime_config_path_override is not None:
+            return self.runtime_config_path_override
+        configured = os.environ.get("AGENTTEAMS_MEMBER_RUNTIME_CONFIG", "").strip()
+        if configured:
+            return Path(configured)
+        return self.worker_home / "runtime" / "runtime.yaml"

--- a/qwenpaw/src/qwenpaw_worker/heartbeat.py
+++ b/qwenpaw/src/qwenpaw_worker/heartbeat.py
@@ -1,0 +1,258 @@
+"""Worker heartbeat snapshot for the managed QwenPaw process."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import json
+import logging
+import os
+from pathlib import Path
+import time
+from typing import Any, Dict, Tuple
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _rfc3339_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_rfc3339(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+@dataclass
+class WorkerHeartbeat:
+    path: Path
+    status: str = "not_ready"
+    message: str = "qwenpaw app not checked"
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def update(
+        self,
+        status: str,
+        message: str = "",
+        details: Dict[str, Any] | None = None,
+    ) -> None:
+        if status not in ("ready", "not_ready"):
+            raise ValueError(f"invalid worker heartbeat status: {status}")
+        self.status = status
+        self.message = message
+        self.details = details or {}
+        self.persist()
+
+    def snapshot(self) -> Dict[str, Any]:
+        return {
+            "status": self.status,
+            "message": self.message,
+            "details": self.details,
+            "updatedAt": _now(),
+        }
+
+    def is_ready(self) -> bool:
+        return self.status == "ready"
+
+    def persist(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(self.snapshot(), indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def check_qwenpaw_heartbeat(port: int) -> Tuple[str, str, Dict[str, Any]]:
+    url = f"http://127.0.0.1:{port}/api/version"
+    try:
+        with urllib.request.urlopen(url, timeout=5) as response:
+            body = response.read().decode("utf-8")
+        return "ready", "qwenpaw API reachable", {"url": url, "body": body[:300]}
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return "not_ready", str(exc), {"url": url}
+
+
+def get_qwenpaw_last_active_at(port: int, agent_id: str = "default") -> str | None:
+    """Read QwenPaw's agent-status endpoint and map it to controller lastActiveAt."""
+
+    url = f"http://127.0.0.1:{port}/api/agents/{agent_id}/agent-status"
+    try:
+        with urllib.request.urlopen(url, timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except Exception as exc:
+        logger.debug("qwenpaw agent-status request failed component=heartbeat error_type=%s", type(exc).__name__)
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("status") == "running":
+        return _rfc3339_utc(datetime.now(timezone.utc))
+
+    candidates = [
+        _parse_rfc3339(payload.get("last_finish_at")),
+        _parse_rfc3339(payload.get("last_run_at")),
+    ]
+    latest = max((item for item in candidates if item is not None), default=None)
+    return _rfc3339_utc(latest) if latest is not None else None
+
+
+@dataclass(frozen=True)
+class ControllerHeartbeatReporter:
+    """Report QwenPaw worker readiness and heartbeat to the AgentTeams controller."""
+
+    worker_name: str
+    controller_url: str = ""
+    token: str = ""
+    cluster_id: str = ""
+
+    @classmethod
+    def from_env(cls, worker_name: str) -> "ControllerHeartbeatReporter":
+        return cls(
+            worker_name=worker_name,
+            controller_url=os.getenv("AGENTTEAMS_CONTROLLER_URL", "").rstrip("/"),
+            cluster_id=os.getenv("AGENTTEAMS_CLUSTER_ID", ""),
+        )
+
+    def enabled(self) -> bool:
+        return bool(self.controller_url)
+
+    def report_ready(self, last_active_at: str | None = None) -> bool:
+        return self._post("ready", last_active_at)
+
+    def report_heartbeat(self, last_active_at: str | None = None) -> bool:
+        return self._post("heartbeat", last_active_at)
+
+    def _post(self, action: str, last_active_at: str | None) -> bool:
+        if not self.enabled():
+            return False
+        path = f"/api/v1/workers/{self.worker_name}/{action}"
+        body = None
+        headers = {}
+        if last_active_at:
+            body = json.dumps({"lastActiveAt": last_active_at}).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        token = self.token or _discover_auth_token()
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        auth_cluster_id = _auth_cluster_id(self.cluster_id)
+        if auth_cluster_id:
+            headers["X-AgentTeams-Cluster-ID"] = auth_cluster_id
+
+        try:
+            request = urllib.request.Request(
+                self.controller_url + path,
+                data=body,
+                headers=headers,
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=10) as response:
+                if response.status < 200 or response.status >= 300:
+                    logger.warning(
+                        "controller report returned HTTP status component=heartbeat action=%s worker=%s http_status=%s",
+                        action,
+                        self.worker_name,
+                        response.status,
+                    )
+                    return False
+            return True
+        except Exception as exc:
+            logger.warning(
+                "controller report failed component=heartbeat action=%s worker=%s error_type=%s",
+                action,
+                self.worker_name,
+                type(exc).__name__,
+            )
+            return False
+
+
+async def run_worker_heartbeat_loop(
+    heartbeat: WorkerHeartbeat,
+    *,
+    worker_name: str,
+    port: int,
+    local_interval: float = 5,
+    report_interval: float | None = None,
+    reporter: ControllerHeartbeatReporter | None = None,
+) -> None:
+    """Probe QwenPaw locally and report worker status to the controller."""
+
+    reporter = reporter or ControllerHeartbeatReporter.from_env(worker_name)
+    report_every = report_interval if report_interval is not None else float(
+        os.getenv("AGENTTEAMS_WORKER_HEARTBEAT_INTERVAL", "60")
+    )
+    ready_reported = False
+    next_report_at = 0.0
+    last_status: tuple[str, str] | None = None
+
+    logger.info(
+        "qwenpaw heartbeat loop started component=heartbeat worker=%s port=%s local_interval_seconds=%s "
+        "report_interval_seconds=%s reporter_enabled=%s",
+        worker_name,
+        port,
+        local_interval,
+        report_every,
+        reporter.enabled(),
+    )
+
+    try:
+        while True:
+            status, message, details = await asyncio.to_thread(check_qwenpaw_heartbeat, port)
+            heartbeat.update(status, message, details)
+            status_key = (status, message)
+            if status_key != last_status:
+                logger.info(
+                    "qwenpaw heartbeat status changed component=heartbeat worker=%s status=%s message=%s",
+                    worker_name,
+                    status,
+                    message,
+                )
+                last_status = status_key
+
+            if status == "ready" and reporter.enabled():
+                last_active_at = await asyncio.to_thread(get_qwenpaw_last_active_at, port)
+                if not ready_reported:
+                    ready_reported = await asyncio.to_thread(reporter.report_ready, last_active_at)
+                    if ready_reported:
+                        logger.info("controller ready report accepted component=heartbeat worker=%s", worker_name)
+                now = time.time()
+                if now >= next_report_at:
+                    reported = await asyncio.to_thread(reporter.report_heartbeat, last_active_at)
+                    if reported:
+                        logger.debug("controller heartbeat report accepted component=heartbeat worker=%s", worker_name)
+                    next_report_at = now + report_every
+
+            await asyncio.sleep(local_interval)
+    except asyncio.CancelledError:
+        logger.info("qwenpaw heartbeat loop stopped component=heartbeat worker=%s", worker_name)
+        raise
+
+
+def _discover_auth_token() -> str:
+    token = os.getenv("AGENTTEAMS_AUTH_TOKEN", "")
+    if token:
+        return token
+    token_file = os.getenv("AGENTTEAMS_AUTH_TOKEN_FILE", "")
+    if token_file:
+        try:
+            return Path(token_file).read_text(encoding="utf-8").strip()
+        except OSError:
+            return ""
+    return ""
+
+
+def _auth_cluster_id(cluster_id: str) -> str:
+    return cluster_id

--- a/qwenpaw/src/qwenpaw_worker/log.py
+++ b/qwenpaw/src/qwenpaw_worker/log.py
@@ -1,0 +1,164 @@
+"""Logging setup for qwenpaw-worker."""
+
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+import os
+from pathlib import Path
+from typing import Optional
+
+
+LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+DEFAULT_LOG_MAX_BYTES = 10 * 1024 * 1024
+DEFAULT_LOG_BACKUP_COUNT = 20
+MAX_LOG_MAX_BYTES = 20 * 1024 * 1024
+MAX_LOG_BACKUP_COUNT = 50
+DEFAULT_LOG_FILE_NAME = "qwenpaw-worker.log"
+
+_CONSOLE_HANDLER_MARK = "_qwenpaw_worker_console_handler"
+_FILE_HANDLER_MARK = "_qwenpaw_worker_file_handler"
+_FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+def configure_worker_logging(working_dir: Optional[Path] = None) -> Optional[Path]:
+    """Configure console and rotating file logging for qwenpaw-worker."""
+
+    root = logging.getLogger()
+    level = _log_level()
+    formatter = logging.Formatter(LOG_FORMAT)
+    root.setLevel(level)
+
+    _ensure_console_handler(root, formatter, level)
+
+    if not _file_logging_enabled():
+        _remove_marked_handlers(root, _FILE_HANDLER_MARK)
+        logging.getLogger(__name__).info(
+            "worker logging configured component=worker stage=logging event=disabled file_enabled=False level=%s",
+            logging.getLevelName(level),
+        )
+        return None
+
+    log_file = _log_file_path(working_dir)
+    max_bytes = _bounded_int(
+        os.environ.get("QWENPAW_WORKER_LOG_MAX_BYTES"),
+        DEFAULT_LOG_MAX_BYTES,
+        minimum=1,
+        maximum=MAX_LOG_MAX_BYTES,
+    )
+    backup_count = _bounded_int(
+        os.environ.get("QWENPAW_WORKER_LOG_BACKUP_COUNT"),
+        DEFAULT_LOG_BACKUP_COUNT,
+        minimum=0,
+        maximum=MAX_LOG_BACKUP_COUNT,
+    )
+    file_handler = _find_marked_handler(root, _FILE_HANDLER_MARK)
+    if file_handler is not None:
+        file_handler.setLevel(level)
+        file_handler.setFormatter(formatter)
+        if isinstance(file_handler, RotatingFileHandler):
+            file_handler.maxBytes = max_bytes
+            file_handler.backupCount = backup_count
+        _log_configured(log_file, level, max_bytes, backup_count)
+        return Path(getattr(file_handler, "baseFilename", log_file))
+
+    try:
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = RotatingFileHandler(
+            log_file,
+            maxBytes=max_bytes,
+            backupCount=backup_count,
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        logging.getLogger(__name__).warning(
+            "worker log file setup failed component=worker stage=logging event=failed path=%s error_type=%s",
+            log_file,
+            type(exc).__name__,
+        )
+        return None
+
+    setattr(file_handler, _FILE_HANDLER_MARK, True)
+    file_handler.setLevel(level)
+    file_handler.setFormatter(formatter)
+    root.addHandler(file_handler)
+    _log_configured(log_file, level, max_bytes, backup_count)
+    return log_file
+
+
+def _log_configured(log_file: Path, level: int, max_bytes: int, backup_count: int) -> None:
+    logging.getLogger(__name__).info(
+        "worker logging configured component=worker stage=logging event=configured file_enabled=True "
+        "path=%s max_bytes=%s backup_count=%s level=%s",
+        log_file,
+        max_bytes,
+        backup_count,
+        logging.getLevelName(level),
+    )
+
+
+def _ensure_console_handler(root: logging.Logger, formatter: logging.Formatter, level: int) -> None:
+    handler = _find_marked_handler(root, _CONSOLE_HANDLER_MARK)
+    if handler is None:
+        handler = logging.StreamHandler()
+        setattr(handler, _CONSOLE_HANDLER_MARK, True)
+        root.addHandler(handler)
+    handler.setLevel(level)
+    handler.setFormatter(formatter)
+
+
+def _find_marked_handler(root: logging.Logger, mark: str) -> Optional[logging.Handler]:
+    for handler in root.handlers:
+        if getattr(handler, mark, False):
+            return handler
+    return None
+
+
+def _remove_marked_handlers(root: logging.Logger, mark: str) -> None:
+    for handler in list(root.handlers):
+        if getattr(handler, mark, False):
+            root.removeHandler(handler)
+            handler.close()
+
+
+def _file_logging_enabled() -> bool:
+    value = os.environ.get("QWENPAW_WORKER_LOG_FILE_ENABLED")
+    if value is None:
+        return True
+    return value.strip().lower() not in _FALSE_VALUES
+
+
+def _log_file_path(working_dir: Optional[Path]) -> Path:
+    log_dir = os.environ.get("QWENPAW_WORKER_LOG_DIR")
+    if log_dir:
+        return Path(log_dir) / DEFAULT_LOG_FILE_NAME
+
+    env_working_dir = os.environ.get("QWENPAW_WORKING_DIR")
+    if env_working_dir:
+        return Path(env_working_dir) / "logs" / DEFAULT_LOG_FILE_NAME
+
+    if working_dir is not None:
+        return Path(working_dir) / "logs" / DEFAULT_LOG_FILE_NAME
+
+    return Path.cwd() / ".qwenpaw" / "logs" / DEFAULT_LOG_FILE_NAME
+
+
+def _log_level() -> int:
+    value = os.environ.get("QWENPAW_LOG_LEVEL", "INFO").strip()
+    if value.isdigit():
+        return int(value)
+
+    level = logging.getLevelName(value.upper())
+    if isinstance(level, int):
+        return level
+    return logging.INFO
+
+
+def _bounded_int(value: Optional[str], default: int, *, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value) if value is not None else default
+    except (TypeError, ValueError):
+        return default
+    if parsed < minimum:
+        return default
+    return min(parsed, maximum)

--- a/qwenpaw/src/qwenpaw_worker/sync.py
+++ b/qwenpaw/src/qwenpaw_worker/sync.py
@@ -1,0 +1,305 @@
+"""Object-storage restore and runtime-state persistence for qwenpaw-worker."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import time
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MC_ALIAS = "agentteams"
+COMPARE_CONTENT_MAX_BYTES = 20 * 1024 * 1024
+
+
+def _to_text(value: object) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value or "")
+
+
+def _looks_like_missing_object_error(stderr: Optional[str] | bytes) -> bool:
+    text = _to_text(stderr)
+    return "Object does not exist" in text or "The specified key does not exist" in text
+
+
+def _mc_error_message(exc: subprocess.CalledProcessError) -> str:
+    text = _to_text(exc.stderr or exc.stdout).strip()
+    return text or f"mc exited with status {exc.returncode}"
+
+
+def _redact_url_userinfo(value: str) -> str:
+    if "://" not in value or "@" not in value:
+        return value
+    scheme, rest = value.split("://", 1)
+    return f"{scheme}://<redacted>@{rest.split('@', 1)[1]}"
+
+
+def _preview_list(values: List[str], limit: int = 20) -> List[str]:
+    if len(values) <= limit:
+        return values
+    return [*values[:limit], f"...({len(values) - limit} more)"]
+
+
+def _storage_alias() -> str:
+    value = os.getenv("AGENTTEAMS_STORAGE_ALIAS", "").strip().strip("/")
+    if value:
+        return value
+    prefix = os.getenv("AGENTTEAMS_STORAGE_PREFIX", "").strip().strip("/")
+    if "/" in prefix:
+        return prefix.split("/", 1)[0]
+    return DEFAULT_MC_ALIAS
+
+
+class FileSync:
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        access_key: str,
+        secret_key: str,
+        bucket: str,
+        worker_name: str,
+        local_dir: Path,
+        shared_dir: Path,
+        remote_prefix: Optional[str] = None,
+        shared_prefix: Optional[str] = None,
+    ) -> None:
+        self.endpoint = endpoint
+        self.access_key = access_key
+        self.secret_key = secret_key
+        self.bucket = bucket
+        self.worker_name = worker_name
+        self.local_dir = local_dir
+        self.shared_dir = shared_dir
+        self.remote_prefix = (remote_prefix or f"agents/{worker_name}").strip("/")
+        self.shared_prefix = (shared_prefix or "shared").strip("/")
+        self.mc_alias = _storage_alias()
+        self._alias_set = False
+
+    def _mc(self, *args: str, check: bool = True, text: bool = True) -> subprocess.CompletedProcess:
+        mc_bin = shutil.which("mc")
+        if not mc_bin:
+            raise RuntimeError("mc binary not found")
+        return subprocess.run(
+            [mc_bin, *args],
+            check=check,
+            capture_output=True,
+            text=text,
+        )
+
+    def ensure_alias(self) -> None:
+        if self._alias_set:
+            return
+        if os.getenv(f"MC_HOST_{self.mc_alias}"):
+            self._alias_set = True
+            logger.info("storage alias ready component=sync worker=%s mode=env", self.worker_name)
+            return
+        if os.getenv("AGENTTEAMS_RUNTIME") == "k8s":
+            self._alias_set = True
+            logger.info("storage alias ready component=sync worker=%s mode=k8s-wrapper", self.worker_name)
+            return
+        missing = [
+            name
+            for name, value in (
+                ("endpoint", self.endpoint),
+                ("access_key", self.access_key),
+                ("secret_key", self.secret_key),
+            )
+            if not value
+        ]
+        if missing:
+            raise RuntimeError(f"missing storage config: {', '.join(missing)}")
+
+        endpoint = self.endpoint.rstrip("/")
+        if not endpoint.startswith(("http://", "https://")):
+            endpoint = f"http://{endpoint}"
+        logger.info(
+            "configuring storage alias component=sync worker=%s endpoint=%s bucket=%s",
+            self.worker_name,
+            _redact_url_userinfo(endpoint),
+            self.bucket,
+        )
+        try:
+            self._mc("alias", "set", self.mc_alias, endpoint, self.access_key, self.secret_key)
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(f"configure storage alias failed: {_mc_error_message(exc)}") from None
+        self._alias_set = True
+        logger.info("storage alias ready component=sync worker=%s mode=static", self.worker_name)
+
+    def _object_path(self, key: str) -> str:
+        return f"{self.mc_alias}/{self.bucket}/{key.strip('/')}"
+
+    def _cat(self, key: str) -> Optional[str]:
+        self.ensure_alias()
+        result = self._mc("cat", self._object_path(key), check=False)
+        if result.returncode == 0:
+            return result.stdout
+        if _looks_like_missing_object_error(result.stderr):
+            return None
+        logger.debug("mc cat failed component=sync key=%s returncode=%s", key, result.returncode)
+        return None
+
+    def _cat_bytes(self, key: str) -> Optional[bytes]:
+        self.ensure_alias()
+        try:
+            result = self._mc("cat", self._object_path(key), check=False, text=False)
+        except Exception as exc:
+            logger.debug("mc cat failed component=sync key=%s error_type=%s", key, type(exc).__name__)
+            return None
+        if result.returncode == 0:
+            stdout = result.stdout
+            if isinstance(stdout, bytes):
+                return stdout
+            return _to_text(stdout).encode("utf-8")
+        if _looks_like_missing_object_error(result.stderr):
+            return None
+        logger.debug("mc cat failed component=sync key=%s returncode=%s", key, result.returncode)
+        return None
+
+    def _mirror_prefix(self, remote_prefix: str, local_dir: Path) -> None:
+        local_dir.mkdir(parents=True, exist_ok=True)
+        remote = f"{self.mc_alias}/{self.bucket}/{remote_prefix.strip('/')}/"
+        logger.info(
+            "mirroring storage prefix component=sync worker=%s remote=%s local=%s",
+            self.worker_name,
+            remote,
+            local_dir,
+        )
+        try:
+            self._mc(
+                "mirror",
+                remote,
+                str(local_dir) + "/",
+                "--overwrite",
+                "--exclude",
+                "credentials/**",
+            )
+        except subprocess.CalledProcessError as exc:
+            if _looks_like_missing_object_error(exc.stderr):
+                logger.info("storage prefix is empty component=sync remote=%s", remote)
+                return
+            raise RuntimeError(f"mirror storage failed: {_mc_error_message(exc)}") from None
+        logger.info(
+            "mirrored storage prefix component=sync worker=%s remote=%s local=%s",
+            self.worker_name,
+            remote,
+            local_dir,
+        )
+
+    def mirror_all(self) -> None:
+        self.ensure_alias()
+        self._mirror_prefix(self.remote_prefix, self.local_dir)
+        self._mirror_prefix(self.shared_prefix, self.shared_dir)
+
+    def mirror_prefix(self, remote_prefix: str, local_dir: Path) -> None:
+        self.ensure_alias()
+        self._mirror_prefix(remote_prefix, local_dir)
+
+    def pull_runtime_config(self, local_path: Path, remote_key: Optional[str] = None) -> bool:
+        self.ensure_alias()
+        key = remote_key or f"{self.remote_prefix}/runtime/runtime.yaml"
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        result = self._mc("cp", self._object_path(key), str(local_path), check=False)
+        if result.returncode == 0:
+            return True
+        if _looks_like_missing_object_error(result.stderr):
+            logger.info("runtime config not found in storage component=sync key=%s", key)
+            return False
+        raise RuntimeError(f"pull runtime config failed: {_mc_error_message(result)}")
+
+
+def _skip_background_push(rel: Path) -> bool:
+    rel_path = rel.as_posix()
+    excluded_prefixes = (
+        "credentials",
+        "runtime",
+        "shared",
+        "global-shared",
+        ".qwenpaw/workspaces/default/shared",
+        ".qwenpaw/workspaces/default/global-shared",
+        ".qwenpaw/workspaces/default/tool_result",
+        ".qwenpaw/workspaces/default/file_store",
+        ".qwenpaw/workspaces/default/media",
+        ".qwenpaw/workspaces/default/embedding_cache",
+    )
+    if any(rel_path == prefix or rel_path.startswith(f"{prefix}/") for prefix in excluded_prefixes):
+        return True
+    excluded_dirs = {".cache", ".local", ".mc", "__pycache__", "logs"}
+    if any(part in excluded_dirs for part in rel.parts):
+        return True
+    excluded_files = {".DS_Store", "qwenpaw.log", "heartbeat.json", "token_usage.json"}
+    if rel.name in excluded_files:
+        return True
+    return rel.suffix in {".lock", ".pyc"}
+
+
+def push_local(sync: FileSync, since: float = 0) -> List[str]:
+    pushed = []
+    local_dir = sync.local_dir
+    if not local_dir.exists():
+        return pushed
+
+    sync.ensure_alias()
+    for path in local_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            stat = path.stat()
+            if stat.st_mtime <= since:
+                continue
+        except OSError:
+            continue
+
+        rel = path.relative_to(local_dir)
+        if _skip_background_push(rel):
+            continue
+
+        key = f"{sync.remote_prefix}/{rel.as_posix()}"
+        try:
+            if stat.st_size <= COMPARE_CONTENT_MAX_BYTES:
+                remote = sync._cat_bytes(key)
+                if remote == path.read_bytes():
+                    continue
+            sync._mc("cp", str(path), sync._object_path(key), check=True)
+            pushed.append(rel.as_posix())
+        except Exception as exc:
+            logger.debug("push_local failed component=sync file=%s error_type=%s", rel, type(exc).__name__)
+
+    return pushed
+
+
+async def push_loop(sync: FileSync, check_interval: float = 5) -> None:
+    last_push_time = 0.0
+    logger.info(
+        "qwenpaw FileSync push loop started component=sync worker=%s interval_seconds=%s",
+        sync.worker_name,
+        check_interval,
+    )
+    while True:
+        try:
+            await asyncio.sleep(check_interval)
+            now = time.time()
+            pushed = await asyncio.to_thread(push_local, sync, last_push_time)
+            last_push_time = now
+            if pushed:
+                logger.info(
+                    "qwenpaw FileSync push uploaded component=sync worker=%s count=%d files=%s",
+                    sync.worker_name,
+                    len(pushed),
+                    _preview_list(pushed),
+                )
+        except asyncio.CancelledError:
+            logger.info("qwenpaw FileSync push loop stopped component=sync worker=%s", sync.worker_name)
+            break
+        except Exception as exc:
+            logger.warning(
+                "qwenpaw FileSync push failed component=sync worker=%s error_type=%s",
+                sync.worker_name,
+                type(exc).__name__,
+            )

--- a/qwenpaw/src/qwenpaw_worker/update.py
+++ b/qwenpaw/src/qwenpaw_worker/update.py
@@ -1,0 +1,1997 @@
+"""Runtime desired-state update support for qwenpaw-worker."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from dataclasses import dataclass
+import hashlib
+import hmac
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import time
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import yaml
+
+from qwenpaw_worker.config import WorkerConfig
+logger = logging.getLogger(__name__)
+DEFAULT_AGENT_ID = "default"
+TEAMS_PROMPT_FILE = "TEAMS.md"
+PACKAGE_PROMPT_FILES = ("AGENTS.md", "SOUL.md")
+TEAMS_CONTEXT_START = "<!-- BEGIN AGENTTEAMS RUNTIME TEAM CONTEXT -->"
+TEAMS_CONTEXT_END = "<!-- END AGENTTEAMS RUNTIME TEAM CONTEXT -->"
+AGENT_IDENTITY_DATA_ENDPOINT_FORMAT = "agentidentitydata.{region_id}.aliyuncs.com"
+REGION_ID_ENV_NAMES = ("AGENTTEAMS_REGION", "ALIBABA_CLOUD_REGION_ID", "REGION_ID")
+
+
+def _section(data: Dict[str, Any], name: str) -> Dict[str, Any]:
+    value = data.get(name) or {}
+    return value if isinstance(value, dict) else {}
+
+
+def _string(value: Any) -> str:
+    return str(value).strip() if value is not None else ""
+
+
+_ENV_NAME_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def _instance_id_from_controller_url(value: str) -> str:
+    host = urlparse(value.strip()).hostname or ""
+    parts = host.split(".")
+    if len(parts) >= 2 and parts[0] == "controller":
+        return parts[1]
+    return ""
+
+
+def _worker_instance_id() -> str:
+    explicit = _string(os.getenv("AGENTTEAMS_INSTANCE_ID"))
+    if explicit:
+        return explicit
+    return _instance_id_from_controller_url(_string(os.getenv("AGENTTEAMS_CONTROLLER_URL")))
+
+
+def _worker_region_id() -> str:
+    for name in REGION_ID_ENV_NAMES:
+        value = _string(os.getenv(name))
+        if value:
+            return value
+    return ""
+
+
+def credential_provider_env_name(provider_name: str, instance_id: str = "") -> str:
+    text = _string(provider_name)
+    if _ENV_NAME_PATTERN.fullmatch(text):
+        return text
+    prefix = f"{_string(instance_id)}-"
+    if prefix != "-" and text.startswith(prefix):
+        suffix = text[len(prefix):]
+        if _ENV_NAME_PATTERN.fullmatch(suffix):
+            return suffix
+    return ""
+
+
+def _credential_provider_env_name(provider_name: str) -> str:
+    return credential_provider_env_name(provider_name, _worker_instance_id())
+
+
+def _download_path_part(value: str, fallback: str) -> str:
+    text = value.strip() or fallback
+    return re.sub(r"[^A-Za-z0-9._=-]+", "_", text).strip("._") or fallback
+
+
+def _string_list(value: Any) -> List[str]:
+    if not isinstance(value, list):
+        return []
+    result = []
+    for item in value:
+        text = _string(item)
+        if text:
+            result.append(text)
+    return result
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value if value is not None else {}, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+
+def _count_collection(value: Any) -> int:
+    if isinstance(value, dict):
+        return len(value)
+    if isinstance(value, list):
+        return len(value)
+    return 0
+
+
+def _named_keys(value: Any) -> str:
+    if not isinstance(value, dict):
+        return "-"
+    names = sorted(str(name).strip() for name in value.keys() if str(name).strip())
+    return ",".join(names) if names else "-"
+
+
+def _duration_ms(started_at: float) -> int:
+    return max(0, int((time.monotonic() - started_at) * 1000))
+
+
+def _strip_json_line_comments(text: str) -> str:
+    result: List[str] = []
+    in_string = False
+    escaped = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if in_string:
+            result.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            index += 1
+            continue
+
+        if char == '"':
+            in_string = True
+            result.append(char)
+            index += 1
+            continue
+        if char == "/" and index + 1 < len(text) and text[index + 1] == "/":
+            index += 2
+            while index < len(text) and text[index] not in "\r\n":
+                index += 1
+            continue
+        result.append(char)
+        index += 1
+    return "".join(result)
+
+
+def _string_fields(value: Any, keys: Iterable[str]) -> Dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    result: Dict[str, str] = {}
+    for key in keys:
+        text = _string(value.get(key))
+        if text:
+            result[key] = text
+    return result
+
+
+def _env_bool(name: str) -> bool:
+    value = _string(os.getenv(name)).lower()
+    return value in {"1", "true", "yes", "on"}
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return _string(value).lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class MemberRuntimeConfig:
+    """Normalized runtime.yaml snapshot used by QwenPaw worker and adapter."""
+
+    path: Path
+    raw: Dict[str, Any]
+
+    @classmethod
+    def load(cls, path: Path) -> "MemberRuntimeConfig":
+        if not path.exists():
+            raise FileNotFoundError(f"runtime config missing: {path}")
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        if not isinstance(data, dict):
+            raise ValueError("runtime config must be a YAML object")
+        member = _section(data, "member")
+        runtime = _string(member.get("runtime"))
+        if runtime and runtime != "qwenpaw":
+            raise ValueError(f"runtime must be qwenpaw, got {runtime}")
+        return cls(path=path, raw=data)
+
+    @property
+    def generation(self) -> str:
+        return _string(_section(self.raw, "metadata").get("generation"))
+
+    @property
+    def team(self) -> Dict[str, Any]:
+        return _section(self.raw, "team")
+
+    @property
+    def team_members(self) -> List[Dict[str, str]]:
+        raw = self.team.get("members")
+        if not isinstance(raw, list):
+            return []
+        members: List[Dict[str, str]] = []
+        for item in raw:
+            entry = _string_fields(item, ("name", "runtimeName", "role", "matrixUserId", "personalRoomId"))
+            if entry:
+                members.append(entry)
+        return members
+
+    @property
+    def member(self) -> Dict[str, Any]:
+        return _section(self.raw, "member")
+
+    @property
+    def desired(self) -> Dict[str, Any]:
+        return _section(self.raw, "desired")
+
+    @property
+    def storage(self) -> Dict[str, Any]:
+        return _section(self.raw, "storage")
+
+    @property
+    def credentials(self) -> Dict[str, Any]:
+        return _section(self.raw, "credentials")
+
+    @property
+    def agent_identity_data(self) -> Dict[str, str]:
+        return _string_fields(_section(self.raw, "agentIdentityData"), ("endpoint", "regionId"))
+
+    @property
+    def agent_identity_data_region_id(self) -> str:
+        return _string(self.agent_identity_data.get("regionId")) or _worker_region_id()
+
+    @property
+    def agent_identity_data_endpoint(self) -> str:
+        endpoint = _string(self.agent_identity_data.get("endpoint"))
+        if endpoint:
+            return endpoint
+        region_id = self.agent_identity_data_region_id
+        if region_id:
+            return AGENT_IDENTITY_DATA_ENDPOINT_FORMAT.format(region_id=region_id)
+        return ""
+
+    @property
+    def agent_identity(self) -> Dict[str, str]:
+        return _string_fields(_section(self.desired, "agentIdentity"), ("workloadIdentityName",))
+
+    @property
+    def workload_identity_name(self) -> str:
+        return _string(self.agent_identity.get("workloadIdentityName"))
+
+    @property
+    def credential_bindings(self) -> List[Dict[str, Any]]:
+        raw = self.desired.get("credentialBindings")
+        if not isinstance(raw, list):
+            return []
+        bindings: List[Dict[str, Any]] = []
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            credential_ref = _string_fields(
+                _section(item, "credentialRef"),
+                ("tokenVaultName", "apiKeyCredentialProviderName"),
+            )
+            if credential_ref:
+                binding: Dict[str, Any] = {"credentialRef": credential_ref}
+                tool_whitelist = _string_list(item.get("toolWhitelist"))
+                if tool_whitelist:
+                    binding["toolWhitelist"] = tool_whitelist
+                bindings.append(binding)
+        return bindings
+
+    @property
+    def credential_binding_env_names(self) -> List[str]:
+        names: List[str] = []
+        for binding in self.credential_bindings:
+            name = _credential_provider_env_name(
+                _string(binding.get("credentialRef", {}).get("apiKeyCredentialProviderName"))
+            )
+            if name and name not in names:
+                names.append(name)
+        return names
+
+    @property
+    def credential_binding_env_provider_names(self) -> Dict[str, str]:
+        providers: Dict[str, str] = {}
+        for binding in self.credential_bindings:
+            provider_name = _string(binding.get("credentialRef", {}).get("apiKeyCredentialProviderName"))
+            env_name = _credential_provider_env_name(provider_name)
+            if env_name and env_name not in providers:
+                providers[env_name] = provider_name
+        return providers
+
+    @property
+    def credential_runtime_identity(self) -> str:
+        return _stable_json(
+            {
+                "agentIdentity": self.agent_identity,
+                "agentIdentityData": self.agent_identity_data,
+                "agentIdentityDataEndpoint": self.agent_identity_data_endpoint,
+                "credentialBindings": self.credential_bindings,
+            }
+        )
+
+    @property
+    def team_name(self) -> str:
+        return _string(self.team.get("name"))
+
+    @property
+    def member_name(self) -> str:
+        return _string(self.member.get("name") or self.member.get("runtimeName"))
+
+    @property
+    def member_role(self) -> str:
+        return _string(self.member.get("role") or "worker")
+
+    @property
+    def agent_package(self) -> Dict[str, Any]:
+        return _section(self.desired, "agentPackage")
+
+    @property
+    def agent_package_identity(self) -> Tuple[str, str, str, str]:
+        package = self.agent_package
+        return (
+            _string(package.get("ref")),
+            _string(package.get("name")),
+            _string(package.get("version")),
+            _string(package.get("digest")),
+        )
+
+    @property
+    def model(self) -> Dict[str, Any]:
+        return _section(self.desired, "model")
+
+    @property
+    def mcp_servers(self) -> Any:
+        value = self.desired.get("mcpServers")
+        return value if value is not None else {}
+
+    @property
+    def channels(self) -> Dict[str, Any]:
+        return _section(self.desired, "channels")
+
+    @property
+    def dingtalk_channel(self) -> Optional[Dict[str, Any]]:
+        value = self.channels.get("dingtalk")
+        return value if isinstance(value, dict) else None
+
+    @property
+    def channel_policy(self) -> Dict[str, Any]:
+        return _section(self.desired, "channelPolicy")
+
+    @property
+    def desired_identity(self) -> Tuple[str, str, str, str, str, str, str, str]:
+        return (
+            *self.agent_package_identity,
+            _stable_json(self.model),
+            _stable_json(self.mcp_servers),
+            _stable_json(self.channels),
+            _stable_json(self.channel_policy),
+        )
+
+    @property
+    def team_context_facts(self) -> Dict[str, Any]:
+        team = _string_fields(
+            self.team,
+            ("name", "teamRoomId", "leaderName", "leaderRuntimeName", "leaderDmRoomId"),
+        )
+        admin = _string_fields(_section(self.team, "admin"), ("name", "matrixUserId"))
+        if admin:
+            team["admin"] = admin  # type: ignore[assignment]
+        if self.team_members:
+            team["members"] = self.team_members  # type: ignore[assignment]
+
+        facts: Dict[str, Any] = {}
+        if self.generation:
+            facts["metadata"] = {"generation": self.generation}
+        if team:
+            facts["team"] = team
+        member = _string_fields(
+            self.member,
+            ("name", "runtimeName", "role", "runtime", "matrixUserId", "personalRoomId"),
+        )
+        if member:
+            facts["member"] = member
+        return facts
+
+    @property
+    def team_context_identity(self) -> str:
+        return _stable_json(self.team_context_facts)
+
+    @property
+    def output_sanitize_policy(self) -> Dict[str, Any]:
+        return _section(self.desired, "outputSanitize")
+
+    @property
+    def output_sanitize_keywords(self) -> List[str]:
+        return _string_list(self.output_sanitize_policy.get("keywords"))
+
+    @property
+    def output_sanitize_env_refs(self) -> List[str]:
+        refs = _string_list(self.output_sanitize_policy.get("envRefs"))
+        for key in (
+            "matrixTokenEnv",
+            "gatewayKeyEnv",
+            "storageAccessKeyEnv",
+            "storageSecretKeyEnv",
+        ):
+            value = _string(self.credentials.get(key))
+            if value and value not in refs:
+                refs.append(value)
+        return refs
+
+    def changed_from(self, previous: "MemberRuntimeConfig") -> bool:
+        return (
+            self.generation != previous.generation
+            or self.desired_identity != previous.desired_identity
+            or self.team_context_identity != previous.team_context_identity
+            or self.credential_runtime_identity != previous.credential_runtime_identity
+        )
+
+
+class AgentPackageManager:
+    """Download and extract desired AgentSpec packages without restarting."""
+
+    def __init__(self, root_dir: Path, workspace_dir: Optional[Path] = None) -> None:
+        self.root_dir = root_dir
+        self.workspace_dir = workspace_dir
+        self.current_dir = root_dir / "current"
+        self.marker_path = root_dir / "current.identity"
+        self.root_dir.mkdir(parents=True, exist_ok=True)
+
+    def apply(self, config: MemberRuntimeConfig) -> Optional[Path]:
+        identity = config.agent_package_identity
+        if not any(identity):
+            return None
+        if self._current_identity() == identity and self.current_dir.exists():
+            self._apply_to_workspace_atomic(self.current_dir)
+            return self.current_dir
+
+        package_path = self._fetch(identity[0])
+        staging = Path(tempfile.mkdtemp(prefix="qwenpaw-agent-package-", dir=str(self.root_dir)))
+        previous = self.current_dir if self.current_dir.exists() else None
+        workspace_snapshot = None
+        try:
+            self._extract(package_path, staging)
+            workspace_snapshot = self._snapshot_workspace(staging, previous)
+            self._cleanup_stale_workspace_targets(previous, staging)
+            self._apply_to_workspace(staging, previous)
+            self._commit_current(staging, identity)
+            self._cleanup_workspace_snapshot(workspace_snapshot)
+            return self.current_dir
+        except Exception:
+            self._restore_workspace_snapshot(workspace_snapshot)
+            shutil.rmtree(staging, ignore_errors=True)
+            raise
+
+    def _current_identity(self) -> Tuple[str, str, str, str]:
+        if not self.marker_path.exists():
+            return ("", "", "", "")
+        parts = self.marker_path.read_text(encoding="utf-8").splitlines()
+        return tuple((parts + ["", "", "", ""])[:4])  # type: ignore[return-value]
+
+    def _fetch(self, ref: str) -> Path:
+        if not ref:
+            raise RuntimeError("desired.agentPackage.ref is required")
+        parsed = urlparse(ref)
+        if parsed.scheme in ("", "file"):
+            path = Path(parsed.path if parsed.scheme == "file" else ref)
+            if not path.exists():
+                raise RuntimeError(f"agent package not found: {ref}")
+            return path
+        if parsed.scheme in ("http", "https"):
+            target = self.root_dir / "downloads" / Path(parsed.path).name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            urllib.request.urlretrieve(ref, target)
+            return target
+        if parsed.scheme == "oss":
+            return self._fetch_oss(parsed)
+        if parsed.scheme == "nacos":
+            return self._fetch_nacos(parsed)
+        raise RuntimeError(f"unsupported agent package ref scheme: {parsed.scheme}")
+
+    def _fetch_oss(self, parsed) -> Path:
+        oss_path = f"{parsed.netloc}{parsed.path}".strip("/")
+        if not oss_path:
+            raise RuntimeError("oss agent package path is required")
+        target = self.root_dir / "downloads" / Path(oss_path).name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists():
+            return target
+
+        storage_prefix = os.getenv("AGENTTEAMS_STORAGE_PREFIX", "").strip().rstrip("/") or "agentteams/agentteams-storage"
+        remote = f"{storage_prefix}/{oss_path}"
+        try:
+            subprocess.run(["mc", "cp", remote, str(target)], check=True, capture_output=True, text=True)
+        except FileNotFoundError:
+            raise RuntimeError("mc binary not found for oss agent package fetch") from None
+        except subprocess.CalledProcessError as exc:
+            detail = (exc.stderr or exc.stdout or "").strip()
+            message = f": {detail}" if detail else ""
+            raise RuntimeError(f"fetch oss agent package failed: {remote}{message}") from None
+        return target
+
+    def _fetch_nacos(self, parsed) -> Path:
+        parts = [part for part in parsed.path.strip("/").split("/") if part]
+        if len(parts) < 2:
+            raise RuntimeError(
+                f"invalid nacos agent package ref: expected nacos://[user:pass@]host:port/"
+                f"{{namespace}}/{{agentspec-name}}[/{{version}}], got {parsed.geturl()}"
+            )
+
+        namespace, spec_name = parts[0], parts[1]
+        version = parts[2] if len(parts) >= 3 else ""
+        label = ""
+        if version.startswith("label:"):
+            label = version.removeprefix("label:")
+            version = ""
+        query = parse_qs(parsed.query)
+        query_version = _string((query.get("version") or [""])[0])
+        query_label = _string((query.get("label") or [""])[0])
+        if query_version:
+            version = query_version
+            label = ""
+        if query_label:
+            label = query_label
+            version = ""
+
+        auth_type = (query.get("authType") or [""])[0].strip()
+        if auth_type == "sts-agentteams":
+            return self._fetch_nacos_cli(parsed, namespace, spec_name, version, label, auth_type)
+
+        output_dir = self._nacos_download_output_dir(namespace, spec_name, version, label)
+        target = output_dir / spec_name
+        if target.exists():
+            shutil.rmtree(target)
+        target.mkdir(parents=True, exist_ok=True)
+
+        spec = self._get_nacos_agentspec(parsed, namespace, spec_name, version, label)
+        resources = spec.get("resource") or {}
+        if isinstance(resources, dict):
+            for resource in resources.values():
+                if isinstance(resource, dict):
+                    self._write_nacos_resource(target, resource)
+
+        content = _string(spec.get("content"))
+        try:
+            content = json.dumps(json.loads(content), ensure_ascii=False, indent=2)
+        except Exception:
+            pass
+        (target / "manifest.json").write_text(content, encoding="utf-8")
+        return target
+
+    def _fetch_nacos_cli(
+        self,
+        parsed,
+        namespace: str,
+        spec_name: str,
+        version: str,
+        label: str,
+        auth_type: str,
+    ) -> Path:
+        host = parsed.hostname
+        if not host:
+            raise RuntimeError(f"invalid nacos agent package ref: missing host in {parsed.geturl()}")
+        port = parsed.port or 8848
+
+        output_dir = self._nacos_download_output_dir(namespace, spec_name, version, label)
+        target = output_dir / spec_name
+        if target.exists():
+            shutil.rmtree(target)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        command = [
+            "nacos-cli",
+            "--host",
+            host,
+            "--port",
+            str(port),
+            "--namespace",
+            namespace,
+        ]
+        if auth_type:
+            command.extend(["--auth-type", auth_type])
+        if auth_type == "sts-agentteams":
+            access_key, secret_key, security_token = self._nacos_sts_credentials()
+            command.extend(["--access-key", access_key, "--secret-key", secret_key])
+            if security_token:
+                command.extend(["--security-token", security_token])
+        command.extend(["agentspec-get", spec_name, "-o", str(output_dir)])
+        if version:
+            command.extend(["--version", version])
+        if label:
+            command.extend(["--label", label])
+
+        logger.info(
+            "fetching nacos agentspec package component=update step=fetch_agentspec host=%s port=%s namespace=%s "
+            "spec=%s version=%s label=%s",
+            host,
+            port,
+            namespace,
+            spec_name,
+            version or "-",
+            label or "-",
+        )
+        try:
+            subprocess.run(command, check=True, capture_output=True, text=True)
+        except FileNotFoundError:
+            raise RuntimeError("nacos-cli binary not found for nacos agent package fetch") from None
+        except subprocess.CalledProcessError as exc:
+            detail = (exc.stderr or exc.stdout or "").strip()
+            message = f": {detail}" if detail else ""
+            raise RuntimeError(f"fetch agentspec {spec_name} from nacos with nacos-cli failed{message}") from None
+
+        if not target.exists():
+            raise RuntimeError(f"nacos-cli agentspec download finished but {target} was not created")
+        if not target.is_dir():
+            raise RuntimeError(f"nacos-cli agentspec output {target} is not a directory")
+        return target
+
+    def _nacos_download_output_dir(
+        self,
+        namespace: str,
+        spec_name: str,
+        version: str,
+        label: str,
+    ) -> Path:
+        if version:
+            selector = f"version-{version}"
+        elif label:
+            selector = f"label-{label}"
+        else:
+            selector = "latest"
+        return (
+            self.root_dir
+            / "downloads"
+            / "nacos"
+            / _download_path_part(namespace, "default")
+            / _download_path_part(spec_name, "agentspec")
+            / _download_path_part(selector, "latest")
+        )
+
+    def _get_nacos_agentspec(self, parsed, namespace: str, spec_name: str, version: str, label: str) -> Dict[str, Any]:
+        host = parsed.hostname
+        if not host:
+            raise RuntimeError(f"invalid nacos agent package ref: missing host in {parsed.geturl()}")
+        port = parsed.port or 8848
+        params = {"namespaceId": namespace, "name": spec_name}
+        if version:
+            params["version"] = version
+        if label:
+            params["label"] = label
+        url = f"http://{host}:{port}/nacos/v3/client/ai/agentspecs?{urlencode(params)}"
+        request = urllib.request.Request(url, headers=self._nacos_auth_headers(parsed, namespace))
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"fetch agentspec {spec_name} from nacos failed: HTTP {exc.code}: {body}") from None
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"fetch agentspec {spec_name} from nacos failed: {exc.reason}") from None
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"fetch agentspec {spec_name} from nacos failed: invalid JSON response") from exc
+
+        if int(payload.get("code", 0)) != 0:
+            raise RuntimeError(
+                f"fetch agentspec {spec_name} from nacos failed: code={payload.get('code')}, "
+                f"message={payload.get('message')}"
+            )
+        data = payload.get("data") or {}
+        if not isinstance(data, dict):
+            raise RuntimeError(f"fetch agentspec {spec_name} from nacos failed: response data must be an object")
+        return data
+
+    def _nacos_auth_headers(self, parsed, namespace: str) -> Dict[str, str]:
+        query = parse_qs(parsed.query)
+        auth_type = (query.get("authType") or [""])[0].strip()
+        token = os.getenv("AGENTTEAMS_NACOS_TOKEN", "").strip()
+        username = parsed.username or os.getenv("AGENTTEAMS_NACOS_USERNAME", "")
+        password = parsed.password or os.getenv("AGENTTEAMS_NACOS_PASSWORD", "")
+
+        if auth_type == "sts-agentteams":
+            return self._nacos_sts_auth_headers(namespace)
+        if auth_type == "":
+            if token:
+                return {"Authorization": f"Bearer {token}"}
+            auth_type = "nacos" if username or password else "none"
+        if auth_type == "none":
+            return {}
+        if auth_type != "nacos":
+            raise RuntimeError(f"unsupported nacos auth type: {auth_type}")
+        if not username or not password:
+            raise RuntimeError("nacos auth requires username and password")
+
+        access_token = self._nacos_login(parsed, username, password)
+        return {"Authorization": f"Bearer {access_token}"}
+
+    def _nacos_sts_auth_headers(self, namespace: str) -> Dict[str, str]:
+        access_key, secret_key, security_token = self._nacos_sts_credentials()
+        timestamp = str(int(time.time() * 1000))
+        sign_data = f"{namespace}+DEFAULT_GROUP+{timestamp}" if namespace else timestamp
+        signature = base64.b64encode(
+            hmac.new(secret_key.encode("utf-8"), sign_data.encode("utf-8"), hashlib.sha1).digest()
+        ).decode("utf-8")
+        headers = {
+            "Spas-AccessKey": access_key,
+            "Timestamp": timestamp,
+            "Spas-Signature": signature,
+        }
+        if security_token:
+            headers["Spas-SecurityToken"] = security_token
+        return headers
+
+    def _nacos_sts_credentials(self) -> Tuple[str, str, str]:
+        sts = self._fetch_controller_sts()
+        access_key = _string(
+            sts.get("access_key_id")
+            or sts.get("accessKeyId")
+            or sts.get("accessKeyID")
+            or sts.get("AccessKeyID")
+        )
+        secret_key = _string(
+            sts.get("access_key_secret")
+            or sts.get("accessKeySecret")
+            or sts.get("AccessKeySecret")
+        )
+        security_token = _string(
+            sts.get("security_token")
+            or sts.get("securityToken")
+            or sts.get("SecurityToken")
+        )
+        if not access_key or not secret_key:
+            raise RuntimeError("controller STS response missing access key fields")
+        return access_key, secret_key, security_token
+
+    def _fetch_controller_sts(self) -> Dict[str, Any]:
+        controller_url = os.getenv("AGENTTEAMS_CONTROLLER_URL", "").strip().rstrip("/")
+        if not controller_url:
+            raise RuntimeError("nacos authType=sts-agentteams requires AGENTTEAMS_CONTROLLER_URL")
+        bearer = self._controller_bearer_token()
+        headers = {"Authorization": f"Bearer {bearer}"}
+        auth_cluster_id = self._auth_cluster_id()
+        if auth_cluster_id:
+            headers["X-AgentTeams-Cluster-ID"] = auth_cluster_id
+        request = urllib.request.Request(
+            f"{controller_url}/api/v1/credentials/sts",
+            data=b"",
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"controller STS request failed: HTTP {exc.code}: {body}") from None
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"controller STS request failed: {exc.reason}") from None
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("controller STS request failed: invalid JSON response") from exc
+        if not isinstance(payload, dict):
+            raise RuntimeError("controller STS response must be an object")
+        return payload
+
+    def _controller_bearer_token(self) -> str:
+        token = os.getenv("AGENTTEAMS_AUTH_TOKEN", "").strip()
+        if token:
+            return token
+        token_file = os.getenv("AGENTTEAMS_AUTH_TOKEN_FILE", "").strip()
+        if token_file:
+            path = Path(token_file)
+            if not path.exists():
+                raise RuntimeError(f"AGENTTEAMS_AUTH_TOKEN_FILE does not exist: {token_file}")
+            token = path.read_text(encoding="utf-8").strip()
+            if token:
+                return token
+        raise RuntimeError("nacos authType=sts-agentteams requires AGENTTEAMS_AUTH_TOKEN or AGENTTEAMS_AUTH_TOKEN_FILE")
+
+    @staticmethod
+    def _auth_cluster_id() -> str:
+        return os.getenv("AGENTTEAMS_CLUSTER_ID", "").strip()
+
+    def _nacos_login(self, parsed, username: str, password: str) -> str:
+        host = parsed.hostname
+        if not host:
+            raise RuntimeError(f"invalid nacos agent package ref: missing host in {parsed.geturl()}")
+        port = parsed.port or 8848
+        body = urlencode({"username": username, "password": password}).encode("utf-8")
+        for path in ("/nacos/v3/auth/user/login", "/nacos/v1/auth/login"):
+            request = urllib.request.Request(
+                f"http://{host}:{port}{path}",
+                data=body,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=60) as response:
+                    payload = json.loads(response.read().decode("utf-8"))
+            except Exception:
+                continue
+            data = payload.get("data") if isinstance(payload.get("data"), dict) else payload
+            token = data.get("accessToken") if isinstance(data, dict) else ""
+            if token:
+                return _string(token)
+        raise RuntimeError("nacos login failed")
+
+    def _write_nacos_resource(self, target: Path, resource: Dict[str, Any]) -> None:
+        content = resource.get("content")
+        if content in (None, ""):
+            return
+        rel = self._nacos_resource_path(resource)
+        if not rel:
+            return
+        self._ensure_inside_target(target, [rel])
+        data = str(content).encode("utf-8")
+        metadata = resource.get("metadata") if isinstance(resource.get("metadata"), dict) else {}
+        if metadata.get("encoding") == "base64":
+            data = base64.b64decode(str(content))
+        destination = target / rel
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(data)
+
+    def _nacos_resource_path(self, resource: Dict[str, Any]) -> str:
+        resource_type = _string(resource.get("type"))
+        resource_name = _string(resource.get("name")).strip("/")
+        if not resource_type:
+            return resource_name
+        prefix = f"{resource_type}/"
+        return resource_name if resource_name.startswith(prefix) else prefix + resource_name
+
+    def _extract(self, package_path: Path, target_dir: Path) -> None:
+        if package_path.is_dir():
+            shutil.copytree(package_path, target_dir, dirs_exist_ok=True)
+            return
+        if tarfile.is_tarfile(package_path):
+            with tarfile.open(package_path) as archive:
+                self._safe_extract_tar(archive, target_dir)
+            return
+        if zipfile.is_zipfile(package_path):
+            with zipfile.ZipFile(package_path) as archive:
+                self._safe_extract_zip(archive, target_dir)
+            return
+        raise RuntimeError(f"unsupported agent package format: {package_path}")
+
+    def _ensure_inside_target(self, target_dir: Path, names: Iterable[str]) -> None:
+        target_root = target_dir.resolve()
+        for name in names:
+            resolved = (target_dir / name).resolve()
+            try:
+                resolved.relative_to(target_root)
+            except ValueError:
+                raise RuntimeError(f"unsafe agent package path: {name}")
+
+    def _safe_extract_tar(self, archive: tarfile.TarFile, target_dir: Path) -> None:
+        members = archive.getmembers()
+        for member in members:
+            if member.issym() or member.islnk():
+                raise RuntimeError(f"unsafe agent package link: {member.name}")
+        self._ensure_inside_target(target_dir, (member.name for member in members))
+        archive.extractall(target_dir, members=members)
+
+    def _safe_extract_zip(self, archive: zipfile.ZipFile, target_dir: Path) -> None:
+        names = archive.namelist()
+        self._ensure_inside_target(target_dir, names)
+        archive.extractall(target_dir)
+
+    def _apply_to_workspace_atomic(self, package_dir: Path) -> None:
+        snapshot = self._snapshot_workspace(package_dir)
+        try:
+            self._apply_to_workspace(package_dir)
+            self._cleanup_workspace_snapshot(snapshot)
+        except Exception:
+            self._restore_workspace_snapshot(snapshot)
+            raise
+
+    def _apply_to_workspace(self, package_dir: Path, previous_package_dir: Optional[Path] = None) -> None:
+        if self.workspace_dir is None:
+            return
+        workspace_dir = self.workspace_dir
+        package_root = self._package_content_root(package_dir)
+        previous_root = self._package_content_root(previous_package_dir) if previous_package_dir is not None else None
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+
+        config_dir = package_root / "config"
+        if config_dir.is_dir():
+            self._copy_config_to_workspace(config_dir)
+        self._clear_missing_package_prompt_files(package_root)
+
+        self._apply_package_mcp_config(package_root, previous_root)
+
+        skills_dir = package_root / "skills"
+        if skills_dir.is_dir():
+            skill_names = self._copy_skills_to_workspace(skills_dir)
+            self._reconcile_workspace_skills(skill_names)
+
+    def _package_content_root(self, package_dir: Path) -> Path:
+        if self._looks_like_agent_package(package_dir):
+            return package_dir
+        children = [path for path in package_dir.iterdir() if path.is_dir()]
+        if len(children) == 1 and self._looks_like_agent_package(children[0]):
+            return children[0]
+        return package_dir
+
+    def _looks_like_agent_package(self, path: Path) -> bool:
+        markers = (
+            "manifest.json",
+            "template.json",
+            "config",
+            "skills",
+            "AGENTS.md",
+            "SOUL.md",
+            "MEMORY.md",
+            "BOOTSTRAP.md",
+            "crons",
+            "mcp.json",
+        )
+        return any((path / marker).exists() for marker in markers)
+
+    def _config_files(self, config_dir: Path) -> List[Tuple[Path, Path]]:
+        if self.workspace_dir is None:
+            return []
+        files: List[Tuple[Path, Path]] = []
+        for child in sorted(config_dir.rglob("*")):
+            if child.is_file():
+                rel = child.relative_to(config_dir)
+                if rel == Path("config/mcporter.json"):
+                    continue
+                files.append((child, self.workspace_dir / rel))
+        return files
+
+    def _workspace_targets(self, package_dir: Path) -> List[Path]:
+        if self.workspace_dir is None:
+            return []
+        package_root = self._package_content_root(package_dir)
+        workspace_dir = self.workspace_dir
+        targets: List[Path] = []
+
+        config_dir = package_root / "config"
+        if config_dir.is_dir():
+            targets.extend(target for _source, target in self._config_files(config_dir))
+        for file_name in PACKAGE_PROMPT_FILES:
+            targets.append(workspace_dir / file_name)
+
+        skills_dir = package_root / "skills"
+        if skills_dir.is_dir():
+            targets.extend(workspace_dir / "skills" / source.name for source in skills_dir.iterdir() if source.is_dir())
+            targets.append(workspace_dir / "skill.json")
+
+        return self._dedupe_paths(targets)
+
+    def _workspace_state_targets(self, package_dir: Path) -> List[Path]:
+        if self.workspace_dir is None:
+            return []
+        package_root = self._package_content_root(package_dir)
+        if self._package_mcp_clients(package_root):
+            return [self.workspace_dir / "agent.json"]
+        return []
+
+    def _snapshot_workspace(
+        self,
+        package_dir: Path,
+        previous_package_dir: Optional[Path] = None,
+    ) -> Optional[Tuple[Path, List[Tuple[Path, Path, bool]]]]:
+        targets = self._dedupe_paths(self._workspace_targets(package_dir) + self._workspace_state_targets(package_dir))
+        if previous_package_dir is not None:
+            targets = self._dedupe_paths(
+                targets + self._workspace_targets(previous_package_dir) + self._workspace_state_targets(previous_package_dir)
+            )
+        if not targets:
+            return None
+        backup_root = Path(tempfile.mkdtemp(prefix="qwenpaw-workspace-rollback-", dir=str(self.root_dir)))
+        entries: List[Tuple[Path, Path, bool]] = []
+        try:
+            for index, target in enumerate(targets):
+                backup = backup_root / str(index)
+                if target.exists():
+                    if target.is_dir():
+                        shutil.copytree(target, backup)
+                    else:
+                        backup.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.copy2(target, backup)
+                    entries.append((target, backup, True))
+                else:
+                    entries.append((target, backup, False))
+            return backup_root, entries
+        except Exception:
+            shutil.rmtree(backup_root, ignore_errors=True)
+            raise
+
+    def _cleanup_stale_workspace_targets(self, previous_package_dir: Optional[Path], package_dir: Path) -> None:
+        if previous_package_dir is None or self.workspace_dir is None:
+            return
+        current_targets = {str(path) for path in self._workspace_targets(package_dir)}
+        for target in self._workspace_targets(previous_package_dir):
+            if str(target) in current_targets or not target.exists():
+                continue
+            if target.parent == self.workspace_dir and target.name in PACKAGE_PROMPT_FILES:
+                target.write_text("", encoding="utf-8")
+                continue
+            if target.is_dir():
+                shutil.rmtree(target)
+            else:
+                target.unlink()
+            self._cleanup_empty_parent_dirs(target.parent)
+
+    def _cleanup_empty_parent_dirs(self, path: Path) -> None:
+        if self.workspace_dir is None:
+            return
+        workspace_root = self.workspace_dir.resolve()
+        current = path
+        while current != self.workspace_dir and str(current.resolve()).startswith(str(workspace_root)):
+            try:
+                current.rmdir()
+            except OSError:
+                return
+            current = current.parent
+
+    def _dedupe_paths(self, paths: Iterable[Path]) -> List[Path]:
+        result = []
+        seen = set()
+        for path in paths:
+            key = str(path)
+            if key not in seen:
+                result.append(path)
+                seen.add(key)
+        return result
+
+    def _restore_workspace_snapshot(self, snapshot: Optional[Tuple[Path, List[Tuple[Path, Path, bool]]]]) -> None:
+        if snapshot is None:
+            return
+        backup_root, entries = snapshot
+        try:
+            for target, backup, existed in reversed(entries):
+                if target.exists():
+                    if target.is_dir():
+                        shutil.rmtree(target)
+                    else:
+                        target.unlink()
+                if existed:
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    if backup.is_dir():
+                        shutil.copytree(backup, target)
+                    else:
+                        shutil.copy2(backup, target)
+        finally:
+            shutil.rmtree(backup_root, ignore_errors=True)
+
+    def _cleanup_workspace_snapshot(self, snapshot: Optional[Tuple[Path, List[Tuple[Path, Path, bool]]]]) -> None:
+        if snapshot is not None:
+            shutil.rmtree(snapshot[0], ignore_errors=True)
+
+    def _commit_current(self, staging: Path, identity: Tuple[str, str, str, str]) -> None:
+        backup = Path(tempfile.mkdtemp(prefix="qwenpaw-agent-package-current-", dir=str(self.root_dir)))
+        shutil.rmtree(backup, ignore_errors=True)
+        moved_current = False
+        moved_staging = False
+        try:
+            if self.current_dir.exists():
+                self.current_dir.rename(backup)
+                moved_current = True
+            staging.rename(self.current_dir)
+            moved_staging = True
+            self._write_current_identity(identity)
+            if moved_current:
+                shutil.rmtree(backup, ignore_errors=True)
+        except Exception:
+            if moved_staging and self.current_dir.exists():
+                shutil.rmtree(self.current_dir, ignore_errors=True)
+            if moved_current and backup.exists():
+                backup.rename(self.current_dir)
+            raise
+
+    def _write_current_identity(self, identity: Tuple[str, str, str, str]) -> None:
+        tmp = self.marker_path.with_name(f".{self.marker_path.name}.tmp")
+        tmp.write_text("\n".join(identity), encoding="utf-8")
+        tmp.replace(self.marker_path)
+
+    def _copy_config_to_workspace(self, config_dir: Path) -> None:
+        if self.workspace_dir is None:
+            return
+        for source, target in self._config_files(config_dir):
+            self._replace_path(source, target)
+
+    def _clear_missing_package_prompt_files(self, package_root: Path) -> None:
+        if self.workspace_dir is None:
+            return
+        config_dir = package_root / "config"
+        for file_name in PACKAGE_PROMPT_FILES:
+            if (config_dir / file_name).is_file():
+                continue
+            target = self.workspace_dir / file_name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("", encoding="utf-8")
+
+    def _apply_package_mcp_config(self, package_root: Path, previous_package_root: Optional[Path]) -> None:
+        current_clients = self._package_mcp_clients(package_root)
+        previous_clients = self._package_mcp_clients(previous_package_root)
+        if not current_clients and not previous_clients:
+            return
+        try:
+            from qwenpaw.config.config import MCPClientConfig, MCPConfig, load_agent_config, save_agent_config
+        except ImportError:
+            logger.info("qwenpaw package unavailable component=update step=apply_package_mcp action=skip")
+            return
+
+        agent_config = load_agent_config(DEFAULT_AGENT_ID)
+        if getattr(agent_config, "mcp", None) is None:
+            agent_config.mcp = MCPConfig()
+        clients = dict(getattr(agent_config.mcp, "clients", None) or {})
+        for name in previous_clients:
+            if name not in current_clients:
+                clients.pop(name, None)
+        for name, payload in current_clients.items():
+            clients[name] = MCPClientConfig(**payload)
+        agent_config.mcp.clients = clients
+        save_agent_config(DEFAULT_AGENT_ID, agent_config)
+
+    def _package_mcp_clients(self, package_root: Optional[Path]) -> Dict[str, Dict[str, Any]]:
+        if package_root is None:
+            return {}
+        mcp_path = package_root / "mcp.json"
+        if not mcp_path.is_file():
+            return {}
+        try:
+            raw = json.loads(_strip_json_line_comments(mcp_path.read_text(encoding="utf-8")))
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"agent package mcp.json is invalid JSON: {mcp_path}") from exc
+        if not isinstance(raw, dict):
+            raise RuntimeError("agent package mcp.json must be a JSON object")
+
+        clients_raw: Any = raw
+        if isinstance(raw.get("mcpServers"), (dict, list)):
+            clients_raw = raw["mcpServers"]
+        elif isinstance(raw.get("clients"), (dict, list)):
+            clients_raw = raw["clients"]
+        elif isinstance(raw.get("mcp"), dict) and isinstance(raw["mcp"].get("clients"), (dict, list)):
+            clients_raw = raw["mcp"]["clients"]
+
+        clients: Dict[str, Dict[str, Any]] = {}
+        if isinstance(clients_raw, list):
+            for item in clients_raw:
+                if not isinstance(item, dict):
+                    continue
+                name = _string(item.get("name") or item.get("id"))
+                if not name:
+                    continue
+                clients[name] = self._qwenpaw_mcp_client_payload(name, item)
+            return clients
+
+        if isinstance(clients_raw, dict):
+            for name, item in clients_raw.items():
+                if not isinstance(item, dict):
+                    continue
+                client_name = _string(item.get("name") or name)
+                if not client_name:
+                    continue
+                clients[client_name] = self._qwenpaw_mcp_client_payload(client_name, item)
+        return clients
+
+    def _qwenpaw_mcp_client_payload(self, name: str, item: Dict[str, Any]) -> Dict[str, Any]:
+        payload = dict(item)
+        payload.pop("id", None)
+        if "name" not in payload:
+            payload["name"] = name
+        if "enabled" not in payload and "isActive" in payload:
+            payload["enabled"] = bool(payload.pop("isActive"))
+        else:
+            payload.pop("isActive", None)
+        if "url" not in payload and "baseUrl" in payload:
+            payload["url"] = payload.pop("baseUrl")
+        else:
+            payload.pop("baseUrl", None)
+        if "transport" not in payload and "type" in payload:
+            payload["transport"] = payload.pop("type")
+        else:
+            payload.pop("type", None)
+        payload = self._expand_mcp_workspace_placeholders(payload)
+        self._ensure_mcp_stdio_workspace_env(payload)
+        return payload
+
+    def _mcp_workspace_env_value(self) -> str:
+        if self.workspace_dir is not None:
+            return str(self.workspace_dir)
+        return _string(os.getenv("AGENT_WORKSPACE"))
+
+    def _expand_mcp_workspace_placeholders(self, value: Any) -> Any:
+        workspace = self._mcp_workspace_env_value()
+        if not workspace:
+            return value
+        if isinstance(value, str):
+            return (
+                value.replace("${AGENT_WORKSPACE}", workspace)
+                .replace("{AGENT_WORKSPACE}", workspace)
+            )
+        if isinstance(value, list):
+            return [self._expand_mcp_workspace_placeholders(item) for item in value]
+        if isinstance(value, dict):
+            return {
+                key: self._expand_mcp_workspace_placeholders(item)
+                for key, item in value.items()
+            }
+        return value
+
+    def _ensure_mcp_stdio_workspace_env(self, payload: Dict[str, Any]) -> None:
+        workspace = self._mcp_workspace_env_value()
+        if not workspace:
+            return
+        transport = _string(payload.get("transport") or "stdio").lower()
+        if transport != "stdio" or not _string(payload.get("command")):
+            return
+        env = payload.get("env")
+        if not isinstance(env, dict):
+            env = {}
+        env["AGENT_WORKSPACE"] = workspace
+        payload["env"] = env
+
+    def _copy_skills_to_workspace(self, skills_dir: Path) -> List[str]:
+        if self.workspace_dir is None:
+            return []
+        target_root = self.workspace_dir / "skills"
+        target_root.mkdir(parents=True, exist_ok=True)
+        copied = []
+        for source in skills_dir.iterdir():
+            if source.is_dir():
+                self._replace_path(source, target_root / source.name)
+                copied.append(source.name)
+        return copied
+
+    def _replace_path(self, source: Path, target: Path) -> None:
+        if target.exists():
+            if target.is_dir():
+                shutil.rmtree(target)
+            else:
+                target.unlink()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_dir():
+            shutil.copytree(source, target)
+        elif source.is_file():
+            shutil.copy2(source, target)
+
+    def _reconcile_workspace_skills(self, skill_names: Optional[List[str]] = None) -> None:
+        if self.workspace_dir is None:
+            return
+        try:
+            from qwenpaw.agents.skill_system.registry import reconcile_workspace_manifest
+        except ImportError:
+            logger.info("qwenpaw package unavailable component=update step=reconcile_workspace_skills action=skip")
+            return
+        reconcile_workspace_manifest(self.workspace_dir)
+        self._enable_workspace_skills(skill_names or [])
+
+    def _enable_workspace_skills(self, skill_names: List[str]) -> None:
+        if self.workspace_dir is None or not skill_names:
+            return
+        manifest_path = self.workspace_dir / "skill.json"
+        if not manifest_path.exists():
+            return
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except Exception:
+            logger.warning("workspace skill manifest is invalid component=update step=enable_workspace_skills action=skip")
+            return
+        skills = manifest.setdefault("skills", {})
+        changed = False
+        for skill_name in skill_names:
+            entry = skills.get(skill_name)
+            if isinstance(entry, dict) and entry.get("enabled") is not True:
+                entry["enabled"] = True
+                changed = True
+        if changed:
+            tmp = manifest_path.with_name(f".{manifest_path.name}.tmp")
+            tmp.write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+            tmp.replace(manifest_path)
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    runtime_config: MemberRuntimeConfig
+    changed: bool
+    agent_package_dir: Optional[Path]
+
+
+class RuntimeUpdater:
+    """Apply controller-projected runtime desired state inside one worker pod."""
+
+    def __init__(
+        self,
+        config: WorkerConfig,
+        adapter_apply: Optional[Callable[[], None]] = None,
+        package_manager: Optional[AgentPackageManager] = None,
+        runtime_config_pull: Optional[Callable[[], None]] = None,
+    ) -> None:
+        self.config = config
+        self.adapter_apply = adapter_apply
+        self.runtime_config_pull = runtime_config_pull
+        self.package_manager = package_manager or AgentPackageManager(
+            config.qwenpaw_working_dir / "agent-packages",
+            workspace_dir=config.default_workspace_dir,
+        )
+        self.current_config: Optional[MemberRuntimeConfig] = None
+
+    def load(self) -> MemberRuntimeConfig:
+        if self.runtime_config_pull is not None:
+            self.runtime_config_pull()
+        return MemberRuntimeConfig.load(self.config.runtime_config_path)
+
+    def apply_once(
+        self,
+        runtime_config: Optional[MemberRuntimeConfig] = None,
+        force: bool = False,
+        reapply_adapter: bool = True,
+    ) -> ApplyResult:
+        started_at = time.monotonic()
+        config = runtime_config or self.load()
+        changed = force or self.current_config is None or config.changed_from(self.current_config)
+        if not changed:
+            logger.info(
+                "runtime config apply skipped component=update worker=%s generation=%s changed=%s "
+                "mcp_server_count=%s channel_names=%s credential_binding_count=%s duration_ms=%s",
+                self.config.worker_name,
+                config.generation,
+                False,
+                _count_collection(config.mcp_servers),
+                _named_keys(config.channels),
+                len(config.credential_bindings),
+                _duration_ms(started_at),
+            )
+            return ApplyResult(runtime_config=config, changed=False, agent_package_dir=None)
+
+        logger.info(
+            "runtime config apply begin component=update worker=%s generation=%s team=%s member=%s role=%s "
+            "force=%s reapply_adapter=%s mcp_server_count=%s channel_names=%s credential_binding_count=%s",
+            self.config.worker_name,
+            config.generation,
+            config.team_name,
+            config.member_name,
+            config.member_role,
+            force,
+            reapply_adapter,
+            _count_collection(config.mcp_servers),
+            _named_keys(config.channels),
+            len(config.credential_bindings),
+        )
+        self._apply_member_identity(config)
+        self._apply_model(config)
+        self._apply_mcp_servers(config)
+        self._apply_matrix_channel(config)
+        self._apply_dingtalk_channel(config)
+        self._apply_channel_policy(config)
+        self._apply_team_context_prompt(config)
+
+        applied_package = self.package_manager.apply(config)
+
+        adapter_applied = False
+        if (
+            reapply_adapter
+            and self.adapter_apply is not None
+            and not self._adapter_neutral_change(config)
+        ):
+            self.adapter_apply()
+            adapter_applied = True
+
+        self.current_config = config
+        logger.info(
+            "runtime config apply complete component=update worker=%s generation=%s changed=%s "
+            "agent_package_dir=%s mcp_server_count=%s channel_names=%s credential_binding_count=%s "
+            "adapter_applied=%s duration_ms=%s",
+            self.config.worker_name,
+            config.generation,
+            True,
+            applied_package,
+            _count_collection(config.mcp_servers),
+            _named_keys(config.channels),
+            len(config.credential_bindings),
+            adapter_applied,
+            _duration_ms(started_at),
+        )
+        return ApplyResult(runtime_config=config, changed=True, agent_package_dir=applied_package)
+
+    def _adapter_neutral_change(self, config: MemberRuntimeConfig) -> bool:
+        previous = self.current_config
+        if previous is None:
+            return False
+        return (
+            config.agent_package_identity == previous.agent_package_identity
+            and _stable_json(config.model) == _stable_json(previous.model)
+            and _stable_json(config.channel_policy) == _stable_json(previous.channel_policy)
+            and config.credential_runtime_identity == previous.credential_runtime_identity
+            and self._team_context_content_identity(config) == self._team_context_content_identity(previous)
+            and (
+                _stable_json(config.mcp_servers) != _stable_json(previous.mcp_servers)
+                or _stable_json(config.channels) != _stable_json(previous.channels)
+            )
+        )
+
+    def _team_context_content_identity(self, config: MemberRuntimeConfig) -> str:
+        facts = dict(config.team_context_facts)
+        facts.pop("metadata", None)
+        return _stable_json(facts)
+
+    def _load_and_apply_once(self) -> None:
+        self.apply_once(runtime_config=self.load(), reapply_adapter=False)
+
+    def _apply_team_context_prompt(self, config: MemberRuntimeConfig) -> None:
+        block = self._runtime_team_context_block(config)
+        if not block:
+            return
+        path = self.config.default_workspace_dir / TEAMS_PROMPT_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        existing = path.read_text(encoding="utf-8") if path.exists() else "# TeamHarness Runtime Context\n"
+        if TEAMS_CONTEXT_START in existing and TEAMS_CONTEXT_END in existing:
+            prefix, rest = existing.split(TEAMS_CONTEXT_START, 1)
+            _old, suffix = rest.split(TEAMS_CONTEXT_END, 1)
+            text = prefix.rstrip() + "\n\n" + block + suffix
+        else:
+            text = existing.rstrip() + "\n\n" + block + "\n"
+        tmp = path.with_name(f".{path.name}.tmp")
+        tmp.write_text(text, encoding="utf-8")
+        tmp.replace(path)
+
+    def _runtime_team_context_block(self, config: MemberRuntimeConfig) -> str:
+        facts = config.team_context_facts
+        if not facts:
+            return ""
+        team = _section(facts, "team")
+        member = _section(facts, "member")
+        lines = [
+            TEAMS_CONTEXT_START,
+            "## Runtime Team Context",
+            "",
+        ]
+        for key, value in (
+            ("team.name", team.get("name")),
+            ("team.teamRoomId", team.get("teamRoomId")),
+            ("team.leaderName", team.get("leaderName")),
+            ("team.leaderRuntimeName", team.get("leaderRuntimeName")),
+            ("team.leaderDmRoomId", team.get("leaderDmRoomId")),
+            ("team.admin.name", _section(team, "admin").get("name")),
+            ("team.admin.matrixUserId", _section(team, "admin").get("matrixUserId")),
+            ("member.name", member.get("name")),
+            ("member.runtimeName", member.get("runtimeName")),
+            ("member.role", member.get("role")),
+            ("member.runtime", member.get("runtime")),
+            ("member.matrixUserId", member.get("matrixUserId")),
+            ("member.personalRoomId", member.get("personalRoomId")),
+        ):
+            text = _string(value)
+            if text:
+                lines.append(f"- {key}: {text}")
+        members = team.get("members")
+        if isinstance(members, list) and members:
+            lines.extend(["", "### Team Members"])
+            for item in members:
+                entry = _string_fields(item, ("name", "runtimeName", "role", "matrixUserId", "personalRoomId"))
+                if entry:
+                    lines.append("- " + ", ".join(f"{key}: {value}" for key, value in entry.items()))
+        lines.extend(["", "Do not write secrets, credentials, or live task status into this file.", TEAMS_CONTEXT_END])
+        return "\n".join(lines)
+
+    def _apply_member_identity(self, config: MemberRuntimeConfig) -> None:
+        role = config.member_role
+        if role:
+            self.config.agent_role = role
+            os.environ["AGENTTEAMS_AGENT_ROLE"] = role
+            os.environ["AGENTTEAMS_WORKER_ROLE"] = role
+
+    def _apply_model(self, config: MemberRuntimeConfig) -> None:
+        model = config.model
+        if not model:
+            return
+        provider_id = _string(model.get("providerId") or model.get("provider_id") or model.get("provider"))
+        model_name = _string(model.get("model") or model.get("name"))
+        if not provider_id or not model_name:
+            return
+        try:
+            from qwenpaw.config.config import ModelSlotConfig, load_agent_config, save_agent_config
+        except ImportError:
+            logger.info("qwenpaw package unavailable component=update step=apply_model action=skip")
+            return
+
+        agent_config = load_agent_config(DEFAULT_AGENT_ID)
+        agent_config.active_model = ModelSlotConfig(provider_id=provider_id, model=model_name)
+        save_agent_config(DEFAULT_AGENT_ID, agent_config)
+        self._apply_openai_compatible_provider(config, provider_id, model_name, ModelSlotConfig)
+
+    def _apply_openai_compatible_provider(
+        self,
+        config: MemberRuntimeConfig,
+        provider_id: str,
+        model_name: str,
+        model_slot_config_class: Any,
+    ) -> None:
+        model = config.model
+        base_url = _string(
+            model.get("baseUrl")
+            or model.get("base_url")
+            or model.get("gatewayUrl")
+            or model.get("gateway_url")
+            or model.get("endpoint")
+            or os.getenv("AGENTTEAMS_AI_GATEWAY_URL")
+        )
+        api_key = _string(model.get("apiKey") or model.get("api_key"))
+        api_key_env = _string(
+            model.get("apiKeyEnv")
+            or model.get("api_key_env")
+            or config.credentials.get("gatewayKeyEnv")
+            or "AGENTTEAMS_WORKER_GATEWAY_KEY"
+        )
+        if not api_key and api_key_env:
+            api_key = _string(os.getenv(api_key_env))
+        if not base_url or not api_key:
+            return
+
+        try:
+            from qwenpaw.providers.provider import ModelInfo, ProviderInfo
+            from qwenpaw.providers.provider_manager import ProviderManager
+        except ImportError:
+            logger.info("qwenpaw provider package unavailable component=update step=apply_provider action=skip")
+            return
+
+        manager = ProviderManager.get_instance()
+        provider_data = ProviderInfo(
+            id=provider_id,
+            name=_string(model.get("providerName") or model.get("provider_name") or provider_id),
+            base_url=self._openai_compatible_base_url(base_url),
+            api_key=api_key,
+            chat_model=_string(model.get("chatModel") or model.get("chat_model") or "OpenAIChatModel"),
+            models=[ModelInfo(id=model_name, name=model_name)],
+            is_custom=True,
+            support_model_discovery=False,
+            support_connection_check=False,
+        )
+        provider = manager._provider_from_data(provider_data.model_dump())
+        manager.custom_providers[provider_id] = provider
+        manager.save_provider_config(provider_id, provider)
+        manager.active_model = model_slot_config_class(provider_id=provider_id, model=model_name)
+        manager.save_active_model(manager.active_model)
+
+    def _openai_compatible_base_url(self, base_url: str) -> str:
+        value = base_url.rstrip("/")
+        if value.endswith("/v1"):
+            return value
+        return f"{value}/v1"
+
+    def _apply_mcp_servers(self, config: MemberRuntimeConfig) -> None:
+        servers = self._mcporter_servers(config)
+        legacy_path = self.config.default_workspace_dir / "mcporter-servers.json"
+        if legacy_path.exists():
+            legacy_path.unlink()
+
+        path = self.config.default_workspace_dir / "config" / "mcporter.json"
+        payload = {"mcpServers": servers}
+        text = json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    def _apply_channel_policy(self, config: MemberRuntimeConfig) -> None:
+        group_allow, dm_allow, group_deny, dm_deny = self._matrix_policy_ids(config)
+        if not (group_allow or dm_allow or group_deny or dm_deny):
+            return
+
+        self_allow = _string(config.member.get("matrixUserId"))
+        self_allowlist = [self_allow] if self_allow else []
+        whitelist = self._dedupe(self_allowlist + group_allow + dm_allow)
+        blacklist = self._dedupe(group_deny + dm_deny)
+        deny_set = set(blacklist)
+        whitelist = [value for value in whitelist if value not in deny_set]
+        self._apply_matrix_channel_access_flags(
+            group_enabled=bool(group_allow or group_deny),
+            dm_enabled=bool(dm_allow or dm_deny),
+        )
+        self._write_matrix_access_control(whitelist, blacklist)
+
+    def _apply_matrix_channel(self, config: MemberRuntimeConfig) -> None:
+        desired = self._matrix_channel_desired_state(config)
+        if desired is None:
+            return
+        try:
+            from qwenpaw.config.config import load_agent_config, save_agent_config
+        except ImportError:
+            logger.info("qwenpaw package unavailable component=update step=apply_matrix_channel action=skip")
+            return
+
+        agent_config = load_agent_config(DEFAULT_AGENT_ID)
+        if getattr(agent_config, "channels", None) is None:
+            try:
+                from qwenpaw.config.config import ChannelConfig
+            except ImportError:
+                return
+            agent_config.channels = ChannelConfig()
+        matrix_config = getattr(agent_config.channels, "matrix", None)
+        if matrix_config is None:
+            return
+
+        changed = False
+        desired_fields = {
+            "enabled": True,
+            "homeserver": desired["homeserver"],
+            "user_id": desired["user_id"],
+            "access_token": desired["access_token"],
+            "password": "",
+            "encryption": _env_bool("AGENTTEAMS_MATRIX_E2EE"),
+            "group_disabled": False,
+            "dm_disabled": False,
+            "filter_tool_messages": False,
+            "filter_thinking": False,
+        }
+        for field, value in desired_fields.items():
+            if getattr(matrix_config, field, None) != value:
+                setattr(matrix_config, field, value)
+                changed = True
+
+        groups = dict(getattr(matrix_config, "groups", None) or {})
+        if self._ensure_require_mention_group(groups, "*"):
+            changed = True
+        room_id = desired["room_id"]
+        if room_id:
+            if self._ensure_require_mention_group(groups, room_id):
+                changed = True
+        if getattr(matrix_config, "groups", None) != groups:
+            matrix_config.groups = groups
+            changed = True
+
+        if changed:
+            save_agent_config(DEFAULT_AGENT_ID, agent_config)
+
+    def _apply_dingtalk_channel(self, config: MemberRuntimeConfig) -> None:
+        desired = config.dingtalk_channel
+        if desired is None:
+            return
+        try:
+            from qwenpaw.config.config import load_agent_config, save_agent_config
+        except ImportError:
+            logger.info("qwenpaw package unavailable component=update step=apply_dingtalk_channel action=skip")
+            return
+
+        agent_config = load_agent_config(DEFAULT_AGENT_ID)
+        if getattr(agent_config, "channels", None) is None:
+            try:
+                from qwenpaw.config.config import ChannelConfig
+            except ImportError:
+                return
+            agent_config.channels = ChannelConfig()
+        dingtalk_config = getattr(agent_config.channels, "dingtalk", None)
+        if dingtalk_config is None:
+            return
+
+        changed = False
+        if not _bool(desired.get("enabled")):
+            if getattr(dingtalk_config, "enabled", None) is not False:
+                dingtalk_config.enabled = False
+                changed = True
+            if changed:
+                save_agent_config(DEFAULT_AGENT_ID, agent_config)
+            return
+
+        streaming_enabled = _bool(desired.get("streaming_enabled"))
+        client_id = _string(desired.get("client_id"))
+        client_secret = _string(desired.get("client_secret"))
+        robot_code = _string(desired.get("robot_code"))
+        desired_fields = {
+            "enabled": True,
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "robot_code": robot_code,
+            "filter_thinking": _bool(desired.get("filter_thinking")),
+            "filter_tool_messages": _bool(desired.get("filter_tool_messages")),
+            "streaming_enabled": streaming_enabled,
+        }
+        if streaming_enabled:
+            missing = [
+                name
+                for name, value in (
+                    ("client_id", client_id),
+                    ("client_secret", client_secret),
+                    ("robot_code", robot_code),
+                    ("card_template_id", _string(desired.get("card_template_id"))),
+                )
+                if not value
+            ]
+            if missing:
+                raise ValueError(
+                    "DingTalk streaming requires client_id, client_secret, "
+                    "robot_code, and card_template_id. Create and publish the "
+                    "streaming card template in DingTalk Open Platform, select "
+                    "card mode, then set card_template_id; missing "
+                    f"{', '.join(missing)}"
+                )
+            card_template_id = _string(desired.get("card_template_id"))
+            previous_message_type = _string(getattr(dingtalk_config, "message_type", ""))
+            previous_template_id = _string(getattr(dingtalk_config, "card_template_id", ""))
+            if (
+                previous_message_type == "card"
+                and previous_template_id
+                and previous_template_id != card_template_id
+            ):
+                logger.warning(
+                    "DingTalk streaming enabled; current runtime card configuration will switch "
+                    "component=update step=apply_dingtalk_channel previous_template=%s next_template=%s "
+                    "existing_template_deleted=False",
+                    previous_template_id,
+                    card_template_id,
+                )
+            desired_fields.update(
+                {
+                    "message_type": "card",
+                    "card_template_id": card_template_id,
+                    "card_template_key": _string(
+                        desired.get("card_template_key") or "content"
+                    ),
+                    "card_auto_layout": False,
+                }
+            )
+        else:
+            if "message_type" in desired:
+                desired_fields["message_type"] = _string(desired.get("message_type") or "markdown")
+            if "card_template_id" in desired:
+                desired_fields["card_template_id"] = _string(desired.get("card_template_id"))
+            if "card_template_key" in desired:
+                desired_fields["card_template_key"] = _string(
+                    desired.get("card_template_key") or "content"
+                )
+            if "card_auto_layout" in desired:
+                desired_fields["card_auto_layout"] = _bool(desired.get("card_auto_layout"))
+        for field, value in desired_fields.items():
+            if getattr(dingtalk_config, field, None) != value:
+                setattr(dingtalk_config, field, value)
+                changed = True
+
+        if changed:
+            save_agent_config(DEFAULT_AGENT_ID, agent_config)
+
+    def _matrix_channel_desired_state(self, config: MemberRuntimeConfig) -> Optional[Dict[str, str]]:
+        homeserver = _string(
+            os.getenv("AGENTTEAMS_MATRIX_URL")
+            or os.getenv("AGENTTEAMS_MATRIX_SERVER")
+            or os.getenv("AGENTTEAMS_MATRIX_HOMESERVER")
+        ).rstrip("/")
+        user_id = _string(config.member.get("matrixUserId") or os.getenv("AGENTTEAMS_MATRIX_USER_ID"))
+        if not user_id:
+            matrix_domain = _string(os.getenv("AGENTTEAMS_MATRIX_DOMAIN"))
+            if config.member_name and matrix_domain:
+                user_id = f"@{config.member_name}:{matrix_domain}"
+        token_env = _string(config.credentials.get("matrixTokenEnv") or "AGENTTEAMS_WORKER_MATRIX_TOKEN")
+        access_token = _string(os.getenv(token_env)) if token_env else ""
+        if not access_token:
+            access_token = _string(os.getenv("AGENTTEAMS_MATRIX_TOKEN"))
+        room_id = _string(config.team.get("teamRoomId") or config.member.get("personalRoomId"))
+        if not (homeserver and user_id and access_token):
+            return None
+        return {
+            "homeserver": homeserver,
+            "user_id": user_id,
+            "access_token": access_token,
+            "room_id": room_id,
+        }
+
+    def _ensure_require_mention_group(self, groups: Dict[str, Any], room_id: str) -> bool:
+        room_cfg = dict(groups.get(room_id) or {})
+        changed = False
+        if room_cfg.pop("autoReply", None) is not None:
+            changed = True
+        if room_cfg.get("requireMention") is not True:
+            room_cfg["requireMention"] = True
+            changed = True
+        if changed:
+            groups[room_id] = room_cfg
+        return changed
+
+    def _matrix_policy_ids(self, config: MemberRuntimeConfig) -> Tuple[List[str], List[str], List[str], List[str]]:
+        policy = config.channel_policy
+        domain = _string(os.getenv("AGENTTEAMS_MATRIX_DOMAIN"))
+        group_allow = self._default_group_allow(config, domain)
+        dm_allow = list(group_allow)
+        group_allow.extend(self._matrix_ids(_string_list(policy.get("groupAllowExtra")), domain))
+        dm_allow.extend(self._matrix_ids(_string_list(policy.get("dmAllowExtra")), domain))
+        group_deny = self._matrix_ids(_string_list(policy.get("groupDenyExtra")), domain)
+        dm_deny = self._matrix_ids(_string_list(policy.get("dmDenyExtra")), domain)
+        return (
+            self._dedupe(group_allow),
+            self._dedupe(dm_allow),
+            self._dedupe(group_deny),
+            self._dedupe(dm_deny),
+        )
+
+    def _default_group_allow(self, config: MemberRuntimeConfig, domain: str) -> List[str]:
+        team_admin = _string(_section(config.team, "admin").get("matrixUserId"))
+        system_admin_user = _string(os.getenv("AGENTTEAMS_ADMIN_USER") or "admin")
+        system_admin = self._matrix_id(system_admin_user, domain)
+        admin = team_admin or system_admin
+        roster_allow = self._team_roster_group_allow(config, domain, admin)
+        if roster_allow:
+            # Ensure system admin is always present even when team admin differs
+            if system_admin and system_admin not in roster_allow:
+                roster_allow.append(system_admin)
+            return roster_allow
+        if config.team and config.member_role not in {"team_leader", "leader"}:
+            leader = _string(config.team.get("leaderRuntimeName") or config.team.get("leaderName"))
+            return [item for item in (self._matrix_id(leader, domain), admin, system_admin) if item]
+        manager = self._matrix_id("manager", domain)
+        return [item for item in (manager, admin, system_admin) if item]
+
+    def _team_roster_group_allow(self, config: MemberRuntimeConfig, domain: str, admin: str) -> List[str]:
+        members = config.team_members
+        if not config.team or not members:
+            return []
+
+        current_names = {
+            _string(config.member.get("name")),
+            _string(config.member.get("runtimeName")),
+        }
+        current_names.discard("")
+        current_mxid = _string(config.member.get("matrixUserId"))
+        leader_roles = {"team_leader", "leader"}
+        leader_ids: List[str] = []
+        peer_ids: List[str] = []
+
+        for member in members:
+            mxid = self._member_matrix_id(member, domain)
+            if not mxid:
+                continue
+            if mxid == current_mxid or _string(member.get("runtimeName") or member.get("name")) in current_names:
+                continue
+            if _string(member.get("role")) in leader_roles:
+                leader_ids.append(mxid)
+            else:
+                peer_ids.append(mxid)
+
+        if config.member_role in leader_roles:
+            manager = self._matrix_id("manager", domain)
+            return [item for item in (manager, admin, *peer_ids) if item]
+
+        leader = _string(config.team.get("leaderRuntimeName") or config.team.get("leaderName"))
+        if not leader_ids:
+            leader_ids = [self._matrix_id(leader, domain)]
+        return [item for item in (*leader_ids, admin, *peer_ids) if item]
+
+    def _member_matrix_id(self, member: Dict[str, str], domain: str) -> str:
+        mxid = _string(member.get("matrixUserId"))
+        if mxid:
+            return mxid
+        return self._matrix_id(_string(member.get("runtimeName") or member.get("name")), domain)
+
+    def _matrix_ids(self, values: List[str], domain: str) -> List[str]:
+        return [mxid for mxid in (self._matrix_id(value, domain) for value in values) if mxid]
+
+    def _matrix_id(self, value: str, domain: str) -> str:
+        text = _string(value)
+        if not text:
+            return ""
+        if text.startswith("@") or text.startswith("!"):
+            return text
+        return f"@{text}:{domain}" if domain else ""
+
+    def _mcporter_servers(self, config: MemberRuntimeConfig) -> Dict[str, Any]:
+        raw = config.mcp_servers
+        gateway_key = self._gateway_key(config)
+        if isinstance(raw, dict) and isinstance(raw.get("mcpServers"), dict):
+            raw = raw["mcpServers"]
+
+        servers: Dict[str, Any] = {}
+        if isinstance(raw, list):
+            for item in raw:
+                if isinstance(item, dict):
+                    name = _string(item.get("name"))
+                    payload = self._mcporter_server_payload(item, gateway_key)
+                    if name and payload:
+                        servers[name] = payload
+            return servers
+
+        if isinstance(raw, dict):
+            for name, item in raw.items():
+                if isinstance(item, dict):
+                    payload = self._mcporter_server_payload(item, gateway_key)
+                    if _string(name) and payload:
+                        servers[_string(name)] = payload
+        return servers
+
+    def _mcporter_server_payload(self, item: Dict[str, Any], gateway_key: str) -> Dict[str, Any]:
+        url = _string(item.get("url"))
+        if not url:
+            return {}
+        headers = item.get("headers")
+        headers = dict(headers) if isinstance(headers, dict) else {}
+        if gateway_key and "Authorization" not in headers:
+            headers["Authorization"] = f"Bearer {gateway_key}"
+        return {
+            "url": url,
+            "transport": _string(item.get("transport") or "http"),
+            "headers": headers,
+        }
+
+    def _gateway_key(self, config: MemberRuntimeConfig) -> str:
+        env_name = _string(config.credentials.get("gatewayKeyEnv") or "AGENTTEAMS_WORKER_GATEWAY_KEY")
+        return os.getenv(env_name, "") if env_name else ""
+
+    def _apply_matrix_channel_access_flags(self, group_enabled: bool, dm_enabled: bool) -> None:
+        try:
+            from qwenpaw.config.config import load_agent_config, save_agent_config
+        except ImportError:
+            logger.info("qwenpaw package unavailable component=update step=apply_channel_access_flags action=skip")
+            return
+
+        agent_config = load_agent_config(DEFAULT_AGENT_ID)
+        if getattr(agent_config, "channels", None) is None:
+            try:
+                from qwenpaw.config.config import ChannelConfig
+            except ImportError:
+                return
+            agent_config.channels = ChannelConfig()
+        matrix_config = getattr(agent_config.channels, "matrix", None)
+        if matrix_config is None:
+            return
+        matrix_config.access_control_group = group_enabled
+        matrix_config.access_control_dm = dm_enabled
+        save_agent_config(DEFAULT_AGENT_ID, agent_config)
+
+    def _write_matrix_access_control(self, whitelist: List[str], blacklist: List[str]) -> None:
+        try:
+            from qwenpaw.app.channels.access_control import get_access_control_store
+        except ImportError:
+            self._write_matrix_access_control_json(whitelist, blacklist)
+            return
+
+        store = get_access_control_store(self.config.default_workspace_dir)
+        store.set_whitelist("matrix", whitelist)
+        store.set_blacklist("matrix", blacklist)
+
+    def _write_matrix_access_control_json(self, whitelist: List[str], blacklist: List[str]) -> None:
+        path = self.config.default_workspace_dir / "access_control.json"
+        existing: Dict[str, Any] = {}
+        if path.exists():
+            try:
+                loaded = json.loads(path.read_text(encoding="utf-8"))
+                existing = loaded if isinstance(loaded, dict) else {}
+            except json.JSONDecodeError:
+                existing = {}
+        matrix = _section(existing, "matrix")
+        pending = matrix.get("pending")
+        existing["matrix"] = {
+            "whitelist": {value: "" for value in whitelist},
+            "blacklist": {value: "" for value in blacklist},
+            "pending": pending if isinstance(pending, list) else [],
+        }
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(existing, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    def _dedupe(self, values: List[str]) -> List[str]:
+        result = []
+        seen = set()
+        for value in values:
+            if value not in seen:
+                result.append(value)
+                seen.add(value)
+        return result
+
+    async def loop(self) -> None:
+        logger.info(
+            "runtime config update loop started component=update worker=%s interval_seconds=%s",
+            self.config.worker_name,
+            self.config.runtime_config_poll_interval,
+        )
+        try:
+            while True:
+                await asyncio.sleep(self.config.runtime_config_poll_interval)
+                try:
+                    started_at = time.monotonic()
+                    await asyncio.to_thread(self._load_and_apply_once)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    logger.warning(
+                        "runtime config update failed component=update worker=%s error_type=%s duration_ms=%s",
+                        self.config.worker_name,
+                        type(exc).__name__,
+                        _duration_ms(started_at),
+                    )
+        except asyncio.CancelledError:
+            logger.info("runtime config update loop stopped component=update worker=%s", self.config.worker_name)
+            raise

--- a/qwenpaw/src/qwenpaw_worker/worker.py
+++ b/qwenpaw/src/qwenpaw_worker/worker.py
@@ -1,0 +1,804 @@
+"""QwenPaw Worker main entry point."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib.util
+import logging
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import time
+import tempfile
+import zipfile
+from typing import Optional
+
+from qwenpaw_worker.config import WorkerConfig, _relative_storage_prefix
+from qwenpaw_worker.heartbeat import WorkerHeartbeat, run_worker_heartbeat_loop
+from qwenpaw_worker.sync import FileSync, push_loop
+from qwenpaw_worker.update import RuntimeUpdater
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_AGENT_ID = "default"
+BUILTIN_QWENPAW_QA_AGENT_ID = "QwenPaw_QA_Agent_0.2"
+DEFAULT_BUILTIN_QWENPAW_PLUGINS_DIR = Path("/opt/agentteams/qwenpaw-builtin/plugins")
+BUILTIN_QWENPAW_PLUGIN_MARKER = ".agentteams-builtin-plugin.sha256"
+SENSITIVE_FILE_AUTO_DENY_RULE = "SENSITIVE_FILE_BLOCK"
+SESSION_FILE_PROMPT_POLICY = """Do not read, list, grep, glob, summarize, copy, or expose files under sessions/.
+Session files are runtime-private state and may contain private conversation history.
+This rule applies to all channels, users, and sessions, not only DingTalk."""
+SESSION_FILE_PROMPT_POLICY_MARKER = "Session files are runtime-private state"
+
+
+def _duration_ms(started_at: float) -> int:
+    return max(0, int((time.monotonic() - started_at) * 1000))
+
+
+def _log_fields(**fields: object) -> str:
+    parts = []
+    for key, value in fields.items():
+        if value is None:
+            continue
+        parts.append(f"{key}={value}")
+    return " ".join(parts)
+
+
+def _redact_url_userinfo(value: str) -> str:
+    if "://" not in value or "@" not in value:
+        return value
+    scheme, rest = value.split("://", 1)
+    return f"{scheme}://<redacted>@{rest.split('@', 1)[1]}"
+
+
+class Worker:
+    def __init__(self, config: WorkerConfig) -> None:
+        self.config = config
+        self.sync: Optional[FileSync] = None
+        self.heartbeat = WorkerHeartbeat(config.qwenpaw_working_dir / "heartbeat.json")
+        self.updater = RuntimeUpdater(config=config, adapter_apply=self._apply_runtime_adapter)
+        self._process: Optional[asyncio.subprocess.Process] = None
+        self._heartbeat_probe_task: Optional[asyncio.Task] = None
+        self._push_task: Optional[asyncio.Task] = None
+        self._update_task: Optional[asyncio.Task] = None
+        self._stopping = False
+        self._workspace_shared_dir: Optional[Path] = None
+
+    async def run(self) -> None:
+        if not await self.start():
+            return
+        try:
+            await self._run_qwenpaw()
+        finally:
+            await self.stop()
+
+    async def start(self) -> bool:
+        self._stopping = False
+        logger.info(
+            "qwenpaw worker startup begin component=worker worker=%s cr_name=%s install_dir=%s storage_endpoint=%s bucket=%s "
+            "storage_prefix=%s shared_prefix=%s console_port=%s",
+            self.config.worker_name,
+            self.config.worker_cr_name,
+            self.config.install_dir,
+            _redact_url_userinfo(self.config.fs_endpoint),
+            self.config.fs_bucket,
+            self.config.storage_prefix,
+            self.config.shared_prefix,
+            self.config.console_port,
+        )
+        self._prepare_env()
+        self.config.default_workspace_dir.mkdir(parents=True, exist_ok=True)
+        self.heartbeat.persist()
+
+        self.sync = FileSync(
+            endpoint=self.config.fs_endpoint,
+            access_key=self.config.fs_access_key,
+            secret_key=self.config.fs_secret_key,
+            bucket=self.config.fs_bucket,
+            worker_name=self.config.worker_name,
+            local_dir=self.config.worker_home,
+            shared_dir=self.config.shared_dir,
+            remote_prefix=self.config.storage_prefix,
+            shared_prefix=self.config.shared_prefix,
+        )
+        self.updater.runtime_config_pull = lambda: self.sync.pull_runtime_config(self.config.runtime_config_path)
+
+        try:
+            stage_started = self._log_worker_stage_begin("mirror_all")
+            self.sync.mirror_all()
+        except Exception as exc:
+            self._log_worker_stage_failed("mirror_all", stage_started, exc)
+            self.heartbeat.update(
+                "not_ready",
+                f"startup mirror failed: {exc}",
+                {"operation": "mirror_all", "error_type": type(exc).__name__},
+            )
+            return False
+        self._log_worker_stage_complete("mirror_all", stage_started)
+
+        try:
+            stage_started = self._log_worker_stage_begin("load_runtime_config", path=self.config.runtime_config_path)
+            runtime_config = self.updater.load()
+        except Exception as exc:
+            self._log_worker_stage_failed("load_runtime_config", stage_started, exc)
+            self.heartbeat.update("not_ready", str(exc))
+            return False
+        self._log_worker_stage_complete(
+            "load_runtime_config",
+            stage_started,
+            generation=runtime_config.generation,
+            team=runtime_config.team_name,
+            member=runtime_config.member_name,
+            role=runtime_config.member_role,
+        )
+
+        self._apply_runtime_identity(runtime_config)
+        self._apply_runtime_storage(runtime_config)
+
+        try:
+            stage_started = self._log_worker_stage_begin("prepare_qwenpaw_runtime")
+            self._link_workspace_shared()
+            self._configure_qwenpaw_runtime()
+        except Exception as exc:
+            self._log_worker_stage_failed("prepare_qwenpaw_runtime", stage_started, exc)
+            self.heartbeat.update("not_ready", str(exc))
+            return False
+        self._log_worker_stage_complete("prepare_qwenpaw_runtime", stage_started)
+
+        try:
+            stage_started = self._log_worker_stage_begin("prepare_default_plugins")
+            self._prepare_default_plugins()
+        except Exception as exc:
+            self._log_worker_stage_failed("prepare_default_plugins", stage_started, exc)
+            self.heartbeat.update("not_ready", str(exc))
+            return False
+        self._log_worker_stage_complete("prepare_default_plugins", stage_started)
+
+        try:
+            stage_started = self._log_worker_stage_begin("apply_desired_state")
+            self.updater.apply_once(runtime_config=runtime_config, force=True, reapply_adapter=False)
+            self._ensure_session_file_prompt_policy()
+        except Exception as exc:
+            self._log_worker_stage_failed("apply_desired_state", stage_started, exc)
+            self.heartbeat.update("not_ready", str(exc))
+            return False
+        self._log_worker_stage_complete("apply_desired_state", stage_started)
+
+        try:
+            stage_started = self._log_worker_stage_begin("sync_teamharness_assets")
+            self._apply_teamharness_assets()
+        except Exception as exc:
+            self._log_worker_stage_failed("sync_teamharness_assets", stage_started, exc)
+            self.heartbeat.update("not_ready", str(exc))
+            return False
+        self._log_worker_stage_complete("sync_teamharness_assets", stage_started)
+
+        try:
+            stage_started = self._log_worker_stage_begin("sync_workerflow_assets")
+            self._apply_workerflow_assets()
+        except Exception as exc:
+            self._log_worker_stage_failed("sync_workerflow_assets", stage_started, exc)
+            self.heartbeat.update("not_ready", str(exc))
+            return False
+        self._log_worker_stage_complete("sync_workerflow_assets", stage_started)
+
+        stage_started = self._log_worker_stage_begin("start_push_loop", interval_seconds=5)
+        self._push_task = asyncio.create_task(
+            push_loop(self.sync, check_interval=5),
+            name=f"qwenpaw-worker-{self.config.worker_name}-push-loop",
+        )
+        self._log_worker_stage_complete("start_push_loop", stage_started, interval_seconds=5)
+        stage_started = self._log_worker_stage_begin(
+            "start_update_loop",
+            interval_seconds=self.config.runtime_config_poll_interval,
+        )
+        self._update_task = asyncio.create_task(
+            self.updater.loop(),
+            name=f"qwenpaw-worker-{self.config.worker_name}-update-loop",
+        )
+        self._log_worker_stage_complete(
+            "start_update_loop",
+            stage_started,
+            interval_seconds=self.config.runtime_config_poll_interval,
+        )
+        logger.info("qwenpaw worker startup complete component=worker worker=%s", self.config.worker_name)
+        return True
+
+    async def stop(self) -> None:
+        self._stopping = True
+        logger.info(
+            "qwenpaw worker stop requested component=worker worker=%s has_process=%s has_push_task=%s has_update_task=%s "
+            "has_heartbeat_task=%s",
+            self.config.worker_name,
+            self._process is not None,
+            self._push_task is not None,
+            self._update_task is not None,
+            self._heartbeat_probe_task is not None,
+        )
+        for attr in ("_update_task", "_push_task", "_heartbeat_probe_task"):
+            task = getattr(self, attr)
+            if task is not None:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                except Exception as exc:
+                    logger.warning(
+                        "background task %s failed during stop component=worker worker=%s error_type=%s",
+                        attr,
+                        self.config.worker_name,
+                        type(exc).__name__,
+                    )
+                setattr(self, attr, None)
+                logger.info("background task stopped component=worker worker=%s task=%s", self.config.worker_name, attr)
+
+        if self._process is not None and self._process.returncode is None:
+            self._process.terminate()
+            try:
+                await asyncio.wait_for(self._process.wait(), timeout=10)
+                logger.info("qwenpaw app terminated component=worker worker=%s", self.config.worker_name)
+            except asyncio.TimeoutError:
+                self._process.kill()
+                await self._process.wait()
+                logger.warning("qwenpaw app killed after stop timeout component=worker worker=%s", self.config.worker_name)
+        self._process = None
+        logger.info("qwenpaw worker stopped component=worker worker=%s", self.config.worker_name)
+
+    def _log_worker_stage_begin(self, stage: str, **fields: object) -> float:
+        started_at = time.monotonic()
+        logger.info(
+            "startup component=worker stage=%s event=begin worker=%s %s",
+            stage,
+            self.config.worker_name,
+            _log_fields(**fields),
+        )
+        return started_at
+
+    def _log_worker_stage_complete(self, stage: str, started_at: float, **fields: object) -> None:
+        logger.info(
+            "startup component=worker stage=%s event=complete worker=%s duration_ms=%s %s",
+            stage,
+            self.config.worker_name,
+            _duration_ms(started_at),
+            _log_fields(**fields),
+        )
+
+    def _log_worker_stage_failed(self, stage: str, started_at: float, exc: Exception, **fields: object) -> None:
+        logger.warning(
+            "startup component=worker stage=%s event=failed worker=%s duration_ms=%s error_type=%s %s",
+            stage,
+            self.config.worker_name,
+            _duration_ms(started_at),
+            type(exc).__name__,
+            _log_fields(**fields),
+        )
+
+    def _log_plugin_step_begin(self, plugin_name: str, step: str, **fields: object) -> float:
+        started_at = time.monotonic()
+        logger.info(
+            "component=plugin plugin=%s step=%s event=begin worker=%s %s",
+            plugin_name,
+            step,
+            self.config.worker_name,
+            _log_fields(**fields),
+        )
+        return started_at
+
+    def _log_plugin_step_complete(self, plugin_name: str, step: str, started_at: float, **fields: object) -> None:
+        logger.info(
+            "component=plugin plugin=%s step=%s event=complete worker=%s duration_ms=%s %s",
+            plugin_name,
+            step,
+            self.config.worker_name,
+            _duration_ms(started_at),
+            _log_fields(**fields),
+        )
+
+    def _log_plugin_step_failed(self, plugin_name: str, step: str, started_at: float, exc: Exception, **fields: object) -> None:
+        logger.warning(
+            "component=plugin plugin=%s step=%s event=failed worker=%s duration_ms=%s error_type=%s %s",
+            plugin_name,
+            step,
+            self.config.worker_name,
+            _duration_ms(started_at),
+            type(exc).__name__,
+            _log_fields(**fields),
+        )
+
+    def _prepare_env(self) -> None:
+        os.environ["AGENTTEAMS_AGENT_NAME"] = self.config.agent_name
+        os.environ["AGENTTEAMS_AGENT_ROLE"] = self.config.agent_role
+        os.environ["AGENTTEAMS_AGENT_HOME"] = str(self.config.worker_home)
+        os.environ["AGENTTEAMS_WORKER_HOME"] = str(self.config.worker_home)
+        os.environ.setdefault("AGENTTEAMS_WORKER_NAME", self.config.worker_name)
+        os.environ["QWENPAW_WORKING_DIR"] = str(self.config.qwenpaw_working_dir)
+        os.environ["AGENT_WORKSPACE"] = str(self.config.default_workspace_dir)
+        os.environ["AGENTTEAMS_SHARED_DIR"] = str(self.config.shared_dir)
+        os.environ["TEAMHARNESS_SHARED_DIR"] = str(self.config.shared_dir)
+        os.environ["TEAMHARNESS_RUNTIME_CONFIG"] = str(self.config.runtime_config_path)
+        os.environ.setdefault("QWENPAW_SECRET_DIR", f"{self.config.qwenpaw_working_dir}.secret")
+        os.environ.setdefault("QWENPAW_RUNNING_IN_CONTAINER", "true")
+
+    def _link_workspace_shared(self) -> None:
+        shared_dir = self._workspace_shared_dir or self.config.shared_dir
+        workspace_shared = self.config.default_workspace_dir / "shared"
+        shared_dir.mkdir(parents=True, exist_ok=True)
+        workspace_shared.parent.mkdir(parents=True, exist_ok=True)
+
+        if workspace_shared.is_symlink():
+            if workspace_shared.resolve() == shared_dir.resolve():
+                return
+            workspace_shared.unlink()
+        elif workspace_shared.exists():
+            if workspace_shared.is_dir():
+                shutil.rmtree(workspace_shared)
+            else:
+                workspace_shared.unlink()
+
+        target = os.path.relpath(shared_dir, workspace_shared.parent)
+        workspace_shared.symlink_to(target, target_is_directory=True)
+        logger.info(
+            "linked qwenpaw workspace shared dir component=worker step=link_workspace_shared worker=%s path=%s target=%s",
+            self.config.worker_name,
+            workspace_shared,
+            target,
+        )
+
+    def _apply_runtime_storage(self, runtime_config) -> None:
+        shared_prefix = self._runtime_shared_prefix(runtime_config)
+        shared_dir = self._local_shared_dir_for_prefix(shared_prefix)
+        self._workspace_shared_dir = shared_dir
+        os.environ["AGENTTEAMS_SHARED_DIR"] = str(shared_dir)
+        os.environ["TEAMHARNESS_SHARED_DIR"] = str(shared_dir)
+        if shared_prefix and shared_prefix != "shared":
+            os.environ["AGENTTEAMS_SHARED_STORAGE_PREFIX"] = shared_prefix
+            if self.sync is not None:
+                logger.info(
+                    "startup component=worker stage=mirror_team_shared event=begin worker=%s shared_prefix=%s local_dir=%s",
+                    self.config.worker_name,
+                    shared_prefix,
+                    shared_dir,
+                )
+                self.sync.mirror_prefix(shared_prefix, shared_dir)
+
+    def _runtime_shared_prefix(self, runtime_config) -> str:
+        storage = getattr(runtime_config, "storage", {}) or {}
+        prefix = str(storage.get("sharedPrefix") or "").strip() if isinstance(storage, dict) else ""
+        if not prefix:
+            return self.config.shared_prefix
+        return _relative_storage_prefix(prefix, self.config.fs_bucket)
+
+    def _local_shared_dir_for_prefix(self, shared_prefix: str) -> Path:
+        if self.config.shared_dir_override is not None:
+            return self.config.shared_dir
+        prefix = shared_prefix.strip().strip("/")
+        if not prefix or prefix == "shared":
+            return self.config.shared_dir
+        path = Path(prefix)
+        if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+            logger.warning(
+                "invalid shared storage prefix component=worker step=runtime_storage action=use_default "
+                "worker=%s shared_prefix=%s",
+                self.config.worker_name,
+                shared_prefix,
+            )
+            return self.config.shared_dir
+        return self.config.install_dir.parent.joinpath(*path.parts)
+
+    def _apply_runtime_identity(self, runtime_config) -> None:
+        role = runtime_config.member_role
+        if not role:
+            return
+        self.config.agent_role = role
+        os.environ["AGENTTEAMS_AGENT_ROLE"] = role
+        os.environ["AGENTTEAMS_WORKER_ROLE"] = role
+
+    def _configure_qwenpaw_runtime(self) -> None:
+        try:
+            from qwenpaw.config.config import AgentProfileConfig, AgentProfileRef, load_agent_config, save_agent_config
+            from qwenpaw.config.utils import load_config, save_config
+        except ImportError:
+            logger.info("qwenpaw package unavailable component=worker step=configure_qwenpaw_runtime action=skip")
+            return
+
+        root = load_config()
+        self._ensure_session_file_guard(root)
+        root.agents.active_agent = DEFAULT_AGENT_ID
+        root.agents.profiles[DEFAULT_AGENT_ID] = AgentProfileRef(
+            id=DEFAULT_AGENT_ID,
+            workspace_dir=str(self.config.default_workspace_dir),
+            enabled=True,
+        )
+        self._disable_builtin_qwenpaw_qa_agent(root, AgentProfileRef)
+        if DEFAULT_AGENT_ID not in root.agents.agent_order:
+            root.agents.agent_order.insert(0, DEFAULT_AGENT_ID)
+        save_config(root)
+
+        try:
+            agent_config = load_agent_config(DEFAULT_AGENT_ID)
+        except Exception:
+            agent_config = AgentProfileConfig(
+                id=DEFAULT_AGENT_ID,
+                name=self.config.agent_name,
+                description=f"AgentTeams QwenPaw {self.config.agent_role}",
+                workspace_dir=str(self.config.default_workspace_dir),
+            )
+
+        agent_config.name = self.config.agent_name
+        agent_config.workspace_dir = str(self.config.default_workspace_dir)
+        agent_config.approval_level = "AUTO"
+        prompt_files = list(agent_config.system_prompt_files or [])
+        for file_name in ("AGENTS.md", "SOUL.md", "TEAMS.md"):
+            if file_name not in prompt_files:
+                prompt_files.append(file_name)
+        agent_config.system_prompt_files = prompt_files
+        save_agent_config(DEFAULT_AGENT_ID, agent_config)
+
+    def _disable_builtin_qwenpaw_qa_agent(self, root, agent_profile_ref_cls) -> None:
+        qa_workspace = (
+            self.config.qwenpaw_working_dir / "workspaces" / BUILTIN_QWENPAW_QA_AGENT_ID
+        )
+        profiles = root.agents.profiles
+        profile = profiles.get(BUILTIN_QWENPAW_QA_AGENT_ID)
+        if profile is None:
+            profiles[BUILTIN_QWENPAW_QA_AGENT_ID] = agent_profile_ref_cls(
+                id=BUILTIN_QWENPAW_QA_AGENT_ID,
+                workspace_dir=str(qa_workspace),
+                enabled=False,
+            )
+            logger.info(
+                "preseeded disabled builtin QwenPaw QA agent profile component=worker "
+                "step=configure_qwenpaw_runtime agent_id=%s",
+                BUILTIN_QWENPAW_QA_AGENT_ID,
+            )
+            return
+
+        if getattr(profile, "enabled", True):
+            profile.enabled = False
+            logger.info(
+                "disabled builtin QwenPaw QA agent profile component=worker "
+                "step=configure_qwenpaw_runtime agent_id=%s",
+                BUILTIN_QWENPAW_QA_AGENT_ID,
+            )
+
+    def _ensure_session_file_guard(self, root) -> None:
+        security = root.security
+        file_guard = security.file_guard
+        tool_guard = security.tool_guard
+
+        file_guard.enabled = True
+        tool_guard.enabled = True
+        tool_guard.guarded_tools = []
+
+        session_path = f"{self.config.default_workspace_dir / 'sessions'}/"
+        sensitive_files = [
+            str(path)
+            for path in (file_guard.sensitive_files or [])
+            if str(path)
+        ]
+        if session_path not in sensitive_files:
+            sensitive_files.append(session_path)
+        file_guard.sensitive_files = sensitive_files
+
+        auto_denied_rules = [
+            str(rule)
+            for rule in (getattr(tool_guard, "auto_denied_rules", None) or [])
+            if str(rule)
+        ]
+        if SENSITIVE_FILE_AUTO_DENY_RULE not in auto_denied_rules:
+            auto_denied_rules.append(SENSITIVE_FILE_AUTO_DENY_RULE)
+        tool_guard.auto_denied_rules = auto_denied_rules
+
+    def _ensure_session_file_prompt_policy(self) -> None:
+        self.config.default_workspace_dir.mkdir(parents=True, exist_ok=True)
+        for file_name in ("AGENTS.md", "SOUL.md"):
+            prompt_file = self.config.default_workspace_dir / file_name
+            existing = prompt_file.read_text(encoding="utf-8") if prompt_file.exists() else ""
+            if SESSION_FILE_PROMPT_POLICY_MARKER in existing:
+                continue
+            separator = "\n" if existing and not existing.endswith("\n") else ""
+            prefix = "\n" if existing.strip() else ""
+            prompt_file.write_text(
+                f"{existing}{separator}{prefix}{SESSION_FILE_PROMPT_POLICY}\n",
+                encoding="utf-8",
+            )
+
+    def _apply_runtime_adapter(self) -> None:
+        self._prepare_default_plugins()
+        self._apply_teamharness_assets()
+        self._apply_workerflow_assets()
+        self._ensure_session_file_prompt_policy()
+
+    def _prepare_default_plugins(self) -> None:
+        builtin_root = self._builtin_qwenpaw_plugins_dir()
+        self._prepare_builtin_plugin("teamharness", builtin_root / "teamharness")
+        self._prepare_builtin_plugin("workerflow", builtin_root / "workerflow")
+
+    def _builtin_qwenpaw_plugins_dir(self) -> Path:
+        configured = os.getenv("AGENTTEAMS_BUILTIN_QWENPAW_PLUGINS_DIR", "").strip()
+        return Path(configured) if configured else DEFAULT_BUILTIN_QWENPAW_PLUGINS_DIR
+
+    def _prepare_builtin_plugin(self, plugin_name: str, source_dir: Path) -> None:
+        target_dir = self.config.qwenpaw_working_dir / "plugins" / plugin_name
+        step_started = self._log_plugin_step_begin(
+            plugin_name,
+            "prepare_builtin",
+            source_dir=source_dir,
+            target_dir=target_dir,
+        )
+        try:
+            self._validate_builtin_plugin(plugin_name, source_dir)
+            if self._builtin_plugin_current(source_dir, target_dir):
+                self._log_plugin_step_complete(plugin_name, "prepare_builtin", step_started, action="unchanged")
+                return
+            if target_dir.is_symlink() or target_dir.is_file():
+                target_dir.unlink()
+            elif target_dir.exists():
+                shutil.rmtree(target_dir)
+            target_dir.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(source_dir, target_dir)
+        except Exception as exc:
+            self._log_plugin_step_failed(plugin_name, "prepare_builtin", step_started, exc)
+            raise
+        self._log_plugin_step_complete(plugin_name, "prepare_builtin", step_started, action="copied")
+
+    def _validate_builtin_plugin(self, plugin_name: str, plugin_dir: Path) -> None:
+        if not plugin_dir.is_dir():
+            raise RuntimeError(f"built-in {plugin_name} qwenpaw plugin missing: {plugin_dir}")
+        for file_name in ("plugin.json", "plugin.py", BUILTIN_QWENPAW_PLUGIN_MARKER):
+            path = plugin_dir / file_name
+            if not path.is_file():
+                raise RuntimeError(f"built-in {plugin_name} qwenpaw plugin file missing: {path}")
+
+    def _builtin_plugin_current(self, source_dir: Path, target_dir: Path) -> bool:
+        source_marker = source_dir / BUILTIN_QWENPAW_PLUGIN_MARKER
+        target_marker = target_dir / BUILTIN_QWENPAW_PLUGIN_MARKER
+        if not (
+            target_marker.is_file()
+            and (target_dir / "plugin.json").is_file()
+            and (target_dir / "plugin.py").is_file()
+        ):
+            return False
+        expected_digest = source_marker.read_text(encoding="utf-8").strip()
+        if not expected_digest:
+            return False
+        return (
+            target_marker.read_text(encoding="utf-8").strip() == expected_digest
+            and self._plugin_directory_digest(target_dir) == expected_digest
+        )
+
+    def _plugin_directory_digest(self, plugin_dir: Path) -> str:
+        digest = hashlib.sha256()
+        for path in sorted(plugin_dir.rglob("*")):
+            if not path.is_file() or path.name == BUILTIN_QWENPAW_PLUGIN_MARKER:
+                continue
+            rel = path.relative_to(plugin_dir).as_posix()
+            digest.update(rel.encode("utf-8"))
+            digest.update(b"\0")
+            digest.update(path.read_bytes())
+            digest.update(b"\0")
+        return digest.hexdigest()
+
+    def _install_teamharness_plugin(self) -> None:
+        plugin_source = Path(
+            os.getenv(
+                "AGENTTEAMS_TEAMHARNESS_QWENPAW_PLUGIN_PACKAGE",
+                "/opt/agentteams/plugins/teamharness-qwenpaw.zip",
+            )
+        )
+        self._install_qwenpaw_plugin_package("teamharness", plugin_source, "teamharness-qwenpaw-plugin-")
+
+    def _install_workerflow_plugin(self) -> None:
+        plugin_source = Path(
+            os.getenv(
+                "AGENTTEAMS_WORKERFLOW_QWENPAW_PLUGIN_PACKAGE",
+                "/opt/agentteams/plugins/workerflow-qwenpaw.zip",
+            )
+        )
+        self._install_qwenpaw_plugin_package("workerflow", plugin_source, "workerflow-qwenpaw-plugin-")
+
+    def _install_default_plugins(self) -> None:
+        self._install_teamharness_plugin()
+        self._install_workerflow_plugin()
+
+    def _install_qwenpaw_plugin_package(self, plugin_name: str, plugin_source: Path, temp_prefix: str) -> None:
+        package_type = self._qwenpaw_plugin_package_type(plugin_source)
+        step_started = self._log_plugin_step_begin(
+            plugin_name,
+            "install",
+            package_type=package_type,
+            package_path=plugin_source,
+        )
+        try:
+            if not plugin_source.exists():
+                raise RuntimeError(f"{plugin_name} qwenpaw plugin package missing: {plugin_source}")
+            qwenpaw_bin = shutil.which("qwenpaw") or str(Path(sys.executable).with_name("qwenpaw"))
+            if plugin_source.is_dir():
+                self._run_qwenpaw_plugin_install(qwenpaw_bin, plugin_source)
+            elif zipfile.is_zipfile(plugin_source):
+                with tempfile.TemporaryDirectory(prefix=temp_prefix) as tmp:
+                    package_dir = self._extract_qwenpaw_plugin_zip(plugin_source, Path(tmp))
+                    self._run_qwenpaw_plugin_install(qwenpaw_bin, package_dir)
+            else:
+                raise RuntimeError(f"{plugin_name} qwenpaw plugin package must be a directory or zip: {plugin_source}")
+        except Exception as exc:
+            self._log_plugin_step_failed(plugin_name, "install", step_started, exc, package_type=package_type)
+            raise
+        self._log_plugin_step_complete(plugin_name, "install", step_started, package_type=package_type)
+
+    def _qwenpaw_plugin_package_type(self, plugin_source: Path) -> str:
+        if plugin_source.is_dir():
+            return "directory"
+        if plugin_source.exists() and zipfile.is_zipfile(plugin_source):
+            return "zip"
+        if not plugin_source.exists():
+            return "missing"
+        return "unsupported"
+
+    def _run_qwenpaw_plugin_install(self, qwenpaw_bin: str, package_dir: Path) -> None:
+        command = [qwenpaw_bin, "plugin", "install", str(package_dir), "--force"]
+        logger.info("installing qwenpaw plugin package=%s", package_dir)
+        subprocess.run(command, check=True)
+
+    def _extract_qwenpaw_plugin_zip(self, zip_path: Path, target_dir: Path) -> Path:
+        with zipfile.ZipFile(zip_path) as archive:
+            target_root = target_dir.resolve()
+            for name in archive.namelist():
+                resolved = (target_dir / name).resolve()
+                try:
+                    resolved.relative_to(target_root)
+                except ValueError:
+                    raise RuntimeError(f"unsafe qwenpaw plugin package path: {name}")
+            archive.extractall(target_dir)
+
+        packages = [
+            path
+            for path in target_dir.iterdir()
+            if path.is_dir() and (path / "plugin.json").is_file()
+        ]
+        if len(packages) != 1:
+            raise RuntimeError(f"expected one qwenpaw plugin package in {zip_path}")
+        return packages[0]
+
+    def _apply_teamharness_assets(self) -> dict:
+        return self._apply_plugin_assets(
+            plugin_name="teamharness",
+            module_name="agentteams_teamharness_qwenpaw_plugin",
+            entrypoint_name="apply_teamharness",
+        )
+
+    def _apply_workerflow_assets(self) -> dict:
+        return self._apply_plugin_assets(
+            plugin_name="workerflow",
+            module_name="agentteams_workerflow_qwenpaw_plugin",
+            entrypoint_name="apply_workerflow",
+        )
+
+    def _apply_plugin_assets(self, *, plugin_name: str, module_name: str, entrypoint_name: str) -> dict:
+        plugin_file = self.config.qwenpaw_working_dir / "plugins" / plugin_name / "plugin.py"
+        step_started = self._log_plugin_step_begin(
+            plugin_name,
+            "load",
+            plugin_file=plugin_file,
+            plugin_file_exists=plugin_file.is_file(),
+            entrypoint=entrypoint_name,
+        )
+        try:
+            if not plugin_file.is_file():
+                raise RuntimeError(f"installed {plugin_name} qwenpaw plugin missing: {plugin_file}")
+
+            spec = importlib.util.spec_from_file_location(module_name, plugin_file)
+            if spec is None or spec.loader is None:
+                raise RuntimeError(f"failed to load {plugin_name} qwenpaw plugin: {plugin_file}")
+
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            apply_plugin = getattr(module, entrypoint_name, None)
+            if not callable(apply_plugin):
+                raise RuntimeError(f"installed {plugin_name} qwenpaw plugin has no {entrypoint_name}: {plugin_file}")
+        except Exception as exc:
+            self._log_plugin_step_failed(plugin_name, "load", step_started, exc, entrypoint=entrypoint_name)
+            raise
+        self._log_plugin_step_complete(plugin_name, "load", step_started, entrypoint=entrypoint_name)
+
+        step_started = self._log_plugin_step_begin(plugin_name, "apply", entrypoint=entrypoint_name)
+        try:
+            result = apply_plugin()
+            if not isinstance(result, dict) or result.get("ok") is not True:
+                raise RuntimeError(f"{plugin_name} asset sync failed: {result!r}")
+        except Exception as exc:
+            self._log_plugin_step_failed(plugin_name, "apply", step_started, exc, entrypoint=entrypoint_name)
+            raise
+        self._log_plugin_step_complete(
+            plugin_name,
+            "apply",
+            step_started,
+            entrypoint=entrypoint_name,
+            ok=result.get("ok"),
+            result_key_count=len(result),
+        )
+        return result
+
+    async def _run_qwenpaw(self) -> None:
+        qwenpaw_bin = shutil.which("qwenpaw") or str(Path(sys.executable).with_name("qwenpaw"))
+        host = "0.0.0.0"
+        log_level = os.getenv("QWENPAW_LOG_LEVEL", "info")
+        command = [
+            qwenpaw_bin,
+            "app",
+            "--host",
+            host,
+            "--port",
+            str(self.config.console_port),
+            "--log-level",
+            log_level,
+        ]
+        stage_started = self._log_worker_stage_begin(
+            "start_qwenpaw_app",
+            binary=qwenpaw_bin,
+            host=host,
+            port=self.config.console_port,
+            cwd=self.config.default_workspace_dir,
+            log_level=log_level,
+        )
+        try:
+            self._process = await asyncio.create_subprocess_exec(
+                *command,
+                cwd=str(self.config.default_workspace_dir),
+            )
+        except Exception as exc:
+            self._log_worker_stage_failed(
+                "start_qwenpaw_app",
+                stage_started,
+                exc,
+                binary=qwenpaw_bin,
+                port=self.config.console_port,
+                cwd=self.config.default_workspace_dir,
+            )
+            self.heartbeat.update(
+                "not_ready",
+                "qwenpaw app failed to start",
+                {"operation": "run_qwenpaw", "error_type": type(exc).__name__},
+            )
+            raise
+        self._log_worker_stage_complete(
+            "start_qwenpaw_app",
+            stage_started,
+            pid=getattr(self._process, "pid", "-"),
+            port=self.config.console_port,
+        )
+        process_started_at = time.monotonic()
+        self._heartbeat_probe_task = asyncio.create_task(self._heartbeat_probe_loop())
+        returncode = await self._process.wait()
+        if not self._stopping:
+            self.heartbeat.update(
+                "not_ready",
+                "qwenpaw app exited unexpectedly",
+                {"operation": "run_qwenpaw", "returncode": returncode},
+            )
+            logger.warning(
+                "qwenpaw app exited component=worker stage=start_qwenpaw_app event=exited worker=%s "
+                "returncode=%s stopping=False duration_ms=%s",
+                self.config.worker_name,
+                returncode,
+                _duration_ms(process_started_at),
+            )
+        else:
+            logger.info(
+                "qwenpaw app exited component=worker stage=start_qwenpaw_app event=exited worker=%s "
+                "returncode=%s stopping=True duration_ms=%s",
+                self.config.worker_name,
+                returncode,
+                _duration_ms(process_started_at),
+            )
+
+    async def _heartbeat_probe_loop(self) -> None:
+        await run_worker_heartbeat_loop(
+            self.heartbeat,
+            worker_name=self.config.worker_cr_name,
+            port=self.config.console_port,
+        )

--- a/qwenpaw/tests/test_config.py
+++ b/qwenpaw/tests/test_config.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+
+from qwenpaw_worker.config import WorkerConfig
+
+
+def _config(tmp_path: Path, **kwargs) -> WorkerConfig:
+    return WorkerConfig(
+        worker_name="worker-a",
+        fs_endpoint="http://minio:9000",
+        fs_access_key="key",
+        fs_secret_key="secret",
+        fs_bucket="agentteams-storage",
+        install_dir=tmp_path / "agents",
+        **kwargs,
+    )
+
+
+def test_worker_config_defaults_to_worker_layout(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("AGENTTEAMS_STORAGE_PREFIX", raising=False)
+    monkeypatch.delenv("AGENTTEAMS_SHARED_STORAGE_PREFIX", raising=False)
+    monkeypatch.delenv("AGENTTEAMS_MEMBER_RUNTIME_CONFIG", raising=False)
+    monkeypatch.delenv("AGENTTEAMS_WORKER_ROLE", raising=False)
+    monkeypatch.delenv("AGENTTEAMS_AGENT_ROLE", raising=False)
+    monkeypatch.delenv("AGENT_WORKSPACE", raising=False)
+
+    config = _config(tmp_path)
+
+    assert config.worker_cr_name == "worker-a"
+    assert config.agent_role == "worker"
+    assert config.agent_name == "worker-a"
+    assert config.worker_home == tmp_path / "agents" / "worker-a"
+    assert config.qwenpaw_working_dir == config.worker_home / ".qwenpaw"
+    assert config.default_workspace_dir == config.qwenpaw_working_dir / "workspaces" / "default"
+    assert config.shared_dir == tmp_path / "shared"
+    assert config.storage_prefix == "agents/worker-a"
+    assert config.shared_prefix == "shared"
+    assert config.runtime_config_path == tmp_path / "agents" / "worker-a" / "runtime" / "runtime.yaml"
+
+
+def test_worker_config_reads_controller_role_env(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENTTEAMS_WORKER_ROLE", "team_leader")
+
+    config = _config(tmp_path)
+
+    assert config.agent_role == "team_leader"
+
+
+def test_worker_config_ignores_agent_workspace_env(tmp_path: Path, monkeypatch) -> None:
+    workspace = tmp_path / "custom-workspace"
+    monkeypatch.setenv("AGENT_WORKSPACE", str(workspace))
+
+    config = _config(tmp_path)
+
+    assert config.default_workspace_dir == config.qwenpaw_working_dir / "workspaces" / "default"
+
+
+def test_worker_config_uses_controller_storage_prefix_without_bucket_duplication(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("AGENTTEAMS_STORAGE_PREFIX", "agentteams/agentteams-storage")
+    monkeypatch.delenv("AGENTTEAMS_SHARED_STORAGE_PREFIX", raising=False)
+
+    config = _config(tmp_path)
+
+    assert config.storage_prefix == "agents/worker-a"
+    assert config.shared_prefix == "shared"
+
+
+def test_worker_config_supports_relative_controller_storage_prefix(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("AGENTTEAMS_STORAGE_PREFIX", "teams/demo")
+    monkeypatch.delenv("AGENTTEAMS_SHARED_STORAGE_PREFIX", raising=False)
+
+    config = _config(tmp_path)
+
+    assert config.storage_prefix == "teams/demo/agents/worker-a"
+    assert config.shared_prefix == "teams/demo/shared"
+
+
+def test_worker_config_allows_explicit_runtime_contract_paths(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("AGENTTEAMS_STORAGE_PREFIX", "teams/demo")
+    monkeypatch.setenv("AGENTTEAMS_SHARED_STORAGE_PREFIX", "teams/override/shared")
+    runtime_config = tmp_path / "runtime.yaml"
+
+    config = _config(
+        tmp_path,
+        storage_prefix="agents/custom-worker",
+        shared_prefix=None,
+        runtime_config_path=runtime_config,
+    )
+
+    assert config.storage_prefix == "agents/custom-worker"
+    assert config.shared_prefix == "teams/override/shared"
+    assert config.runtime_config_path == runtime_config

--- a/qwenpaw/tests/test_heartbeat.py
+++ b/qwenpaw/tests/test_heartbeat.py
@@ -1,0 +1,262 @@
+import asyncio
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+import threading
+
+import pytest
+
+from qwenpaw_worker.heartbeat import (
+    ControllerHeartbeatReporter,
+    WorkerHeartbeat,
+    check_qwenpaw_heartbeat,
+    get_qwenpaw_last_active_at,
+    run_worker_heartbeat_loop,
+)
+
+
+def test_worker_heartbeat_persists_qwenpaw_process_status(tmp_path: Path) -> None:
+    heartbeat = WorkerHeartbeat(tmp_path / "heartbeat.json")
+
+    heartbeat.update("not_ready", "qwenpaw app is starting")
+
+    data = json.loads((tmp_path / "heartbeat.json").read_text(encoding="utf-8"))
+    assert data["status"] == "not_ready"
+    assert data["message"] == "qwenpaw app is starting"
+    assert data["details"] == {}
+
+    heartbeat.update("ready", "qwenpaw app reachable", {"url": "http://127.0.0.1:8088/api/version"})
+
+    data = json.loads((tmp_path / "heartbeat.json").read_text(encoding="utf-8"))
+    assert data["status"] == "ready"
+    assert data["message"] == "qwenpaw app reachable"
+    assert data["details"]["url"].endswith("/api/version")
+
+
+def test_qwenpaw_health_probe_uses_native_version_endpoint() -> None:
+    server, requests = _start_server(
+        {
+            "GET /api/version": (200, {"version": "0.1.0"}),
+        }
+    )
+    try:
+        status, message, details = check_qwenpaw_heartbeat(server.server_port)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert status == "ready"
+    assert message == "qwenpaw API reachable"
+    assert details["url"].endswith("/api/version")
+    assert requests[0]["path"] == "/api/version"
+
+
+def test_qwenpaw_last_active_uses_agent_status_endpoint() -> None:
+    server, requests = _start_server(
+        {
+            "GET /api/agents/default/agent-status": (
+                200,
+                {
+                    "status": "idle",
+                    "running_task_count": 0,
+                    "last_run_at": "2026-05-13T00:00:00Z",
+                    "last_finish_at": "2026-05-13T00:03:00+00:00",
+                },
+            ),
+        }
+    )
+    try:
+        last_active = get_qwenpaw_last_active_at(server.server_port)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert last_active == "2026-05-13T00:03:00Z"
+    assert requests[0]["path"] == "/api/agents/default/agent-status"
+
+
+def test_controller_reporter_posts_ready_with_auth_and_cluster_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    server, requests = _start_server(
+        {
+            "POST /api/v1/workers/worker-a/ready": (204, None),
+        }
+    )
+    monkeypatch.setenv("AGENTTEAMS_CONTROLLER_URL", f"http://127.0.0.1:{server.server_port}")
+    monkeypatch.setenv("AGENTTEAMS_AUTH_TOKEN", "worker-token")
+    monkeypatch.setenv("AGENTTEAMS_CLUSTER_ID", "remote-cluster-a")
+
+    try:
+        reporter = ControllerHeartbeatReporter.from_env("worker-a")
+        assert reporter.report_ready("2026-05-13T00:00:00Z") is True
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    request = requests[0]
+    headers = {key.lower(): value for key, value in request["headers"].items()}
+    assert request["method"] == "POST"
+    assert request["path"] == "/api/v1/workers/worker-a/ready"
+    assert headers["authorization"] == "Bearer worker-token"
+    assert headers["x-agentteams-cluster-id"] == "remote-cluster-a"
+    assert json.loads(request["body"]) == {"lastActiveAt": "2026-05-13T00:00:00Z"}
+
+
+def test_controller_reporter_rereads_token_file_for_heartbeat(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server, requests = _start_server(
+        {
+            "POST /api/v1/workers/worker-a/heartbeat": (204, None),
+        }
+    )
+    token_file = tmp_path / "token"
+    token_file.write_text("file-token\n", encoding="utf-8")
+    monkeypatch.delenv("AGENTTEAMS_AUTH_TOKEN", raising=False)
+    monkeypatch.setenv("AGENTTEAMS_AUTH_TOKEN_FILE", str(token_file))
+    monkeypatch.setenv("AGENTTEAMS_CONTROLLER_URL", f"http://127.0.0.1:{server.server_port}")
+
+    try:
+        reporter = ControllerHeartbeatReporter.from_env("worker-a")
+        assert reporter.report_heartbeat() is True
+        token_file.write_text("file-token-2\n", encoding="utf-8")
+        assert reporter.report_heartbeat() is True
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert [request["path"] for request in requests] == [
+        "/api/v1/workers/worker-a/heartbeat",
+        "/api/v1/workers/worker-a/heartbeat",
+    ]
+    auth_headers = [
+        {key.lower(): value for key, value in request["headers"].items()}["authorization"]
+        for request in requests
+    ]
+    assert auth_headers == ["Bearer file-token", "Bearer file-token-2"]
+    assert [request["body"] for request in requests] == ["", ""]
+
+
+def test_controller_reporter_without_cluster_id_skips_auth_cluster_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server, requests = _start_server(
+        {
+            "POST /api/v1/workers/worker-a/heartbeat": (204, None),
+        }
+    )
+    monkeypatch.setenv("AGENTTEAMS_CONTROLLER_URL", f"http://127.0.0.1:{server.server_port}")
+    monkeypatch.setenv("AGENTTEAMS_AUTH_TOKEN", "worker-token")
+    monkeypatch.delenv("AGENTTEAMS_CLUSTER_ID", raising=False)
+
+    try:
+        reporter = ControllerHeartbeatReporter.from_env("worker-a")
+        assert reporter.report_heartbeat() is True
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    headers = {key.lower(): value for key, value in requests[0]["headers"].items()}
+    assert headers["authorization"] == "Bearer worker-token"
+    assert "x-agentteams-cluster-id" not in headers
+
+
+@pytest.mark.anyio
+async def test_worker_heartbeat_loop_reports_ready_and_heartbeat(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    server, requests = _start_server(
+        {
+            "GET /api/agents/default/agent-status": (
+                200,
+                {
+                    "status": "idle",
+                    "running_task_count": 0,
+                    "last_run_at": "2026-05-13T00:00:00Z",
+                    "last_finish_at": "2026-05-13T00:04:00Z",
+                },
+            ),
+            "POST /api/v1/workers/worker-a/ready": (204, None),
+            "POST /api/v1/workers/worker-a/heartbeat": (204, None),
+        }
+    )
+    heartbeat = WorkerHeartbeat(tmp_path / "heartbeat.json")
+    ticks = 0
+
+    def check(_port):
+        return "ready", "qwenpaw ready", {}
+
+    async def cancel_after_tick(_seconds):
+        nonlocal ticks
+        ticks += 1
+        raise asyncio.CancelledError
+
+    monkeypatch.setenv("AGENTTEAMS_CONTROLLER_URL", f"http://127.0.0.1:{server.server_port}")
+    monkeypatch.setattr("qwenpaw_worker.heartbeat.check_qwenpaw_heartbeat", check)
+    monkeypatch.setattr("qwenpaw_worker.heartbeat.asyncio.sleep", cancel_after_tick)
+
+    try:
+        with pytest.raises(asyncio.CancelledError):
+                await run_worker_heartbeat_loop(
+                    heartbeat,
+                    worker_name="worker-a",
+                    port=server.server_port,
+                    local_interval=0.01,
+                    report_interval=60,
+                )
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    data = json.loads((tmp_path / "heartbeat.json").read_text(encoding="utf-8"))
+    assert data["status"] == "ready"
+    post_requests = [request for request in requests if request["method"] == "POST"]
+    assert [request["path"] for request in post_requests] == [
+        "/api/v1/workers/worker-a/ready",
+        "/api/v1/workers/worker-a/heartbeat",
+    ]
+    assert [json.loads(request["body"]) for request in post_requests] == [
+        {"lastActiveAt": "2026-05-13T00:04:00Z"},
+        {"lastActiveAt": "2026-05-13T00:04:00Z"},
+    ]
+
+
+def _start_server(routes):
+    requests = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self._handle()
+
+        def do_POST(self):
+            self._handle()
+
+        def log_message(self, *_args):
+            return
+
+        def _handle(self):
+            length = int(self.headers.get("Content-Length", "0") or "0")
+            body = self.rfile.read(length).decode("utf-8") if length else ""
+            requests.append(
+                {
+                    "method": self.command,
+                    "path": self.path,
+                    "headers": dict(self.headers),
+                    "body": body,
+                }
+            )
+            status, payload = routes.get(f"{self.command} {self.path}", (404, {"message": "not found"}))
+            data = b"" if payload is None else json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            if payload is not None:
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            if data:
+                self.wfile.write(data)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, requests

--- a/qwenpaw/tests/test_logging_config.py
+++ b/qwenpaw/tests/test_logging_config.py
@@ -1,0 +1,141 @@
+import logging
+from contextlib import contextmanager
+from logging.handlers import RotatingFileHandler
+
+
+@contextmanager
+def _clear_root_handlers():
+    root = logging.getLogger()
+    previous_handlers = list(root.handlers)
+    previous_level = root.level
+    for handler in previous_handlers:
+        root.removeHandler(handler)
+    try:
+        yield root
+    finally:
+        for handler in list(root.handlers):
+            root.removeHandler(handler)
+            handler.close()
+        for handler in previous_handlers:
+            root.addHandler(handler)
+        root.setLevel(previous_level)
+
+
+def test_configure_worker_logging_writes_default_rotating_file(tmp_path, monkeypatch) -> None:
+    from qwenpaw_worker.log import configure_worker_logging
+
+    monkeypatch.setenv("QWENPAW_WORKING_DIR", str(tmp_path / ".qwenpaw"))
+    monkeypatch.delenv("QWENPAW_WORKER_LOG_DIR", raising=False)
+    monkeypatch.delenv("QWENPAW_WORKER_LOG_FILE_ENABLED", raising=False)
+
+    with _clear_root_handlers() as root:
+        log_file = configure_worker_logging()
+
+        logging.getLogger("qwenpaw_worker.test").info("component=worker stage=start duration_ms=1")
+        for handler in root.handlers:
+            handler.flush()
+
+        assert log_file == tmp_path / ".qwenpaw" / "logs" / "qwenpaw-worker.log"
+        assert any(isinstance(handler, RotatingFileHandler) for handler in root.handlers)
+        assert any(
+            isinstance(handler, logging.StreamHandler) and not isinstance(handler, RotatingFileHandler)
+            for handler in root.handlers
+        )
+        assert "component=worker stage=start duration_ms=1" in log_file.read_text(encoding="utf-8")
+        assert "worker logging configured component=worker stage=logging event=configured" in log_file.read_text(
+            encoding="utf-8"
+        )
+        assert "max_bytes=" in log_file.read_text(encoding="utf-8")
+        assert "backup_count=" in log_file.read_text(encoding="utf-8")
+
+
+def test_configure_worker_logging_rotates_file(tmp_path, monkeypatch) -> None:
+    from qwenpaw_worker.log import configure_worker_logging
+
+    monkeypatch.setenv("QWENPAW_WORKING_DIR", str(tmp_path / ".qwenpaw"))
+    monkeypatch.setenv("QWENPAW_WORKER_LOG_MAX_BYTES", "160")
+    monkeypatch.setenv("QWENPAW_WORKER_LOG_BACKUP_COUNT", "1")
+
+    with _clear_root_handlers() as root:
+        log_file = configure_worker_logging()
+
+        logger = logging.getLogger("qwenpaw_worker.rotate")
+        for index in range(20):
+            logger.info("component=worker stage=rotate duration_ms=%d payload=%s", index, "x" * 80)
+        for handler in root.handlers:
+            handler.flush()
+
+        assert log_file is not None
+        assert log_file.exists()
+        assert log_file.with_name("qwenpaw-worker.log.1").exists()
+
+
+def test_configure_worker_logging_can_disable_file_logging(tmp_path, monkeypatch) -> None:
+    from qwenpaw_worker.log import configure_worker_logging
+
+    monkeypatch.setenv("QWENPAW_WORKING_DIR", str(tmp_path / ".qwenpaw"))
+
+    with _clear_root_handlers() as root:
+        configure_worker_logging()
+        monkeypatch.setenv("QWENPAW_WORKER_LOG_FILE_ENABLED", "false")
+
+        log_file = configure_worker_logging()
+
+        assert log_file is None
+        assert not any(isinstance(handler, RotatingFileHandler) for handler in root.handlers)
+        assert any(isinstance(handler, logging.StreamHandler) for handler in root.handlers)
+
+
+def test_configure_worker_logging_is_idempotent(tmp_path, monkeypatch) -> None:
+    from qwenpaw_worker.log import configure_worker_logging
+
+    monkeypatch.setenv("QWENPAW_WORKING_DIR", str(tmp_path / ".qwenpaw"))
+
+    with _clear_root_handlers() as root:
+        first = configure_worker_logging()
+        second = configure_worker_logging()
+
+        assert second == first
+        assert sum(isinstance(handler, RotatingFileHandler) for handler in root.handlers) == 1
+        assert (
+            sum(
+                isinstance(handler, logging.StreamHandler) and not isinstance(handler, RotatingFileHandler)
+                for handler in root.handlers
+            )
+            == 1
+        )
+
+
+def test_configure_worker_logging_falls_back_for_invalid_rotation_env(tmp_path, monkeypatch) -> None:
+    from qwenpaw_worker.log import DEFAULT_LOG_BACKUP_COUNT, DEFAULT_LOG_MAX_BYTES, configure_worker_logging
+
+    monkeypatch.setenv("QWENPAW_WORKING_DIR", str(tmp_path / ".qwenpaw"))
+    monkeypatch.setenv("QWENPAW_WORKER_LOG_MAX_BYTES", "not-a-number")
+    monkeypatch.setenv("QWENPAW_WORKER_LOG_BACKUP_COUNT", "-1")
+
+    with _clear_root_handlers() as root:
+        configure_worker_logging()
+
+        file_handler = next(handler for handler in root.handlers if isinstance(handler, RotatingFileHandler))
+        assert file_handler.maxBytes == DEFAULT_LOG_MAX_BYTES
+        assert file_handler.backupCount == DEFAULT_LOG_BACKUP_COUNT
+
+
+def test_configure_worker_logging_clamps_rotation_env_to_upper_limits(tmp_path, monkeypatch) -> None:
+    from qwenpaw_worker.log import MAX_LOG_BACKUP_COUNT, MAX_LOG_MAX_BYTES, configure_worker_logging
+
+    monkeypatch.setenv("QWENPAW_WORKING_DIR", str(tmp_path / ".qwenpaw"))
+    monkeypatch.setenv("QWENPAW_WORKER_LOG_MAX_BYTES", str(MAX_LOG_MAX_BYTES * 100))
+    monkeypatch.setenv("QWENPAW_WORKER_LOG_BACKUP_COUNT", str(MAX_LOG_BACKUP_COUNT * 100))
+
+    with _clear_root_handlers() as root:
+        log_file = configure_worker_logging()
+
+        file_handler = next(handler for handler in root.handlers if isinstance(handler, RotatingFileHandler))
+        for handler in root.handlers:
+            handler.flush()
+
+        assert file_handler.maxBytes == MAX_LOG_MAX_BYTES
+        assert file_handler.backupCount == MAX_LOG_BACKUP_COUNT
+        assert f"max_bytes={MAX_LOG_MAX_BYTES}" in log_file.read_text(encoding="utf-8")
+        assert f"backup_count={MAX_LOG_BACKUP_COUNT}" in log_file.read_text(encoding="utf-8")

--- a/qwenpaw/tests/test_matrix_overlay.py
+++ b/qwenpaw/tests/test_matrix_overlay.py
@@ -1,0 +1,1255 @@
+from pathlib import Path
+import ast
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+OVERLAY = ROOT / "src" / "matrix" / "channel.py"
+
+
+def _overlay_source() -> str:
+    return OVERLAY.read_text(encoding="utf-8")
+
+
+def test_matrix_overlay_preserves_invite_join_and_marks_ready() -> None:
+    source = _overlay_source()
+
+    assert "for room_id in resp.rooms.invite" in source
+    assert "await self._client.join(room_id)" in source
+    assert "AGENTTEAMS_MATRIX_CHANNEL_READY_FILE" in source
+    assert "self._mark_channel_ready()" in source
+    assert "timeout=0" in source
+
+
+def test_matrix_overlay_writes_visible_structured_mentions() -> None:
+    source = _overlay_source()
+
+    assert "mention_user_ids" in source
+    assert "https://matrix.to/#/" in source
+    assert 'content["formatted_body"]' in source
+    assert 'content["m.mentions"]' in source
+
+
+def test_matrix_overlay_is_valid_python() -> None:
+    ast.parse(_overlay_source(), filename=str(OVERLAY))
+
+
+def test_matrix_overlay_supports_streaming_reasoning_hooks() -> None:
+    source = _overlay_source()
+
+    assert "streaming_enabled: bool = True" in source
+    assert 'streaming_enabled=bool(raw.get("streaming_enabled", True))' in source
+    assert "async def on_streaming_start" in source
+    assert "async def on_streaming_delta" in source
+    assert "async def on_streaming_end" in source
+
+
+def _install_module(name: str, **attrs):
+    module = types.ModuleType(name)
+    module.__dict__.update(attrs)
+    sys.modules[name] = module
+    return module
+
+
+def _load_overlay_module():
+    root = "_qwenpaw_overlay_test"
+
+    class _Dummy:
+        pass
+
+    class _BaseChannel:
+        async def _on_consume_error(self, _request, _to_handle, _err_text):
+            return None
+
+    class _ContentType:
+        TEXT = "text"
+        REFUSAL = "refusal"
+        DATA = "data"
+        IMAGE = "image"
+        VIDEO = "video"
+        AUDIO = "audio"
+        FILE = "file"
+
+    class _MessageType:
+        MESSAGE = "MESSAGE"
+        REASONING = "REASONING"
+
+    class _RunStatus:
+        Completed = "COMPLETED"
+        InProgress = "INPROGRESS"
+
+    def _content_init(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+    content_class = type("_Content", (), {"__init__": _content_init})
+
+    _install_module(root)
+    _install_module(f"{root}.app")
+    _install_module(f"{root}.app.channels")
+    _install_module(f"{root}.app.channels.matrix")
+    _install_module(f"{root}.app.channels.base", BaseChannel=_BaseChannel)
+    _install_module(
+        f"{root}.app.channels.utils",
+        file_url_to_local_path=lambda value: value,
+    )
+    _install_module(f"{root}.constant", WORKING_DIR="/tmp")
+
+    _install_module(
+        "nio",
+        **{
+            name: _Dummy
+            for name in (
+                "AsyncClient",
+                "AsyncClientConfig",
+                "KeysUploadResponse",
+                "LoginResponse",
+                "KeyVerificationCancel",
+                "KeyVerificationEvent",
+                "KeyVerificationKey",
+                "KeyVerificationMac",
+                "KeyVerificationStart",
+                "LocalProtocolError",
+                "MatrixRoom",
+                "MegolmEvent",
+                "RoomEncryptedAudio",
+                "RoomEncryptedFile",
+                "RoomEncryptedImage",
+                "RoomEncryptedVideo",
+                "RoomMessageAudio",
+                "RoomMessageFile",
+                "RoomMessageImage",
+                "RoomMessageText",
+                "RoomMessageVideo",
+                "SyncResponse",
+                "ToDeviceEvent",
+                "ToDeviceError",
+                "UploadResponse",
+            )
+        },
+    )
+    _install_module("nio.event_builders")
+    _install_module("nio.event_builders.direct_messages", ToDeviceMessage=_Dummy)
+    _install_module("nio.events")
+    _install_module(
+        "nio.events.to_device",
+        RoomKeyRequest=_Dummy,
+        RoomKeyRequestCancellation=_Dummy,
+    )
+    _install_module(
+        "nio.responses",
+        JoinedMembersResponse=_Dummy,
+        RoomGetStateEventResponse=_Dummy,
+        RoomSendError=_Dummy,
+        SyncError=_Dummy,
+        WhoamiResponse=_Dummy,
+    )
+    _install_module("agentscope_runtime")
+    _install_module("agentscope_runtime.engine")
+    _install_module("agentscope_runtime.engine.schemas")
+    _install_module(
+        "agentscope_runtime.engine.schemas.agent_schemas",
+        AudioContent=content_class,
+        ContentType=_ContentType,
+        FileContent=content_class,
+        ImageContent=content_class,
+        MessageType=_MessageType,
+        RunStatus=_RunStatus,
+        TextContent=content_class,
+        VideoContent=content_class,
+    )
+
+    module_name = f"{root}.app.channels.matrix.channel"
+    spec = importlib.util.spec_from_file_location(module_name, OVERLAY)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeClient:
+    def __init__(self):
+        self.rooms = {}
+        self.sent = []
+
+    async def room_send(self, room_id, message_type, content, **kwargs):
+        self.sent.append((room_id, message_type, dict(content), kwargs))
+        return SimpleNamespace(event_id=f"$sent{len(self.sent)}")
+
+
+async def _noop_typing(_room_id, _typing):
+    return None
+
+
+async def _noop_prepare(_room_id):
+    return None
+
+
+def _make_thread_channel():
+    module = _load_overlay_module()
+    channel = module.MatrixChannel.__new__(module.MatrixChannel)
+    channel._client = _FakeClient()
+    channel._user_id = "@bot:hs.local"
+    channel._active_thread_roots = {}
+    channel._send_typing = _noop_typing
+    channel._prepare_room_send = _noop_prepare
+    channel._message_to_content_parts = lambda event: [
+        SimpleNamespace(type=module.ContentType.TEXT, text=event.text)
+    ]
+
+    async def _send_message_content(to_handle, event, meta):
+        await channel.send(to_handle, event.text, meta)
+
+    async def _send_content_parts(to_handle, parts, meta):
+        for part in parts:
+            await channel.send(to_handle, part.text, meta)
+
+    channel.send_message_content = _send_message_content
+    channel.send_content_parts = _send_content_parts
+    return module, channel
+
+
+def test_matrix_send_media_adds_attachment_relation(tmp_path) -> None:
+    module, channel = _make_thread_channel()
+    media_path = tmp_path / "report.md"
+    media_path.write_text("report\n", encoding="utf-8")
+
+    async def _upload_file(_file_ref):
+        return "mxc://hs.local/report"
+
+    async def _flush_pending_thread_parts(_room_id, _meta):
+        return None
+
+    channel._upload_file = _upload_file
+    channel._flush_pending_thread_parts = _flush_pending_thread_parts
+
+    meta = {"matrixAttachmentParentEventId": "$parent-text"}
+    media_uri = asyncio.run(
+        channel.send_media(
+            "!room:hs.local",
+            SimpleNamespace(type=module.ContentType.FILE, file_url=str(media_path)),
+            meta,
+        ),
+    )
+
+    assert media_uri == "mxc://hs.local/report"
+    content = channel._client.sent[0][2]
+    assert content["msgtype"] == "m.file"
+    assert content["m.relates_to"] == {
+        "rel_type": "com.agentteams.attachment",
+        "event_id": "$parent-text",
+    }
+    assert module._MATRIX_OWN_THREAD_ROOT_KEY not in meta
+
+
+def test_matrix_send_media_does_not_inherit_thread_relation(tmp_path) -> None:
+    module, channel = _make_thread_channel()
+    media_path = tmp_path / "report.md"
+    media_path.write_text("report\n", encoding="utf-8")
+
+    async def _upload_file(_file_ref):
+        return "mxc://hs.local/report"
+
+    channel._upload_file = _upload_file
+
+    media_uri = asyncio.run(
+        channel.send_media(
+            "!room:hs.local",
+            SimpleNamespace(type=module.ContentType.FILE, file_url=str(media_path)),
+            {module._MATRIX_THREAD_META_KEY: "$thread-root"},
+        ),
+    )
+
+    assert media_uri == "mxc://hs.local/report"
+    content = channel._client.sent[0][2]
+    assert content["msgtype"] == "m.file"
+    assert "m.relates_to" not in content
+
+
+def test_matrix_thread_root_writes_attachment_context(tmp_path, monkeypatch) -> None:
+    _module, channel = _make_thread_channel()
+    context_file = tmp_path / "matrix-context.json"
+    monkeypatch.setenv("TEAMHARNESS_MATRIX_CONTEXT_FILE", str(context_file))
+    meta = {}
+
+    asyncio.run(channel._ensure_thread_root("!room:hs.local", meta))
+
+    data = json.loads(context_file.read_text(encoding="utf-8"))
+    record = data["rooms"]["!room:hs.local"]
+    assert record["attachmentParentEventId"] == "$sent1"
+    assert record["eventId"] == "$sent1"
+
+
+def test_matrix_thread_message_only_response_edits_processing_root() -> None:
+    _module, channel = _make_thread_channel()
+    meta = {"thread_root_event_id": "$incoming"}
+
+    asyncio.run(
+        channel.on_event_message_completed(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(type="MessageType.MESSAGE", text="final answer"),
+            meta,
+        ),
+    )
+    asyncio.run(
+        channel._on_process_completed(
+            SimpleNamespace(),
+            "!room:hs.local",
+            meta,
+        ),
+    )
+
+    assert channel._client.sent[0][2]["body"] == "处理中..."
+    assert channel._client.sent[1][2]["m.relates_to"] == {
+        "rel_type": "m.replace",
+        "event_id": "$sent1",
+    }
+    assert channel._client.sent[1][2]["format"] == "org.matrix.custom.html"
+    assert channel._client.sent[1][2]["formatted_body"].startswith("<p>* ")
+    assert channel._client.sent[1][2]["m.new_content"]["body"] == "final answer"
+    assert (
+        channel._client.sent[1][2]["m.new_content"]["format"]
+        == "org.matrix.custom.html"
+    )
+    assert "final answer" in channel._client.sent[1][2]["m.new_content"]["formatted_body"]
+
+
+def test_matrix_edit_fallback_html_does_not_embed_markdown_block_html() -> None:
+    _module, channel = _make_thread_channel()
+    meta = {"thread_root_event_id": "$incoming"}
+    text = 'Result:\n\n```json\n{"ok": true}\n```'
+
+    asyncio.run(
+        channel.on_event_message_completed(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(type="MessageType.MESSAGE", text=text),
+            meta,
+        ),
+    )
+    asyncio.run(
+        channel._on_process_completed(
+            SimpleNamespace(),
+            "!room:hs.local",
+            meta,
+        ),
+    )
+
+    edit = channel._client.sent[1][2]
+    assert edit["m.relates_to"] == {
+        "rel_type": "m.replace",
+        "event_id": "$sent1",
+    }
+    assert edit["formatted_body"].startswith("<p>* ")
+    assert "* <pre" not in edit["formatted_body"]
+    assert "<pre><code" in edit["m.new_content"]["formatted_body"]
+
+
+def test_matrix_thread_parts_prefer_own_processing_root_over_incoming_root() -> None:
+    _module, channel = _make_thread_channel()
+    meta = {"thread_root_event_id": "$incoming"}
+
+    asyncio.run(
+        channel.on_event_message_completed(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(type="MessageType.MESSAGE", text="first note"),
+            meta,
+        ),
+    )
+    asyncio.run(
+        channel.on_event_message_completed(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(type="MessageType.MCP_TOOL_CALL", text="tool call"),
+            meta,
+        ),
+    )
+
+    assert channel._client.sent[0][2]["body"] == "处理中..."
+    thread_events = [
+        content
+        for _room_id, _message_type, content, _kwargs in channel._client.sent[1:]
+        if content.get("m.relates_to", {}).get("rel_type") == "m.thread"
+    ]
+    assert [event["body"] for event in thread_events] == [
+        "first note",
+        "tool call",
+    ]
+    assert {
+        event["m.relates_to"]["event_id"] for event in thread_events
+    } == {"$sent1"}
+
+
+def test_matrix_streaming_reasoning_waits_for_end_before_thread_item() -> None:
+    module, channel = _make_thread_channel()
+    meta = {"thread_root_event_id": "$incoming"}
+
+    asyncio.run(
+        channel.on_streaming_start(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(type="reasoning", id="reasoning-1"),
+            meta,
+            "reasoning",
+        ),
+    )
+    asyncio.run(
+        channel.on_streaming_delta(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(text="ignored"),
+            meta,
+            "reasoning",
+            accumulated_text="partial thinking",
+        ),
+    )
+    assert len(channel._client.sent) == 1
+
+    asyncio.run(
+        channel.on_streaming_delta(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(text="ignored"),
+            meta,
+            "reasoning",
+            accumulated_text="partial thinking hidden by throttle",
+        ),
+    )
+    assert len(channel._client.sent) == 1
+
+    meta[module._MATRIX_STREAMING_REASONING_LAST_EDIT_KEY] = -10
+    asyncio.run(
+        channel.on_streaming_delta(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(text="ignored"),
+            meta,
+            "reasoning",
+            accumulated_text="partial thinking and updated thinking",
+        ),
+    )
+    assert len(channel._client.sent) == 1
+
+    asyncio.run(
+        channel.on_streaming_end(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(type="reasoning", text="fallback"),
+            meta,
+            "reasoning",
+            accumulated_text="partial thinking and updated thinking final tail",
+        ),
+    )
+    assert meta.get(module._MATRIX_STREAMING_REASONING_EVENT_ID_KEY) is None
+    assert meta.get(module._MATRIX_STREAMING_REASONING_STREAM_ID_KEY) is None
+    thinking = channel._client.sent[1][2]
+    assert thinking["msgtype"] == "m.notice"
+    assert thinking["body"] == (
+        "Thinking:\n\npartial thinking and updated thinking final tail"
+    )
+    assert thinking["m.relates_to"] == {
+        "rel_type": "m.thread",
+        "event_id": "$sent1",
+        "is_falling_back": False,
+    }
+    asyncio.run(
+        channel.on_event_message_completed(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(type="MessageType.MCP_TOOL_CALL", text="tool call"),
+            meta,
+        ),
+    )
+    asyncio.run(
+        channel.on_streaming_start(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(type="reasoning", id="reasoning-2"),
+            meta,
+            "reasoning",
+        ),
+    )
+    asyncio.run(
+        channel.on_streaming_delta(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(text="ignored"),
+            meta,
+            "reasoning",
+            accumulated_text="second step thinking",
+        ),
+    )
+    asyncio.run(
+        channel.on_streaming_end(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(type="reasoning", text="fallback"),
+            meta,
+            "reasoning",
+            accumulated_text="second step thinking",
+        ),
+    )
+    asyncio.run(
+        channel.on_streaming_end(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(type="message", text="fallback final"),
+            meta,
+            "message",
+            accumulated_text="final answer",
+        ),
+    )
+    asyncio.run(
+        channel._on_process_completed(
+            SimpleNamespace(),
+            "!room:hs.local",
+            meta,
+        ),
+    )
+
+    assert channel._client.sent[0][2]["body"] == "处理中..."
+    tool_call = channel._client.sent[2][2]
+    assert tool_call["body"] == "tool call"
+    assert tool_call["m.relates_to"] == {
+        "rel_type": "m.thread",
+        "event_id": "$sent1",
+        "is_falling_back": False,
+    }
+    second_thinking = channel._client.sent[3][2]
+    assert second_thinking["body"] == "Thinking:\n\nsecond step thinking"
+    assert second_thinking["m.relates_to"] == {
+        "rel_type": "m.thread",
+        "event_id": "$sent1",
+        "is_falling_back": False,
+    }
+    final = channel._client.sent[4][2]
+    assert final["m.relates_to"] == {
+        "rel_type": "m.replace",
+        "event_id": "$sent1",
+    }
+    assert final["m.new_content"]["body"] == "final answer"
+
+
+def test_matrix_streaming_message_only_edits_processing_root_on_completion() -> None:
+    _module, channel = _make_thread_channel()
+    meta = {"thread_root_event_id": "$incoming"}
+
+    asyncio.run(
+        channel.on_streaming_start(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(type="message"),
+            meta,
+            "message",
+        ),
+    )
+    asyncio.run(
+        channel.on_streaming_delta(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(text="ignored"),
+            meta,
+            "message",
+            accumulated_text="partial",
+        ),
+    )
+    assert channel._client.sent[0][2]["body"] == "处理中..."
+    assert len(channel._client.sent) == 1
+
+    asyncio.run(
+        channel.on_streaming_delta(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(text="ignored"),
+            meta,
+            "message",
+            accumulated_text="partial hidden by throttle",
+        ),
+    )
+    assert len(channel._client.sent) == 1
+
+    asyncio.run(
+        channel.on_streaming_delta(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(text="ignored"),
+            meta,
+            "message",
+            accumulated_text="partial updated",
+        ),
+    )
+    assert len(channel._client.sent) == 1
+
+    asyncio.run(
+        channel.on_streaming_end(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(type="message", text="fallback final"),
+            meta,
+            "message",
+            accumulated_text="final answer",
+        ),
+    )
+    assert len(channel._client.sent) == 1
+
+    asyncio.run(
+        channel._on_process_completed(
+            SimpleNamespace(),
+            "!room:hs.local",
+            meta,
+        ),
+    )
+    assert len(channel._client.sent) == 2
+    final = channel._client.sent[1][2]
+    assert final["m.relates_to"] == {
+        "rel_type": "m.replace",
+        "event_id": "$sent1",
+    }
+    assert final["m.new_content"]["body"] == "final answer"
+
+
+def test_matrix_no_reply_final_closes_processing_root_as_processed() -> None:
+    _module, channel = _make_thread_channel()
+    meta = {"thread_root_event_id": "$incoming"}
+
+    asyncio.run(
+        channel.on_streaming_start(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(type="message"),
+            meta,
+            "message",
+        ),
+    )
+    asyncio.run(
+        channel.on_streaming_end(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(type="message", text="NO_REPLY"),
+            meta,
+            "message",
+            accumulated_text="NO_REPLY",
+        ),
+    )
+    asyncio.run(
+        channel._on_process_completed(
+            SimpleNamespace(),
+            "!room:hs.local",
+            meta,
+        ),
+    )
+
+    assert channel._client.sent[0][2]["body"] == "处理中..."
+    final = channel._client.sent[1][2]
+    assert final["m.relates_to"] == {
+        "rel_type": "m.replace",
+        "event_id": "$sent1",
+    }
+    assert final["m.new_content"]["body"] == "已处理"
+    assert "!room:hs.local" not in channel._active_thread_roots
+
+
+def test_matrix_short_text_sends_direct_message() -> None:
+    _module, channel = _make_thread_channel()
+
+    asyncio.run(channel.send("!room:hs.local", "short answer", {}))
+
+    assert len(channel._client.sent) == 1
+    content = channel._client.sent[0][2]
+    assert content["msgtype"] == "m.text"
+    assert content["body"] == "short answer"
+    assert content["format"] == "org.matrix.custom.html"
+
+
+def test_matrix_long_text_uses_media_fallback(tmp_path: Path) -> None:
+    module, channel = _make_thread_channel()
+    channel._workspace_dir = tmp_path
+    uploaded = []
+
+    async def _fake_upload(file_ref):
+        uploaded.append(Path(file_ref))
+        return "mxc://hs.local/full-content"
+
+    channel._upload_file = _fake_upload
+    long_text = "long-content\n" + ("x" * (module.MATRIX_TEXT_EVENT_SAFE_BYTES + 1000))
+
+    asyncio.run(channel.send("!room:hs.local", long_text, {}))
+
+    assert len(channel._client.sent) == 2
+    assert uploaded and uploaded[0].read_text(encoding="utf-8") == long_text
+    summary = channel._client.sent[0][2]
+    media = channel._client.sent[1][2]
+    assert media["msgtype"] == "m.file"
+    assert media["url"] == "mxc://hs.local/full-content"
+    assert media["m.relates_to"] == {
+        "rel_type": "com.agentteams.attachment",
+        "event_id": "$sent1",
+    }
+    assert summary["msgtype"] == "m.text"
+    assert summary["body"].startswith("long-content\n")
+    assert "单条 Matrix 消息已按安全长度截断" in summary["body"]
+    assert "完整内容已缓存为 Matrix 附件" in summary["body"]
+    assert "附件地址：mxc://hs.local/full-content" in summary["body"]
+    assert long_text not in summary["body"]
+    assert summary[module.MATRIX_LONG_MESSAGE_METADATA_KEY] == {
+        "version": 1,
+        "url": "mxc://hs.local/full-content",
+        "filename": uploaded[0].name,
+        "mimetype": "text/markdown; charset=utf-8",
+    }
+    assert (
+        module._matrix_event_payload_size(summary)
+        <= module.MATRIX_TEXT_EVENT_FALLBACK_BUDGET_BYTES
+    )
+
+
+def test_matrix_long_text_fallback_summary_stays_under_threshold(tmp_path: Path) -> None:
+    module, channel = _make_thread_channel()
+    channel._workspace_dir = tmp_path
+
+    async def _fake_upload(_file_ref):
+        return None
+
+    channel._upload_file = _fake_upload
+    long_text = "z" * (module.MATRIX_TEXT_EVENT_SAFE_BYTES * 4)
+
+    asyncio.run(channel.send("!room:hs.local", long_text, {}))
+
+    assert len(channel._client.sent) == 1
+    summary = channel._client.sent[0][2]
+    assert summary["msgtype"] == "m.text"
+    assert summary["body"].startswith("z" * 100)
+    assert "单条 Matrix 消息已按安全长度截断" in summary["body"]
+    assert "完整内容已缓存为本地文件" in summary["body"]
+    assert "Matrix 附件上传失败" in summary["body"]
+    assert long_text not in summary["body"]
+    assert module.MATRIX_LONG_MESSAGE_METADATA_KEY not in summary
+    assert (
+        module._matrix_event_payload_size(summary)
+        <= module.MATRIX_TEXT_EVENT_FALLBACK_BUDGET_BYTES
+    )
+
+
+def test_matrix_long_edit_uses_media_fallback(tmp_path: Path) -> None:
+    module, channel = _make_thread_channel()
+    channel._workspace_dir = tmp_path
+    uploaded = []
+
+    async def _fake_upload(file_ref):
+        uploaded.append(Path(file_ref))
+        return "mxc://hs.local/edited-full-content"
+
+    channel._upload_file = _fake_upload
+    long_text = "final\n" + ("y" * (module.MATRIX_TEXT_EVENT_SAFE_BYTES + 1000))
+
+    asyncio.run(
+        channel._edit_matrix_event(
+            "!room:hs.local",
+            "$root",
+            long_text,
+            msgtype="m.text",
+            html=module._md_to_html(long_text),
+        ),
+    )
+
+    assert len(channel._client.sent) == 2
+    edit = channel._client.sent[0][2]
+    media = channel._client.sent[1][2]
+    assert media["msgtype"] == "m.file"
+    assert media["m.relates_to"] == {
+        "rel_type": "com.agentteams.attachment",
+        "event_id": "$root",
+    }
+    assert edit["m.relates_to"] == {"rel_type": "m.replace", "event_id": "$root"}
+    assert edit["m.new_content"]["body"].startswith("final\n")
+    assert "单条 Matrix 消息已按安全长度截断" in edit["m.new_content"]["body"]
+    assert "完整内容已缓存为 Matrix 附件" in edit["m.new_content"]["body"]
+    assert "附件地址：mxc://hs.local/edited-full-content" in edit["m.new_content"]["body"]
+    assert long_text not in edit["m.new_content"]["body"]
+    expected_metadata = {
+        "version": 1,
+        "url": "mxc://hs.local/edited-full-content",
+        "filename": uploaded[0].name,
+        "mimetype": "text/markdown; charset=utf-8",
+    }
+    assert edit[module.MATRIX_LONG_MESSAGE_METADATA_KEY] == expected_metadata
+    assert (
+        edit["m.new_content"][module.MATRIX_LONG_MESSAGE_METADATA_KEY]
+        == expected_metadata
+    )
+    assert (
+        module._matrix_event_payload_size(edit)
+        <= module.MATRIX_TEXT_EVENT_FALLBACK_BUDGET_BYTES
+    )
+
+
+def test_matrix_long_edit_fallback_failure_does_not_block_completion_cleanup(
+    tmp_path: Path,
+) -> None:
+    module, channel = _make_thread_channel()
+    channel._workspace_dir = tmp_path
+    meta = {"thread_root_event_id": "$incoming"}
+    typing_events = []
+
+    async def _capture_typing(room_id, typing):
+        typing_events.append((room_id, typing))
+
+    async def _fake_upload(_file_ref):
+        return "mxc://hs.local/edited-full-content"
+
+    async def _failing_prepare(room_id):
+        if len(channel._client.sent) >= 2:
+            raise RuntimeError("summary send failed")
+
+    channel._send_typing = _capture_typing
+    channel._prepare_room_send = _failing_prepare
+    channel._upload_file = _fake_upload
+    long_text = "final\n" + ("y" * (module.MATRIX_TEXT_EVENT_SAFE_BYTES + 1000))
+
+    asyncio.run(
+        channel.on_streaming_start(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(type="message"),
+            meta,
+            "message",
+        ),
+    )
+    asyncio.run(
+        channel.on_streaming_end(
+            SimpleNamespace(),
+            "!room:hs.local",
+            SimpleNamespace(type="message", text="fallback final"),
+            meta,
+            "message",
+            accumulated_text=long_text,
+        ),
+    )
+    asyncio.run(
+        channel._on_process_completed(
+            SimpleNamespace(),
+            "!room:hs.local",
+            meta,
+        ),
+    )
+
+    assert "!room:hs.local" not in channel._active_thread_roots
+    assert typing_events[-1] == ("!room:hs.local", False)
+
+
+def test_matrix_consume_error_closes_processing_root() -> None:
+    _module, channel = _make_thread_channel()
+    meta = {"thread_root_event_id": "$incoming"}
+
+    asyncio.run(channel._ensure_thread_root("!room:hs.local", meta))
+    asyncio.run(
+        channel._on_consume_error(
+            SimpleNamespace(),
+            "!room:hs.local",
+            "runtime loop failed",
+        ),
+    )
+
+    assert channel._client.sent[0][2]["body"] == "处理中..."
+    error = channel._client.sent[1][2]
+    assert error["m.relates_to"] == {
+        "rel_type": "m.replace",
+        "event_id": "$sent1",
+    }
+    assert error["m.new_content"]["body"] == "处理异常"
+    assert "!room:hs.local" not in channel._active_thread_roots
+
+
+class _FakeCommandRegistry:
+    def is_control_command(self, text):
+        return text.strip().lower().split(None, 1)[0] in {
+            "/stop",
+            "/clear",
+            "/approve",
+        }
+
+
+class _FakeInboundRoom:
+    room_id = "!room:hs.local"
+    users = {}
+    topic = ""
+
+    def user_name(self, user_id):
+        if user_id == "@copywriting-assistant:hs.local":
+            return "copywriting-assistant"
+        return user_id
+
+
+async def _false_dm(*_args):
+    return False
+
+
+async def _noop_read_receipt(_room_id, _event_id):
+    return None
+
+
+def _make_inbound_channel(command_registry=True):
+    module = _load_overlay_module()
+    channel = module.MatrixChannel.__new__(module.MatrixChannel)
+    channel._user_id = "@copywriting-assistant:hs.local"
+    channel._client = _FakeClient()
+    channel.dm_disabled = False
+    channel.group_disabled = False
+    channel.groups = {}
+    channel.history_limit = 50
+    channel._room_histories = {}
+    if command_registry:
+        channel._command_registry = _FakeCommandRegistry()
+    channel._is_dm_room = _false_dm
+    channel._check_allowed = lambda *_args: True
+    channel._require_mention = lambda _room_id: True
+    channel._send_read_receipt = _noop_read_receipt
+    channel._send_typing = _noop_typing
+    channel.enqueued = []
+    channel._enqueue = channel.enqueued.append
+    return channel
+
+
+def _matrix_event(body: str, mentioned: bool = False):
+    mentions = (
+        {"user_ids": ["@copywriting-assistant:hs.local"]}
+        if mentioned
+        else {}
+    )
+    return SimpleNamespace(
+        sender="@alice:hs.local",
+        body=body,
+        event_id="$event",
+        server_timestamp=0,
+        source={"content": {"m.mentions": mentions}},
+    )
+
+
+class _FakeTaskRoom(_FakeInboundRoom):
+    room_id = "!task:hs.local"
+    topic = "Task room for demo-001 [source: dingtalk]"
+    users = {
+        "@copywriting-assistant:hs.local": object(),
+        "@worker:hs.local": object(),
+    }
+
+    def user_name(self, user_id):
+        if user_id == "@copywriting-assistant:hs.local":
+            return "copywriting-assistant"
+        if user_id == "@worker:hs.local":
+            return "worker"
+        return user_id
+
+
+def _matrix_event_from(
+    sender: str,
+    body: str,
+    *,
+    event_id: str = "$event",
+    content_extra=None,
+):
+    content = {"m.mentions": {}}
+    if content_extra:
+        content.update(content_extra)
+    return SimpleNamespace(
+        sender=sender,
+        body=body,
+        event_id=event_id,
+        server_timestamp=0,
+        source={"content": content},
+    )
+
+
+def _use_real_dm_detector(channel):
+    module = sys.modules[channel.__class__.__module__]
+    delattr(channel, "_is_dm_room")
+    channel._dm_room_cache = {}
+
+    async def _joined_members(_room_id):
+        response = module.JoinedMembersResponse()
+        response.members = [
+            SimpleNamespace(user_id="@copywriting-assistant:hs.local"),
+            SimpleNamespace(user_id="@worker:hs.local"),
+        ]
+        return response
+
+    channel._client.joined_members = _joined_members
+    return module
+
+
+def _first_text(payload):
+    return payload["content_parts"][0].text
+
+
+def test_matrix_teamharness_task_room_is_not_dm_even_with_two_members() -> None:
+    channel = _make_inbound_channel()
+    _use_real_dm_detector(channel)
+    room = _FakeTaskRoom()
+
+    is_dm = asyncio.run(
+        channel._is_dm_room(
+            room.room_id,
+            "@worker:hs.local",
+            room,
+        ),
+    )
+
+    assert is_dm is False
+
+
+def test_matrix_teamharness_task_room_detected_from_task_meta(tmp_path) -> None:
+    channel = _make_inbound_channel()
+    _use_real_dm_detector(channel)
+    channel._workspace_dir = tmp_path
+    task_dir = tmp_path / "shared" / "tasks" / "demo-001"
+    task_dir.mkdir(parents=True)
+    (task_dir / "meta.json").write_text(
+        '{"task_id":"demo-001","room_id":"!task:hs.local"}',
+        encoding="utf-8",
+    )
+    room = SimpleNamespace(room_id="!task:hs.local", users=_FakeTaskRoom.users)
+
+    is_dm = asyncio.run(
+        channel._is_dm_room(
+            room.room_id,
+            "@worker:hs.local",
+            room,
+        ),
+    )
+
+    assert is_dm is False
+
+
+def test_matrix_task_room_filters_tool_echo_but_accepts_completion() -> None:
+    channel = _make_inbound_channel()
+    _use_real_dm_detector(channel)
+    room = _FakeTaskRoom()
+
+    asyncio.run(
+        channel._on_room_event(
+            room,
+            _matrix_event_from(
+                "@worker:hs.local",
+                '🔧 **read_file**\n```\n{"file_path":"shared/tasks/demo-001/spec.md"}\n```',
+                event_id="$tool",
+                content_extra={
+                    "m.relates_to": {
+                        "rel_type": "m.thread",
+                        "event_id": "$root",
+                    },
+                },
+            ),
+        ),
+    )
+
+    assert channel.enqueued == []
+
+    asyncio.run(
+        channel._on_room_event(
+            room,
+            _matrix_event_from(
+                "@worker:hs.local",
+                "@copywriting-assistant:hs.local TASK_COMPLETED: demo-001 - "
+                "Result: shared/tasks/demo-001/result.md",
+                event_id="$done",
+            ),
+        ),
+    )
+
+    assert len(channel.enqueued) == 1
+    assert "TASK_COMPLETED: demo-001" in _first_text(channel.enqueued[0])
+
+
+def test_matrix_task_room_filters_plain_tool_display_before_context() -> None:
+    channel = _make_inbound_channel()
+    _use_real_dm_detector(channel)
+    room = _FakeTaskRoom()
+
+    asyncio.run(
+        channel._on_room_event(
+            room,
+            _matrix_event_from(
+                "@teamleader:hs.local",
+                "teamleader: 🔧 **projectflow**\n"
+                "```\n"
+                '{"action":"plan_dag","payload":{"tasks":[{"assignedTo":'
+                '"@copywriting-assistant:hs.local"}]}}\n'
+                "```",
+                event_id="$tool-display",
+                content_extra={
+                    "m.mentions": {
+                        "user_ids": ["@copywriting-assistant:hs.local"],
+                    },
+                },
+            ),
+        ),
+    )
+
+    assert channel.enqueued == []
+    assert channel._room_histories == {}
+
+    asyncio.run(
+        channel._on_room_event(
+            room,
+            _matrix_event_from(
+                "@teamleader:hs.local",
+                "@copywriting-assistant:hs.local TASK_ASSIGNED: demo-001",
+                event_id="$assigned",
+            ),
+        ),
+    )
+
+    assert len(channel.enqueued) == 1
+    assert "TASK_ASSIGNED: demo-001" in _first_text(channel.enqueued[0])
+
+
+def test_matrix_ordinary_own_message_is_skipped() -> None:
+    channel = _make_inbound_channel()
+
+    asyncio.run(
+        channel._on_room_event(
+            _FakeInboundRoom(),
+            _matrix_event_from(
+                "@copywriting-assistant:hs.local",
+                "ordinary self echo",
+            ),
+        ),
+    )
+
+    assert channel.enqueued == []
+
+
+def test_matrix_teamharness_self_trigger_bypasses_own_skip_and_mention_gate() -> None:
+    channel = _make_inbound_channel()
+
+    asyncio.run(
+        channel._on_room_event(
+            _FakeInboundRoom(),
+            _matrix_event_from(
+                "@copywriting-assistant:hs.local",
+                "PROJECT_REQUESTED: req-123",
+                content_extra={
+                    "m.teamharness.trigger": {
+                        "kind": "self_cross_session",
+                        "type": "PROJECT_REQUESTED",
+                        "targetRoomId": "!room:hs.local",
+                        "targetSession": "matrix:!room:hs.local",
+                    },
+                },
+            ),
+        ),
+    )
+
+    assert len(channel.enqueued) == 1
+    payload = channel.enqueued[0]
+    assert "PROJECT_REQUESTED: req-123" in _first_text(payload)
+    assert payload["meta"]["teamharness_trigger"] is True
+    assert payload["meta"]["teamharness_trigger_type"] == "PROJECT_REQUESTED"
+
+
+def test_matrix_teamharness_self_trigger_requires_allowlisted_type() -> None:
+    channel = _make_inbound_channel()
+
+    asyncio.run(
+        channel._on_room_event(
+            _FakeInboundRoom(),
+            _matrix_event_from(
+                "@copywriting-assistant:hs.local",
+                "TASK_COMPLETED: not a project request",
+                content_extra={
+                    "m.teamharness.trigger": {
+                        "kind": "self_cross_session",
+                        "type": "TASK_COMPLETED",
+                        "targetRoomId": "!room:hs.local",
+                    },
+                },
+            ),
+        ),
+    )
+
+    assert channel.enqueued == []
+
+
+def test_matrix_control_command_strips_mention_before_enqueue() -> None:
+    channel = _make_inbound_channel()
+
+    asyncio.run(
+        channel._on_room_event(
+            _FakeInboundRoom(),
+            _matrix_event("copywriting-assistant: /stop", mentioned=True),
+        ),
+    )
+
+    assert len(channel.enqueued) == 1
+    assert _first_text(channel.enqueued[0]) == "/stop"
+
+
+def test_matrix_double_slash_control_command_normalizes_with_mention() -> None:
+    channel = _make_inbound_channel()
+
+    asyncio.run(
+        channel._on_room_event(
+            _FakeInboundRoom(),
+            _matrix_event("copywriting-assistant: //stop", mentioned=True),
+        ),
+    )
+
+    assert len(channel.enqueued) == 1
+    assert _first_text(channel.enqueued[0]) == "/stop"
+
+
+def test_matrix_known_slash_command_normalizes_without_registry() -> None:
+    channel = _make_inbound_channel(command_registry=False)
+
+    asyncio.run(
+        channel._on_room_event(
+            _FakeInboundRoom(),
+            _matrix_event("copywriting-assistant: //clear", mentioned=True),
+        ),
+    )
+
+    assert len(channel.enqueued) == 1
+    assert _first_text(channel.enqueued[0]) == "/clear"
+
+
+def test_matrix_stop_command_passes_through_without_registry() -> None:
+    channel = _make_inbound_channel(command_registry=False)
+
+    asyncio.run(
+        channel._on_room_event(
+            _FakeInboundRoom(),
+            _matrix_event("copywriting-assistant: /stop", mentioned=True),
+        ),
+    )
+
+    assert len(channel.enqueued) == 1
+    assert _first_text(channel.enqueued[0]) == "/stop"
+
+
+def test_matrix_bare_stop_not_recognized_without_slash() -> None:
+    channel = _make_inbound_channel()
+
+    asyncio.run(
+        channel._on_room_event(
+            _FakeInboundRoom(),
+            _matrix_event("copywriting-assistant: stop", mentioned=True),
+        ),
+    )
+
+    assert len(channel.enqueued) == 1
+    assert "/stop" not in _first_text(channel.enqueued[0])
+
+
+def test_matrix_control_command_requires_mention_in_group() -> None:
+    channel = _make_inbound_channel()
+
+    asyncio.run(channel._on_room_event(_FakeInboundRoom(), _matrix_event("/approve")))
+
+    assert len(channel.enqueued) == 0

--- a/qwenpaw/tests/test_package_update.py
+++ b/qwenpaw/tests/test_package_update.py
@@ -1,0 +1,1108 @@
+import json
+import tarfile
+import os
+import subprocess
+import threading
+import zipfile
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+import shutil
+import sys
+import types
+from urllib.parse import parse_qs, urlparse
+
+from qwenpaw_worker.update import AgentPackageManager, MemberRuntimeConfig, _strip_json_line_comments
+
+
+def _package(
+    tmp_path: Path,
+    version: str,
+    *,
+    materials: bool = False,
+    mcp_servers=None,
+    mcp_json=None,
+) -> Path:
+    source_dir = tmp_path / f"src-{version}"
+    config_dir = source_dir / "config"
+    skill_dir = source_dir / "skills" / "code-review"
+    config_dir.mkdir(parents=True)
+    skill_dir.mkdir(parents=True)
+    (source_dir / "manifest.json").write_text('{"version":"1.0"}\n', encoding="utf-8")
+    if mcp_json is None:
+        mcp_json = {"mcpServers": mcp_servers or {}}
+    if isinstance(mcp_json, str):
+        mcp_json_text = mcp_json if mcp_json.endswith("\n") else f"{mcp_json}\n"
+    else:
+        mcp_json_text = json.dumps(mcp_json, ensure_ascii=False) + "\n"
+    (source_dir / "mcp.json").write_text(mcp_json_text, encoding="utf-8")
+    (config_dir / "AGENTS.md").write_text(f"agent package {version}\n", encoding="utf-8")
+    (config_dir / "SOUL.md").write_text(f"soul {version}\n", encoding="utf-8")
+    (config_dir / "MEMORY.md").write_text(f"memory {version}\n", encoding="utf-8")
+    if materials:
+        (config_dir / "BOOTSTRAP.md").write_text(f"bootstrap {version}\n", encoding="utf-8")
+        materials_dir = config_dir / "materials"
+        materials_dir.mkdir()
+        (materials_dir / "custom.md").write_text(f"custom docs {version}\n", encoding="utf-8")
+        crons_dir = config_dir / "crons"
+        crons_dir.mkdir()
+        (crons_dir / "daily.md").write_text(f"cron {version}\n", encoding="utf-8")
+        runtime_config_dir = config_dir / "config"
+        runtime_config_dir.mkdir()
+        (runtime_config_dir / "settings.yaml").write_text(f"settings: {version}\n", encoding="utf-8")
+        (runtime_config_dir / "credagent.json").write_text(f'{{"version":"{version}"}}\n', encoding="utf-8")
+        (runtime_config_dir / "mcporter.json").write_text(f'{{"package":"{version}"}}\n', encoding="utf-8")
+        bootstrap_dir = config_dir / "bootstrap"
+        bootstrap_dir.mkdir()
+        (bootstrap_dir / "seed.md").write_text(f"config bootstrap {version}\n", encoding="utf-8")
+    (skill_dir / "SKILL.md").write_text(f"skill {version}\n", encoding="utf-8")
+    package_path = tmp_path / f"dev-worker-{version}.tar.gz"
+    with tarfile.open(package_path, "w:gz") as archive:
+        archive.add(source_dir, arcname=".")
+    return package_path
+
+
+def _empty_package(tmp_path: Path, version: str) -> Path:
+    source_dir = tmp_path / f"empty-src-{version}"
+    source_dir.mkdir()
+    (source_dir / "manifest.json").write_text('{"version":"1.0"}\n', encoding="utf-8")
+    package_path = tmp_path / f"empty-dev-worker-{version}.tar.gz"
+    with tarfile.open(package_path, "w:gz") as archive:
+        archive.add(source_dir, arcname=".")
+    return package_path
+
+
+def _runtime_config(tmp_path: Path, package_path: Path, version: str) -> MemberRuntimeConfig:
+    path = tmp_path / f"runtime-{version}.yaml"
+    path.write_text(
+        f"""
+kind: MemberRuntimeConfig
+metadata:
+  generation: {version}
+member:
+  name: worker-a
+  runtime: qwenpaw
+desired:
+  agentPackage:
+    ref: file://{package_path}
+    name: dev-worker
+    version: {version}
+    digest: sha256:{version}
+""",
+        encoding="utf-8",
+    )
+    return MemberRuntimeConfig.load(path)
+
+
+def _runtime_config_ref(tmp_path: Path, ref: str, version: str) -> MemberRuntimeConfig:
+    path = tmp_path / f"runtime-ref-{version}.yaml"
+    path.write_text(
+        f"""
+kind: MemberRuntimeConfig
+metadata:
+  generation: {version}
+member:
+  name: worker-a
+  runtime: qwenpaw
+desired:
+  agentPackage:
+    ref: {ref}
+    name: dev-worker
+    version: {version}
+    digest: sha256:{version}
+""",
+        encoding="utf-8",
+    )
+    return MemberRuntimeConfig.load(path)
+
+
+def _runtime_config_without_package(tmp_path: Path) -> MemberRuntimeConfig:
+    path = tmp_path / "runtime-without-package.yaml"
+    path.write_text(
+        """
+kind: MemberRuntimeConfig
+metadata:
+  generation: no-package
+member:
+  name: worker-a
+  runtime: qwenpaw
+desired: {}
+""",
+        encoding="utf-8",
+    )
+    return MemberRuntimeConfig.load(path)
+
+
+def _install_fake_qwenpaw_mcp_config(monkeypatch):
+    saved: dict[str, object] = {}
+    agent_config = types.SimpleNamespace(mcp=None)
+
+    class MCPConfig:
+        def __init__(self) -> None:
+            self.clients = {}
+
+    class MCPClientConfig:
+        def __init__(self, **kwargs) -> None:
+            self.__dict__.update(kwargs)
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.MCPConfig = MCPConfig
+    config_module.MCPClientConfig = MCPClientConfig
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved.update({agent_id: value})
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+    return saved, agent_config
+
+
+def test_agent_package_manager_applies_changed_package_without_restart_signal(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package_v1 = _package(tmp_path, "1")
+    package_v2 = _package(tmp_path, "2")
+
+    applied_v1 = manager.apply(_runtime_config(tmp_path, package_v1, "1"))
+    assert applied_v1 == manager.current_dir
+    assert (manager.current_dir / "config" / "AGENTS.md").read_text(encoding="utf-8") == "agent package 1\n"
+    assert (workspace_dir / "AGENTS.md").read_text(encoding="utf-8") == "agent package 1\n"
+    assert (workspace_dir / "SOUL.md").read_text(encoding="utf-8") == "soul 1\n"
+    assert (workspace_dir / "MEMORY.md").read_text(encoding="utf-8") == "memory 1\n"
+    assert (workspace_dir / "skills" / "code-review" / "SKILL.md").read_text(encoding="utf-8") == "skill 1\n"
+
+    same = manager.apply(_runtime_config(tmp_path, package_v1, "1"))
+    assert same == manager.current_dir
+    assert (workspace_dir / "AGENTS.md").read_text(encoding="utf-8") == "agent package 1\n"
+
+    applied_v2 = manager.apply(_runtime_config(tmp_path, package_v2, "2"))
+    assert applied_v2 == manager.current_dir
+    assert (workspace_dir / "AGENTS.md").read_text(encoding="utf-8") == "agent package 2\n"
+    assert (workspace_dir / "skills" / "code-review" / "SKILL.md").read_text(encoding="utf-8") == "skill 2\n"
+    assert manager.marker_path.read_text(encoding="utf-8").splitlines() == [
+        f"file://{package_v2}",
+        "dev-worker",
+        "2",
+        "sha256:2",
+    ]
+
+
+def test_agent_package_manager_fetches_oss_package_from_storage_prefix(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    storage_prefix = tmp_path / "agentteams" / "agentteams-storage"
+    remote_package = storage_prefix / "agent" / "worker-a" / "packages" / "dev-worker-1.tar.gz"
+    remote_package.parent.mkdir(parents=True)
+    shutil.copy2(_package(tmp_path, "1"), remote_package)
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    mc = fake_bin / "mc"
+    mc.write_text(
+        """#!/bin/sh
+set -eu
+if [ "$1" != "cp" ]; then
+  echo "unexpected mc command: $*" >&2
+  exit 2
+fi
+cp "$2" "$3"
+""",
+        encoding="utf-8",
+    )
+    mc.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}:{os.environ.get('PATH', '')}")
+    monkeypatch.setenv("AGENTTEAMS_STORAGE_PREFIX", str(storage_prefix))
+
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    applied = manager.apply(
+        _runtime_config_ref(
+            tmp_path,
+            "oss://agent/worker-a/packages/dev-worker-1.tar.gz",
+            "1",
+        )
+    )
+
+    assert applied == manager.current_dir
+    assert (workspace_dir / "AGENTS.md").read_text(encoding="utf-8") == "agent package 1\n"
+    assert (workspace_dir / "skills" / "code-review" / "SKILL.md").read_text(encoding="utf-8") == "skill 1\n"
+
+
+def test_agent_package_manager_copies_package_materials_to_default_workspace(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    (workspace_dir / "config").mkdir(parents=True)
+    (workspace_dir / "config" / "mcporter.json").write_text('{"runtime":true}\n', encoding="utf-8")
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package_v1 = _package(tmp_path, "1", materials=True)
+    package_v2 = _package(tmp_path, "2", materials=True)
+
+    manager.apply(_runtime_config(tmp_path, package_v1, "1"))
+
+    assert (manager.current_dir / "config" / "BOOTSTRAP.md").read_text(encoding="utf-8") == "bootstrap 1\n"
+    assert (workspace_dir / "BOOTSTRAP.md").read_text(encoding="utf-8") == "bootstrap 1\n"
+    assert (workspace_dir / "materials" / "custom.md").read_text(encoding="utf-8") == "custom docs 1\n"
+    assert (workspace_dir / "crons" / "daily.md").read_text(encoding="utf-8") == "cron 1\n"
+    assert (workspace_dir / "config" / "settings.yaml").read_text(encoding="utf-8") == "settings: 1\n"
+    assert (workspace_dir / "config" / "credagent.json").read_text(encoding="utf-8") == '{"version":"1"}\n'
+    assert (workspace_dir / "bootstrap" / "seed.md").read_text(encoding="utf-8") == "config bootstrap 1\n"
+    assert (workspace_dir / "config" / "mcporter.json").read_text(encoding="utf-8") == '{"runtime":true}\n'
+    assert not (workspace_dir / "manifest.json").exists()
+    assert not (workspace_dir / "mcp.json").exists()
+
+    manager.apply(_runtime_config(tmp_path, package_v2, "2"))
+
+    assert (workspace_dir / "BOOTSTRAP.md").read_text(encoding="utf-8") == "bootstrap 2\n"
+    assert (workspace_dir / "materials" / "custom.md").read_text(encoding="utf-8") == "custom docs 2\n"
+    assert (workspace_dir / "crons" / "daily.md").read_text(encoding="utf-8") == "cron 2\n"
+    assert (workspace_dir / "config" / "settings.yaml").read_text(encoding="utf-8") == "settings: 2\n"
+    assert (workspace_dir / "config" / "credagent.json").read_text(encoding="utf-8") == '{"version":"2"}\n'
+    assert (workspace_dir / "bootstrap" / "seed.md").read_text(encoding="utf-8") == "config bootstrap 2\n"
+    assert (workspace_dir / "config" / "mcporter.json").read_text(encoding="utf-8") == '{"runtime":true}\n'
+
+
+def test_agent_package_manager_embeds_root_mcp_json_into_qwenpaw_agent_config(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    (workspace_dir / "agent.json").write_text('{"existing":true}\n', encoding="utf-8")
+    saved: dict[str, object] = {}
+    agent_config = types.SimpleNamespace(mcp=None)
+
+    class MCPConfig:
+        def __init__(self) -> None:
+            self.clients = {}
+
+    class MCPClientConfig:
+        def __init__(self, **kwargs) -> None:
+            self.__dict__.update(kwargs)
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.MCPConfig = MCPConfig
+    config_module.MCPClientConfig = MCPClientConfig
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved.update({agent_id: value})
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package_v1 = _package(
+        tmp_path,
+        "1",
+        mcp_servers={
+            "package-docs": {
+                "url": "https://package.example.com/mcp",
+                "transport": "http",
+                "description": "Package docs",
+            }
+        },
+    )
+    package_v2 = _package(tmp_path, "2")
+
+    manager.apply(_runtime_config(tmp_path, package_v1, "1"))
+
+    assert not (workspace_dir / "mcp.json").exists()
+    client = saved["default"].mcp.clients["package-docs"]
+    assert client.name == "package-docs"
+    assert client.url == "https://package.example.com/mcp"
+    assert client.transport == "http"
+    assert client.description == "Package docs"
+
+    manager.apply(_runtime_config(tmp_path, package_v2, "2"))
+
+    assert "package-docs" not in saved["default"].mcp.clients
+    assert (workspace_dir / "agent.json").read_text(encoding="utf-8") == '{"existing":true}\n'
+
+
+def test_agent_package_mcp_json_expands_agent_workspace_placeholders(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    saved: dict[str, object] = {}
+    agent_config = types.SimpleNamespace(mcp=None)
+
+    class MCPConfig:
+        def __init__(self) -> None:
+            self.clients = {}
+
+    class MCPClientConfig:
+        def __init__(self, **kwargs) -> None:
+            self.__dict__.update(kwargs)
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.MCPConfig = MCPConfig
+    config_module.MCPClientConfig = MCPClientConfig
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved.update({agent_id: value})
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package_v1 = _package(
+        tmp_path,
+        "1",
+        mcp_servers={
+            "workspace-tools": {
+                "command": "python",
+                "args": [
+                    "{AGENT_WORKSPACE}/server.py",
+                    "${AGENT_WORKSPACE}/data",
+                ],
+                "cwd": "{AGENT_WORKSPACE}",
+                "env": {
+                    "AGENT_WORKSPACE": "/tmp/wrong-workspace",
+                    "CUSTOM_DIR": "${AGENT_WORKSPACE}/custom",
+                },
+            }
+        },
+    )
+
+    manager.apply(_runtime_config(tmp_path, package_v1, "1"))
+
+    client = saved["default"].mcp.clients["workspace-tools"]
+    assert client.args == [
+        str(workspace_dir / "server.py"),
+        str(workspace_dir / "data"),
+    ]
+    assert client.cwd == str(workspace_dir)
+    assert client.env["AGENT_WORKSPACE"] == str(workspace_dir)
+    assert client.env["CUSTOM_DIR"] == str(workspace_dir / "custom")
+
+
+def test_agent_package_manager_accepts_mcporter_style_mcp_json(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    saved, _agent_config = _install_fake_qwenpaw_mcp_config(monkeypatch)
+
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package_path = _package(
+        tmp_path,
+        "mcporter",
+        mcp_json={
+            "mcpServers": {
+                "remote-docs": {
+                    "description": "Remote docs",
+                    "baseUrl": "https://docs.example.com/mcp",
+                    "transport": "http",
+                    "headers": {"Authorization": "$env:DOCS_TOKEN"},
+                },
+                "local-tools": {
+                    "description": "Local tools",
+                    "command": "npx",
+                    "args": ["-y", "local-tools-mcp"],
+                    "env": {"TOKEN": "$env:LOCAL_TOOLS_TOKEN"},
+                },
+            }
+        },
+    )
+
+    manager.apply(_runtime_config(tmp_path, package_path, "mcporter"))
+
+    clients = saved["default"].mcp.clients
+    remote = clients["remote-docs"]
+    assert remote.name == "remote-docs"
+    assert remote.url == "https://docs.example.com/mcp"
+    assert remote.transport == "http"
+    assert remote.headers == {"Authorization": "$env:DOCS_TOKEN"}
+
+    local = clients["local-tools"]
+    assert local.name == "local-tools"
+    assert local.command == "npx"
+    assert local.args == ["-y", "local-tools-mcp"]
+    assert local.env == {
+        "TOKEN": "$env:LOCAL_TOOLS_TOKEN",
+        "AGENT_WORKSPACE": str(workspace_dir),
+    }
+
+
+def test_agent_package_manager_accepts_line_comments_in_mcp_json(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    saved, _agent_config = _install_fake_qwenpaw_mcp_config(monkeypatch)
+
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package_path = _package(
+        tmp_path,
+        "commented-mcp",
+        mcp_json="""
+{
+  "mcpServers": {
+    // "disabled-docs": {"url": "https://disabled.example.com/mcp"},
+    "remote-docs": {
+      "url": "https://docs.example.com/mcp", // keep URL schemes intact
+      "transport": "http"
+    }
+  }
+}
+""",
+    )
+
+    manager.apply(_runtime_config(tmp_path, package_path, "commented-mcp"))
+
+    clients = saved["default"].mcp.clients
+    assert "disabled-docs" not in clients
+    assert clients["remote-docs"].url == "https://docs.example.com/mcp"
+    assert clients["remote-docs"].transport == "http"
+
+
+def test_agent_package_manager_accepts_commented_mcp_json_shapes(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    cases = {
+        "mcp-list": (
+            """
+{
+  // list shape is accepted for older packages
+  "mcpServers": [
+    {"name": "list-docs", "url": "https://list.example.com/mcp", "transport": "sse"} // trailing comment
+  ]
+}
+""",
+            "list-docs",
+            "https://list.example.com/mcp",
+        ),
+        "clients": (
+            """
+{
+  "clients": {
+    // legacy clients shape
+    "legacy-docs": {"url": "https://legacy.example.com/mcp"}
+  }
+}
+""",
+            "legacy-docs",
+            "https://legacy.example.com/mcp",
+        ),
+        "nested": (
+            """
+{
+  "mcp": {
+    "clients": {
+      "nested-docs": {"url": "https://nested.example.com/mcp"} // nested legacy shape
+    }
+  }
+}
+""",
+            "nested-docs",
+            "https://nested.example.com/mcp",
+        ),
+    }
+
+    for version, (mcp_json, client_name, url) in cases.items():
+        case_dir = tmp_path / version
+        workspace_dir = case_dir / "workspace"
+        workspace_dir.mkdir(parents=True)
+        saved, _agent_config = _install_fake_qwenpaw_mcp_config(monkeypatch)
+        manager = AgentPackageManager(case_dir / "packages", workspace_dir=workspace_dir)
+        package_path = _package(case_dir, version, mcp_json=mcp_json)
+
+        manager.apply(_runtime_config(case_dir, package_path, version))
+
+        client = saved["default"].mcp.clients[client_name]
+        assert client.name == client_name
+        assert client.url == url
+
+
+def test_agent_package_mcp_json_comment_stripper_preserves_string_slashes_and_escapes() -> None:
+    raw = json.loads(
+        _strip_json_line_comments(
+            """
+{
+  "mcpServers": {
+    "docs": {
+      "url": "https://docs.example.com/a//b",
+      "args": ["--literal=//not-comment", "quoted \\\" // still string"]
+    } // trailing comment
+  }
+}
+"""
+        )
+    )
+
+    docs = raw["mcpServers"]["docs"]
+    assert docs["url"] == "https://docs.example.com/a//b"
+    assert docs["args"] == ["--literal=//not-comment", 'quoted " // still string']
+
+
+def test_agent_package_manager_reads_legacy_mcp_json_shapes(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    cases = {
+        "clients": {"clients": {"docs": {"url": "https://clients.example.com/mcp"}}},
+        "nested": {"mcp": {"clients": {"docs": {"url": "https://nested.example.com/mcp"}}}},
+        "top-level": {"docs": {"url": "https://top-level.example.com/mcp"}},
+    }
+
+    for version, mcp_json in cases.items():
+        case_dir = tmp_path / version
+        workspace_dir = case_dir / "workspace"
+        workspace_dir.mkdir(parents=True)
+        saved, _agent_config = _install_fake_qwenpaw_mcp_config(monkeypatch)
+        manager = AgentPackageManager(case_dir / "packages", workspace_dir=workspace_dir)
+        package_path = _package(case_dir, version, mcp_json=mcp_json)
+
+        manager.apply(_runtime_config(case_dir, package_path, version))
+
+        client = saved["default"].mcp.clients["docs"]
+        assert client.name == "docs"
+        assert client.url == mcp_json.get("docs", {"url": f"https://{version}.example.com/mcp"})["url"]
+
+
+def test_agent_package_mcp_json_does_not_overwrite_mcporter_config(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    (workspace_dir / "config").mkdir(parents=True)
+    mcporter_path = workspace_dir / "config" / "mcporter.json"
+    mcporter_path.write_text('{"mcpServers":{"runtime":{"url":"https://runtime.example.com/mcp"}}}\n', encoding="utf-8")
+    saved, _agent_config = _install_fake_qwenpaw_mcp_config(monkeypatch)
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package_path = _package(
+        tmp_path,
+        "package-mcp",
+        mcp_json={
+            "mcpServers": {
+                "package-docs": {
+                    "baseUrl": "https://package.example.com/mcp",
+                    "transport": "http",
+                }
+            }
+        },
+    )
+
+    manager.apply(_runtime_config(tmp_path, package_path, "package-mcp"))
+
+    assert saved["default"].mcp.clients["package-docs"].url == "https://package.example.com/mcp"
+    assert mcporter_path.read_text(encoding="utf-8") == '{"mcpServers":{"runtime":{"url":"https://runtime.example.com/mcp"}}}\n'
+    assert not (workspace_dir / "mcp.json").exists()
+
+
+def test_agent_package_update_removes_materials_missing_from_new_package(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package_v1 = _package(tmp_path, "1", materials=True)
+    package_v2 = _package(tmp_path, "2")
+
+    manager.apply(_runtime_config(tmp_path, package_v1, "1"))
+    assert (workspace_dir / "BOOTSTRAP.md").exists()
+    assert (workspace_dir / "materials" / "custom.md").exists()
+    assert (workspace_dir / "crons" / "daily.md").exists()
+    assert (workspace_dir / "bootstrap" / "seed.md").exists()
+
+    manager.apply(_runtime_config(tmp_path, package_v2, "2"))
+
+    assert (workspace_dir / "AGENTS.md").read_text(encoding="utf-8") == "agent package 2\n"
+    assert not (workspace_dir / "BOOTSTRAP.md").exists()
+    assert not (workspace_dir / "materials").exists()
+    assert not (workspace_dir / "crons").exists()
+    assert not (workspace_dir / "config").exists()
+
+
+def test_agent_package_manager_fetches_nacos_agentspec_package(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    requests: list[tuple[str, dict[str, list[str]]]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            query = parse_qs(parsed.query)
+            requests.append((parsed.path, query))
+            if parsed.path != "/nacos/v3/client/ai/agentspecs":
+                self.send_response(404)
+                self.end_headers()
+                return
+            body = {
+                "code": 0,
+                "message": "success",
+                "data": {
+                    "namespaceId": query["namespaceId"][0],
+                    "name": query["name"][0],
+                    "description": "demo",
+                    "content": '{"version":"1.0"}',
+                    "resource": {
+                        "agents": {
+                            "name": "AGENTS.md",
+                            "type": "config",
+                            "content": "agent package nacos\n",
+                        },
+                        "soul": {
+                            "name": "SOUL.md",
+                            "type": "config",
+                            "content": "soul nacos\n",
+                        },
+                        "skill": {
+                            "name": "code-review/SKILL.md",
+                            "type": "skills",
+                            "content": "skill nacos\n",
+                        },
+                    },
+                },
+            }
+            data = json.dumps(body).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def log_message(self, *_args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+        applied = manager.apply(
+            _runtime_config_ref(
+                tmp_path,
+                f"nacos://{server.server_address[0]}:{server.server_address[1]}/public/dev-worker/1.0.0",
+                "1",
+            )
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    assert applied == manager.current_dir
+    assert requests == [
+        (
+            "/nacos/v3/client/ai/agentspecs",
+            {"namespaceId": ["public"], "name": ["dev-worker"], "version": ["1.0.0"]},
+        )
+    ]
+    assert (manager.current_dir / "manifest.json").read_text(encoding="utf-8").strip() == '{\n  "version": "1.0"\n}'
+    versioned_manifest = (
+        tmp_path
+        / "packages"
+        / "downloads"
+        / "nacos"
+        / "public"
+        / "dev-worker"
+        / "version-1.0.0"
+        / "dev-worker"
+        / "manifest.json"
+    )
+    assert versioned_manifest.is_file()
+    assert (workspace_dir / "AGENTS.md").read_text(encoding="utf-8") == "agent package nacos\n"
+    assert (workspace_dir / "SOUL.md").read_text(encoding="utf-8") == "soul nacos\n"
+    assert (workspace_dir / "skills" / "code-review" / "SKILL.md").read_text(encoding="utf-8") == "skill nacos\n"
+
+
+def test_agent_package_manager_fetches_nacos_agentspec_with_user_password(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    seen_auth = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            if self.path != "/nacos/v3/auth/user/login":
+                self.send_response(404)
+                self.end_headers()
+                return
+            self.rfile.read(int(self.headers.get("Content-Length", "0")))
+            data = json.dumps({"accessToken": "nacos-token", "tokenTtl": 3600}).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def do_GET(self):
+            seen_auth.append(self.headers.get("Authorization"))
+            body = {
+                "code": 0,
+                "message": "success",
+                "data": {
+                    "namespaceId": "public",
+                    "name": "dev-worker",
+                    "content": '{"version":"1.0"}',
+                    "resource": {
+                        "agents": {
+                            "name": "AGENTS.md",
+                            "type": "config",
+                            "content": "agent package nacos auth\n",
+                        },
+                    },
+                },
+            }
+            data = json.dumps(body).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def log_message(self, *_args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+        manager.apply(
+            _runtime_config_ref(
+                tmp_path,
+                f"nacos://user:pass@{server.server_address[0]}:{server.server_address[1]}/public/dev-worker",
+                "1",
+            )
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    assert seen_auth == ["Bearer nacos-token"]
+    assert (workspace_dir / "AGENTS.md").read_text(encoding="utf-8") == "agent package nacos auth\n"
+
+
+def test_agent_package_manager_fetches_nacos_agentspec_with_sts_agentteams_url_query(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    seen_run = []
+
+    def fake_run(command, check, capture_output, text):
+        seen_run.append(
+            {
+                "command": command,
+                "check": check,
+                "capture_output": capture_output,
+                "text": text,
+            }
+        )
+        output_dir = Path(command[command.index("-o") + 1])
+        spec_name = command[command.index("agentspec-get") + 1]
+        package_dir = output_dir / spec_name
+        config_dir = package_dir / "config"
+        config_dir.mkdir(parents=True)
+        (package_dir / "manifest.json").write_text('{"version":"1.2.0"}\n', encoding="utf-8")
+        (config_dir / "AGENTS.md").write_text("agent package nacos sts\n", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("qwenpaw_worker.update.subprocess.run", fake_run)
+
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    monkeypatch.setattr(
+        manager,
+        "_fetch_controller_sts",
+        lambda: {
+            "access_key_id": "sts-ak",
+            "access_key_secret": "sts-sk",
+            "security_token": "sts-token",
+        },
+    )
+    manager.apply(
+        _runtime_config_ref(
+            tmp_path,
+            "nacos://ai-registry-poc.mse.cn-hangzhou.aliyuncs.com:80/"
+            "95d1a6bb-a3aa-4af0-936e-8447c9156f3b/github-manager-rocketmq"
+            "?version=0.0.2&authType=sts-agentteams",
+            "1",
+        )
+    )
+
+    assert seen_run == [
+        {
+            "command": [
+                "nacos-cli",
+                "--host",
+                "ai-registry-poc.mse.cn-hangzhou.aliyuncs.com",
+                "--port",
+                "80",
+                "--namespace",
+                "95d1a6bb-a3aa-4af0-936e-8447c9156f3b",
+                "--auth-type",
+                "sts-agentteams",
+                "--access-key",
+                "sts-ak",
+                "--secret-key",
+                "sts-sk",
+                "--security-token",
+                "sts-token",
+                "agentspec-get",
+                "github-manager-rocketmq",
+                "-o",
+                str(
+                    tmp_path
+                    / "packages"
+                    / "downloads"
+                    / "nacos"
+                    / "95d1a6bb-a3aa-4af0-936e-8447c9156f3b"
+                    / "github-manager-rocketmq"
+                    / "version-0.0.2"
+                ),
+                "--version",
+                "0.0.2",
+            ],
+            "check": True,
+            "capture_output": True,
+            "text": True,
+        }
+    ]
+    assert (workspace_dir / "AGENTS.md").read_text(encoding="utf-8") == "agent package nacos sts\n"
+
+
+def test_agent_package_manager_versions_nacos_download_dirs(tmp_path: Path) -> None:
+    manager = AgentPackageManager(tmp_path / "packages")
+
+    version_1 = manager._nacos_download_output_dir("public", "dev-worker", "1.0.0", "")
+    version_2 = manager._nacos_download_output_dir("public", "dev-worker", "2.0.0", "")
+
+    assert version_1 != version_2
+    assert version_1.parts[-2:] == ("dev-worker", "version-1.0.0")
+    assert version_2.parts[-2:] == ("dev-worker", "version-2.0.0")
+
+
+def test_agent_package_manager_keeps_workspace_when_desired_package_is_empty(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package_v1 = _package(tmp_path, "1")
+
+    manager.apply(_runtime_config(tmp_path, package_v1, "1"))
+    applied = manager.apply(_runtime_config_without_package(tmp_path))
+
+    assert applied is None
+    assert (workspace_dir / "AGENTS.md").read_text(encoding="utf-8") == "agent package 1\n"
+    assert (workspace_dir / "skills" / "code-review" / "SKILL.md").read_text(encoding="utf-8") == "skill 1\n"
+    assert manager.marker_path.read_text(encoding="utf-8").splitlines() == [
+        f"file://{package_v1}",
+        "dev-worker",
+        "1",
+        "sha256:1",
+    ]
+
+
+def test_agent_package_update_overwrites_runtime_edits_to_package_seed(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package_v1 = _package(tmp_path, "1")
+    package_v2 = _package(tmp_path, "2")
+
+    manager.apply(_runtime_config(tmp_path, package_v1, "1"))
+    (workspace_dir / "AGENTS.md").write_text("agent runtime edit\n", encoding="utf-8")
+    (workspace_dir / "skills" / "code-review" / "SKILL.md").write_text("agent skill edit\n", encoding="utf-8")
+
+    manager.apply(_runtime_config(tmp_path, package_v2, "2"))
+
+    assert (workspace_dir / "AGENTS.md").read_text(encoding="utf-8") == "agent package 2\n"
+    assert (workspace_dir / "skills" / "code-review" / "SKILL.md").read_text(encoding="utf-8") == "skill 2\n"
+
+
+def test_agent_package_update_clears_prompt_files_missing_from_new_package(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package_v1 = _package(tmp_path, "1")
+    package_v2 = _empty_package(tmp_path, "2")
+
+    manager.apply(_runtime_config(tmp_path, package_v1, "1"))
+    manager.apply(_runtime_config(tmp_path, package_v2, "2"))
+
+    assert (workspace_dir / "AGENTS.md").read_text(encoding="utf-8") == ""
+    assert (workspace_dir / "SOUL.md").read_text(encoding="utf-8") == ""
+    assert not (workspace_dir / "MEMORY.md").exists()
+    assert not (workspace_dir / "skills" / "code-review").exists()
+    assert not (workspace_dir / "skill.json").exists()
+
+
+def test_agent_package_manager_creates_empty_prompt_files_when_package_has_none(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package = _empty_package(tmp_path, "empty")
+
+    manager.apply(_runtime_config(tmp_path, package, "empty"))
+
+    assert (workspace_dir / "AGENTS.md").read_text(encoding="utf-8") == ""
+    assert (workspace_dir / "SOUL.md").read_text(encoding="utf-8") == ""
+
+
+def test_agent_package_manager_reconciles_qwenpaw_workspace_skill_manifest(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    calls: list[Path] = []
+    registry_module = types.ModuleType("qwenpaw.agents.skill_system.registry")
+    registry_module.reconcile_workspace_manifest = lambda path: calls.append(path)
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.agents", types.ModuleType("qwenpaw.agents"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.agents.skill_system", types.ModuleType("qwenpaw.agents.skill_system"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.agents.skill_system.registry", registry_module)
+
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package_v1 = _package(tmp_path, "1")
+
+    manager.apply(_runtime_config(tmp_path, package_v1, "1"))
+
+    assert calls == [workspace_dir]
+
+
+def test_agent_package_manager_enables_package_skills_in_workspace_manifest(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+
+    def reconcile_workspace_manifest(path):
+        manifest = path / "skill.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "schema_version": "workspace-skill-manifest.v1",
+                    "skills": {"code-review": {"enabled": False}},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    registry_module = types.ModuleType("qwenpaw.agents.skill_system.registry")
+    registry_module.reconcile_workspace_manifest = reconcile_workspace_manifest
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.agents", types.ModuleType("qwenpaw.agents"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.agents.skill_system", types.ModuleType("qwenpaw.agents.skill_system"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.agents.skill_system.registry", registry_module)
+
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package_v1 = _package(tmp_path, "1")
+
+    manager.apply(_runtime_config(tmp_path, package_v1, "1"))
+
+    manifest = json.loads((workspace_dir / "skill.json").read_text(encoding="utf-8"))
+    assert manifest["skills"]["code-review"]["enabled"] is True
+
+
+def test_agent_package_manager_rolls_back_workspace_and_current_when_workspace_apply_fails(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    registry_module = types.ModuleType("qwenpaw.agents.skill_system.registry")
+    calls = 0
+
+    def reconcile_or_fail(_path):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("skill manifest failed")
+
+    registry_module.reconcile_workspace_manifest = reconcile_or_fail
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.agents", types.ModuleType("qwenpaw.agents"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.agents.skill_system", types.ModuleType("qwenpaw.agents.skill_system"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.agents.skill_system.registry", registry_module)
+
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package_v1 = _package(tmp_path, "1")
+    package_v2 = _package(tmp_path, "2")
+
+    manager.apply(_runtime_config(tmp_path, package_v1, "1"))
+
+    try:
+        manager.apply(_runtime_config(tmp_path, package_v2, "2"))
+    except RuntimeError as exc:
+        assert str(exc) == "skill manifest failed"
+    else:
+        raise AssertionError("expected workspace apply failure")
+
+    assert (manager.current_dir / "config" / "AGENTS.md").read_text(encoding="utf-8") == "agent package 1\n"
+    assert (workspace_dir / "AGENTS.md").read_text(encoding="utf-8") == "agent package 1\n"
+    assert (workspace_dir / "SOUL.md").read_text(encoding="utf-8") == "soul 1\n"
+    assert (workspace_dir / "MEMORY.md").read_text(encoding="utf-8") == "memory 1\n"
+    assert (workspace_dir / "skills" / "code-review" / "SKILL.md").read_text(encoding="utf-8") == "skill 1\n"
+    assert manager.marker_path.read_text(encoding="utf-8").splitlines() == [
+        f"file://{package_v1}",
+        "dev-worker",
+        "1",
+        "sha256:1",
+    ]
+
+
+def test_agent_package_manager_keeps_previous_version_when_new_package_is_invalid(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package_v1 = _package(tmp_path, "1")
+    broken_package = tmp_path / "broken-package.txt"
+    broken_package.write_text("not an agent package archive\n", encoding="utf-8")
+
+    manager.apply(_runtime_config(tmp_path, package_v1, "1"))
+
+    try:
+        manager.apply(_runtime_config(tmp_path, broken_package, "2"))
+    except RuntimeError as exc:
+        assert "unsupported agent package format" in str(exc)
+    else:
+        raise AssertionError("expected invalid package failure")
+
+    assert (manager.current_dir / "config" / "AGENTS.md").read_text(encoding="utf-8") == "agent package 1\n"
+    assert (workspace_dir / "AGENTS.md").read_text(encoding="utf-8") == "agent package 1\n"
+    assert manager.marker_path.read_text(encoding="utf-8").splitlines() == [
+        f"file://{package_v1}",
+        "dev-worker",
+        "1",
+        "sha256:1",
+    ]
+
+
+def test_agent_package_manager_keeps_previous_version_when_mcp_json_is_invalid(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package_v1 = _package(tmp_path, "1")
+    package_v2 = _package(
+        tmp_path,
+        "2",
+        mcp_json='{"mcpServers":{"docs":{"url":"https://docs.example.com/mcp",}}}\n',
+    )
+
+    manager.apply(_runtime_config(tmp_path, package_v1, "1"))
+
+    try:
+        manager.apply(_runtime_config(tmp_path, package_v2, "2"))
+    except RuntimeError as exc:
+        assert "agent package mcp.json is invalid JSON" in str(exc)
+    else:
+        raise AssertionError("expected invalid mcp.json failure")
+
+    assert (manager.current_dir / "config" / "AGENTS.md").read_text(encoding="utf-8") == "agent package 1\n"
+    assert (workspace_dir / "AGENTS.md").read_text(encoding="utf-8") == "agent package 1\n"
+    assert manager.marker_path.read_text(encoding="utf-8").splitlines() == [
+        f"file://{package_v1}",
+        "dev-worker",
+        "1",
+        "sha256:1",
+    ]
+
+
+def test_agent_package_manager_rejects_archive_path_traversal(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    zip_path = tmp_path / "evil.zip"
+    with zipfile.ZipFile(zip_path, "w") as archive:
+        archive.writestr("../staging-evil/evil.txt", "escape\n")
+
+    try:
+        manager.apply(_runtime_config(tmp_path, zip_path, "1"))
+    except RuntimeError as exc:
+        assert "unsafe agent package path" in str(exc)
+    else:
+        raise AssertionError("expected unsafe archive path failure")
+
+    assert not (tmp_path / "packages" / "staging-evil").exists()

--- a/qwenpaw/tests/test_runtime_config.py
+++ b/qwenpaw/tests/test_runtime_config.py
@@ -1,0 +1,626 @@
+from pathlib import Path
+
+import pytest
+
+from qwenpaw_worker.update import REGION_ID_ENV_NAMES, MemberRuntimeConfig
+
+
+@pytest.fixture(autouse=True)
+def clear_region_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in REGION_ID_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_load_runtime_config_reads_team_member_package_and_sanitizer(tmp_path: Path) -> None:
+    path = tmp_path / "runtime.yaml"
+    path.write_text(
+        """
+apiVersion: agentteams.io/v1beta1
+kind: MemberRuntimeConfig
+metadata:
+  generation: 7
+team:
+  name: demo-team
+  teamRoomId: "!team:matrix.local"
+  leaderName: leader
+  leaderRuntimeName: leader-runtime
+  admin:
+    name: admin
+    matrixUserId: "@admin:matrix.local"
+  members:
+    - name: leader
+      runtimeName: leader-runtime
+      role: team_leader
+      matrixUserId: "@leader-runtime:matrix.local"
+      personalRoomId: "!leader-dm:matrix.local"
+    - name: worker-a
+      runtimeName: worker-a
+      role: worker
+      matrixUserId: "@worker-a:matrix.local"
+      personalRoomId: "!worker-dm:matrix.local"
+    - name: human-coord
+      role: coordinator
+      matrixUserId: "@human:matrix.local"
+member:
+  name: worker-a
+  runtimeName: worker-a
+  role: worker
+  runtime: qwenpaw
+  matrixUserId: "@worker-a:matrix.local"
+desired:
+  model:
+    provider: hiclaw-gateway
+    model: qwen-max
+  mcpServers:
+    taskflow:
+      command: python3
+      args: ["server.py"]
+  channelPolicy:
+    allowedChannels:
+      - matrix
+  agentPackage:
+    ref: file:///tmp/dev-worker.tar.gz
+    name: dev-worker
+    version: 1.2.0
+    digest: sha256:abc
+  outputSanitize:
+    keywords:
+      - internal-token
+    envRefs:
+      - AGENTTEAMS_WORKER_MATRIX_TOKEN
+storage:
+  memberPrefix: agents/worker-a
+credentials:
+  matrixTokenEnv: AGENTTEAMS_WORKER_MATRIX_TOKEN
+  gatewayKeyEnv: AGENTTEAMS_WORKER_GATEWAY_KEY
+""",
+        encoding="utf-8",
+    )
+
+    config = MemberRuntimeConfig.load(path)
+
+    assert config.generation == "7"
+    assert config.team_name == "demo-team"
+    assert config.member_name == "worker-a"
+    assert config.member_role == "worker"
+    assert config.agent_package_identity == (
+        "file:///tmp/dev-worker.tar.gz",
+        "dev-worker",
+        "1.2.0",
+        "sha256:abc",
+    )
+    assert config.model["model"] == "qwen-max"
+    assert config.mcp_servers["taskflow"]["command"] == "python3"
+    assert config.channel_policy["allowedChannels"] == ["matrix"]
+    assert config.team_members == [
+        {
+            "name": "leader",
+            "runtimeName": "leader-runtime",
+            "role": "team_leader",
+            "matrixUserId": "@leader-runtime:matrix.local",
+            "personalRoomId": "!leader-dm:matrix.local",
+        },
+        {
+            "name": "worker-a",
+            "runtimeName": "worker-a",
+            "role": "worker",
+            "matrixUserId": "@worker-a:matrix.local",
+            "personalRoomId": "!worker-dm:matrix.local",
+        },
+        {
+            "name": "human-coord",
+            "role": "coordinator",
+            "matrixUserId": "@human:matrix.local",
+        },
+    ]
+    assert config.output_sanitize_keywords == ["internal-token"]
+    assert config.output_sanitize_env_refs == [
+        "AGENTTEAMS_WORKER_MATRIX_TOKEN",
+        "AGENTTEAMS_WORKER_GATEWAY_KEY",
+    ]
+
+
+def test_load_runtime_config_reads_desired_dingtalk_channel(tmp_path: Path) -> None:
+    path = tmp_path / "runtime.yaml"
+    path.write_text(
+        """
+kind: MemberRuntimeConfig
+member:
+  runtime: qwenpaw
+desired:
+  channels:
+    dingtalk:
+      enabled: true
+      client_id: demo-client-id
+      client_secret: test-client-secret
+      robot_code: demo-robot-code
+      filter_thinking: false
+      filter_tool_messages: true
+      streaming_enabled: true
+      message_type: card
+      card_template_id: card-template-1
+      card_template_key: content
+      card_auto_layout: false
+""",
+        encoding="utf-8",
+    )
+
+    config = MemberRuntimeConfig.load(path)
+
+    assert config.channels["dingtalk"] == {
+        "enabled": True,
+        "client_id": "demo-client-id",
+        "client_secret": "test-client-secret",
+        "robot_code": "demo-robot-code",
+        "filter_thinking": False,
+        "filter_tool_messages": True,
+        "streaming_enabled": True,
+        "message_type": "card",
+        "card_template_id": "card-template-1",
+        "card_template_key": "content",
+        "card_auto_layout": False,
+    }
+    assert config.dingtalk_channel == config.channels["dingtalk"]
+
+
+def test_runtime_config_rejects_non_qwenpaw_runtime(tmp_path: Path) -> None:
+    path = tmp_path / "runtime.yaml"
+    path.write_text(
+        """
+kind: MemberRuntimeConfig
+member:
+  name: worker-a
+  runtime: copaw
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="runtime must be qwenpaw"):
+        MemberRuntimeConfig.load(path)
+
+
+def test_runtime_config_reads_agent_identity_and_credential_bindings(tmp_path: Path) -> None:
+    path = tmp_path / "runtime.yaml"
+    path.write_text(
+        """
+kind: MemberRuntimeConfig
+member:
+  name: worker-a
+  runtime: qwenpaw
+desired:
+  agentIdentity:
+    workloadIdentityName: wi-worker-a
+  credentialBindings:
+    - credentialRef:
+        tokenVaultName: default
+        apiKeyCredentialProviderName: GITHUB_TOKEN
+      toolWhitelist:
+        - gh
+        - ""
+    - credentialRef:
+        tokenVaultName: default
+        apiKeyCredentialProviderName: ALIBABA_CLOUD_ACCESS_KEY_ID
+agentIdentityData:
+  endpoint: agentidentitydata.cn-beijing.aliyuncs.com
+""",
+        encoding="utf-8",
+    )
+
+    config = MemberRuntimeConfig.load(path)
+
+    assert config.agent_identity == {"workloadIdentityName": "wi-worker-a"}
+    assert config.workload_identity_name == "wi-worker-a"
+    assert config.credential_bindings == [
+        {
+            "credentialRef": {
+                "tokenVaultName": "default",
+                "apiKeyCredentialProviderName": "GITHUB_TOKEN",
+            },
+            "toolWhitelist": ["gh"],
+        },
+        {
+            "credentialRef": {
+                "tokenVaultName": "default",
+                "apiKeyCredentialProviderName": "ALIBABA_CLOUD_ACCESS_KEY_ID",
+            }
+        },
+    ]
+    assert config.credential_binding_env_names == [
+        "GITHUB_TOKEN",
+        "ALIBABA_CLOUD_ACCESS_KEY_ID",
+    ]
+    assert config.credential_binding_env_provider_names == {
+        "GITHUB_TOKEN": "GITHUB_TOKEN",
+        "ALIBABA_CLOUD_ACCESS_KEY_ID": "ALIBABA_CLOUD_ACCESS_KEY_ID",
+    }
+    assert config.agent_identity_data == {
+        "endpoint": "agentidentitydata.cn-beijing.aliyuncs.com"
+    }
+    assert config.agent_identity_data["endpoint"] == "agentidentitydata.cn-beijing.aliyuncs.com"
+    assert config.agent_identity_data_endpoint == "agentidentitydata.cn-beijing.aliyuncs.com"
+
+
+def test_runtime_config_prefers_agentidentitydata_endpoint_over_region_id_and_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENTTEAMS_REGION", "cn-shanghai")
+    config = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={
+            "agentIdentityData": {
+                "regionId": "cn-hangzhou",
+                "endpoint": "agentidentitydata-vpc-pre.cn-hangzhou.aliyuncs.com",
+            }
+        },
+    )
+
+    assert config.agent_identity_data_region_id == "cn-hangzhou"
+    assert config.agent_identity_data_endpoint == "agentidentitydata-vpc-pre.cn-hangzhou.aliyuncs.com"
+
+
+def test_runtime_config_derives_agentidentitydata_endpoint_from_region_id(tmp_path: Path) -> None:
+    config = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={"agentIdentityData": {"regionId": "cn-hangzhou"}},
+    )
+
+    assert config.agent_identity_data_region_id == "cn-hangzhou"
+    assert config.agent_identity_data_endpoint == "agentidentitydata.cn-hangzhou.aliyuncs.com"
+
+
+def test_runtime_config_derives_agentidentitydata_endpoint_from_region_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENTTEAMS_REGION", "cn-hangzhou")
+    config = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={},
+    )
+
+    assert config.agent_identity_data_region_id == "cn-hangzhou"
+    assert config.agent_identity_data_endpoint == "agentidentitydata.cn-hangzhou.aliyuncs.com"
+
+
+def test_runtime_config_derives_env_names_from_prefixed_credential_providers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "AGENTTEAMS_CONTROLLER_URL",
+        "http://controller.at-cn-4b84u92kf0f.vpc.agentteams.aliyuncs.com",
+    )
+    path = tmp_path / "runtime.yaml"
+    path.write_text(
+        """
+kind: MemberRuntimeConfig
+member:
+  name: worker-a
+  runtime: qwenpaw
+desired:
+  credentialBindings:
+    - credentialRef:
+        tokenVaultName: default
+        apiKeyCredentialProviderName: at-cn-4b84u92kf0f-ALIBABA_CLOUD_ACCESS_KEY_ID
+      toolWhitelist:
+        - aliyun
+    - credentialRef:
+        tokenVaultName: default
+        apiKeyCredentialProviderName: at-cn-4b84u92kf0f-ALIBABA_CLOUD_ACCESS_KEY_SECRET
+      toolWhitelist:
+        - aliyun
+""",
+        encoding="utf-8",
+    )
+
+    config = MemberRuntimeConfig.load(path)
+
+    assert config.credential_binding_env_names == [
+        "ALIBABA_CLOUD_ACCESS_KEY_ID",
+        "ALIBABA_CLOUD_ACCESS_KEY_SECRET",
+    ]
+    assert config.credential_binding_env_provider_names == {
+        "ALIBABA_CLOUD_ACCESS_KEY_ID": "at-cn-4b84u92kf0f-ALIBABA_CLOUD_ACCESS_KEY_ID",
+        "ALIBABA_CLOUD_ACCESS_KEY_SECRET": "at-cn-4b84u92kf0f-ALIBABA_CLOUD_ACCESS_KEY_SECRET",
+    }
+
+
+def test_runtime_config_does_not_strip_other_instance_provider_prefix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "AGENTTEAMS_CONTROLLER_URL",
+        "http://controller.at-cn-4b84u92kf0f.vpc.agentteams.aliyuncs.com",
+    )
+    config = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={
+            "desired": {
+                "credentialBindings": [
+                    {
+                        "credentialRef": {
+                            "tokenVaultName": "default",
+                            "apiKeyCredentialProviderName": "other-instance-ALIBABA_CLOUD_ACCESS_KEY_ID",
+                        },
+                    },
+                ],
+            },
+        },
+    )
+
+    assert config.credential_binding_env_names == []
+    assert config.credential_binding_env_provider_names == {}
+
+
+def test_runtime_config_keeps_credential_bindings_reference_only(tmp_path: Path) -> None:
+    config = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={
+            "desired": {
+                "agentIdentity": {
+                    "workloadIdentityName": "wi-worker-a",
+                    "token": "should-not-survive",
+                },
+                "credentialBindings": [
+                    {
+                        "credentialRef": {
+                            "tokenVaultName": "default",
+                            "apiKeyCredentialProviderName": "GITHUB_TOKEN",
+                            "apiKey": "real-secret",
+                        },
+                        "value": "another-secret",
+                        "toolWhitelist": ["gh", "", " "],
+                    },
+                ],
+            },
+        },
+    )
+
+    assert config.agent_identity == {"workloadIdentityName": "wi-worker-a"}
+    assert config.credential_bindings == [
+        {
+            "credentialRef": {
+                "tokenVaultName": "default",
+                "apiKeyCredentialProviderName": "GITHUB_TOKEN",
+            },
+            "toolWhitelist": ["gh"],
+        }
+    ]
+    assert "real-secret" not in repr(config.credential_bindings)
+    assert "another-secret" not in repr(config.credential_bindings)
+
+
+def test_runtime_config_change_detection_includes_model_mcp_and_channel_policy(tmp_path: Path) -> None:
+    first = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={
+            "metadata": {"generation": "1"},
+            "desired": {
+                "model": {"provider": "hiclaw-gateway", "model": "qwen-max"},
+                "mcpServers": {"taskflow": {"command": "python3"}},
+                "channelPolicy": {"allowedChannels": ["matrix"]},
+            },
+        },
+    )
+    second = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={
+            "metadata": {"generation": "1"},
+            "desired": {
+                "model": {"provider": "hiclaw-gateway", "model": "qwen-plus"},
+                "mcpServers": {"taskflow": {"command": "python3"}},
+                "channelPolicy": {"allowedChannels": ["matrix"]},
+            },
+        },
+    )
+    third = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={
+            "metadata": {"generation": "1"},
+            "desired": {
+                "model": {"provider": "hiclaw-gateway", "model": "qwen-max"},
+                "mcpServers": {"taskflow": {"command": "python3"}},
+                "channelPolicy": {"allowedChannels": ["matrix"]},
+            },
+        },
+    )
+
+    assert second.changed_from(first)
+    assert not third.changed_from(first)
+
+
+def test_runtime_config_change_detection_includes_desired_channels(tmp_path: Path) -> None:
+    first = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={
+            "metadata": {"generation": "1"},
+            "desired": {"channels": {"dingtalk": {"enabled": False}}},
+        },
+    )
+    second = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={
+            "metadata": {"generation": "1"},
+            "desired": {"channels": {"dingtalk": {"enabled": True, "client_id": "demo-client-id"}}},
+        },
+    )
+
+    assert second.changed_from(first)
+
+
+def test_runtime_config_change_detection_includes_team_members(tmp_path: Path) -> None:
+    first = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={
+            "metadata": {"generation": "1"},
+            "team": {
+                "members": [
+                    {
+                        "name": "dev",
+                        "runtimeName": "dev-runtime",
+                        "role": "worker",
+                        "matrixUserId": "@dev-runtime:matrix.local",
+                    }
+                ]
+            },
+        },
+    )
+    second = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={
+            "metadata": {"generation": "1"},
+            "team": {
+                "members": [
+                    {
+                        "name": "dev",
+                        "runtimeName": "dev-runtime",
+                        "role": "worker",
+                        "matrixUserId": "@dev-new:matrix.local",
+                    }
+                ]
+            },
+        },
+    )
+
+    assert second.changed_from(first)
+
+
+def test_runtime_config_change_detection_includes_agent_identity_and_credential_bindings(
+    tmp_path: Path,
+) -> None:
+    first = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={
+            "metadata": {"generation": "1"},
+            "desired": {
+                "agentIdentity": {"workloadIdentityName": "wi-worker-a"},
+                "credentialBindings": [
+                    {
+                        "credentialRef": {
+                            "tokenVaultName": "default",
+                            "apiKeyCredentialProviderName": "GITHUB_TOKEN",
+                        }
+                    }
+                ],
+            },
+            "agentIdentityData": {"endpoint": "agentidentitydata.cn-beijing.aliyuncs.com"},
+        },
+    )
+    changed_workload = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={
+            "metadata": {"generation": "1"},
+            "desired": {
+                "agentIdentity": {"workloadIdentityName": "wi-worker-b"},
+                "credentialBindings": [
+                    {
+                        "credentialRef": {
+                            "tokenVaultName": "default",
+                            "apiKeyCredentialProviderName": "GITHUB_TOKEN",
+                        }
+                    }
+                ],
+            },
+            "agentIdentityData": {"endpoint": "agentidentitydata.cn-beijing.aliyuncs.com"},
+        },
+    )
+    changed_binding = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={
+            "metadata": {"generation": "1"},
+            "desired": {
+                "agentIdentity": {"workloadIdentityName": "wi-worker-a"},
+                "credentialBindings": [
+                    {
+                        "credentialRef": {
+                            "tokenVaultName": "default",
+                            "apiKeyCredentialProviderName": "ALIBABA_CLOUD_ACCESS_KEY_ID",
+                        }
+                    }
+                ],
+            },
+            "agentIdentityData": {"endpoint": "agentidentitydata.cn-beijing.aliyuncs.com"},
+        },
+    )
+    changed_tool_whitelist = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={
+            "metadata": {"generation": "1"},
+            "desired": {
+                "agentIdentity": {"workloadIdentityName": "wi-worker-a"},
+                "credentialBindings": [
+                    {
+                        "credentialRef": {
+                            "tokenVaultName": "default",
+                            "apiKeyCredentialProviderName": "GITHUB_TOKEN",
+                        },
+                        "toolWhitelist": ["gh"],
+                    }
+                ],
+            },
+            "agentIdentityData": {"endpoint": "agentidentitydata.cn-beijing.aliyuncs.com"},
+        },
+    )
+    changed_endpoint = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={
+            "metadata": {"generation": "1"},
+            "desired": {
+                "agentIdentity": {"workloadIdentityName": "wi-worker-a"},
+                "credentialBindings": [
+                    {
+                        "credentialRef": {
+                            "tokenVaultName": "default",
+                            "apiKeyCredentialProviderName": "GITHUB_TOKEN",
+                        }
+                    }
+                ],
+            },
+            "agentIdentityData": {"endpoint": "agentidentitydata.cn-shanghai.aliyuncs.com"},
+        },
+    )
+    changed_region = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={
+            "metadata": {"generation": "1"},
+            "desired": {
+                "agentIdentity": {"workloadIdentityName": "wi-worker-a"},
+                "credentialBindings": [
+                    {
+                        "credentialRef": {
+                            "tokenVaultName": "default",
+                            "apiKeyCredentialProviderName": "GITHUB_TOKEN",
+                        }
+                    }
+                ],
+            },
+            "agentIdentityData": {"regionId": "cn-hangzhou"},
+        },
+    )
+    unchanged = MemberRuntimeConfig(
+        path=tmp_path / "runtime.yaml",
+        raw={
+            "metadata": {"generation": "1"},
+            "desired": {
+                "agentIdentity": {"workloadIdentityName": "wi-worker-a"},
+                "credentialBindings": [
+                    {
+                        "credentialRef": {
+                            "tokenVaultName": "default",
+                            "apiKeyCredentialProviderName": "GITHUB_TOKEN",
+                        }
+                    }
+                ],
+            },
+            "agentIdentityData": {"endpoint": "agentidentitydata.cn-beijing.aliyuncs.com"},
+        },
+    )
+
+    assert changed_workload.changed_from(first)
+    assert changed_binding.changed_from(first)
+    assert changed_tool_whitelist.changed_from(first)
+    assert changed_endpoint.changed_from(first)
+    assert changed_region.changed_from(first)
+    assert not unchanged.changed_from(first)

--- a/qwenpaw/tests/test_sync.py
+++ b/qwenpaw/tests/test_sync.py
@@ -1,0 +1,292 @@
+import os
+import subprocess
+from pathlib import Path
+
+from qwenpaw_worker.sync import FileSync, push_local
+
+
+def _sync(tmp_path: Path) -> FileSync:
+    return FileSync(
+        endpoint="http://minio:9000",
+        access_key="minio",
+        secret_key="password",
+        bucket="agentteams-storage",
+        worker_name="worker-a",
+        local_dir=tmp_path / "agents" / "worker-a",
+        shared_dir=tmp_path / "shared",
+        remote_prefix="agents/worker-a",
+        shared_prefix="shared",
+    )
+
+
+def test_mirror_all_restores_worker_and_shared_storage(tmp_path: Path, monkeypatch) -> None:
+    sync = _sync(tmp_path)
+    commands = []
+
+    monkeypatch.setattr(sync, "ensure_alias", lambda: None)
+
+    def fake_mc(*args, **_kwargs):
+        commands.append(args)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(sync, "_mc", fake_mc)
+
+    sync.mirror_all()
+
+    assert commands == [
+        (
+            "mirror",
+            "agentteams/agentteams-storage/agents/worker-a/",
+            f"{sync.local_dir}/",
+            "--overwrite",
+            "--exclude",
+            "credentials/**",
+        ),
+        (
+            "mirror",
+            "agentteams/agentteams-storage/shared/",
+            f"{sync.shared_dir}/",
+            "--overwrite",
+            "--exclude",
+            "credentials/**",
+        ),
+    ]
+
+
+def test_pull_runtime_config_downloads_controller_projection(tmp_path: Path, monkeypatch) -> None:
+    sync = _sync(tmp_path)
+    commands = []
+    target = sync.local_dir / "runtime" / "runtime.yaml"
+
+    monkeypatch.setattr(sync, "ensure_alias", lambda: None)
+
+    def fake_mc(*args, **kwargs):
+        commands.append((args, kwargs))
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("member:\n  runtime: qwenpaw\n", encoding="utf-8")
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(sync, "_mc", fake_mc)
+
+    assert sync.pull_runtime_config(target) is True
+
+    assert target.read_text(encoding="utf-8").startswith("member:")
+    assert commands == [
+        (
+            (
+                "cp",
+                "agentteams/agentteams-storage/agents/worker-a/runtime/runtime.yaml",
+                str(target),
+            ),
+            {"check": False},
+        )
+    ]
+
+
+def test_ensure_alias_skips_static_alias_in_k8s_mode(tmp_path: Path, monkeypatch) -> None:
+    sync = FileSync(
+        endpoint="https://oss.example.test",
+        access_key="access-key",
+        secret_key="secret-key",
+        bucket="agentteams-storage",
+        worker_name="worker-a",
+        local_dir=tmp_path / "agents" / "worker-a",
+        shared_dir=tmp_path / "shared",
+    )
+    commands = []
+    monkeypatch.setenv("AGENTTEAMS_RUNTIME", "k8s")
+
+    def fake_mc(*args, **_kwargs):
+        commands.append(args)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(sync, "_mc", fake_mc)
+
+    sync.ensure_alias()
+
+    assert sync._alias_set is True
+    assert commands == []
+
+
+def test_storage_alias_derives_from_agentteams_storage_prefix(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENTTEAMS_STORAGE_PREFIX", "agentteams/agentteams-storage")
+
+    sync = _sync(tmp_path)
+
+    assert sync.mc_alias == "agentteams"
+    assert sync._object_path("agents/worker-a/file.txt") == "agentteams/agentteams-storage/agents/worker-a/file.txt"
+
+
+def test_push_local_uploads_worker_files_but_skips_controller_owned_state(tmp_path: Path, monkeypatch) -> None:
+    sync = _sync(tmp_path)
+    uploads = []
+
+    files = {
+        "SOUL.md": "worker soul",
+        ".qwenpaw/workspaces/default/AGENTS.md": "runtime prompt",
+        ".qwenpaw/workspaces/default/TEAMS.md": "team prompt",
+        ".qwenpaw/workspaces/default/config/mcporter.json": '{"mcpServers":{}}',
+        ".qwenpaw/plugins/teamharness/plugin.py": "installed plugin",
+        ".qwenpaw/skill_pool/teamharness-communication/SKILL.md": "skill",
+        ".qwenpaw/workspaces/default/skills/custom/SKILL.md": "workspace skill",
+        ".qwenpaw/agent-packages/current/AGENTS.md": "agent package",
+        ".qwenpaw/qwenpaw.log": "log",
+        ".qwenpaw/logs/qwenpaw-worker.log": "worker log",
+        ".qwenpaw/workspaces/default/tool_result/result.json": "{}",
+        ".qwenpaw/workspaces/default/file_store/a.bin": "file",
+        "runtime/runtime.yaml": "controller owned runtime config",
+        "credentials/token": "secret",
+        "shared/tasks/t-1/result.md": "team shared",
+        "global-shared/reference.md": "global shared",
+    }
+    for rel, content in files.items():
+        path = sync.local_dir / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    monkeypatch.setattr(sync, "ensure_alias", lambda: None)
+    monkeypatch.setattr(sync, "_cat_bytes", lambda _key: None)
+
+    def fake_mc(*args, **_kwargs):
+        if args[0] == "cp":
+            uploads.append(args[2])
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(sync, "_mc", fake_mc)
+
+    pushed = push_local(sync, since=0)
+
+    assert set(pushed) == {
+        "SOUL.md",
+        ".qwenpaw/workspaces/default/AGENTS.md",
+        ".qwenpaw/workspaces/default/TEAMS.md",
+        ".qwenpaw/workspaces/default/config/mcporter.json",
+        ".qwenpaw/plugins/teamharness/plugin.py",
+        ".qwenpaw/skill_pool/teamharness-communication/SKILL.md",
+        ".qwenpaw/workspaces/default/skills/custom/SKILL.md",
+        ".qwenpaw/agent-packages/current/AGENTS.md",
+    }
+    assert "runtime/runtime.yaml" not in pushed
+    assert not any("credentials" in item for item in pushed)
+    assert not any("logs/" in item for item in pushed)
+    assert not any("shared/" in item for item in pushed)
+    assert set(uploads) == {
+        "agentteams/agentteams-storage/agents/worker-a/SOUL.md",
+        "agentteams/agentteams-storage/agents/worker-a/.qwenpaw/workspaces/default/AGENTS.md",
+        "agentteams/agentteams-storage/agents/worker-a/.qwenpaw/workspaces/default/TEAMS.md",
+        "agentteams/agentteams-storage/agents/worker-a/.qwenpaw/workspaces/default/config/mcporter.json",
+        "agentteams/agentteams-storage/agents/worker-a/.qwenpaw/plugins/teamharness/plugin.py",
+        "agentteams/agentteams-storage/agents/worker-a/.qwenpaw/skill_pool/teamharness-communication/SKILL.md",
+        "agentteams/agentteams-storage/agents/worker-a/.qwenpaw/workspaces/default/skills/custom/SKILL.md",
+        "agentteams/agentteams-storage/agents/worker-a/.qwenpaw/agent-packages/current/AGENTS.md",
+    }
+
+
+def test_push_local_does_not_remove_remote_files_missing_from_local_state(tmp_path: Path, monkeypatch) -> None:
+    sync = _sync(tmp_path)
+    commands = []
+
+    current = sync.local_dir / ".qwenpaw" / "workspaces" / "default" / "AGENTS.md"
+    current.parent.mkdir(parents=True, exist_ok=True)
+    current.write_text("runtime prompt", encoding="utf-8")
+
+    monkeypatch.setattr(sync, "ensure_alias", lambda: None)
+    monkeypatch.setattr(sync, "_cat_bytes", lambda key: b"runtime prompt" if key.endswith("/AGENTS.md") else None)
+
+    def fake_mc(*args, **_kwargs):
+        commands.append(args)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(sync, "_mc", fake_mc)
+
+    assert push_local(sync, since=0) == []
+    assert not any(args[0] == "rm" for args in commands)
+    assert not any(args[0] == "find" for args in commands)
+
+
+def test_push_local_skips_older_and_unchanged_files(tmp_path: Path, monkeypatch) -> None:
+    sync = _sync(tmp_path)
+    uploads = []
+
+    old_file = sync.local_dir / "old.txt"
+    old_file.parent.mkdir(parents=True, exist_ok=True)
+    old_file.write_text("old", encoding="utf-8")
+    os.utime(old_file, (1, 1))
+
+    same_file = sync.local_dir / "same.txt"
+    same_file.write_text("same", encoding="utf-8")
+
+    changed_file = sync.local_dir / "changed.txt"
+    changed_file.write_text("changed", encoding="utf-8")
+
+    monkeypatch.setattr(sync, "ensure_alias", lambda: None)
+    monkeypatch.setattr(sync, "_cat_bytes", lambda key: b"same" if key.endswith("/same.txt") else None)
+
+    def fake_mc(*args, **_kwargs):
+        if args[0] == "cp":
+            uploads.append(args[2])
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(sync, "_mc", fake_mc)
+
+    assert push_local(sync, since=100) == ["changed.txt"]
+    assert uploads == ["agentteams/agentteams-storage/agents/worker-a/changed.txt"]
+
+
+def test_push_local_compares_small_binary_files_as_bytes(tmp_path: Path, monkeypatch) -> None:
+    sync = _sync(tmp_path)
+    uploads = []
+
+    same_file = sync.local_dir / "same.bin"
+    same_file.parent.mkdir(parents=True, exist_ok=True)
+    same_file.write_bytes(b"\xff\x00same")
+
+    changed_file = sync.local_dir / "changed.bin"
+    changed_file.write_bytes(b"\xff\x00changed")
+
+    monkeypatch.setattr(sync, "ensure_alias", lambda: None)
+
+    def fake_cat_bytes(key):
+        if key.endswith("/same.bin"):
+            return b"\xff\x00same"
+        if key.endswith("/changed.bin"):
+            return b"\xff\x00old"
+        return None
+
+    monkeypatch.setattr(sync, "_cat_bytes", fake_cat_bytes)
+
+    def fake_mc(*args, **_kwargs):
+        if args[0] == "cp":
+            uploads.append(args[2])
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(sync, "_mc", fake_mc)
+
+    assert push_local(sync, since=0) == ["changed.bin"]
+    assert uploads == ["agentteams/agentteams-storage/agents/worker-a/changed.bin"]
+
+
+def test_push_local_uploads_large_files_without_remote_content_compare(tmp_path: Path, monkeypatch) -> None:
+    sync = _sync(tmp_path)
+    uploads = []
+
+    large_file = sync.local_dir / "large.zip"
+    large_file.parent.mkdir(parents=True, exist_ok=True)
+    large_file.write_bytes(b"0" * (21 * 1024 * 1024))
+
+    monkeypatch.setattr(sync, "ensure_alias", lambda: None)
+
+    def fail_cat_bytes(_key):
+        raise AssertionError("large files should not download remote content for comparison")
+
+    monkeypatch.setattr(sync, "_cat_bytes", fail_cat_bytes)
+
+    def fake_mc(*args, **_kwargs):
+        if args[0] == "cp":
+            uploads.append(args[2])
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(sync, "_mc", fake_mc)
+
+    assert push_local(sync, since=0) == ["large.zip"]
+    assert uploads == ["agentteams/agentteams-storage/agents/worker-a/large.zip"]

--- a/qwenpaw/tests/test_update.py
+++ b/qwenpaw/tests/test_update.py
@@ -1,0 +1,1721 @@
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+from qwenpaw_worker.config import WorkerConfig
+from qwenpaw_worker.update import MemberRuntimeConfig, RuntimeUpdater
+
+
+@pytest.fixture(autouse=True)
+def _clear_agent_workspace_env():
+    original = os.environ.pop("AGENT_WORKSPACE", None)
+    try:
+        yield
+    finally:
+        if original is None:
+            os.environ.pop("AGENT_WORKSPACE", None)
+        else:
+            os.environ["AGENT_WORKSPACE"] = original
+
+
+def _config(tmp_path: Path) -> WorkerConfig:
+    return WorkerConfig(
+        worker_name="worker-a",
+        worker_cr_name="worker-a-cr",
+        fs_endpoint="http://minio:9000",
+        fs_access_key="key",
+        fs_secret_key="secret",
+        install_dir=tmp_path / "agents",
+        runtime_config_poll_interval=0.01,
+    )
+
+
+def test_runtime_updater_applies_changed_config_and_reapplies_adapter(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    applied: list[str] = []
+    adapter_calls: list[str] = []
+
+    class FakePackageManager:
+        def apply(self, runtime_config: MemberRuntimeConfig):
+            applied.append(runtime_config.generation)
+            return tmp_path / "packages" / runtime_config.generation
+
+    updater = RuntimeUpdater(
+        config=config,
+        adapter_apply=lambda: adapter_calls.append("adapter"),
+        package_manager=FakePackageManager(),
+    )
+
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={"metadata": {"generation": "1"}, "member": {"runtime": "qwenpaw"}},
+        )
+    )
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={"metadata": {"generation": "1"}, "member": {"runtime": "qwenpaw"}},
+        )
+    )
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={"metadata": {"generation": "2"}, "member": {"runtime": "qwenpaw"}},
+        )
+    )
+
+    assert applied == ["1", "2"]
+    assert adapter_calls == ["adapter", "adapter"]
+    assert updater.current_config is not None
+    assert updater.current_config.generation == "2"
+
+
+def test_runtime_updater_load_and_apply_once_does_not_reapply_adapter(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    applied: list[str] = []
+    adapter_calls: list[str] = []
+
+    class FakePackageManager:
+        def apply(self, runtime_config: MemberRuntimeConfig):
+            applied.append(runtime_config.generation)
+            return tmp_path / "packages" / runtime_config.generation
+
+    config.runtime_config_path.parent.mkdir(parents=True, exist_ok=True)
+    config.runtime_config_path.write_text(
+        """
+metadata:
+  generation: "2"
+member:
+  runtime: qwenpaw
+""",
+        encoding="utf-8",
+    )
+    updater = RuntimeUpdater(
+        config=config,
+        adapter_apply=lambda: adapter_calls.append("adapter"),
+        package_manager=FakePackageManager(),
+    )
+    updater.current_config = MemberRuntimeConfig(
+        path=config.runtime_config_path,
+        raw={"metadata": {"generation": "1"}, "member": {"runtime": "qwenpaw"}},
+    )
+
+    updater._load_and_apply_once()
+
+    assert applied == ["2"]
+    assert adapter_calls == []
+    assert updater.current_config is not None
+    assert updater.current_config.generation == "2"
+
+
+def test_runtime_updater_logs_safe_apply_summary_without_sensitive_values(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config = _config(tmp_path)
+    adapter_calls: list[str] = []
+    caplog.set_level(logging.INFO, logger="qwenpaw_worker.update")
+    updater = RuntimeUpdater(
+        config=config,
+        adapter_apply=lambda: adapter_calls.append("adapter"),
+        package_manager=_NoopPackageManager(),
+    )
+
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "42"},
+                "team": {"name": "demo-team"},
+                "member": {"name": "worker-a", "role": "worker", "runtime": "qwenpaw"},
+                "desired": {
+                    "mcpServers": {
+                        "alpha": {"command": "alpha", "env": {"TOKEN": "mcp-secret-token"}},
+                        "beta": {"command": "beta"},
+                    },
+                    "channels": {
+                        "matrix": {"enabled": True, "access_token": "matrix-secret-token"},
+                        "dingtalk": {"enabled": True, "client_secret": "dingtalk-secret"},
+                    },
+                    "credentialBindings": [
+                        {
+                            "credentialRef": {
+                                "tokenVaultName": "vault-a",
+                                "apiKeyCredentialProviderName": "provider-a",
+                            },
+                            "toolWhitelist": ["shell"],
+                        }
+                    ],
+                    "model": {"api_key": "model-secret-token"},
+                },
+            },
+        )
+    )
+
+    assert adapter_calls == ["adapter"]
+    assert "component=update" in caplog.text
+    assert "worker=worker-a" in caplog.text
+    assert "generation=42" in caplog.text
+    assert "mcp_server_count=2" in caplog.text
+    assert "channel_names=dingtalk,matrix" in caplog.text
+    assert "credential_binding_count=1" in caplog.text
+    assert "adapter_applied=True" in caplog.text
+    assert "duration_ms=" in caplog.text
+    assert "mcp-secret-token" not in caplog.text
+    assert "matrix-secret-token" not in caplog.text
+    assert "dingtalk-secret" not in caplog.text
+    assert "model-secret-token" not in caplog.text
+    assert "provider-a" not in caplog.text
+
+
+def test_runtime_config_identity_distinguishes_empty_list_and_empty_object(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    first = MemberRuntimeConfig(
+        path=config.runtime_config_path,
+        raw={
+            "metadata": {"generation": "1"},
+            "member": {"runtime": "qwenpaw"},
+            "desired": {"mcpServers": []},
+        },
+    )
+    second = MemberRuntimeConfig(
+        path=config.runtime_config_path,
+        raw={
+            "metadata": {"generation": "1"},
+            "member": {"runtime": "qwenpaw"},
+            "desired": {"mcpServers": {}},
+        },
+    )
+
+    assert first.desired_identity != second.desired_identity
+
+
+def test_runtime_updater_does_not_reapply_adapter_for_mcp_only_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    monkeypatch.setenv("AGENTTEAMS_WORKER_GATEWAY_KEY", "gateway-secret")
+    adapter_calls: list[str] = []
+    updater = RuntimeUpdater(
+        config=config,
+        adapter_apply=lambda: adapter_calls.append("adapter"),
+        package_manager=_NoopPackageManager(),
+    )
+
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "mcpServers": [
+                        {
+                            "name": "docs",
+                            "url": "https://gw.example.com/mcp-servers/docs/mcp",
+                        }
+                    ]
+                },
+            },
+        )
+    )
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "2"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "mcpServers": [
+                        {
+                            "name": "docs",
+                            "url": "https://gw.example.com/mcp-servers/docs-v2/mcp",
+                        }
+                    ]
+                },
+            },
+        )
+    )
+
+    assert adapter_calls == ["adapter"]
+    default_config = json.loads((config.default_workspace_dir / "config" / "mcporter.json").read_text(encoding="utf-8"))
+    assert default_config["mcpServers"]["docs"]["url"] == "https://gw.example.com/mcp-servers/docs-v2/mcp"
+
+
+def test_runtime_updater_reapplies_adapter_when_credentials_change_with_mcp(
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path)
+    adapter_calls: list[str] = []
+    updater = RuntimeUpdater(
+        config=config,
+        adapter_apply=lambda: adapter_calls.append("adapter"),
+        package_manager=_NoopPackageManager(),
+    )
+
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "mcpServers": [{"name": "docs", "url": "https://one.example/mcp"}],
+                    "agentIdentity": {"workloadIdentityName": "wi-worker-a"},
+                    "credentialBindings": [
+                        {
+                            "credentialRef": {
+                                "tokenVaultName": "default",
+                                "apiKeyCredentialProviderName": "GITHUB_TOKEN",
+                            }
+                        }
+                    ],
+                },
+            },
+        )
+    )
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "2"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "mcpServers": [{"name": "docs", "url": "https://two.example/mcp"}],
+                    "agentIdentity": {"workloadIdentityName": "wi-worker-a"},
+                    "credentialBindings": [
+                        {
+                            "credentialRef": {
+                                "tokenVaultName": "default",
+                                "apiKeyCredentialProviderName": "ALIBABA_CLOUD_ACCESS_KEY_ID",
+                            }
+                        }
+                    ],
+                },
+            },
+        )
+    )
+
+    assert adapter_calls == ["adapter", "adapter"]
+
+
+def test_runtime_updater_does_not_reapply_adapter_for_dingtalk_channel_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    monkeypatch.setenv("AGENTTEAMS_WORKER_GATEWAY_KEY", "gateway-secret")
+    adapter_calls: list[str] = []
+    updater = RuntimeUpdater(
+        config=config,
+        adapter_apply=lambda: adapter_calls.append("adapter"),
+        package_manager=_NoopPackageManager(),
+    )
+
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "channels": {"dingtalk": {"enabled": False}},
+                },
+            },
+        )
+    )
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "2"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "channels": {
+                        "dingtalk": {
+                            "enabled": True,
+                            "client_id": "demo-client-id",
+                            "client_secret": "test-client-secret",
+                        }
+                    },
+                },
+            },
+        )
+    )
+
+    assert adapter_calls == ["adapter"]
+
+
+def test_runtime_updater_does_not_reapply_adapter_for_mcp_and_channel_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    monkeypatch.setenv("AGENTTEAMS_WORKER_GATEWAY_KEY", "gateway-secret")
+    adapter_calls: list[str] = []
+    updater = RuntimeUpdater(
+        config=config,
+        adapter_apply=lambda: adapter_calls.append("adapter"),
+        package_manager=_NoopPackageManager(),
+    )
+
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "mcpServers": [{"name": "docs", "url": "https://gw.example.com/mcp/docs-v1"}],
+                    "channels": {"dingtalk": {"enabled": False}},
+                },
+            },
+        )
+    )
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "2"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "mcpServers": [{"name": "docs", "url": "https://gw.example.com/mcp/docs-v2"}],
+                    "channels": {
+                        "dingtalk": {
+                            "enabled": True,
+                            "client_id": "demo-client-id",
+                            "client_secret": "test-client-secret",
+                        }
+                    },
+                },
+            },
+        )
+    )
+
+    assert adapter_calls == ["adapter"]
+
+
+def test_runtime_updater_applies_member_role_to_config_and_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AGENTTEAMS_WORKER_ROLE", raising=False)
+    monkeypatch.delenv("AGENTTEAMS_AGENT_ROLE", raising=False)
+    config = _config(tmp_path)
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw", "role": "team_leader"},
+            },
+        )
+    )
+
+    assert config.agent_role == "team_leader"
+    assert os.environ["AGENTTEAMS_WORKER_ROLE"] == "team_leader"
+    assert os.environ["AGENTTEAMS_AGENT_ROLE"] == "team_leader"
+
+
+def test_runtime_updater_refreshes_teams_md_without_secrets(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    teams_md = config.default_workspace_dir / "TEAMS.md"
+    teams_md.parent.mkdir(parents=True)
+    teams_md.write_text(
+        """# Static TeamHarness Prompt
+
+<!-- BEGIN AGENTTEAMS RUNTIME TEAM CONTEXT -->
+old context
+<!-- END AGENTTEAMS RUNTIME TEAM CONTEXT -->
+""",
+        encoding="utf-8",
+    )
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "team": {
+                    "name": "demo-team",
+                    "teamRoomId": "!team:matrix.local",
+                    "leaderName": "leader",
+                    "leaderRuntimeName": "leader-runtime",
+                    "admin": {"name": "admin", "matrixUserId": "@admin:matrix.local"},
+                    "members": [
+                        {
+                            "name": "leader",
+                            "runtimeName": "leader-runtime",
+                            "role": "team_leader",
+                            "matrixUserId": "@leader-runtime:matrix.local",
+                            "personalRoomId": "!leader-dm:matrix.local",
+                        },
+                        {
+                            "name": "worker-a",
+                            "runtimeName": "worker-a",
+                            "role": "worker",
+                            "matrixUserId": "@worker-a:matrix.local",
+                            "personalRoomId": "!worker-dm:matrix.local",
+                        },
+                    ],
+                },
+                "member": {
+                    "name": "worker-a",
+                    "runtimeName": "worker-a",
+                    "role": "worker",
+                    "runtime": "qwenpaw",
+                    "matrixUserId": "@worker-a:matrix.local",
+                    "personalRoomId": "!worker-dm:matrix.local",
+                },
+                "credentials": {
+                    "matrixTokenEnv": "AGENTTEAMS_WORKER_MATRIX_TOKEN",
+                    "gatewayKeyEnv": "AGENTTEAMS_WORKER_GATEWAY_KEY",
+                },
+                "storage": {"bucket": "secret-ish-bucket"},
+                "desired": {"model": {"model": "qwen-plus"}},
+            },
+        )
+    )
+
+    text = teams_md.read_text(encoding="utf-8")
+    assert "# Static TeamHarness Prompt" in text
+    assert "old context" not in text
+    assert "## Runtime Team Context" in text
+    assert "runtimeName: leader-runtime" in text
+    assert "member.runtimeName: worker-a" in text
+    assert not (config.qwenpaw_working_dir / "teamharness" / "team-context.json").exists()
+    assert "desired" not in text
+    assert "storage" not in text
+    assert "matrixTokenEnv" not in text
+    assert "gatewayKeyEnv" not in text
+    assert "AGENTTEAMS_WORKER_MATRIX_TOKEN" not in text
+    assert "secret-ish-bucket" not in text
+
+
+def test_runtime_updater_applies_desired_model_to_qwenpaw_agent_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    saved = {}
+    agent_config = types.SimpleNamespace(active_model=None)
+
+    class ModelSlotConfig:
+        def __init__(self, provider_id, model):
+            self.provider_id = provider_id
+            self.model = model
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.ModelSlotConfig = ModelSlotConfig
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved.update({agent_id: value})
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {"model": {"providerId": "hiclaw-gateway", "model": "qwen-plus"}},
+            },
+        )
+    )
+
+    assert saved["default"].active_model.provider_id == "hiclaw-gateway"
+    assert saved["default"].active_model.model == "qwen-plus"
+
+
+def test_runtime_updater_configures_openai_compatible_provider_from_runtime_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    monkeypatch.setenv("REAL_MODEL_KEY", "real-model-secret")
+
+    saved_agent = {}
+    saved_provider = {}
+    saved_active = {}
+    agent_config = types.SimpleNamespace(active_model=None)
+
+    class ModelSlotConfig:
+        def __init__(self, provider_id, model):
+            self.provider_id = provider_id
+            self.model = model
+
+    class ModelInfo:
+        def __init__(self, id, name):
+            self.id = id
+            self.name = name
+
+    class ProviderInfo:
+        def __init__(self, **kwargs):
+            self.data = kwargs
+
+        def model_dump(self):
+            return self.data
+
+    class ProviderManager:
+        def __init__(self):
+            self.custom_providers = {}
+            self.active_model = None
+
+        @classmethod
+        def get_instance(cls):
+            return manager
+
+        def _provider_from_data(self, data):
+            return types.SimpleNamespace(**data)
+
+        def save_provider_config(self, provider_id, provider):
+            saved_provider[provider_id] = provider
+
+        def save_active_model(self, value):
+            saved_active["active"] = value
+
+    manager = ProviderManager()
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.ModelSlotConfig = ModelSlotConfig
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved_agent.update({agent_id: value})
+
+    provider_module = types.ModuleType("qwenpaw.providers.provider")
+    provider_module.ModelInfo = ModelInfo
+    provider_module.ProviderInfo = ProviderInfo
+
+    provider_manager_module = types.ModuleType("qwenpaw.providers.provider_manager")
+    provider_manager_module.ProviderManager = ProviderManager
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+    monkeypatch.setitem(sys.modules, "qwenpaw.providers", types.ModuleType("qwenpaw.providers"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.providers.provider", provider_module)
+    monkeypatch.setitem(sys.modules, "qwenpaw.providers.provider_manager", provider_manager_module)
+
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "model": {
+                        "providerId": "hiclaw-gateway",
+                        "model": "qwen-plus",
+                        "gatewayUrl": "https://dashscope.aliyuncs.com/compatible-mode",
+                        "apiKeyEnv": "REAL_MODEL_KEY",
+                    }
+                },
+            },
+        )
+    )
+
+    provider = saved_provider["hiclaw-gateway"]
+    assert provider.base_url == "https://dashscope.aliyuncs.com/compatible-mode/v1"
+    assert provider.api_key == "real-model-secret"
+    assert provider.chat_model == "OpenAIChatModel"
+    assert provider.models[0].id == "qwen-plus"
+    assert manager.custom_providers["hiclaw-gateway"] is provider
+    assert saved_active["active"].provider_id == "hiclaw-gateway"
+    assert saved_active["active"].model == "qwen-plus"
+    assert saved_agent["default"].active_model.provider_id == "hiclaw-gateway"
+    assert saved_agent["default"].active_model.model == "qwen-plus"
+
+
+def test_runtime_updater_writes_mcporter_config_from_desired_mcp_servers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    monkeypatch.setenv("AGENTTEAMS_WORKER_GATEWAY_KEY", "gateway-secret")
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "credentials": {"gatewayKeyEnv": "AGENTTEAMS_WORKER_GATEWAY_KEY"},
+                "desired": {
+                    "mcpServers": [
+                        {
+                            "name": "github",
+                            "url": "https://gw.example.com/mcp-servers/github/mcp",
+                            "transport": "http",
+                        }
+                    ]
+                },
+            },
+        )
+    )
+
+    legacy_config = config.default_workspace_dir / "mcporter-servers.json"
+    default_config = json.loads((config.default_workspace_dir / "config" / "mcporter.json").read_text(encoding="utf-8"))
+    assert not legacy_config.exists()
+    assert default_config["mcpServers"]["github"] == {
+        "url": "https://gw.example.com/mcp-servers/github/mcp",
+        "transport": "http",
+        "headers": {"Authorization": "Bearer gateway-secret"},
+    }
+
+
+def test_runtime_updater_writes_empty_mcporter_config_when_mcp_servers_are_omitted(
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path)
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "mcpServers": [
+                        {
+                            "name": "github",
+                            "url": "https://gw.example.com/mcp-servers/github/mcp",
+                        }
+                    ]
+                },
+            },
+        )
+    )
+    legacy_config = config.default_workspace_dir / "mcporter-servers.json"
+    default_config = config.default_workspace_dir / "config" / "mcporter.json"
+    legacy_config.write_text('{"mcpServers":{"legacy":{"url":"https://old.example.com/mcp"}}}\n', encoding="utf-8")
+    assert default_config.exists()
+
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {},
+            },
+        )
+    )
+
+    assert not legacy_config.exists()
+    assert json.loads(default_config.read_text(encoding="utf-8")) == {"mcpServers": {}}
+
+
+def test_runtime_updater_configures_matrix_channel_in_agent_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    monkeypatch.setenv("AGENTTEAMS_MATRIX_URL", "http://matrix.example.com:6167")
+    monkeypatch.setenv("AGENTTEAMS_WORKER_MATRIX_TOKEN", "matrix-token")
+    monkeypatch.setenv("AGENTTEAMS_MATRIX_E2EE", "1")
+    saved = {}
+    matrix_config = types.SimpleNamespace(
+        enabled=False,
+        homeserver="",
+        user_id="",
+        access_token="",
+        password="legacy",
+        encryption=True,
+        group_disabled=True,
+        dm_disabled=True,
+        filter_tool_messages=False,
+        filter_thinking=False,
+        groups={},
+    )
+    channel_config = types.SimpleNamespace(matrix=matrix_config)
+    agent_config = types.SimpleNamespace(channels=channel_config)
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved.update({agent_id: value})
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "team": {"teamRoomId": "!team:matrix.local"},
+                "member": {
+                    "runtime": "qwenpaw",
+                    "matrixUserId": "@worker-a:matrix.local",
+                },
+                "credentials": {"matrixTokenEnv": "AGENTTEAMS_WORKER_MATRIX_TOKEN"},
+            },
+        )
+    )
+
+    matrix = saved["default"].channels.matrix
+    assert matrix.enabled is True
+    assert matrix.homeserver == "http://matrix.example.com:6167"
+    assert matrix.user_id == "@worker-a:matrix.local"
+    assert matrix.access_token == "matrix-token"
+    assert matrix.password == ""
+    assert matrix.encryption is True
+    assert matrix.group_disabled is False
+    assert matrix.dm_disabled is False
+    assert matrix.filter_tool_messages is False
+    assert matrix.filter_thinking is False
+    assert matrix.groups["*"]["requireMention"] is True
+    assert matrix.groups["!team:matrix.local"]["requireMention"] is True
+
+
+def test_runtime_updater_configures_dingtalk_channel_in_agent_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    saved = {}
+    dingtalk_config = types.SimpleNamespace(
+        enabled=False,
+        client_id="",
+        client_secret="",
+        robot_code="",
+        filter_thinking=True,
+        filter_tool_messages=False,
+        streaming_enabled=False,
+        message_type="markdown",
+        card_template_id="",
+        card_template_key="content",
+        card_auto_layout=True,
+    )
+    channel_config = types.SimpleNamespace(dingtalk=dingtalk_config)
+    agent_config = types.SimpleNamespace(channels=channel_config)
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved.update({agent_id: value})
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "channels": {
+                        "dingtalk": {
+                            "enabled": True,
+                            "client_id": "demo-client-id",
+                            "client_secret": "test-client-secret",
+                            "robot_code": "demo-robot-code",
+                            "filter_thinking": False,
+                            "filter_tool_messages": True,
+                            "streaming_enabled": True,
+                            "message_type": "card",
+                            "card_template_id": "card-template-1",
+                            "card_template_key": "content",
+                            "card_auto_layout": False,
+                        }
+                    }
+                },
+            },
+        )
+    )
+
+    dingtalk = saved["default"].channels.dingtalk
+    assert dingtalk.enabled is True
+    assert dingtalk.client_id == "demo-client-id"
+    assert dingtalk.client_secret == "test-client-secret"
+    assert dingtalk.robot_code == "demo-robot-code"
+    assert dingtalk.filter_thinking is False
+    assert dingtalk.filter_tool_messages is True
+    assert dingtalk.streaming_enabled is True
+    assert dingtalk.message_type == "card"
+    assert dingtalk.card_template_id == "card-template-1"
+    assert dingtalk.card_template_key == "content"
+    assert dingtalk.card_auto_layout is False
+    assert not (config.default_workspace_dir / "config.json").exists()
+
+
+def test_runtime_updater_uses_provided_stream_dingtalk_card_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config = _config(tmp_path)
+    saved = {}
+    dingtalk_config = types.SimpleNamespace(
+        enabled=True,
+        client_id="old-client-id",
+        client_secret="old-secret",
+        robot_code="old-robot",
+        filter_thinking=True,
+        filter_tool_messages=True,
+        streaming_enabled=False,
+        message_type="card",
+        card_template_id="custom-template.schema",
+        card_template_key="custom_content",
+        card_auto_layout=True,
+    )
+    channel_config = types.SimpleNamespace(dingtalk=dingtalk_config)
+    agent_config = types.SimpleNamespace(channels=channel_config)
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved.update({agent_id: value})
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+
+    caplog.set_level(logging.WARNING)
+    updater = RuntimeUpdater(
+        config=config,
+        package_manager=_NoopPackageManager(),
+    )
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "channels": {
+                        "dingtalk": {
+                            "enabled": True,
+                            "client_id": "demo-client-id",
+                            "client_secret": "test-client-secret",
+                            "robot_code": "demo-robot-code",
+                            "streaming_enabled": True,
+                            "filter_thinking": False,
+                            "filter_tool_messages": False,
+                            "card_template_id": "stream-template.schema",
+                        }
+                    }
+                },
+            },
+        )
+    )
+
+    dingtalk = saved["default"].channels.dingtalk
+    assert dingtalk.enabled is True
+    assert dingtalk.client_id == "demo-client-id"
+    assert dingtalk.client_secret == "test-client-secret"
+    assert dingtalk.robot_code == "demo-robot-code"
+    assert dingtalk.streaming_enabled is True
+    assert dingtalk.message_type == "card"
+    assert dingtalk.card_template_id == "stream-template.schema"
+    assert dingtalk.card_template_key == "content"
+    assert dingtalk.card_auto_layout is False
+    assert dingtalk.filter_thinking is False
+    assert dingtalk.filter_tool_messages is False
+    assert "current runtime card configuration will switch" in caplog.text
+    assert "custom-template.schema" in caplog.text
+    assert "test-client-secret" not in caplog.text
+
+
+def test_runtime_updater_rejects_incomplete_dingtalk_streaming_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    saved = {}
+    dingtalk_config = types.SimpleNamespace(
+        enabled=False,
+        client_id="",
+        client_secret="",
+        robot_code="",
+    )
+    channel_config = types.SimpleNamespace(dingtalk=dingtalk_config)
+    agent_config = types.SimpleNamespace(channels=channel_config)
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved.update({agent_id: value})
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+    with pytest.raises(ValueError, match="DingTalk streaming requires"):
+        updater.apply_once(
+            runtime_config=MemberRuntimeConfig(
+                path=config.runtime_config_path,
+                raw={
+                    "metadata": {"generation": "1"},
+                    "member": {"runtime": "qwenpaw"},
+                    "desired": {
+                        "channels": {
+                            "dingtalk": {
+                                "enabled": True,
+                                "client_id": "demo-client-id",
+                                "client_secret": "test-client-secret",
+                                "streaming_enabled": True,
+                            }
+                        }
+                    },
+                },
+            )
+        )
+
+    assert saved == {}
+    assert dingtalk_config.enabled is False
+
+
+def test_runtime_updater_preserves_card_config_when_dingtalk_streaming_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    saved = {}
+    dingtalk_config = types.SimpleNamespace(
+        enabled=True,
+        client_id="old-client-id",
+        client_secret="old-secret",
+        robot_code="old-robot",
+        filter_thinking=True,
+        filter_tool_messages=True,
+        streaming_enabled=True,
+        message_type="card",
+        card_template_id="custom-template.schema",
+        card_template_key="custom_content",
+        card_auto_layout=True,
+    )
+    channel_config = types.SimpleNamespace(dingtalk=dingtalk_config)
+    agent_config = types.SimpleNamespace(channels=channel_config)
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved.update({agent_id: value})
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "channels": {
+                        "dingtalk": {
+                            "enabled": True,
+                            "client_id": "demo-client-id",
+                            "client_secret": "test-client-secret",
+                            "robot_code": "demo-robot-code",
+                            "streaming_enabled": False,
+                        }
+                    }
+                },
+            },
+        )
+    )
+
+    dingtalk = saved["default"].channels.dingtalk
+    assert dingtalk.streaming_enabled is False
+    assert dingtalk.message_type == "card"
+    assert dingtalk.card_template_id == "custom-template.schema"
+    assert dingtalk.card_template_key == "custom_content"
+    assert dingtalk.card_auto_layout is True
+
+
+def test_runtime_updater_disables_dingtalk_channel_from_runtime_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    saved = {}
+    dingtalk_config = types.SimpleNamespace(enabled=True, client_secret="existing-secret")
+    channel_config = types.SimpleNamespace(dingtalk=dingtalk_config)
+    agent_config = types.SimpleNamespace(channels=channel_config)
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved.update({agent_id: value})
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {"channels": {"dingtalk": {"enabled": False}}},
+            },
+        )
+    )
+
+    assert saved["default"].channels.dingtalk.enabled is False
+    assert saved["default"].channels.dingtalk.client_secret == "existing-secret"
+    assert not (config.default_workspace_dir / "config.json").exists()
+
+
+def test_runtime_updater_leaves_dingtalk_channel_when_runtime_omits_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    saved = {}
+    dingtalk_config = types.SimpleNamespace(enabled=True, client_id="existing-client-id")
+    channel_config = types.SimpleNamespace(dingtalk=dingtalk_config)
+    agent_config = types.SimpleNamespace(channels=channel_config)
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved.update({agent_id: value})
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {},
+            },
+        )
+    )
+
+    assert saved == {}
+    assert dingtalk_config.enabled is True
+    assert dingtalk_config.client_id == "existing-client-id"
+
+
+def test_runtime_updater_applies_copaw_style_matrix_channel_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    saved = {}
+    matrix_config = types.SimpleNamespace(access_control_dm=False, access_control_group=False)
+    channel_config = types.SimpleNamespace(matrix=matrix_config)
+    agent_config = types.SimpleNamespace(channels=channel_config)
+    whitelist_calls: list[tuple[str, list[str]]] = []
+    blacklist_calls: list[tuple[str, list[str]]] = []
+    monkeypatch.setenv("AGENTTEAMS_MATRIX_DOMAIN", "matrix.local")
+    monkeypatch.setenv("AGENTTEAMS_ADMIN_USER", "admin")
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved.update({agent_id: value})
+
+    class Store:
+        def set_whitelist(self, channel, values):
+            whitelist_calls.append((channel, values))
+
+        def set_blacklist(self, channel, values):
+            blacklist_calls.append((channel, values))
+
+    access_module = types.ModuleType("qwenpaw.app.channels.access_control")
+    access_module.get_access_control_store = lambda workspace_dir: Store()
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+    monkeypatch.setitem(sys.modules, "qwenpaw.app", types.ModuleType("qwenpaw.app"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.app.channels", types.ModuleType("qwenpaw.app.channels"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.app.channels.access_control", access_module)
+
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "team": {
+                    "leaderRuntimeName": "leader-a",
+                    "members": [
+                        {
+                            "runtimeName": "leader-a",
+                            "role": "team_leader",
+                            "matrixUserId": "@leader-a:matrix.local",
+                        },
+                        {
+                            "runtimeName": "worker-a",
+                            "role": "worker",
+                            "matrixUserId": "@worker-a:matrix.local",
+                        },
+                    ],
+                },
+                "member": {
+                    "runtime": "qwenpaw",
+                    "runtimeName": "leader-a",
+                    "matrixUserId": "@leader-a:matrix.local",
+                    "role": "team_leader",
+                },
+                "desired": {
+                    "channelPolicy": {
+                        "groupAllowExtra": ["worker-b"],
+                        "dmAllowExtra": ["@human:matrix.local"],
+                        "groupDenyExtra": ["blocked-worker"],
+                        "dmDenyExtra": ["@blocked:matrix.local"],
+                    }
+                },
+            },
+        )
+    )
+
+    assert saved["default"].channels.matrix.access_control_group is True
+    assert saved["default"].channels.matrix.access_control_dm is True
+    assert whitelist_calls == [
+        (
+            "matrix",
+            [
+                "@leader-a:matrix.local",
+                "@manager:matrix.local",
+                "@admin:matrix.local",
+                "@worker-a:matrix.local",
+                "@worker-b:matrix.local",
+                "@human:matrix.local",
+            ],
+        )
+    ]
+    assert blacklist_calls == [("matrix", ["@blocked-worker:matrix.local", "@blocked:matrix.local"])]
+
+
+def test_runtime_updater_self_matrix_id_still_respects_deny_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    saved = {}
+    matrix_config = types.SimpleNamespace(access_control_dm=False, access_control_group=False)
+    channel_config = types.SimpleNamespace(matrix=matrix_config)
+    agent_config = types.SimpleNamespace(channels=channel_config)
+    whitelist_calls: list[tuple[str, list[str]]] = []
+    blacklist_calls: list[tuple[str, list[str]]] = []
+    monkeypatch.setenv("AGENTTEAMS_MATRIX_DOMAIN", "matrix.local")
+    monkeypatch.setenv("AGENTTEAMS_ADMIN_USER", "admin")
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved.update({agent_id: value})
+
+    class Store:
+        def set_whitelist(self, channel, values):
+            whitelist_calls.append((channel, values))
+
+        def set_blacklist(self, channel, values):
+            blacklist_calls.append((channel, values))
+
+    access_module = types.ModuleType("qwenpaw.app.channels.access_control")
+    access_module.get_access_control_store = lambda workspace_dir: Store()
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+    monkeypatch.setitem(sys.modules, "qwenpaw.app", types.ModuleType("qwenpaw.app"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.app.channels", types.ModuleType("qwenpaw.app.channels"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.app.channels.access_control", access_module)
+
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "team": {
+                    "leaderRuntimeName": "leader-a",
+                    "members": [
+                        {
+                            "runtimeName": "leader-a",
+                            "role": "team_leader",
+                            "matrixUserId": "@leader-a:matrix.local",
+                        },
+                        {
+                            "runtimeName": "worker-a",
+                            "role": "worker",
+                            "matrixUserId": "@worker-a:matrix.local",
+                        },
+                    ],
+                },
+                "member": {
+                    "runtime": "qwenpaw",
+                    "runtimeName": "leader-a",
+                    "matrixUserId": "@leader-a:matrix.local",
+                    "role": "team_leader",
+                },
+                "desired": {
+                    "channelPolicy": {
+                        "dmDenyExtra": ["@leader-a:matrix.local"],
+                    },
+                },
+            },
+        )
+    )
+
+    assert "@leader-a:matrix.local" not in whitelist_calls[0][1]
+    assert blacklist_calls == [("matrix", ["@leader-a:matrix.local"])]
+
+
+def test_runtime_updater_applies_team_roster_matrix_defaults_for_team_worker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    saved = {}
+    matrix_config = types.SimpleNamespace(access_control_dm=False, access_control_group=False)
+    channel_config = types.SimpleNamespace(matrix=matrix_config)
+    agent_config = types.SimpleNamespace(channels=channel_config)
+    whitelist_calls: list[tuple[str, list[str]]] = []
+    blacklist_calls: list[tuple[str, list[str]]] = []
+    monkeypatch.setenv("AGENTTEAMS_MATRIX_DOMAIN", "matrix.local")
+    monkeypatch.setenv("AGENTTEAMS_ADMIN_USER", "admin")
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved.update({agent_id: value})
+
+    class Store:
+        def set_whitelist(self, channel, values):
+            whitelist_calls.append((channel, values))
+
+        def set_blacklist(self, channel, values):
+            blacklist_calls.append((channel, values))
+
+    access_module = types.ModuleType("qwenpaw.app.channels.access_control")
+    access_module.get_access_control_store = lambda workspace_dir: Store()
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+    monkeypatch.setitem(sys.modules, "qwenpaw.app", types.ModuleType("qwenpaw.app"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.app.channels", types.ModuleType("qwenpaw.app.channels"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.app.channels.access_control", access_module)
+
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "team": {
+                    "leaderRuntimeName": "leader-a",
+                    "members": [
+                        {
+                            "runtimeName": "leader-a",
+                            "role": "team_leader",
+                            "matrixUserId": "@leader-a:matrix.local",
+                        },
+                        {
+                            "runtimeName": "worker-a",
+                            "role": "worker",
+                            "matrixUserId": "@worker-a:matrix.local",
+                        },
+                        {
+                            "runtimeName": "worker-b",
+                            "role": "worker",
+                            "matrixUserId": "@worker-b:matrix.local",
+                        },
+                    ],
+                },
+                "member": {
+                    "runtime": "qwenpaw",
+                    "runtimeName": "worker-a",
+                    "matrixUserId": "@worker-a:matrix.local",
+                    "role": "worker",
+                },
+            },
+        )
+    )
+
+    assert saved["default"].channels.matrix.access_control_group is True
+    assert saved["default"].channels.matrix.access_control_dm is True
+    assert whitelist_calls == [
+        ("matrix", ["@worker-a:matrix.local", "@leader-a:matrix.local", "@admin:matrix.local", "@worker-b:matrix.local"])
+    ]
+    assert blacklist_calls == [("matrix", [])]
+
+
+def test_runtime_updater_system_admin_in_allowlist_when_team_admin_differs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: system admin must remain in whitelist even when
+    team.admin.matrixUserId is a *different* user than AGENTTEAMS_ADMIN_USER."""
+    config = _config(tmp_path)
+    saved = {}
+    matrix_config = types.SimpleNamespace(access_control_dm=False, access_control_group=False)
+    channel_config = types.SimpleNamespace(matrix=matrix_config)
+    agent_config = types.SimpleNamespace(channels=channel_config)
+    whitelist_calls: list[tuple[str, list[str]]] = []
+    blacklist_calls: list[tuple[str, list[str]]] = []
+    monkeypatch.setenv("AGENTTEAMS_MATRIX_DOMAIN", "matrix.local")
+    # System admin is "sysadmin", but team admin is a different user.
+    monkeypatch.setenv("AGENTTEAMS_ADMIN_USER", "sysadmin")
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved.update({agent_id: value})
+
+    class Store:
+        def set_whitelist(self, channel, values):
+            whitelist_calls.append((channel, values))
+
+        def set_blacklist(self, channel, values):
+            blacklist_calls.append((channel, values))
+
+    access_module = types.ModuleType("qwenpaw.app.channels.access_control")
+    access_module.get_access_control_store = lambda workspace_dir: Store()
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+    monkeypatch.setitem(sys.modules, "qwenpaw.app", types.ModuleType("qwenpaw.app"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.app.channels", types.ModuleType("qwenpaw.app.channels"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.app.channels.access_control", access_module)
+
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "team": {
+                    "leaderRuntimeName": "leader-a",
+                    "admin": {"matrixUserId": "@team-human:matrix.local"},
+                    "members": [
+                        {
+                            "runtimeName": "leader-a",
+                            "role": "team_leader",
+                            "matrixUserId": "@leader-a:matrix.local",
+                        },
+                        {
+                            "runtimeName": "worker-a",
+                            "role": "worker",
+                            "matrixUserId": "@worker-a:matrix.local",
+                        },
+                    ],
+                },
+                "member": {
+                    "runtime": "qwenpaw",
+                    "runtimeName": "worker-a",
+                    "matrixUserId": "@worker-a:matrix.local",
+                    "role": "worker",
+                },
+            },
+        )
+    )
+
+    # Both team admin (@team-human) and system admin (@sysadmin) must be present.
+    assert len(whitelist_calls) == 1
+    channel, wl = whitelist_calls[0]
+    assert channel == "matrix"
+    assert "@team-human:matrix.local" in wl, "team admin must be in whitelist"
+    assert "@sysadmin:matrix.local" in wl, "system admin must be in whitelist"
+    assert "@leader-a:matrix.local" in wl, "leader must be in whitelist"
+    assert "@worker-a:matrix.local" in wl, "current member must be in whitelist"
+
+
+def test_runtime_updater_applies_copaw_style_matrix_defaults_for_team_worker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    saved = {}
+    matrix_config = types.SimpleNamespace(access_control_dm=False, access_control_group=False)
+    channel_config = types.SimpleNamespace(matrix=matrix_config)
+    agent_config = types.SimpleNamespace(channels=channel_config)
+    whitelist_calls: list[tuple[str, list[str]]] = []
+    blacklist_calls: list[tuple[str, list[str]]] = []
+    monkeypatch.setenv("AGENTTEAMS_MATRIX_DOMAIN", "matrix.local")
+    monkeypatch.setenv("AGENTTEAMS_ADMIN_USER", "admin")
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved.update({agent_id: value})
+
+    class Store:
+        def set_whitelist(self, channel, values):
+            whitelist_calls.append((channel, values))
+
+        def set_blacklist(self, channel, values):
+            blacklist_calls.append((channel, values))
+
+    access_module = types.ModuleType("qwenpaw.app.channels.access_control")
+    access_module.get_access_control_store = lambda workspace_dir: Store()
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+    monkeypatch.setitem(sys.modules, "qwenpaw.app", types.ModuleType("qwenpaw.app"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.app.channels", types.ModuleType("qwenpaw.app.channels"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.app.channels.access_control", access_module)
+
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "team": {"leaderRuntimeName": "leader-a"},
+                "member": {"runtime": "qwenpaw", "role": "worker"},
+            },
+        )
+    )
+
+    assert saved["default"].channels.matrix.access_control_group is True
+    assert saved["default"].channels.matrix.access_control_dm is True
+    assert whitelist_calls == [("matrix", ["@leader-a:matrix.local", "@admin:matrix.local"])]
+    assert blacklist_calls == [("matrix", [])]
+
+
+def test_runtime_updater_applies_copaw_style_matrix_defaults_for_standalone_worker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    saved = {}
+    matrix_config = types.SimpleNamespace(access_control_dm=False, access_control_group=False)
+    channel_config = types.SimpleNamespace(matrix=matrix_config)
+    agent_config = types.SimpleNamespace(channels=channel_config)
+    whitelist_calls: list[tuple[str, list[str]]] = []
+    blacklist_calls: list[tuple[str, list[str]]] = []
+    monkeypatch.setenv("AGENTTEAMS_MATRIX_DOMAIN", "matrix.local")
+    monkeypatch.setenv("AGENTTEAMS_ADMIN_USER", "admin")
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved.update({agent_id: value})
+
+    class Store:
+        def set_whitelist(self, channel, values):
+            whitelist_calls.append((channel, values))
+
+        def set_blacklist(self, channel, values):
+            blacklist_calls.append((channel, values))
+
+    access_module = types.ModuleType("qwenpaw.app.channels.access_control")
+    access_module.get_access_control_store = lambda workspace_dir: Store()
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+    monkeypatch.setitem(sys.modules, "qwenpaw.app", types.ModuleType("qwenpaw.app"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.app.channels", types.ModuleType("qwenpaw.app.channels"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.app.channels.access_control", access_module)
+
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw", "role": "worker"},
+            },
+        )
+    )
+
+    assert saved["default"].channels.matrix.access_control_group is True
+    assert saved["default"].channels.matrix.access_control_dm is True
+    assert whitelist_calls == [("matrix", ["@manager:matrix.local", "@admin:matrix.local"])]
+    assert blacklist_calls == [("matrix", [])]
+
+
+def test_runtime_updater_skips_short_name_matrix_policy_without_matrix_domain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    saved = {}
+    matrix_config = types.SimpleNamespace(access_control_dm=False, access_control_group=False)
+    channel_config = types.SimpleNamespace(matrix=matrix_config)
+    agent_config = types.SimpleNamespace(channels=channel_config)
+    whitelist_calls: list[tuple[str, list[str]]] = []
+    blacklist_calls: list[tuple[str, list[str]]] = []
+    monkeypatch.delenv("AGENTTEAMS_MATRIX_DOMAIN", raising=False)
+    monkeypatch.setenv("AGENTTEAMS_ADMIN_USER", "admin")
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, value: saved.update({agent_id: value})
+
+    class Store:
+        def set_whitelist(self, channel, values):
+            whitelist_calls.append((channel, values))
+
+        def set_blacklist(self, channel, values):
+            blacklist_calls.append((channel, values))
+
+    access_module = types.ModuleType("qwenpaw.app.channels.access_control")
+    access_module.get_access_control_store = lambda workspace_dir: Store()
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+    monkeypatch.setitem(sys.modules, "qwenpaw.app", types.ModuleType("qwenpaw.app"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.app.channels", types.ModuleType("qwenpaw.app.channels"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.app.channels.access_control", access_module)
+
+    updater = RuntimeUpdater(config=config, package_manager=_NoopPackageManager())
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw", "role": "worker"},
+                "desired": {
+                    "channelPolicy": {
+                        "groupAllowExtra": ["worker-b"],
+                        "dmDenyExtra": ["blocked-worker"],
+                    }
+                },
+            },
+        )
+    )
+
+    assert saved == {}
+    assert whitelist_calls == []
+    assert blacklist_calls == []
+
+
+@pytest.mark.anyio
+async def test_runtime_update_loop_survives_bad_config_and_applies_next_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config = _config(tmp_path)
+    updater = RuntimeUpdater(config=config)
+    caplog.set_level(logging.INFO, logger="qwenpaw_worker.update")
+    loads = [
+        RuntimeError("runtime config parse failed secret-token-value"),
+        MemberRuntimeConfig(path=config.runtime_config_path, raw={"metadata": {"generation": "2"}}),
+    ]
+    applied: list[str] = []
+    sleeps = 0
+
+    async def sleep_tick(_seconds):
+        nonlocal sleeps
+        sleeps += 1
+        if sleeps > 2:
+            raise asyncio.CancelledError
+
+    def fake_load(_path):
+        value = loads.pop(0)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    def fake_apply_once(self, runtime_config=None, force=False, reapply_adapter=True):
+        assert runtime_config is not None
+        applied.append(runtime_config.generation)
+        self.current_config = runtime_config
+
+    monkeypatch.setattr("qwenpaw_worker.update.asyncio.sleep", sleep_tick)
+    monkeypatch.setattr("qwenpaw_worker.update.MemberRuntimeConfig.load", fake_load)
+    monkeypatch.setattr("qwenpaw_worker.update.RuntimeUpdater.apply_once", fake_apply_once)
+
+    with pytest.raises(asyncio.CancelledError):
+        await updater.loop()
+
+    assert applied == ["2"]
+    assert "runtime config update loop started component=update" in caplog.text
+    assert "runtime config update failed component=update" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
+    assert "runtime config update loop stopped component=update" in caplog.text
+    assert "secret-token-value" not in caplog.text
+
+
+@pytest.mark.anyio
+async def test_runtime_update_loop_offloads_load_and_apply_to_thread(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    updater = RuntimeUpdater(config=config)
+    applied: list[str] = []
+    to_thread_calls: list[str] = []
+    sleeps = 0
+
+    async def sleep_tick(_seconds):
+        nonlocal sleeps
+        sleeps += 1
+        if sleeps > 1:
+            raise asyncio.CancelledError
+
+    async def fake_to_thread(func, *args, **kwargs):
+        to_thread_calls.append(getattr(func, "__name__", repr(func)))
+        return func(*args, **kwargs)
+
+    def fake_load(_path):
+        return MemberRuntimeConfig(path=config.runtime_config_path, raw={"metadata": {"generation": "3"}})
+
+    def fake_apply_once(self, runtime_config=None, force=False, reapply_adapter=True):
+        assert runtime_config is not None
+        applied.append(runtime_config.generation)
+        self.current_config = runtime_config
+
+    monkeypatch.setattr("qwenpaw_worker.update.asyncio.sleep", sleep_tick)
+    monkeypatch.setattr("qwenpaw_worker.update.asyncio.to_thread", fake_to_thread)
+    monkeypatch.setattr("qwenpaw_worker.update.MemberRuntimeConfig.load", fake_load)
+    monkeypatch.setattr("qwenpaw_worker.update.RuntimeUpdater.apply_once", fake_apply_once)
+
+    with pytest.raises(asyncio.CancelledError):
+        await updater.loop()
+
+    assert to_thread_calls == ["_load_and_apply_once"]
+    assert applied == ["3"]
+
+
+def test_runtime_updater_pulls_runtime_config_before_loading(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    pulls: list[str] = []
+
+    def pull_runtime_config() -> None:
+        pulls.append("pull")
+        config.runtime_config_path.parent.mkdir(parents=True, exist_ok=True)
+        config.runtime_config_path.write_text(
+            """
+metadata:
+  generation: "7"
+member:
+  runtime: qwenpaw
+""",
+            encoding="utf-8",
+        )
+
+    updater = RuntimeUpdater(config=config, runtime_config_pull=pull_runtime_config)
+
+    loaded = updater.load()
+
+    assert pulls == ["pull"]
+    assert loaded.generation == "7"
+
+
+class _NoopPackageManager:
+    def apply(self, _runtime_config: MemberRuntimeConfig):
+        return None

--- a/qwenpaw/tests/test_worker_lifecycle.py
+++ b/qwenpaw/tests/test_worker_lifecycle.py
@@ -1,0 +1,1243 @@
+import asyncio
+import hashlib
+import importlib.util
+import json
+import logging
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import textwrap
+import types
+import zipfile
+
+import pytest
+
+from qwenpaw_worker.config import WorkerConfig
+from qwenpaw_worker.update import MemberRuntimeConfig
+from qwenpaw_worker.worker import BUILTIN_QWENPAW_PLUGIN_MARKER, Worker
+
+
+@pytest.fixture(autouse=True)
+def _clear_agent_workspace_env():
+    original = os.environ.pop("AGENT_WORKSPACE", None)
+    try:
+        yield
+    finally:
+        if original is None:
+            os.environ.pop("AGENT_WORKSPACE", None)
+        else:
+            os.environ["AGENT_WORKSPACE"] = original
+
+
+def _runtime_yaml(
+    path: Path,
+    generation: int = 1,
+    version: str = "1.0.0",
+    shared_prefix: str = "shared",
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"""
+apiVersion: agentteams.io/v1beta1
+kind: MemberRuntimeConfig
+metadata:
+  generation: {generation}
+team:
+  name: demo-team
+  teamRoomId: "!team:matrix.local"
+  leaderName: leader
+  admin:
+    name: admin
+    matrixUserId: "@admin:matrix.local"
+member:
+  name: worker-a
+  runtimeName: worker-a
+  role: worker
+  runtime: qwenpaw
+  matrixUserId: "@worker-a:matrix.local"
+desired:
+  agentPackage:
+    ref: file:///tmp/dev-worker.tar.gz
+    name: dev-worker
+    version: {version}
+    digest: sha256:{version}
+  outputSanitize:
+    keywords: [internal-token]
+storage:
+  memberPrefix: agents/worker-a
+  sharedPrefix: {shared_prefix}
+credentials:
+  matrixTokenEnv: AGENTTEAMS_WORKER_MATRIX_TOKEN
+""",
+        encoding="utf-8",
+    )
+
+
+def _config(tmp_path: Path) -> WorkerConfig:
+    return WorkerConfig(
+        worker_name="worker-a",
+        worker_cr_name="worker-a-cr",
+        fs_endpoint="http://minio:9000",
+        fs_access_key="key",
+        fs_secret_key="secret",
+        install_dir=tmp_path / "agents",
+        runtime_config_poll_interval=0.01,
+    )
+
+
+def _write_plugin_zip(tmp_path: Path, plugin_id: str, package_name: str, zip_name: str) -> Path:
+    package_root = tmp_path / f"package-{plugin_id}" / package_name
+    package_root.mkdir(parents=True)
+    (package_root / "plugin.json").write_text(json.dumps({"id": plugin_id}) + "\n", encoding="utf-8")
+    (package_root / "plugin.py").write_text("plugin = object()\n", encoding="utf-8")
+    zip_path = tmp_path / zip_name
+    with zipfile.ZipFile(zip_path, "w") as archive:
+        archive.write(package_root / "plugin.json", f"{package_name}/plugin.json")
+        archive.write(package_root / "plugin.py", f"{package_name}/plugin.py")
+    return zip_path
+
+
+def _builtin_plugin_digest(plugin_dir: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(plugin_dir.rglob("*")):
+        if not path.is_file() or path.name == BUILTIN_QWENPAW_PLUGIN_MARKER:
+            continue
+        rel = path.relative_to(plugin_dir).as_posix()
+        digest.update(rel.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _write_builtin_plugin(root: Path, plugin_id: str, apply_name: str) -> Path:
+    plugin_dir = root / plugin_id
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": plugin_id, "name": plugin_id.title(), "version": "1.0.0"}) + "\n",
+        encoding="utf-8",
+    )
+    (plugin_dir / "plugin.py").write_text(
+        f"def {apply_name}():\n    return {{'ok': True, 'plugin': {plugin_id!r}}}\n",
+        encoding="utf-8",
+    )
+    asset_dir = plugin_dir / "assets"
+    asset_dir.mkdir()
+    (asset_dir / "builtin.txt").write_text(f"{plugin_id} asset\n", encoding="utf-8")
+    (plugin_dir / BUILTIN_QWENPAW_PLUGIN_MARKER).write_text(
+        _builtin_plugin_digest(plugin_dir) + "\n",
+        encoding="utf-8",
+    )
+    return plugin_dir
+
+
+def test_link_workspace_shared_points_to_canonical_shared(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    worker = Worker(config)
+
+    worker._link_workspace_shared()
+
+    workspace_shared = config.default_workspace_dir / "shared"
+    assert workspace_shared.is_symlink()
+    assert workspace_shared.resolve() == config.shared_dir.resolve()
+
+    task_note = workspace_shared / "tasks" / "task-1" / "workspace" / "note.txt"
+    task_note.parent.mkdir(parents=True)
+    task_note.write_text("ready\n", encoding="utf-8")
+
+    assert (config.shared_dir / "tasks" / "task-1" / "workspace" / "note.txt").read_text(encoding="utf-8") == "ready\n"
+
+
+def test_configure_qwenpaw_runtime_uses_workspace_teams_prompt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = types.SimpleNamespace(
+        agents=types.SimpleNamespace(
+            active_agent="",
+            profiles={},
+            agent_order=[],
+        ),
+        security=types.SimpleNamespace(
+            file_guard=types.SimpleNamespace(enabled=False, sensitive_files=[]),
+            tool_guard=types.SimpleNamespace(enabled=False, guarded_tools=None, auto_denied_rules=[]),
+        ),
+    )
+    saved_agents = {}
+    agent_config = types.SimpleNamespace(
+        name="",
+        workspace_dir="",
+        system_prompt_files=["AGENTS.md"],
+        running=types.SimpleNamespace(shell_command_executable="custom-shell"),
+    )
+
+    class AgentProfileRef:
+        def __init__(self, id, workspace_dir, enabled):
+            self.id = id
+            self.workspace_dir = workspace_dir
+            self.enabled = enabled
+
+    class AgentProfileConfig:
+        def __init__(self, id, name, description, workspace_dir):
+            self.id = id
+            self.name = name
+            self.description = description
+            self.workspace_dir = workspace_dir
+            self.system_prompt_files = []
+            self.running = types.SimpleNamespace(shell_command_executable="custom-shell")
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.AgentProfileConfig = AgentProfileConfig
+    config_module.AgentProfileRef = AgentProfileRef
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, config: saved_agents.update({agent_id: config})
+
+    utils_module = types.ModuleType("qwenpaw.config.utils")
+    utils_module.load_config = lambda: root
+    utils_module.save_config = lambda _root: None
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.utils", utils_module)
+
+    config = _config(tmp_path)
+    Worker(config)._configure_qwenpaw_runtime()
+
+    saved = saved_agents["default"]
+    workspace = tmp_path / "agents" / "worker-a" / ".qwenpaw" / "workspaces" / "default"
+    assert saved.workspace_dir == str(workspace)
+    assert saved.approval_level == "AUTO"
+    assert saved.system_prompt_files == ["AGENTS.md", "SOUL.md", "TEAMS.md"]
+    assert not any("shared" in prompt for prompt in saved.system_prompt_files)
+    assert saved.running.shell_command_executable == "custom-shell"
+
+    qa_profile = root.agents.profiles["QwenPaw_QA_Agent_0.2"]
+    assert qa_profile.enabled is False
+    assert qa_profile.workspace_dir == str(workspace.parent / "QwenPaw_QA_Agent_0.2")
+
+
+def test_configure_qwenpaw_runtime_disables_existing_builtin_qa_agent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class AgentProfileRef:
+        def __init__(self, id, workspace_dir, enabled):
+            self.id = id
+            self.workspace_dir = workspace_dir
+            self.enabled = enabled
+
+    qa_workspace = (
+        tmp_path / "agents" / "worker-a" / ".qwenpaw" / "workspaces" / "QwenPaw_QA_Agent_0.2"
+    )
+    root = types.SimpleNamespace(
+        agents=types.SimpleNamespace(
+            active_agent="QwenPaw_QA_Agent_0.2",
+            profiles={
+                "QwenPaw_QA_Agent_0.2": AgentProfileRef(
+                    id="QwenPaw_QA_Agent_0.2",
+                    workspace_dir=str(qa_workspace),
+                    enabled=True,
+                ),
+            },
+            agent_order=["QwenPaw_QA_Agent_0.2"],
+        ),
+        security=types.SimpleNamespace(
+            file_guard=types.SimpleNamespace(enabled=False, sensitive_files=[]),
+            tool_guard=types.SimpleNamespace(enabled=False, guarded_tools=None, auto_denied_rules=[]),
+        ),
+    )
+    saved_agents = {}
+    agent_config = types.SimpleNamespace(
+        name="",
+        workspace_dir="",
+        system_prompt_files=[],
+    )
+
+    class AgentProfileConfig:
+        def __init__(self, id, name, description, workspace_dir):
+            self.id = id
+            self.name = name
+            self.description = description
+            self.workspace_dir = workspace_dir
+            self.system_prompt_files = []
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.AgentProfileConfig = AgentProfileConfig
+    config_module.AgentProfileRef = AgentProfileRef
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, config: saved_agents.update({agent_id: config})
+
+    utils_module = types.ModuleType("qwenpaw.config.utils")
+    utils_module.load_config = lambda: root
+    utils_module.save_config = lambda _root: None
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.utils", utils_module)
+
+    Worker(_config(tmp_path))._configure_qwenpaw_runtime()
+
+    assert root.agents.active_agent == "default"
+    assert root.agents.profiles["QwenPaw_QA_Agent_0.2"].enabled is False
+    assert root.agents.profiles["QwenPaw_QA_Agent_0.2"].workspace_dir == str(qa_workspace)
+
+
+def test_configure_qwenpaw_runtime_protects_session_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing_sensitive = "/var/run/agentteams/credential.json"
+    existing_auto_deny_rule = "CUSTOM_RULE"
+    file_guard = types.SimpleNamespace(enabled=False, sensitive_files=[existing_sensitive])
+    tool_guard = types.SimpleNamespace(
+        enabled=False,
+        guarded_tools=["execute_shell_command"],
+        auto_denied_rules=[existing_auto_deny_rule],
+    )
+    root = types.SimpleNamespace(
+        agents=types.SimpleNamespace(
+            active_agent="",
+            profiles={},
+            agent_order=[],
+        ),
+        security=types.SimpleNamespace(
+            file_guard=file_guard,
+            tool_guard=tool_guard,
+        ),
+    )
+    saved_roots = []
+    saved_agents = {}
+    agent_config = types.SimpleNamespace(
+        name="",
+        workspace_dir="",
+        system_prompt_files=[],
+    )
+
+    class AgentProfileRef:
+        def __init__(self, id, workspace_dir, enabled):
+            self.id = id
+            self.workspace_dir = workspace_dir
+            self.enabled = enabled
+
+    class AgentProfileConfig:
+        def __init__(self, id, name, description, workspace_dir):
+            self.id = id
+            self.name = name
+            self.description = description
+            self.workspace_dir = workspace_dir
+            self.system_prompt_files = []
+
+    config_module = types.ModuleType("qwenpaw.config.config")
+    config_module.AgentProfileConfig = AgentProfileConfig
+    config_module.AgentProfileRef = AgentProfileRef
+    config_module.load_agent_config = lambda _agent_id: agent_config
+    config_module.save_agent_config = lambda agent_id, config: saved_agents.update({agent_id: config})
+
+    utils_module = types.ModuleType("qwenpaw.config.utils")
+    utils_module.load_config = lambda: root
+    utils_module.save_config = lambda saved_root: saved_roots.append(saved_root)
+
+    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config", types.ModuleType("qwenpaw.config"))
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
+    monkeypatch.setitem(sys.modules, "qwenpaw.config.utils", utils_module)
+
+    config = _config(tmp_path)
+    Worker(config)._configure_qwenpaw_runtime()
+    Worker(config)._configure_qwenpaw_runtime()
+
+    sessions_dir = config.default_workspace_dir / "sessions"
+    assert root.security.file_guard.enabled is True
+    assert root.security.tool_guard.enabled is True
+    assert root.security.file_guard.sensitive_files.count(existing_sensitive) == 1
+    assert root.security.file_guard.sensitive_files.count(f"{sessions_dir}/") == 1
+    assert root.security.tool_guard.guarded_tools == []
+    assert root.security.tool_guard.auto_denied_rules.count(existing_auto_deny_rule) == 1
+    assert root.security.tool_guard.auto_denied_rules.count("SENSITIVE_FILE_BLOCK") == 1
+    assert len(saved_roots) == 2
+
+
+def test_session_file_prompt_policy_is_appended_idempotently(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    config.default_workspace_dir.mkdir(parents=True)
+    agents = config.default_workspace_dir / "AGENTS.md"
+    soul = config.default_workspace_dir / "SOUL.md"
+    agents.write_text("Existing agents prompt.\n", encoding="utf-8")
+    soul.write_text("Existing soul prompt.\n", encoding="utf-8")
+
+    worker = Worker(config)
+    worker._ensure_session_file_prompt_policy()
+    worker._ensure_session_file_prompt_policy()
+
+    for prompt_file in (agents, soul):
+        content = prompt_file.read_text(encoding="utf-8")
+        assert "Do not read, list, grep, glob, summarize, copy, or expose files under sessions/." in content
+        assert "This rule applies to all channels, users, and sessions, not only DingTalk." in content
+        assert content.count("Session files are runtime-private state") == 1
+
+
+def test_file_guard_blocks_explicit_session_file_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("QWENPAW_WORKING_DIR", str(tmp_path / ".qwenpaw"))
+    file_guardian = pytest.importorskip("qwenpaw.security.tool_guard.guardians.file_guardian")
+    models = pytest.importorskip("qwenpaw.security.tool_guard.models")
+
+    sessions_dir = tmp_path / "workspace" / "sessions"
+    session_files = [
+        sessions_dir / "dingtalk" / "user-a_session-a.json",
+        sessions_dir / "console" / "user-b_session-b.json",
+        sessions_dir / "legacy-session.json",
+    ]
+    for session_file in session_files:
+        session_file.parent.mkdir(parents=True, exist_ok=True)
+        session_file.write_text('{"marker":"fake-session-marker"}\n', encoding="utf-8")
+
+    guard = file_guardian.FilePathToolGuardian(sensitive_files=[f"{sessions_dir}/"])
+
+    for session_file in session_files:
+        findings = guard.guard("read_file", {"file_path": str(session_file)})
+        assert findings
+        assert findings[0].category == models.GuardThreatCategory.SENSITIVE_FILE_ACCESS
+
+    shell_findings = guard.guard("execute_shell_command", {"command": f"cat {session_files[0]}"})
+    assert shell_findings
+    assert shell_findings[0].category == models.GuardThreatCategory.SENSITIVE_FILE_ACCESS
+
+
+def test_worker_configured_active_tool_guard_auto_denies_session_files(tmp_path: Path) -> None:
+    if importlib.util.find_spec("qwenpaw") is None:
+        pytest.skip("qwenpaw package unavailable")
+    pytest.importorskip("qwenpaw.agents.tool_guard_mixin")
+
+    script = textwrap.dedent(
+        """
+        import asyncio
+        from pathlib import Path
+        import sys
+
+        from qwenpaw_worker.config import WorkerConfig
+        from qwenpaw_worker.worker import DEFAULT_AGENT_ID, Worker
+
+        root_dir = Path(sys.argv[1])
+        config = WorkerConfig(
+            worker_name="worker-a",
+            worker_cr_name="worker-a-cr",
+            fs_endpoint="http://minio:9000",
+            fs_access_key="key",
+            fs_secret_key="secret",
+            install_dir=root_dir / "agents",
+            runtime_config_poll_interval=0.01,
+        )
+        Worker(config)._configure_qwenpaw_runtime()
+
+        from qwenpaw.agents.tool_guard_mixin import ToolGuardMixin
+        from qwenpaw.config.config import load_agent_config
+        from qwenpaw.config.utils import load_config
+        from qwenpaw.security.tool_guard.engine import ToolGuardEngine
+
+        root = load_config()
+        agent_config = load_agent_config(DEFAULT_AGENT_ID)
+        sessions_dir = config.default_workspace_dir / "sessions"
+        session_file = sessions_dir / "console" / "user-a_session-a.json"
+        session_file.parent.mkdir(parents=True, exist_ok=True)
+        session_file.write_text('{"marker":"fake-session-marker"}\\n', encoding="utf-8")
+
+        class GuardProbe(ToolGuardMixin):
+            pass
+
+        probe = GuardProbe()
+        probe._agent_config = agent_config
+        probe._request_context = {"session_id": "fake-request-session"}
+        probe._tool_guard_engine = ToolGuardEngine(enabled=True)
+
+        async def decide(tool_call):
+            return await probe._decide_guard_action(tool_call)
+
+        shell_action = asyncio.run(
+            decide(
+                {
+                    "name": "execute_shell_command",
+                    "input": {"command": "rm -rf /tmp/qwenpaw-worker-fake-target"},
+                },
+            ),
+        )
+        if shell_action is not None:
+            raise AssertionError(f"expected no approval action for ordinary shell tools; got {shell_action.kind!r}")
+
+        action = asyncio.run(decide({"name": "read_file", "input": {"file_path": str(session_file)}}))
+        if action is None:
+            raise AssertionError(
+                "expected active tool guard action for sessions file; "
+                f"approval_level={agent_config.approval_level!r} "
+                f"guarded_tools={root.security.tool_guard.guarded_tools!r} "
+                f"auto_denied_rules={root.security.tool_guard.auto_denied_rules!r}"
+            )
+        assert action.kind == "auto_denied"
+        assert any(finding.rule_id == "SENSITIVE_FILE_BLOCK" for finding in action.guard_result.findings)
+        assert root.security.file_guard.sensitive_files.count(f"{sessions_dir}/") == 1
+        assert root.security.tool_guard.guarded_tools == []
+        assert root.security.tool_guard.auto_denied_rules.count("SENSITIVE_FILE_BLOCK") == 1
+        """
+    )
+
+    env = os.environ.copy()
+    qwenpaw_src = str(Path(__file__).resolve().parents[1] / "src")
+    env["PYTHONPATH"] = os.pathsep.join(part for part in (qwenpaw_src, env.get("PYTHONPATH", "")) if part)
+    env["QWENPAW_WORKING_DIR"] = str(tmp_path / ".qwenpaw")
+    env["QWENPAW_SECRET_DIR"] = str(tmp_path / ".qwenpaw.secret")
+    env.pop("COPAW_WORKING_DIR", None)
+    env.pop("COPAW_SECRET_DIR", None)
+
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+
+def test_prepare_env_exposes_agent_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = _config(tmp_path)
+    monkeypatch.delenv("AGENT_WORKSPACE", raising=False)
+
+    Worker(config)._prepare_env()
+
+    assert os.environ["AGENT_WORKSPACE"] == str(config.default_workspace_dir)
+
+
+def test_runtime_updater_uses_default_workspace_for_package_materialization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "agent-workspace"
+    monkeypatch.setenv("AGENT_WORKSPACE", str(workspace))
+
+    config = _config(tmp_path)
+    worker = Worker(config)
+
+    assert worker.updater.package_manager.workspace_dir == config.default_workspace_dir
+
+
+def test_install_teamharness_plugin_unpacks_zip_before_qwenpaw_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    zip_path = _write_plugin_zip(tmp_path, "teamharness", "teamharness-qwenpaw-0.1.0", "teamharness-qwenpaw.zip")
+    calls: list[list[str]] = []
+
+    def fake_run(command, check):
+        assert check is True
+        plugin_dir = Path(command[3])
+        assert plugin_dir.is_dir()
+        assert (plugin_dir / "plugin.json").is_file()
+        calls.append(command)
+
+    monkeypatch.setenv("AGENTTEAMS_TEAMHARNESS_QWENPAW_PLUGIN_PACKAGE", str(zip_path))
+    monkeypatch.setattr("qwenpaw_worker.worker.shutil.which", lambda _name: "/usr/bin/qwenpaw")
+    monkeypatch.setattr("qwenpaw_worker.worker.subprocess.run", fake_run)
+
+    Worker(_config(tmp_path))._install_teamharness_plugin()
+
+    assert len(calls) == 1
+    assert calls[0][:3] == ["/usr/bin/qwenpaw", "plugin", "install"]
+    assert calls[0][4] == "--force"
+
+
+def test_plugin_install_logs_package_summary_without_sensitive_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    zip_path = _write_plugin_zip(tmp_path, "teamharness", "teamharness-qwenpaw-0.1.0", "teamharness-qwenpaw.zip")
+    config = _config(tmp_path)
+    config.fs_secret_key = "credential-secret-value"
+
+    def fake_run(command, check):
+        assert check is True
+
+    monkeypatch.setenv("AGENTTEAMS_AUTH_TOKEN", "worker-auth-token")
+    monkeypatch.setattr("qwenpaw_worker.worker.shutil.which", lambda _name: "/usr/bin/qwenpaw")
+    monkeypatch.setattr("qwenpaw_worker.worker.subprocess.run", fake_run)
+    caplog.set_level(logging.INFO, logger="qwenpaw_worker.worker")
+
+    Worker(config)._install_qwenpaw_plugin_package("teamharness", zip_path, "teamharness-qwenpaw-plugin-")
+
+    assert "component=plugin plugin=teamharness step=install event=begin" in caplog.text
+    assert "component=plugin plugin=teamharness step=install event=complete" in caplog.text
+    assert "package_type=zip" in caplog.text
+    assert "duration_ms=" in caplog.text
+    assert "credential-secret-value" not in caplog.text
+    assert "worker-auth-token" not in caplog.text
+
+
+def test_install_default_plugins_installs_teamharness_and_workerflow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    teamharness_zip = _write_plugin_zip(
+        tmp_path,
+        "teamharness",
+        "teamharness-qwenpaw-0.1.0",
+        "teamharness-qwenpaw.zip",
+    )
+    workerflow_zip = _write_plugin_zip(
+        tmp_path,
+        "workerflow",
+        "workerflow-qwenpaw-0.1.0",
+        "workerflow-qwenpaw.zip",
+    )
+    installed: list[str] = []
+
+    def fake_run(command, check):
+        assert check is True
+        plugin_dir = Path(command[3])
+        manifest = json.loads((plugin_dir / "plugin.json").read_text(encoding="utf-8"))
+        installed.append(manifest["id"])
+
+    monkeypatch.setenv("AGENTTEAMS_TEAMHARNESS_QWENPAW_PLUGIN_PACKAGE", str(teamharness_zip))
+    monkeypatch.setenv("AGENTTEAMS_WORKERFLOW_QWENPAW_PLUGIN_PACKAGE", str(workerflow_zip))
+    monkeypatch.setattr("qwenpaw_worker.worker.shutil.which", lambda _name: "/usr/bin/qwenpaw")
+    monkeypatch.setattr("qwenpaw_worker.worker.subprocess.run", fake_run)
+
+    Worker(_config(tmp_path))._install_default_plugins()
+
+    assert installed == ["teamharness", "workerflow"]
+
+
+@pytest.mark.anyio
+async def test_start_uses_image_builtin_plugins_without_runtime_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    _runtime_yaml(config.runtime_config_path)
+    builtin_plugins = tmp_path / "image-builtin" / "plugins"
+    _write_builtin_plugin(builtin_plugins, "teamharness", "apply_teamharness")
+    _write_builtin_plugin(builtin_plugins, "workerflow", "apply_workerflow")
+    teamharness_zip = _write_plugin_zip(
+        tmp_path,
+        "teamharness",
+        "teamharness-qwenpaw-0.1.0",
+        "teamharness-qwenpaw.zip",
+    )
+    workerflow_zip = _write_plugin_zip(
+        tmp_path,
+        "workerflow",
+        "workerflow-qwenpaw-0.1.0",
+        "workerflow-qwenpaw.zip",
+    )
+    install_commands: list[list[str]] = []
+
+    def fake_run(command, check):
+        assert check is True
+        install_commands.append(command)
+
+    monkeypatch.setenv("AGENTTEAMS_BUILTIN_QWENPAW_PLUGINS_DIR", str(builtin_plugins))
+    monkeypatch.setenv("AGENTTEAMS_TEAMHARNESS_QWENPAW_PLUGIN_PACKAGE", str(teamharness_zip))
+    monkeypatch.setenv("AGENTTEAMS_WORKERFLOW_QWENPAW_PLUGIN_PACKAGE", str(workerflow_zip))
+    monkeypatch.setattr("qwenpaw_worker.worker.shutil.which", lambda _name: "/usr/bin/qwenpaw")
+    monkeypatch.setattr("qwenpaw_worker.worker.subprocess.run", fake_run)
+    monkeypatch.setattr("qwenpaw_worker.sync.FileSync.mirror_all", lambda _self: None)
+    monkeypatch.setattr("qwenpaw_worker.sync.FileSync.pull_runtime_config", lambda _self, _path: True)
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._configure_qwenpaw_runtime", lambda _self: None)
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._apply_teamharness_assets", lambda _self: {"ok": True})
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._apply_workerflow_assets", lambda _self: {"ok": True})
+
+    def fake_apply_once(self, runtime_config=None, force=False, reapply_adapter=True):
+        self.current_config = runtime_config or self.load()
+
+    monkeypatch.setattr("qwenpaw_worker.update.RuntimeUpdater.apply_once", fake_apply_once)
+
+    async def fake_push_loop(sync, check_interval=5, heartbeat=None):
+        await asyncio.Event().wait()
+
+    async def fake_update_loop(self):
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr("qwenpaw_worker.worker.push_loop", fake_push_loop)
+    monkeypatch.setattr("qwenpaw_worker.update.RuntimeUpdater.loop", fake_update_loop)
+
+    worker = Worker(config)
+
+    assert await worker.start() is True
+    await asyncio.sleep(0)
+    await worker.stop()
+
+    assert install_commands == []
+    assert (config.qwenpaw_working_dir / "plugins" / "teamharness" / "plugin.py").is_file()
+    assert (config.qwenpaw_working_dir / "plugins" / "workerflow" / "plugin.py").is_file()
+
+
+def test_install_teamharness_plugin_rejects_zip_path_traversal(tmp_path: Path) -> None:
+    zip_path = tmp_path / "teamharness-qwenpaw.zip"
+    with zipfile.ZipFile(zip_path, "w") as archive:
+        archive.writestr("../target-evil/plugin.json", "{}\n")
+
+    try:
+        Worker(_config(tmp_path))._extract_qwenpaw_plugin_zip(zip_path, tmp_path / "target")
+    except RuntimeError as exc:
+        assert "unsafe qwenpaw plugin package path" in str(exc)
+    else:
+        raise AssertionError("expected unsafe plugin package path failure")
+
+    assert not (tmp_path / "target-evil").exists()
+
+
+def test_runtime_adapter_reapplies_builtin_assets_without_runtime_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    builtin_plugins = tmp_path / "image-builtin" / "plugins"
+    _write_builtin_plugin(builtin_plugins, "teamharness", "apply_teamharness")
+    _write_builtin_plugin(builtin_plugins, "workerflow", "apply_workerflow")
+    install_commands: list[list[str]] = []
+    applied: list[str] = []
+
+    def fake_run(command, check):
+        assert check is True
+        install_commands.append(command)
+
+    monkeypatch.setenv("AGENTTEAMS_BUILTIN_QWENPAW_PLUGINS_DIR", str(builtin_plugins))
+    monkeypatch.setattr("qwenpaw_worker.worker.subprocess.run", fake_run)
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._apply_teamharness_assets", lambda _self: applied.append("teamharness"))
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._apply_workerflow_assets", lambda _self: applied.append("workerflow"))
+
+    Worker(config)._apply_runtime_adapter()
+
+    assert install_commands == []
+    assert applied == ["teamharness", "workerflow"]
+    assert (config.qwenpaw_working_dir / "plugins" / "teamharness" / "plugin.py").is_file()
+    assert (config.qwenpaw_working_dir / "plugins" / "workerflow" / "plugin.py").is_file()
+
+
+def test_prepare_builtin_plugin_repairs_partial_target_with_matching_marker(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    worker = Worker(config)
+    source_dir = _write_builtin_plugin(tmp_path / "image-builtin" / "plugins", "teamharness", "apply_teamharness")
+    target_dir = config.qwenpaw_working_dir / "plugins" / "teamharness"
+    shutil.copytree(source_dir, target_dir)
+
+    (target_dir / "assets" / "builtin.txt").unlink()
+
+    assert worker._builtin_plugin_current(source_dir, target_dir) is False
+
+    worker._prepare_builtin_plugin("teamharness", source_dir)
+
+    assert (target_dir / "assets" / "builtin.txt").read_text(encoding="utf-8") == "teamharness asset\n"
+
+
+def test_apply_teamharness_assets_runs_installed_adapter(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    plugin_dir = config.qwenpaw_working_dir / "plugins" / "teamharness"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.py").write_text(
+        """
+from pathlib import Path
+
+
+def apply_teamharness():
+    Path(__file__).with_name("applied.txt").write_text("ok\\n", encoding="utf-8")
+    return {"ok": True, "source": __file__}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = Worker(config)._apply_teamharness_assets()
+
+    assert result["ok"] is True
+    assert (plugin_dir / "applied.txt").read_text(encoding="utf-8") == "ok\n"
+
+
+def test_plugin_load_and_apply_logs_safe_summary_without_result_payload(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config = _config(tmp_path)
+    plugin_dir = config.qwenpaw_working_dir / "plugins" / "teamharness"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.py").write_text(
+        """
+def apply_teamharness():
+    return {
+        "ok": True,
+        "source": __file__,
+        "secret": "plugin-secret-token",
+        "prompt": "private prompt body",
+    }
+""".lstrip(),
+        encoding="utf-8",
+    )
+    caplog.set_level(logging.INFO, logger="qwenpaw_worker.worker")
+
+    result = Worker(config)._apply_teamharness_assets()
+
+    assert result["ok"] is True
+    assert "component=plugin plugin=teamharness step=load event=begin" in caplog.text
+    assert "component=plugin plugin=teamharness step=load event=complete" in caplog.text
+    assert "entrypoint=apply_teamharness" in caplog.text
+    assert "component=plugin plugin=teamharness step=apply event=complete" in caplog.text
+    assert "ok=True" in caplog.text
+    assert "result_key_count=4" in caplog.text
+    assert "plugin-secret-token" not in caplog.text
+    assert "private prompt body" not in caplog.text
+    assert "prompt" not in caplog.text
+
+
+def test_apply_workerflow_assets_runs_installed_adapter(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    plugin_dir = config.qwenpaw_working_dir / "plugins" / "workerflow"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.py").write_text(
+        """
+from pathlib import Path
+
+
+def apply_workerflow():
+    Path(__file__).with_name("applied.txt").write_text("ok\\n", encoding="utf-8")
+    return {"ok": True, "source": __file__}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = Worker(config)._apply_workerflow_assets()
+
+    assert result["ok"] is True
+    assert (plugin_dir / "applied.txt").read_text(encoding="utf-8") == "ok\n"
+
+
+@pytest.mark.anyio
+async def test_start_reads_runtime_config_installs_adapter_and_starts_loops(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    _runtime_yaml(config.runtime_config_path)
+    calls: list[str] = []
+
+    monkeypatch.setattr("qwenpaw_worker.sync.FileSync.mirror_all", lambda _self: calls.append("mirror"))
+    monkeypatch.setattr("qwenpaw_worker.sync.FileSync.pull_runtime_config", lambda _self, _path: calls.append("pull"))
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._configure_qwenpaw_runtime", lambda self: calls.append("runtime"))
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._prepare_default_plugins", lambda self: calls.append("plugins"))
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._apply_teamharness_assets", lambda self: calls.append("teamharness-sync"))
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._apply_workerflow_assets", lambda self: calls.append("workerflow-sync"))
+
+    def fake_apply_once(self, runtime_config=None, force=False, reapply_adapter=True):
+        runtime_config = runtime_config or self.load()
+        self.current_config = runtime_config
+        calls.append(f"update:{runtime_config.generation}:{force}:{reapply_adapter}")
+
+    monkeypatch.setattr("qwenpaw_worker.update.RuntimeUpdater.apply_once", fake_apply_once)
+
+    async def fake_push_loop(sync, check_interval=5, heartbeat=None):
+        calls.append(f"push:{check_interval}")
+        await asyncio.Event().wait()
+
+    async def fake_update_loop(self):
+        calls.append("update-loop")
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr("qwenpaw_worker.worker.push_loop", fake_push_loop)
+    monkeypatch.setattr("qwenpaw_worker.update.RuntimeUpdater.loop", fake_update_loop)
+
+    worker = Worker(config)
+
+    assert await worker.start() is True
+    await asyncio.sleep(0)
+
+    assert calls[:7] == [
+        "mirror",
+        "pull",
+        "runtime",
+        "plugins",
+        "update:1:True:False",
+        "teamharness-sync",
+        "workerflow-sync",
+    ]
+    assert "push:5" in calls
+    assert "update-loop" in calls
+    assert worker.updater.current_config is not None
+    assert worker.updater.current_config.member_name == "worker-a"
+
+    await worker.stop()
+
+
+@pytest.mark.anyio
+async def test_start_logs_worker_stage_durations_without_sensitive_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config = _config(tmp_path)
+    config.fs_secret_key = "credential-secret-value"
+    config.fs_endpoint = "https://user:storage-secret-value@storage.example"
+    _runtime_yaml(config.runtime_config_path)
+    monkeypatch.setenv("AGENTTEAMS_AUTH_TOKEN", "worker-auth-token")
+    calls: list[str] = []
+
+    monkeypatch.setattr("qwenpaw_worker.sync.FileSync.mirror_all", lambda _self: calls.append("mirror"))
+    monkeypatch.setattr("qwenpaw_worker.sync.FileSync.pull_runtime_config", lambda _self, _path: calls.append("pull"))
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._configure_qwenpaw_runtime", lambda self: calls.append("runtime"))
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._prepare_default_plugins", lambda self: calls.append("plugins"))
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._apply_teamharness_assets", lambda self: calls.append("teamharness-sync"))
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._apply_workerflow_assets", lambda self: calls.append("workerflow-sync"))
+
+    def fake_apply_once(self, runtime_config=None, force=False, reapply_adapter=True):
+        runtime_config = runtime_config or self.load()
+        self.current_config = runtime_config
+        calls.append(f"update:{runtime_config.generation}:{force}:{reapply_adapter}")
+
+    monkeypatch.setattr("qwenpaw_worker.update.RuntimeUpdater.apply_once", fake_apply_once)
+
+    async def fake_push_loop(sync, check_interval=5, heartbeat=None):
+        calls.append(f"push:{check_interval}")
+        await asyncio.Event().wait()
+
+    async def fake_update_loop(self):
+        calls.append("update-loop")
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr("qwenpaw_worker.worker.push_loop", fake_push_loop)
+    monkeypatch.setattr("qwenpaw_worker.update.RuntimeUpdater.loop", fake_update_loop)
+
+    caplog.set_level(logging.INFO, logger="qwenpaw_worker.worker")
+    worker = Worker(config)
+
+    assert await worker.start() is True
+    await asyncio.sleep(0)
+    await worker.stop()
+
+    assert "component=worker stage=mirror_all" in caplog.text
+    assert "component=worker stage=load_runtime_config" in caplog.text
+    assert "duration_ms=" in caplog.text
+    assert "generation=1" in caplog.text
+    assert "team=demo-team" in caplog.text
+    assert "member=worker-a" in caplog.text
+    assert "credential-secret-value" not in caplog.text
+    assert "storage-secret-value" not in caplog.text
+    assert "https://<redacted>@storage.example" in caplog.text
+    assert "worker-auth-token" not in caplog.text
+    assert "internal-token" not in caplog.text
+    assert "prompt" not in caplog.text
+    assert "session content" not in caplog.text
+
+
+@pytest.mark.anyio
+async def test_start_links_workspace_shared_to_runtime_team_shared_prefix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    _runtime_yaml(config.runtime_config_path, shared_prefix="teams/demo-team/shared")
+    calls: list[str] = []
+
+    monkeypatch.delenv("AGENTTEAMS_SHARED_STORAGE_PREFIX", raising=False)
+    monkeypatch.setattr("qwenpaw_worker.sync.FileSync.mirror_all", lambda _self: calls.append("mirror"))
+    monkeypatch.setattr("qwenpaw_worker.sync.FileSync.pull_runtime_config", lambda _self, _path: calls.append("pull"))
+
+    def fake_mirror_prefix(_self, remote_prefix, local_dir):
+        local_dir.mkdir(parents=True, exist_ok=True)
+        calls.append(f"mirror-prefix:{remote_prefix}:{local_dir}")
+
+    monkeypatch.setattr("qwenpaw_worker.sync.FileSync.mirror_prefix", fake_mirror_prefix)
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._configure_qwenpaw_runtime", lambda self: calls.append("runtime"))
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._prepare_default_plugins", lambda self: calls.append("plugins"))
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._apply_teamharness_assets", lambda self: calls.append("teamharness-sync"))
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._apply_workerflow_assets", lambda self: calls.append("workerflow-sync"))
+
+    def fake_apply_once(self, runtime_config=None, force=False, reapply_adapter=True):
+        runtime_config = runtime_config or self.load()
+        self.current_config = runtime_config
+        calls.append(f"update:{runtime_config.generation}:{force}:{reapply_adapter}")
+
+    monkeypatch.setattr("qwenpaw_worker.update.RuntimeUpdater.apply_once", fake_apply_once)
+
+    async def fake_push_loop(sync, check_interval=5, heartbeat=None):
+        calls.append(f"push:{check_interval}")
+        await asyncio.Event().wait()
+
+    async def fake_update_loop(self):
+        calls.append("update-loop")
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr("qwenpaw_worker.worker.push_loop", fake_push_loop)
+    monkeypatch.setattr("qwenpaw_worker.update.RuntimeUpdater.loop", fake_update_loop)
+
+    worker = Worker(config)
+
+    assert await worker.start() is True
+    await asyncio.sleep(0)
+
+    team_shared = tmp_path / "teams" / "demo-team" / "shared"
+    workspace_shared = config.default_workspace_dir / "shared"
+    assert workspace_shared.is_symlink()
+    assert workspace_shared.resolve() == team_shared.resolve()
+    assert config.runtime_config_path == tmp_path / "agents" / "worker-a" / "runtime" / "runtime.yaml"
+    assert os.environ["TEAMHARNESS_SHARED_DIR"] == str(team_shared)
+    assert os.environ["AGENTTEAMS_SHARED_STORAGE_PREFIX"] == "teams/demo-team/shared"
+    assert f"mirror-prefix:teams/demo-team/shared:{team_shared}" in calls
+
+    await worker.stop()
+
+
+@pytest.mark.anyio
+async def test_start_fails_when_runtime_config_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    monkeypatch.setattr("qwenpaw_worker.sync.FileSync.mirror_all", lambda _self: None)
+    monkeypatch.setattr("qwenpaw_worker.sync.FileSync.pull_runtime_config", lambda _self, _path: False)
+
+    worker = Worker(config)
+
+    assert await worker.start() is False
+
+    data = json.loads((config.qwenpaw_working_dir / "heartbeat.json").read_text(encoding="utf-8"))
+    assert data["status"] == "not_ready"
+    assert "runtime config missing" in data["message"]
+
+
+@pytest.mark.anyio
+async def test_builtin_plugin_prepare_failure_marks_worker_unready(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    _runtime_yaml(config.runtime_config_path)
+
+    monkeypatch.setattr("qwenpaw_worker.sync.FileSync.mirror_all", lambda _self: None)
+    monkeypatch.setattr("qwenpaw_worker.sync.FileSync.pull_runtime_config", lambda _self, _path: True)
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._configure_qwenpaw_runtime", lambda self: None)
+
+    def fail_prepare(_self):
+        raise RuntimeError("plugin prepare failed")
+
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._prepare_default_plugins", fail_prepare)
+
+    worker = Worker(config)
+
+    assert await worker.start() is False
+
+    data = json.loads((config.qwenpaw_working_dir / "heartbeat.json").read_text(encoding="utf-8"))
+    assert data["status"] == "not_ready"
+    assert data["message"] == "plugin prepare failed"
+
+
+@pytest.mark.anyio
+async def test_qwenpaw_config_failure_marks_qwenpaw_config_unready(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    _runtime_yaml(config.runtime_config_path)
+
+    monkeypatch.setattr("qwenpaw_worker.sync.FileSync.mirror_all", lambda _self: None)
+    monkeypatch.setattr("qwenpaw_worker.sync.FileSync.pull_runtime_config", lambda _self, _path: True)
+
+    def fail_config(_self):
+        raise RuntimeError("qwenpaw config failed")
+
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._configure_qwenpaw_runtime", fail_config)
+
+    worker = Worker(config)
+
+    assert await worker.start() is False
+
+    data = json.loads((config.qwenpaw_working_dir / "heartbeat.json").read_text(encoding="utf-8"))
+    assert data["status"] == "not_ready"
+    assert data["message"] == "qwenpaw config failed"
+
+
+@pytest.mark.anyio
+async def test_hot_update_failure_does_not_relabel_qwenpaw_config_unready(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    _runtime_yaml(config.runtime_config_path)
+
+    monkeypatch.setattr("qwenpaw_worker.sync.FileSync.mirror_all", lambda _self: None)
+    monkeypatch.setattr("qwenpaw_worker.sync.FileSync.pull_runtime_config", lambda _self, _path: True)
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._configure_qwenpaw_runtime", lambda _self: None)
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._prepare_default_plugins", lambda _self: None)
+
+    def fail_update(_self, runtime_config=None, force=False, reapply_adapter=True):
+        raise RuntimeError("agent package failed")
+
+    monkeypatch.setattr("qwenpaw_worker.update.RuntimeUpdater.apply_once", fail_update)
+
+    worker = Worker(config)
+
+    assert await worker.start() is False
+
+    data = json.loads((config.qwenpaw_working_dir / "heartbeat.json").read_text(encoding="utf-8"))
+    assert data["status"] == "not_ready"
+    assert data["message"] == "agent package failed"
+
+
+def test_hot_update_apply_does_not_replace_qwenpaw_process(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    worker = Worker(config)
+    process = object()
+    package_calls: list[str] = []
+    adapter_calls: list[str] = []
+
+    class FakePackageManager:
+        def apply(self, runtime_config):
+            package_calls.append(runtime_config.generation)
+            return tmp_path / "packages" / runtime_config.generation
+
+    worker._process = process
+    worker.updater.package_manager = FakePackageManager()
+    worker.updater.adapter_apply = lambda: adapter_calls.append("adapter")
+    worker.updater.current_config = MemberRuntimeConfig(
+        path=config.runtime_config_path,
+        raw={"metadata": {"generation": "1"}, "member": {"runtime": "qwenpaw"}},
+    )
+
+    worker.updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={"metadata": {"generation": "2"}, "member": {"runtime": "qwenpaw"}},
+        )
+    )
+
+    assert package_calls == ["2"]
+    assert adapter_calls == ["adapter"]
+    assert worker._process is process
+
+
+@pytest.mark.anyio
+async def test_qwenpaw_process_exit_marks_runtime_not_ready(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config = _config(tmp_path)
+    worker = Worker(config)
+    caplog.set_level(logging.INFO, logger="qwenpaw_worker.worker")
+
+    class FakeProcess:
+        pid = 12345
+        returncode = 7
+
+        async def wait(self):
+            return self.returncode
+
+    async def fake_create_subprocess_exec(*_args, **_kwargs):
+        return FakeProcess()
+
+    async def idle_heartbeat_probe_loop(self):
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr("qwenpaw_worker.worker.asyncio.create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("qwenpaw_worker.worker.Worker._heartbeat_probe_loop", idle_heartbeat_probe_loop)
+
+    await worker._run_qwenpaw()
+    await worker.stop()
+
+    data = json.loads((config.qwenpaw_working_dir / "heartbeat.json").read_text(encoding="utf-8"))
+    assert data["status"] == "not_ready"
+    assert data["details"]["returncode"] == 7
+    assert "component=worker stage=start_qwenpaw_app event=begin" in caplog.text
+    assert "component=worker stage=start_qwenpaw_app event=complete" in caplog.text
+    assert "component=worker stage=start_qwenpaw_app event=exited" in caplog.text
+    assert "pid=12345" in caplog.text
+    assert "returncode=7" in caplog.text
+
+
+@pytest.mark.anyio
+async def test_stop_logs_failed_background_task_and_still_terminates_process(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config = _config(tmp_path)
+    worker = Worker(config)
+    terminated: list[str] = []
+
+    async def failed_task():
+        raise RuntimeError("background exploded")
+
+    task = asyncio.create_task(failed_task())
+    await asyncio.sleep(0)
+    worker._update_task = task
+
+    class FakeProcess:
+        returncode = None
+
+        def terminate(self):
+            terminated.append("terminate")
+            self.returncode = 0
+
+        async def wait(self):
+            return self.returncode
+
+    worker._process = FakeProcess()
+
+    await worker.stop()
+
+    assert terminated == ["terminate"]
+    assert worker._update_task is None
+    assert "background task _update_task failed during stop" in caplog.text
+
+
+@pytest.mark.anyio
+async def test_qwenpaw_process_start_failure_marks_runtime_not_ready(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config = _config(tmp_path)
+    worker = Worker(config)
+    caplog.set_level(logging.INFO, logger="qwenpaw_worker.worker")
+
+    async def fail_create_subprocess_exec(*_args, **_kwargs):
+        raise FileNotFoundError("qwenpaw not found secret-token-value")
+
+    monkeypatch.setattr("qwenpaw_worker.worker.asyncio.create_subprocess_exec", fail_create_subprocess_exec)
+
+    with pytest.raises(FileNotFoundError):
+        await worker._run_qwenpaw()
+
+    data = json.loads((config.qwenpaw_working_dir / "heartbeat.json").read_text(encoding="utf-8"))
+    assert data["status"] == "not_ready"
+    assert data["message"] == "qwenpaw app failed to start"
+    assert data["details"]["error_type"] == "FileNotFoundError"
+    assert "secret-token-value" not in json.dumps(data)
+    assert "component=worker stage=start_qwenpaw_app event=failed" in caplog.text
+    assert "error_type=FileNotFoundError" in caplog.text
+    assert "secret-token-value" not in caplog.text
+
+
+@pytest.mark.anyio
+async def test_heartbeat_probe_loop_delegates_to_heartbeat_module(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    worker = Worker(config)
+    calls: list[tuple[str, int]] = []
+
+    async def fake_loop(heartbeat, *, worker_name, port):
+        calls.append((worker_name, port))
+        heartbeat.update("ready", "qwenpaw ready")
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr("qwenpaw_worker.worker.run_worker_heartbeat_loop", fake_loop)
+    with pytest.raises(asyncio.CancelledError):
+        await worker._heartbeat_probe_loop()
+
+    data = json.loads((config.qwenpaw_working_dir / "heartbeat.json").read_text(encoding="utf-8"))
+    assert data["status"] == "ready"
+    assert data["message"] == "qwenpaw ready"
+    assert calls == [("worker-a-cr", config.console_port)]


### PR DESCRIPTION
## Summary
- add the QwenPaw worker runtime Python package baseline
- include runtime config sync, storage sync, heartbeat reporting, Matrix channel overlay, and focused unit tests
- document this PR's package-only boundary

## Explicitly out of scope
- controller/Helm runtime selection wiring
- worker image/Dockerfile and image integration tests
- TeamHarness/WorkerFlow adapter artifacts
- Edge/local remote worker credential/JWT flows

## Validation
- uv run --project qwenpaw --with pytest pytest qwenpaw/tests -q
- git diff --check --cached
- added-line naming scan for intermediate HiClaw names