### PR TITLE
feat(workerflow): add QwenPaw adapter

### DIFF
--- a/plugins/tests/workerflow/adapters/qwenpaw/test_adapter.py
+++ b/plugins/tests/workerflow/adapters/qwenpaw/test_adapter.py
@@ -1,0 +1,72 @@
+"""Tests for WorkerFlow QwenPaw adapter wiring."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+PLUGIN_PATH = REPO_ROOT / "plugins" / "workerflow" / "adapters" / "qwenpaw" / "plugin.py"
+
+
+def load_plugin():
+    spec = importlib.util.spec_from_file_location("workerflow_qwenpaw_plugin_test", PLUGIN_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load plugin from {PLUGIN_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class WorkerFlowQwenPawAdapterTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.env_keys = [
+            "TEAMHARNESS_RUNTIME_CONFIG",
+            "AGENTTEAMS_MEMBER_RUNTIME_CONFIG",
+            "AGENTTEAMS_MATRIX_URL",
+            "AGENTTEAMS_MATRIX_SERVER",
+            "AGENTTEAMS_MATRIX_HOMESERVER",
+            "AGENTTEAMS_WORKER_MATRIX_TOKEN",
+            "AGENTTEAMS_MATRIX_TOKEN",
+            "AGENTTEAMS_MATRIX_USER_ID",
+            "AGENTTEAMS_MATRIX_DOMAIN",
+            "AGENTTEAMS_WORKER_ROLE",
+            "AGENTTEAMS_AGENT_ROLE",
+            "AGENTTEAMS_WORKER_NAME",
+            "QWENPAW_WORKING_DIR",
+        ]
+        self.old_env = {key: os.environ.get(key) for key in self.env_keys}
+        for key in self.env_keys:
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        for key, value in self.old_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def test_mcp_client_env_includes_runtime_and_matrix_inputs(self) -> None:
+        module = load_plugin()
+        os.environ["TEAMHARNESS_RUNTIME_CONFIG"] = "/shared/runtime/worker/runtime.yaml"
+        os.environ["AGENTTEAMS_MATRIX_URL"] = "http://matrix.local"
+        os.environ["AGENTTEAMS_WORKER_MATRIX_TOKEN"] = "matrix-token"
+        os.environ["AGENTTEAMS_MATRIX_USER_ID"] = "@worker:matrix.local"
+        os.environ["AGENTTEAMS_WORKER_NAME"] = "worker-a"
+        os.environ["QWENPAW_WORKING_DIR"] = "/root/.qwenpaw"
+
+        env = module._mcp_client_env()
+
+        self.assertEqual(env["TEAMHARNESS_RUNTIME_CONFIG"], "/shared/runtime/worker/runtime.yaml")
+        self.assertEqual(env["AGENTTEAMS_MATRIX_URL"], "http://matrix.local")
+        self.assertEqual(env["AGENTTEAMS_WORKER_MATRIX_TOKEN"], "matrix-token")
+        self.assertEqual(env["AGENTTEAMS_MATRIX_USER_ID"], "@worker:matrix.local")
+        self.assertEqual(env["AGENTTEAMS_WORKER_NAME"], "worker-a")
+        self.assertEqual(env["QWENPAW_WORKING_DIR"], "/root/.qwenpaw")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/plugins/tests/workerflow/adapters/qwenpaw/test_workerflow_package.py
+++ b/plugins/tests/workerflow/adapters/qwenpaw/test_workerflow_package.py
@@ -1,0 +1,65 @@
+import json
+import os
+import re
+import subprocess
+import zipfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+MANIFEST = REPO_ROOT / "plugins" / "workerflow" / "plugin.yaml"
+BUILD_SCRIPT = (
+    REPO_ROOT
+    / "plugins"
+    / "workerflow"
+    / "adapters"
+    / "qwenpaw"
+    / "scripts"
+    / "build-qwenpaw-plugin.rb"
+)
+
+
+def _manifest_version() -> str:
+    match = re.search(r"^  version:\s*(\S+)\s*$", MANIFEST.read_text(encoding="utf-8"), re.MULTILINE)
+    assert match is not None
+    return match.group(1)
+
+
+def test_build_qwenpaw_native_workerflow_plugin_package(tmp_path: Path) -> None:
+    result = subprocess.run(
+        ["ruby", str(BUILD_SCRIPT), str(MANIFEST)],
+        cwd=REPO_ROOT,
+        env={**os.environ, "OUT_DIR": str(tmp_path)},
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+    zip_path = Path(result.stdout.strip().splitlines()[-1])
+    assert zip_path.is_file()
+    assert (tmp_path / "workerflow-qwenpaw.zip").is_file()
+
+    version = _manifest_version()
+    root = f"workerflow-qwenpaw-{version}"
+    with zipfile.ZipFile(zip_path) as archive:
+        names = set(archive.namelist())
+        assert f"{root}/plugin.json" in names
+        assert f"{root}/plugin.py" in names
+        assert f"{root}/workerflow/plugin.yaml" in names
+        assert f"{root}/workerflow/prompts/team/WORKERFLOW.md" in names
+        assert f"{root}/workerflow/prompts/agent/worker.md" in names
+        assert f"{root}/workerflow/skills/agent/worker-internal-workflow/SKILL.md" in names
+        assert f"{root}/workerflow/mcp/server.py" in names
+
+        skill = archive.read(
+            f"{root}/workerflow/skills/agent/worker-internal-workflow/SKILL.md"
+        ).decode("utf-8")
+        manifest = json.loads(archive.read(f"{root}/plugin.json"))
+
+    assert skill.startswith("---\n")
+    assert "name: workerflow-internal-workflow" in skill
+    assert manifest["id"] == "workerflow"
+    assert manifest["version"] == version
+    assert manifest["entry"]["backend"] == "plugin.py"
+    assert "workerflow-mcp" in manifest["meta"]["features"]

--- a/plugins/tests/workerflow/mcp/test_server.py
+++ b/plugins/tests/workerflow/mcp/test_server.py
@@ -1,0 +1,864 @@
+#!/usr/bin/env python3
+"""Tests for WorkerFlow MCP server filesystem utilities."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SERVER_PATH = REPO_ROOT / "plugins" / "workerflow" / "mcp" / "server.py"
+
+
+def load_server():
+    spec = importlib.util.spec_from_file_location("workerflow_mcp_server", SERVER_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class WorkerFlowSharedDirTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory(prefix="workerflow-shared-")
+        self.root = Path(self.tmp.name)
+        self.old_env = {
+            "QWENPAW_WORKING_DIR": os.environ.get("QWENPAW_WORKING_DIR"),
+            "QWENPAW_DEFAULT_WORKSPACE_DIR": os.environ.get("QWENPAW_DEFAULT_WORKSPACE_DIR"),
+            "QWENPAW_API_BASE_URL": os.environ.get("QWENPAW_API_BASE_URL"),
+            "QWENPAW_BASE_URL": os.environ.get("QWENPAW_BASE_URL"),
+            "TEAMHARNESS_RUNTIME_CONFIG": os.environ.get("TEAMHARNESS_RUNTIME_CONFIG"),
+            "AGENTTEAMS_MEMBER_RUNTIME_CONFIG": os.environ.get("AGENTTEAMS_MEMBER_RUNTIME_CONFIG"),
+            "AGENTTEAMS_MATRIX_URL": os.environ.get("AGENTTEAMS_MATRIX_URL"),
+            "AGENTTEAMS_MATRIX_SERVER": os.environ.get("AGENTTEAMS_MATRIX_SERVER"),
+            "AGENTTEAMS_MATRIX_HOMESERVER": os.environ.get("AGENTTEAMS_MATRIX_HOMESERVER"),
+            "AGENTTEAMS_WORKER_MATRIX_TOKEN": os.environ.get("AGENTTEAMS_WORKER_MATRIX_TOKEN"),
+            "AGENTTEAMS_MATRIX_TOKEN": os.environ.get("AGENTTEAMS_MATRIX_TOKEN"),
+            "WORKERFLOW_MATRIX_TOKEN": os.environ.get("WORKERFLOW_MATRIX_TOKEN"),
+            "AGENTTEAMS_MATRIX_USER_ID": os.environ.get("AGENTTEAMS_MATRIX_USER_ID"),
+        }
+        os.environ["QWENPAW_WORKING_DIR"] = str(self.root / ".qwenpaw")
+        os.environ.pop("QWENPAW_DEFAULT_WORKSPACE_DIR", None)
+        os.environ.pop("QWENPAW_API_BASE_URL", None)
+        os.environ.pop("QWENPAW_BASE_URL", None)
+        os.environ.pop("TEAMHARNESS_RUNTIME_CONFIG", None)
+        os.environ.pop("AGENTTEAMS_MEMBER_RUNTIME_CONFIG", None)
+        os.environ.pop("AGENTTEAMS_MATRIX_URL", None)
+        os.environ.pop("AGENTTEAMS_MATRIX_SERVER", None)
+        os.environ.pop("AGENTTEAMS_MATRIX_HOMESERVER", None)
+        os.environ.pop("AGENTTEAMS_WORKER_MATRIX_TOKEN", None)
+        os.environ.pop("AGENTTEAMS_MATRIX_TOKEN", None)
+        os.environ.pop("WORKERFLOW_MATRIX_TOKEN", None)
+        os.environ.pop("AGENTTEAMS_MATRIX_USER_ID", None)
+        self.server = load_server()
+
+    def tearDown(self) -> None:
+        for key, value in self.old_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        self.tmp.cleanup()
+
+    def test_api_base_argument_must_be_loopback(self) -> None:
+        self.assertEqual(
+            self.server._api_base("http://127.0.0.1:8088"),
+            "http://127.0.0.1:8088/api",
+        )
+        self.assertEqual(
+            self.server._api_base("http://localhost:8088/api/"),
+            "http://localhost:8088/api",
+        )
+
+        with self.assertRaisesRegex(ValueError, "loopback"):
+            self.server._api_base("http://169.254.169.254/latest")
+
+    def test_shared_dir_survives_temp_workspace_cleanup(self) -> None:
+        agent_id = "tmp-workerflow-test"
+        workspace = self.root / ".qwenpaw" / "workspaces" / agent_id
+        shared = self.server._resolve_shared_dir("", "run-abc", agent_id)
+
+        result = self.server._setup_shared_dir(agent_id, workspace, shared)
+
+        self.assertTrue((shared / "inputs").is_dir())
+        self.assertTrue((shared / "outputs" / agent_id).is_dir())
+        self.assertEqual(result["path"], str(shared.resolve()))
+
+        metadata = json.loads((workspace / ".workerflow" / "shared.json").read_text(encoding="utf-8"))
+        self.assertEqual(metadata["agentId"], agent_id)
+        self.assertEqual(metadata["sharedPath"], str(shared.resolve()))
+        self.assertEqual(metadata["inputsPath"], str((shared / "inputs").resolve()))
+        self.assertEqual(metadata["outputPath"], str((shared / "outputs" / agent_id).resolve()))
+
+        link = workspace / "shared"
+        self.assertTrue(link.is_symlink())
+        self.assertEqual(link.resolve(), shared.resolve())
+
+        cleanup = self.server._safe_cleanup_workspace(agent_id, str(workspace))
+
+        self.assertTrue(cleanup["removed"])
+        self.assertFalse(workspace.exists())
+        self.assertTrue(shared.exists())
+
+    def test_cleanup_shared_only_removes_workerflow_shared_root_children(self) -> None:
+        outside = self.root / "outside"
+        outside.mkdir()
+
+        rejected = self.server._safe_cleanup_shared(outside)
+
+        self.assertFalse(rejected["removed"])
+        self.assertEqual(rejected["reason"], "shared_dir_outside_workerflow_root")
+        self.assertTrue(outside.exists())
+
+        shared = self.server._resolve_shared_dir("", "run-clean", "tmp-workerflow-test")
+        (shared / "inputs").mkdir(parents=True)
+
+        removed = self.server._safe_cleanup_shared(shared)
+
+        self.assertTrue(removed["removed"])
+        self.assertFalse(shared.exists())
+
+    def test_workflow_start_and_update_send_matrix_card(self) -> None:
+        runtime = self.root / "runtime.yaml"
+        runtime.write_text(
+            "\n".join(
+                [
+                    "team:",
+                    "  teamRoomId: '!team:example.test'",
+                    "member:",
+                    "  matrixUserId: '@worker:example.test'",
+                    "  personalRoomId: '!personal:example.test'",
+                ],
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        os.environ["TEAMHARNESS_RUNTIME_CONFIG"] = str(runtime)
+        os.environ["AGENTTEAMS_WORKER_MATRIX_TOKEN"] = "test-token"
+
+        captured: list[dict[str, object]] = []
+
+        def fake_send(room_id: str, content: dict[str, object]) -> str:
+            captured.append({"roomId": room_id, "content": content})
+            return f"$event{len(captured)}"
+
+        self.server._matrix_send_content = fake_send
+
+        started = self.server._agentflow(
+            {
+                "action": "workflow_start",
+                "runId": "run-ui",
+                "roomId": "!dm:example.test",
+                "title": "WorkerFlow Review",
+                "summary": "creating subagents",
+                "subagents": [
+                    {"agentId": "tmp-a", "role": "review", "status": "running", "summary": "started"},
+                ],
+            },
+        )
+
+        self.assertTrue(started["ok"])
+        self.assertEqual(started["eventId"], "$event1")
+        self.assertEqual(started["roomId"], "!dm:example.test")
+        first = captured[0]
+        self.assertEqual(first["roomId"], "!dm:example.test")
+        first_body = first["content"]
+        self.assertEqual(first_body["msgtype"], "m.notice")
+        self.assertEqual(first_body["hiclaw.workflow"]["coordinator"], "@worker:example.test")
+        self.assertEqual(first_body["hiclaw.workflow"]["subagents"][0]["agentId"], "tmp-a")
+        self.assertNotIn("helpers", first_body["hiclaw.workflow"])
+        self.assertIn("<table>", first_body["formatted_body"])
+
+        state_path = Path(started["statePath"])
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        self.assertEqual(state["eventId"], "$event1")
+        self.assertEqual(state["roomId"], "!dm:example.test")
+
+        updated = self.server._agentflow(
+            {
+                "action": "workflow_update",
+                "runId": "run-ui",
+                "status": "merging",
+                "summary": "subagent result ready",
+                "subagents": [
+                    {"agentId": "tmp-a", "role": "review", "status": "done", "summary": "ok"},
+                ],
+            },
+        )
+
+        self.assertTrue(updated["ok"])
+        self.assertEqual(updated["eventId"], "$event1")
+        self.assertEqual(updated["editEventId"], "$event2")
+        second_body = captured[1]["content"]
+        self.assertEqual(second_body["m.relates_to"]["rel_type"], "m.replace")
+        self.assertEqual(second_body["m.relates_to"]["event_id"], "$event1")
+        self.assertEqual(second_body["m.new_content"]["hiclaw.workflow"]["status"], "merging")
+        self.assertNotIn("helpers", second_body["m.new_content"]["hiclaw.workflow"])
+        updated_state = json.loads(state_path.read_text(encoding="utf-8"))
+        self.assertEqual(updated_state["lastEditEventId"], "$event2")
+
+    def test_workflow_update_syncs_step_status_to_subagents_and_renders_step_id(self) -> None:
+        runtime = self.root / "runtime-subagents.yaml"
+        runtime.write_text(
+            "\n".join(
+                [
+                    "member:",
+                    "  matrixUserId: '@worker:example.test'",
+                ],
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        os.environ["TEAMHARNESS_RUNTIME_CONFIG"] = str(runtime)
+        os.environ["AGENTTEAMS_WORKER_MATRIX_TOKEN"] = "test-token"
+
+        captured: list[dict[str, object]] = []
+
+        def fake_send(room_id: str, content: dict[str, object]) -> str:
+            captured.append({"roomId": room_id, "content": content})
+            return f"$event{len(captured)}"
+
+        self.server._matrix_send_content = fake_send
+
+        started = self.server._agentflow(
+            {
+                "action": "workflow_start",
+                "runId": "run-sync",
+                "roomId": "!dm:example.test",
+                "title": "Pig diagnosis",
+                "summary": "subagents ready",
+                "subagents": [
+                    {
+                        "id": "disease_analysis",
+                        "agentId": "tmp-workerflow-run-sync-disease_analysis",
+                        "role": "disease-analysis-agent",
+                        "status": "waiting",
+                        "summary": "waiting for base_info",
+                    },
+                ],
+            },
+        )
+
+        self.assertTrue(started["ok"])
+        state_path = Path(started["statePath"])
+
+        updated = self.server._agentflow(
+            {
+                "action": "workflow_update",
+                "runId": "run-sync",
+                "status": "running",
+                "summary": "disease analysis done",
+                "steps": [
+                    {
+                        "id": "disease_analysis",
+                        "status": "done",
+                        "summary": "风险HIGH",
+                    },
+                ],
+            },
+        )
+
+        self.assertTrue(updated["ok"])
+        workflow = captured[1]["content"]["m.new_content"]["hiclaw.workflow"]
+        self.assertEqual(workflow["subagents"][0]["status"], "done")
+        self.assertEqual(workflow["subagents"][0]["summary"], "风险HIGH")
+        self.assertNotIn("helpers", workflow)
+        formatted = captured[1]["content"]["m.new_content"]["formatted_body"]
+        self.assertIn("<h4>Subagents</h4>", formatted)
+        self.assertIn("<td>disease_analysis</td><td>done</td><td>风险HIGH</td>", formatted)
+        updated_state = json.loads(state_path.read_text(encoding="utf-8"))
+        self.assertEqual(updated_state["subagents"][0]["status"], "done")
+        self.assertNotIn("helpers", updated_state)
+
+    def test_workflow_run_creates_subagents_and_submit_instructions(self) -> None:
+        subagent = self.root / ".qwenpaw" / "workspaces" / "default" / "subagents" / "security-reviewer"
+        subagent.mkdir(parents=True)
+        (subagent / "AGENTS.md").write_text("Review security only.\n", encoding="utf-8")
+
+        captured_matrix: list[dict[str, object]] = []
+        requests: list[dict[str, object]] = []
+
+        def fake_send(room_id: str, content: dict[str, object]) -> str:
+            captured_matrix.append({"roomId": room_id, "content": content})
+            return f"$event{len(captured_matrix)}"
+
+        def fake_json_request(method: str, _base_url: str, path: str, payload: dict[str, object] | None = None) -> dict[str, object]:
+            requests.append({"method": method, "path": path, "payload": payload})
+            if method == "POST" and path == "/agents":
+                assert payload is not None
+                return dict(payload)
+            raise AssertionError(f"unexpected request: {method} {path}")
+
+        self.server._matrix_send_content = fake_send
+        self.server._json_request = fake_json_request
+
+        result = self.server._agentflow(
+            {
+                "action": "workflow_run",
+                "runId": "run-dyn",
+                "roomId": "!dm:example.test",
+                "title": "Security review",
+                "input": "Review auth.py",
+                "subagents": [
+                    {
+                        "id": "security",
+                        "subagent": "security-reviewer",
+                        "task": "检查鉴权和权限边界风险",
+                    },
+                ],
+            },
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["action"], "workflow_run")
+        self.assertEqual(result["runId"], "run-dyn")
+        self.assertEqual(len(requests), 1)
+        payload = requests[0]["payload"]
+        self.assertEqual(payload["id"], "tmp-workerflow-run-dyn-security")
+        self.assertEqual(result["subagents"][0]["agentId"], "tmp-workerflow-run-dyn-security")
+        self.assertEqual(result["subagents"][0]["status"], "ready")
+        self.assertIn("submitPrompt", result["subagents"][0])
+        self.assertIn("Review auth.py", result["subagents"][0]["submitPrompt"])
+        self.assertIn("检查鉴权和权限边界风险", result["subagents"][0]["submitPrompt"])
+        self.assertNotIn("helpers", result)
+
+        self.assertEqual(captured_matrix[0]["roomId"], "!dm:example.test")
+        self.assertEqual(captured_matrix[0]["content"]["hiclaw.workflow"]["status"], "spawning")
+        workflow = captured_matrix[1]["content"]["m.new_content"]["hiclaw.workflow"]
+        self.assertEqual(workflow["status"], "ready")
+        self.assertEqual(workflow["subagents"][0]["agentId"], "tmp-workerflow-run-dyn-security")
+        self.assertNotIn("helpers", workflow)
+
+        state = json.loads(Path(result["statePath"]).read_text(encoding="utf-8"))
+        self.assertEqual(state["status"], "ready")
+        self.assertEqual(state["subagents"][0]["status"], "ready")
+        self.assertEqual(state["subagents"][0]["subagent"], "security-reviewer")
+        self.assertNotIn("helpers", state)
+
+    def test_workflow_finish_deletes_workflow_temp_agents_without_workspace_cleanup(self) -> None:
+        subagents_root = self.root / ".qwenpaw" / "workspaces" / "default" / "subagents"
+        for name in ("base-info-agent", "report-agent"):
+            path = subagents_root / name
+            path.mkdir(parents=True)
+            (path / "AGENTS.md").write_text(f"{name}\n", encoding="utf-8")
+
+        captured_matrix: list[dict[str, object]] = []
+        requests: list[dict[str, object]] = []
+
+        def fake_send(room_id: str, content: dict[str, object]) -> str:
+            captured_matrix.append({"roomId": room_id, "content": content})
+            return f"$event{len(captured_matrix)}"
+
+        def fake_json_request(method: str, _base_url: str, path: str, payload: dict[str, object] | None = None) -> dict[str, object]:
+            requests.append({"method": method, "path": path, "payload": payload})
+            if method == "POST" and path == "/agents":
+                assert payload is not None
+                return dict(payload)
+            if method == "DELETE" and path.startswith("/agents/"):
+                return {"deleted": path.rsplit("/", 1)[-1]}
+            raise AssertionError(f"unexpected request: {method} {path}")
+
+        self.server._matrix_send_content = fake_send
+        self.server._json_request = fake_json_request
+
+        started = self.server._agentflow(
+            {
+                "action": "workflow_run",
+                "runId": "run-cleanup",
+                "roomId": "!dm:example.test",
+                "title": "Cleanup check",
+                "input": "Generate report",
+                "nodes": [
+                    {
+                        "id": "base_info",
+                        "subagent": "base-info-agent",
+                        "task": "整理基础信息",
+                    },
+                    {
+                        "id": "report",
+                        "subagent": "report-agent",
+                        "task": "生成报告",
+                        "dependsOn": ["base_info"],
+                    },
+                ],
+            },
+        )
+
+        finished = self.server._agentflow(
+            {
+                "action": "workflow_finish",
+                "runId": "run-cleanup",
+                "summary": "done",
+            },
+        )
+
+        self.assertTrue(started["ok"])
+        self.assertTrue(finished["ok"])
+        deleted_paths = [request["path"] for request in requests if request["method"] == "DELETE"]
+        self.assertEqual(
+            deleted_paths,
+            [
+                "/agents/tmp-workerflow-run-cleanup-base_info",
+                "/agents/tmp-workerflow-run-cleanup-report",
+            ],
+        )
+        cleanup = finished["cleanupTempAgents"]
+        self.assertEqual(cleanup["deleted"], 2)
+        self.assertEqual(cleanup["failed"], 0)
+        self.assertEqual([item["cleanup"]["reason"] for item in cleanup["agents"]], ["cleanup_disabled", "cleanup_disabled"])
+        state = json.loads(Path(finished["statePath"]).read_text(encoding="utf-8"))
+        self.assertEqual(state["cleanupTempAgents"]["deleted"], 2)
+        self.assertEqual(captured_matrix[-1]["content"]["m.new_content"]["hiclaw.workflow"]["status"], "done")
+
+    def test_workflow_fail_deletes_workflow_temp_agents(self) -> None:
+        shared_dir = self.server._resolve_shared_dir("", "run-fail-cleanup", "run-fail-cleanup")
+        self.server._write_json(
+            self.server._workflow_state_path(shared_dir),
+            {
+                "runId": "run-fail-cleanup",
+                "roomId": "!dm:example.test",
+                "eventId": "$original",
+                "title": "Fail cleanup",
+                "status": "running",
+                "sharedPath": str(shared_dir),
+                "subagents": [
+                    {
+                        "agentId": "tmp-workerflow-run-fail-cleanup-report",
+                        "status": "running",
+                    },
+                ],
+            },
+        )
+
+        deleted_paths: list[str] = []
+
+        def fake_send(_room_id: str, _content: dict[str, object]) -> str:
+            return "$edit"
+
+        def fake_json_request(method: str, _base_url: str, path: str, _payload: dict[str, object] | None = None) -> dict[str, object]:
+            if method == "DELETE" and path.startswith("/agents/"):
+                deleted_paths.append(path)
+                return {}
+            raise AssertionError(f"unexpected request: {method} {path}")
+
+        self.server._matrix_send_content = fake_send
+        self.server._json_request = fake_json_request
+
+        failed = self.server._agentflow(
+            {
+                "action": "workflow_fail",
+                "runId": "run-fail-cleanup",
+                "summary": "failed",
+            },
+        )
+
+        self.assertTrue(failed["ok"])
+        self.assertEqual(deleted_paths, ["/agents/tmp-workerflow-run-fail-cleanup-report"])
+        self.assertEqual(failed["cleanupTempAgents"]["deleted"], 1)
+        state = json.loads(Path(failed["statePath"]).read_text(encoding="utf-8"))
+        self.assertEqual(state["status"], "failed")
+        self.assertEqual(state["cleanupTempAgents"]["failed"], 0)
+
+    def test_workflow_run_failure_marks_failed_and_deletes_created_temp_agents(self) -> None:
+        subagents_root = self.root / ".qwenpaw" / "workspaces" / "default" / "subagents"
+        for name in ("base-info-agent", "report-agent"):
+            path = subagents_root / name
+            path.mkdir(parents=True)
+            (path / "AGENTS.md").write_text(f"{name}\n", encoding="utf-8")
+
+        captured_matrix: list[dict[str, object]] = []
+        requests: list[dict[str, object]] = []
+
+        def fake_send(room_id: str, content: dict[str, object]) -> str:
+            captured_matrix.append({"roomId": room_id, "content": content})
+            return f"$event{len(captured_matrix)}"
+
+        def fake_json_request(method: str, _base_url: str, path: str, payload: dict[str, object] | None = None) -> dict[str, object]:
+            requests.append({"method": method, "path": path, "payload": payload})
+            if method == "POST" and path == "/agents":
+                assert payload is not None
+                if payload["id"] == "tmp-workerflow-run-spawn-fail-report":
+                    raise RuntimeError("create failed")
+                return dict(payload)
+            if method == "DELETE" and path.startswith("/agents/"):
+                return {}
+            raise AssertionError(f"unexpected request: {method} {path}")
+
+        self.server._matrix_send_content = fake_send
+        self.server._json_request = fake_json_request
+
+        with self.assertRaisesRegex(RuntimeError, "create failed"):
+            self.server._agentflow(
+                {
+                    "action": "workflow_run",
+                    "runId": "run-spawn-fail",
+                    "roomId": "!dm:example.test",
+                    "title": "Spawn failure",
+                    "input": "Generate report",
+                    "nodes": [
+                        {
+                            "id": "base_info",
+                            "subagent": "base-info-agent",
+                            "task": "整理基础信息",
+                        },
+                        {
+                            "id": "report",
+                            "subagent": "report-agent",
+                            "task": "生成报告",
+                        },
+                    ],
+                },
+            )
+
+        deleted_paths = [request["path"] for request in requests if request["method"] == "DELETE"]
+        self.assertEqual(deleted_paths, ["/agents/tmp-workerflow-run-spawn-fail-base_info"])
+        self.assertEqual(captured_matrix[0]["content"]["hiclaw.workflow"]["status"], "spawning")
+        failed_workflow = captured_matrix[-1]["content"]["m.new_content"]["hiclaw.workflow"]
+        self.assertEqual(failed_workflow["status"], "failed")
+        self.assertEqual(failed_workflow["subagents"][0]["agentId"], "tmp-workerflow-run-spawn-fail-base_info")
+        state_path = self.server._workflow_state_path(
+            self.server._resolve_shared_dir("", "run-spawn-fail", "run-spawn-fail")
+        )
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        self.assertEqual(state["status"], "failed")
+        self.assertEqual(state["cleanupTempAgents"]["deleted"], 1)
+
+    def test_workflow_run_failure_after_remote_create_deletes_current_temp_agent(self) -> None:
+        subagent = self.root / ".qwenpaw" / "workspaces" / "default" / "subagents" / "base-info-agent"
+        subagent.mkdir(parents=True)
+        (subagent / "AGENTS.md").write_text("base-info-agent\n", encoding="utf-8")
+
+        captured_matrix: list[dict[str, object]] = []
+        requests: list[dict[str, object]] = []
+
+        def fake_send(room_id: str, content: dict[str, object]) -> str:
+            captured_matrix.append({"roomId": room_id, "content": content})
+            return f"$event{len(captured_matrix)}"
+
+        def fake_json_request(method: str, _base_url: str, path: str, payload: dict[str, object] | None = None) -> dict[str, object]:
+            requests.append({"method": method, "path": path, "payload": payload})
+            if method == "POST" and path == "/agents":
+                assert payload is not None
+                return dict(payload)
+            if method == "DELETE" and path.startswith("/agents/"):
+                return {}
+            raise AssertionError(f"unexpected request: {method} {path}")
+
+        def fail_copy_template(_template_path: str, _workspace_dir: Path) -> dict[str, object]:
+            raise RuntimeError("copy failed")
+
+        self.server._matrix_send_content = fake_send
+        self.server._json_request = fake_json_request
+        self.server._copy_template = fail_copy_template
+
+        with self.assertRaisesRegex(RuntimeError, "copy failed"):
+            self.server._agentflow(
+                {
+                    "action": "workflow_run",
+                    "runId": "run-init-fail",
+                    "roomId": "!dm:example.test",
+                    "title": "Init failure",
+                    "input": "Collect info",
+                    "nodes": [
+                        {
+                            "id": "base_info",
+                            "subagent": "base-info-agent",
+                            "task": "整理基础信息",
+                        },
+                    ],
+                },
+            )
+
+        deleted_paths = [request["path"] for request in requests if request["method"] == "DELETE"]
+        self.assertEqual(deleted_paths, ["/agents/tmp-workerflow-run-init-fail-base_info"])
+        failed_workflow = captured_matrix[-1]["content"]["m.new_content"]["hiclaw.workflow"]
+        self.assertEqual(failed_workflow["status"], "failed")
+        self.assertEqual(failed_workflow["subagents"][0]["agentId"], "tmp-workerflow-run-init-fail-base_info")
+        state_path = self.server._workflow_state_path(
+            self.server._resolve_shared_dir("", "run-init-fail", "run-init-fail")
+        )
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        self.assertEqual(state["cleanupTempAgents"]["deleted"], 1)
+
+    def test_workflow_run_supports_dag_nodes_with_waiting_dependencies(self) -> None:
+        subagents_root = self.root / ".qwenpaw" / "workspaces" / "default" / "subagents"
+        for name in ("base-info-agent", "pathogen-agent", "disease-analysis-agent"):
+            path = subagents_root / name
+            path.mkdir(parents=True)
+            (path / "AGENTS.md").write_text(f"{name}\n", encoding="utf-8")
+
+        captured_matrix: list[dict[str, object]] = []
+        requests: list[dict[str, object]] = []
+
+        def fake_send(room_id: str, content: dict[str, object]) -> str:
+            captured_matrix.append({"roomId": room_id, "content": content})
+            return f"$event{len(captured_matrix)}"
+
+        def fake_json_request(method: str, _base_url: str, path: str, payload: dict[str, object] | None = None) -> dict[str, object]:
+            requests.append({"method": method, "path": path, "payload": payload})
+            if method == "POST" and path == "/agents":
+                assert payload is not None
+                return dict(payload)
+            raise AssertionError(f"unexpected request: {method} {path}")
+
+        self.server._matrix_send_content = fake_send
+        self.server._json_request = fake_json_request
+
+        result = self.server._agentflow(
+            {
+                "action": "workflow_run",
+                "runId": "pig-diagnosis",
+                "roomId": "!dm:example.test",
+                "title": "猪病诊断报告生成",
+                "input": "批次号 B001",
+                "nodes": [
+                    {
+                        "id": "base_info",
+                        "name": "基础信息梳理",
+                        "role": "基础信息梳理",
+                        "subagent": "base-info-agent",
+                        "task": "处理基础信息",
+                    },
+                    {
+                        "id": "pathogen",
+                        "name": "病原线索分析",
+                        "role": "病原线索分析",
+                        "subagent": "pathogen-agent",
+                        "task": "分析病原",
+                    },
+                    {
+                        "id": "disease_analysis",
+                        "name": "疾病综合研判",
+                        "role": "疾病综合研判",
+                        "subagent": "disease-analysis-agent",
+                        "task": "综合诊断猪病",
+                        "dependsOn": ["base_info", "pathogen"],
+                    },
+                ],
+            },
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(len(requests), 3)
+        self.assertEqual(requests[0]["payload"]["name"], "基础信息梳理")
+        self.assertEqual(
+            [request["payload"]["id"] for request in requests],
+            [
+                "tmp-workerflow-pig-diagnosis-base_info",
+                "tmp-workerflow-pig-diagnosis-pathogen",
+                "tmp-workerflow-pig-diagnosis-disease_analysis",
+            ],
+        )
+        self.assertEqual([node["status"] for node in result["nodes"]], ["ready", "ready", "waiting"])
+        self.assertEqual([item["id"] for item in result["submitInstructions"]], ["base_info", "pathogen"])
+        self.assertEqual([item["id"] for item in result["waitingInstructions"]], ["disease_analysis"])
+        waiting_prompt = result["waitingInstructions"][0]["submitPrompt"]
+        self.assertIn("Upstream outputs:", waiting_prompt)
+        self.assertIn("base_info", waiting_prompt)
+        self.assertIn("pathogen", waiting_prompt)
+
+        workflow = captured_matrix[1]["content"]["m.new_content"]["hiclaw.workflow"]
+        self.assertEqual(workflow["subagents"][0]["name"], "基础信息梳理")
+        self.assertEqual(workflow["subagents"][0]["role"], "基础信息梳理")
+        self.assertEqual(workflow["subagents"][2]["status"], "waiting")
+        self.assertNotIn("helpers", workflow)
+        formatted = captured_matrix[1]["content"]["m.new_content"]["formatted_body"]
+        self.assertIn("<td>基础信息梳理</td><td>基础信息梳理</td><td>ready</td>", formatted)
+
+        state = json.loads(Path(result["statePath"]).read_text(encoding="utf-8"))
+        self.assertEqual(state["nodes"][2]["dependsOn"], ["base_info", "pathogen"])
+        self.assertEqual(len(state["submitInstructions"]), 2)
+        self.assertEqual(len(state["waitingInstructions"]), 1)
+
+    def test_workflow_update_unblocks_dag_nodes_after_dependency_steps_done(self) -> None:
+        subagents_root = self.root / ".qwenpaw" / "workspaces" / "default" / "subagents"
+        for name in ("base-info-agent", "pathogen-agent", "disease-analysis-agent"):
+            path = subagents_root / name
+            path.mkdir(parents=True)
+            (path / "AGENTS.md").write_text(f"{name}\n", encoding="utf-8")
+
+        captured_matrix: list[dict[str, object]] = []
+
+        def fake_send(room_id: str, content: dict[str, object]) -> str:
+            captured_matrix.append({"roomId": room_id, "content": content})
+            return f"$event{len(captured_matrix)}"
+
+        def fake_json_request(method: str, _base_url: str, path: str, payload: dict[str, object] | None = None) -> dict[str, object]:
+            if method == "POST" and path == "/agents":
+                assert payload is not None
+                return dict(payload)
+            raise AssertionError(f"unexpected request: {method} {path}")
+
+        self.server._matrix_send_content = fake_send
+        self.server._json_request = fake_json_request
+
+        started = self.server._agentflow(
+            {
+                "action": "workflow_run",
+                "runId": "run-advance",
+                "roomId": "!dm:example.test",
+                "title": "猪病诊断报告生成",
+                "input": "批次号 B001",
+                "nodes": [
+                    {
+                        "id": "base_info",
+                        "subagent": "base-info-agent",
+                        "task": "处理基础信息",
+                    },
+                    {
+                        "id": "pathogen",
+                        "subagent": "pathogen-agent",
+                        "task": "分析病原",
+                    },
+                    {
+                        "id": "disease_analysis",
+                        "subagent": "disease-analysis-agent",
+                        "task": "综合诊断猪病",
+                        "dependsOn": ["base_info", "pathogen"],
+                    },
+                ],
+            },
+        )
+
+        self.assertEqual([item["id"] for item in started["waitingInstructions"]], ["disease_analysis"])
+
+        updated = self.server._agentflow(
+            {
+                "action": "workflow_update",
+                "runId": "run-advance",
+                "status": "running",
+                "summary": "upstream done",
+                "steps": [
+                    {"id": "base_info", "status": "done", "summary": "基础信息完成"},
+                    {"id": "pathogen", "status": "done", "summary": "病原分析完成"},
+                ],
+            },
+        )
+
+        self.assertTrue(updated["ok"])
+        self.assertEqual([item["id"] for item in updated["readyInstructions"]], ["disease_analysis"])
+        ready_prompt = updated["readyInstructions"][0]["submitPrompt"]
+        self.assertIn("Upstream summaries:", ready_prompt)
+        self.assertIn("base_info: 基础信息完成", ready_prompt)
+        self.assertIn("pathogen: 病原分析完成", ready_prompt)
+
+        workflow = captured_matrix[2]["content"]["m.new_content"]["hiclaw.workflow"]
+        self.assertEqual(workflow["subagents"][2]["status"], "ready")
+        self.assertEqual(workflow["subagents"][2]["summary"], "dependencies done; ready for submit")
+
+        state = json.loads(Path(updated["statePath"]).read_text(encoding="utf-8"))
+        self.assertEqual([item["id"] for item in state["waitingInstructions"]], [])
+        self.assertEqual([item["id"] for item in state["readyInstructions"]], ["disease_analysis"])
+        self.assertEqual([node["status"] for node in state["nodes"]], ["done", "done", "ready"])
+
+    def test_workflow_run_dry_run_returns_plan_without_side_effects(self) -> None:
+        subagent = self.root / ".qwenpaw" / "workspaces" / "default" / "subagents" / "test-reviewer"
+        subagent.mkdir(parents=True)
+        (subagent / "AGENTS.md").write_text("Review tests only.\n", encoding="utf-8")
+
+        def fail_send(_room_id: str, _content: dict[str, object]) -> str:
+            raise AssertionError("dry run should not send matrix messages")
+
+        def fail_json_request(_method: str, _base_url: str, _path: str, _payload: dict[str, object] | None = None) -> dict[str, object]:
+            raise AssertionError("dry run should not call qwenpaw api")
+
+        self.server._matrix_send_content = fail_send
+        self.server._json_request = fail_json_request
+
+        result = self.server._agentflow(
+            {
+                "action": "workflow_run",
+                "runId": "run-plan",
+                "roomId": "!dm:example.test",
+                "title": "Test review",
+                "input": "Review tests/test_auth.py",
+                "subagents": [
+                    {
+                        "id": "tests",
+                        "subagent": "test-reviewer",
+                        "task": "检查测试覆盖缺口",
+                    },
+                ],
+                "dryRun": True,
+            },
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["dryRun"])
+        self.assertEqual(result["subagents"][0]["agentId"], "tmp-workerflow-run-plan-tests")
+        self.assertNotIn("helpers", result)
+        self.assertIn("Review tests/test_auth.py", result["submitInstructions"][0]["submitPrompt"])
+        self.assertFalse(Path(result["statePath"]).exists())
+
+    def test_workflow_start_requires_explicit_room_id_without_fallback(self) -> None:
+        runtime = self.root / "runtime-with-rooms.yaml"
+        runtime.write_text(
+            "\n".join(
+                [
+                    "team:",
+                    "  teamRoomId: '!team:example.test'",
+                    "member:",
+                    "  personalRoomId: '!personal:example.test'",
+                ],
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        os.environ["TEAMHARNESS_RUNTIME_CONFIG"] = str(runtime)
+
+        with self.assertRaisesRegex(ValueError, "roomId is required"):
+            self.server._agentflow(
+                {
+                    "action": "workflow_start",
+                    "runId": "run-no-room",
+                    "dryRun": True,
+                },
+            )
+
+    def test_workflow_update_dry_run_builds_replace_content(self) -> None:
+        dry = self.server._agentflow(
+            {
+                "action": "workflow_update",
+                "runId": "run-dry",
+                "roomId": "!room:example.test",
+                "eventId": "$original",
+                "status": "running",
+                "summary": "checking",
+                "dryRun": True,
+            },
+        )
+
+        self.assertTrue(dry["ok"])
+        self.assertTrue(dry["dryRun"])
+        self.assertEqual(dry["content"]["msgtype"], "m.notice")
+        self.assertEqual(dry["content"]["m.relates_to"]["event_id"], "$original")
+        self.assertEqual(dry["content"]["m.new_content"]["hiclaw.workflow"]["runId"], "run-dry")
+
+    def test_matrix_env_aliases_and_runtime_token_env(self) -> None:
+        runtime = self.root / "runtime-token.yaml"
+        runtime.write_text(
+            "\n".join(
+                [
+                    "credentials:",
+                    "  matrixTokenEnv: WORKERFLOW_MATRIX_TOKEN",
+                ],
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        os.environ["TEAMHARNESS_RUNTIME_CONFIG"] = str(runtime)
+        os.environ["AGENTTEAMS_MATRIX_SERVER"] = "http://matrix.example.test"
+        os.environ["WORKERFLOW_MATRIX_TOKEN"] = "custom-token"
+
+        self.assertEqual(self.server._matrix_homeserver(), "http://matrix.example.test")
+        self.assertEqual(self.server._matrix_token(), "custom-token")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/plugins/workerflow/adapters/qwenpaw/README.md
+++ b/plugins/workerflow/adapters/qwenpaw/README.md
@@ -1,0 +1,8 @@
+# WorkerFlow QwenPaw Adapter
+
+This adapter packages WorkerFlow as a QwenPaw plugin. Installation registers the
+WorkerFlow skill and configures a `workerflow` MCP client for enabled QwenPaw
+agents.
+
+WorkerFlow is Worker-local. It does not install TeamHarness project, task, room,
+or requester routing behavior.

--- a/plugins/workerflow/adapters/qwenpaw/install.sh
+++ b/plugins/workerflow/adapters/qwenpaw/install.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKERFLOW_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BUILD_SCRIPT="${SCRIPT_DIR}/scripts/build-qwenpaw-plugin.rb"
+
+if ! command -v qwenpaw >/dev/null 2>&1; then
+  echo "ERROR: qwenpaw command not found" >&2
+  exit 1
+fi
+
+if ! command -v ruby >/dev/null 2>&1; then
+  echo "ERROR: ruby is required to build the QwenPaw plugin package" >&2
+  exit 1
+fi
+
+stage_dir="$(mktemp -d "${TMPDIR:-/tmp}/workerflow-qwenpaw-install.XXXXXX")"
+cleanup() {
+  rm -rf "$stage_dir"
+}
+trap cleanup EXIT
+
+package_zip="$(OUT_DIR="${stage_dir}/dist" ruby "${BUILD_SCRIPT}" "${WORKERFLOW_DIR}/plugin.yaml" | tail -n 1)"
+unpack_dir="${stage_dir}/unpacked"
+mkdir -p "$unpack_dir"
+
+python3 - "$package_zip" "$unpack_dir" <<'PY'
+import sys
+import zipfile
+
+with zipfile.ZipFile(sys.argv[1]) as archive:
+    archive.extractall(sys.argv[2])
+PY
+
+package_dir="$(find "$unpack_dir" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+if [ -z "$package_dir" ] || [ ! -f "$package_dir/plugin.json" ]; then
+  echo "ERROR: generated QwenPaw plugin package is invalid" >&2
+  exit 1
+fi
+
+qwenpaw plugin install "$package_dir" --force

--- a/plugins/workerflow/adapters/qwenpaw/plugin.py
+++ b/plugins/workerflow/adapters/qwenpaw/plugin.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""QwenPaw adapter for WorkerFlow."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+from typing import Any
+
+
+PLUGIN_DIR = Path(__file__).resolve().parent
+ASSET_DIR = PLUGIN_DIR / "workerflow"
+if not (ASSET_DIR / "plugin.yaml").exists():
+    ASSET_DIR = PLUGIN_DIR.parent.parent
+
+MCP_CLIENT_ID = "workerflow"
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    try:
+        import yaml
+
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (FileNotFoundError, ImportError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _section(data: dict[str, Any], key: str) -> dict[str, Any]:
+    value = data.get(key) or {}
+    return value if isinstance(value, dict) else {}
+
+
+def _iter_qwenpaw_agents() -> list[tuple[str, Path]]:
+    try:
+        from qwenpaw.config.utils import load_config
+    except ImportError:
+        workspace = os.getenv("QWENPAW_WORKSPACE_DIR", "").strip()
+        return [("default", Path(workspace))] if workspace else []
+
+    root = load_config()
+    profiles = getattr(getattr(root, "agents", None), "profiles", {}) or {}
+    agents: list[tuple[str, Path]] = []
+    for agent_id, ref in profiles.items():
+        if getattr(ref, "enabled", True) is False:
+            continue
+        workspace_dir = Path(getattr(ref, "workspace_dir", "")).expanduser()
+        if str(workspace_dir):
+            agents.append((str(agent_id), workspace_dir))
+    return agents
+
+
+def _copytree_replace(source: Path, target: Path) -> None:
+    if target.exists():
+        shutil.rmtree(target)
+    shutil.copytree(source, target, ignore=shutil.ignore_patterns("__pycache__", ".DS_Store", "*.pyc"))
+
+
+def _skill_entries() -> list[dict[str, Any]]:
+    manifest = _read_yaml(ASSET_DIR / "plugin.yaml")
+    entries: list[dict[str, Any]] = []
+    for group_entries in _section(manifest, "skills").values():
+        if isinstance(group_entries, list):
+            for entry in group_entries:
+                if isinstance(entry, dict):
+                    entries.append(entry)
+    return entries
+
+
+def _install_skills() -> dict[str, Any]:
+    installed: list[str] = []
+    try:
+        from qwenpaw.agents.skill_system.registry import ensure_skill_pool_initialized, reconcile_pool_manifest
+        from qwenpaw.agents.skill_system.store import get_skill_pool_dir
+    except ImportError:
+        return {"installed": installed, "skipped": "qwenpaw skill API unavailable"}
+
+    ensure_skill_pool_initialized()
+    pool_dir = get_skill_pool_dir()
+    pool_dir.mkdir(parents=True, exist_ok=True)
+    for entry in _skill_entries():
+        skill_id = str(entry.get("id") or "").strip()
+        source = ASSET_DIR / str(entry.get("path") or "")
+        if not skill_id or not source.exists():
+            continue
+        target = pool_dir / f"workerflow-{skill_id}"
+        _copytree_replace(source, target)
+        installed.append(target.name)
+    reconcile_pool_manifest()
+    return {"installed": installed}
+
+
+def _enable_workspace_skills(workspace_dir: Path) -> dict[str, Any]:
+    installed: list[str] = []
+    failed: list[dict[str, str]] = []
+    try:
+        from qwenpaw.agents.skill_system.pool_service import SkillPoolService
+    except ImportError:
+        return {"installed": installed, "skipped": "qwenpaw skill pool API unavailable"}
+
+    service = SkillPoolService()
+    for entry in _skill_entries():
+        skill_id = str(entry.get("id") or "").strip()
+        if not skill_id:
+            continue
+        skill_name = f"workerflow-{skill_id}"
+        result = service.download_to_workspace(skill_name, workspace_dir, overwrite=True)
+        if result.get("success"):
+            installed.append(skill_name)
+        else:
+            failed.append({"name": skill_name, "reason": str(result.get("reason") or "unknown")})
+    return {"installed": installed, "failed": failed}
+
+
+def _mcp_client_env() -> dict[str, str]:
+    env: dict[str, str] = {}
+    for name in (
+        "TEAMHARNESS_RUNTIME_CONFIG",
+        "AGENTTEAMS_MEMBER_RUNTIME_CONFIG",
+        "AGENTTEAMS_MATRIX_URL",
+        "AGENTTEAMS_MATRIX_SERVER",
+        "AGENTTEAMS_MATRIX_HOMESERVER",
+        "AGENTTEAMS_WORKER_MATRIX_TOKEN",
+        "AGENTTEAMS_MATRIX_TOKEN",
+        "AGENTTEAMS_MATRIX_USER_ID",
+        "AGENTTEAMS_MATRIX_DOMAIN",
+        "AGENTTEAMS_WORKER_ROLE",
+        "AGENTTEAMS_AGENT_ROLE",
+        "AGENTTEAMS_WORKER_NAME",
+        "QWENPAW_API_BASE_URL",
+        "QWENPAW_BASE_URL",
+        "QWENPAW_WORKING_DIR",
+        "QWENPAW_WORKSPACE_DIR",
+        "COPAW_WORKING_DIR",
+    ):
+        value = os.getenv(name, "").strip()
+        if value:
+            env[name] = value
+    return env
+
+
+def _ensure_mcp_client(agent_id: str, workspace_dir: Path) -> dict[str, Any]:
+    try:
+        from qwenpaw.config.config import MCPClientConfig, MCPConfig, load_agent_config, save_agent_config
+    except ImportError:
+        marker = workspace_dir / ".workerflow" / "mcp-client.json"
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(json.dumps({"id": MCP_CLIENT_ID}, indent=2), encoding="utf-8")
+        return {"agent": agent_id, "action": "marker", "path": str(marker)}
+
+    agent_config = load_agent_config(agent_id)
+    if agent_config.mcp is None:
+        agent_config.mcp = MCPConfig()
+    server_path = ASSET_DIR / "mcp" / "server.py"
+    client = MCPClientConfig(
+        name=MCP_CLIENT_ID,
+        description="Worker-local agent workflow MCP server",
+        enabled=True,
+        transport="stdio",
+        command=sys.executable,
+        args=[str(server_path)],
+        cwd=str(ASSET_DIR),
+        env=_mcp_client_env(),
+    )
+    agent_config.mcp.clients[MCP_CLIENT_ID] = client
+    save_agent_config(agent_id, agent_config)
+    return {"agent": agent_id, "action": "configured"}
+
+
+def apply_workerflow() -> dict[str, Any]:
+    skills = _install_skills()
+    agents = []
+    mcp = []
+    for agent_id, workspace_dir in _iter_qwenpaw_agents():
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+        agents.append({"agent": agent_id, "workspace": str(workspace_dir), "skills": _enable_workspace_skills(workspace_dir)})
+        mcp.append(_ensure_mcp_client(agent_id, workspace_dir))
+    return {"ok": True, "agents": agents, "skills": skills, "mcp": mcp}
+
+
+class WorkerFlowPlugin:
+    def __init__(self) -> None:
+        self.last_apply_result: dict[str, Any] = {}
+
+    def register(self, api: Any) -> None:
+        def sync() -> dict[str, Any]:
+            self.last_apply_result = apply_workerflow()
+            return self.last_apply_result
+
+        api.register_startup_hook("workerflow_sync", sync, priority=45)
+        self._register_http(api)
+
+    def _register_http(self, api: Any) -> None:
+        try:
+            from fastapi import APIRouter
+        except Exception:
+            return
+        router = APIRouter()
+
+        @router.get("/health")
+        def health() -> dict[str, Any]:
+            return {"ok": True, "plugin": "workerflow", "adapter": "qwenpaw"}
+
+        @router.get("/status")
+        def status() -> dict[str, Any]:
+            return {"ok": True, "lastApply": self.last_apply_result}
+
+        @router.post("/sync")
+        def sync_endpoint() -> dict[str, Any]:
+            self.last_apply_result = apply_workerflow()
+            return self.last_apply_result
+
+        api.register_http_router(router, prefix="/workerflow", tags=["workerflow"])
+
+
+plugin = WorkerFlowPlugin()

--- a/plugins/workerflow/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb
+++ b/plugins/workerflow/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb
@@ -1,0 +1,129 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "open3"
+require "pathname"
+require "tmpdir"
+require "yaml"
+
+manifest_path = Pathname.new(ARGV[0] || "plugins/workerflow/plugin.yaml").expand_path
+plugin_root = manifest_path.dirname
+repo_root = plugin_root.ascend.find { |path| (path / ".git").directory? } || plugin_root
+adapter_root = plugin_root / "adapters/qwenpaw"
+out_dir = Pathname.new(ENV["OUT_DIR"] || (repo_root / "dist/adapters/qwenpaw").to_s).expand_path
+
+abort("missing manifest: #{manifest_path}") unless manifest_path.file?
+abort("missing qwenpaw adapter: #{adapter_root}") unless adapter_root.directory?
+
+manifest = YAML.load_file(manifest_path)
+name = manifest.fetch("metadata").fetch("name")
+version = manifest.fetch("metadata").fetch("version")
+package_name = "#{name}-qwenpaw-#{version}"
+
+def copy_entry(source_root, target_root, entry)
+  src = source_root / entry
+  abort("missing qwenpaw package source: #{src}") unless src.exist?
+
+  dst = target_root / entry
+  if src.directory?
+    FileUtils.mkdir_p(dst)
+    entries = Dir.glob((src / "*").to_s, File::FNM_DOTMATCH).reject do |path|
+      [".", ".."].include?(File.basename(path))
+    end
+    FileUtils.cp_r(entries, dst)
+  else
+    FileUtils.mkdir_p(dst.dirname)
+    FileUtils.cp(src, dst)
+  end
+end
+
+def prune_generated(path)
+  Dir.glob((path / "**/*").to_s, File::FNM_DOTMATCH).each do |item|
+    base = File.basename(item)
+    FileUtils.rm_rf(item) if base == "__pycache__" || base == ".DS_Store" || base.end_with?(".pyc")
+  end
+end
+
+def zip_dir(root, package_name, out_path)
+  FileUtils.rm_f(out_path)
+  if system("zip", "-v", out: File::NULL, err: File::NULL)
+    Dir.chdir(root) do
+      system("zip", "-qry", out_path.to_s, package_name) || abort("zip failed")
+    end
+    return
+  end
+
+  python = <<~PY
+    import os, zipfile
+    root = #{root.to_s.dump}
+    package = #{package_name.dump}
+    out = #{out_path.to_s.dump}
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as zf:
+        base = os.path.join(root, package)
+        for dirpath, _, filenames in os.walk(base):
+            for filename in filenames:
+                path = os.path.join(dirpath, filename)
+                rel = os.path.relpath(path, root)
+                zf.write(path, rel)
+  PY
+  stdout, stderr, status = Open3.capture3("python3", "-c", python)
+  abort("python zip failed: #{stderr}#{stdout}") unless status.success?
+end
+
+out_dir.mkpath
+out_zip = out_dir / "#{package_name}.zip"
+stable_zip = out_dir / "workerflow-qwenpaw.zip"
+
+Dir.mktmpdir("workerflow-qwenpaw-") do |tmp|
+  tmp_root = Pathname.new(tmp)
+  staging = tmp_root / package_name
+  asset_dir = staging / "workerflow"
+  staging.mkpath
+  asset_dir.mkpath
+
+  %w[
+    plugin.yaml
+    prompts
+    skills
+    mcp
+  ].each do |entry|
+    copy_entry(plugin_root, asset_dir, entry)
+  end
+
+  copy_entry(adapter_root, staging, "plugin.py")
+
+  qwenpaw_manifest = {
+    "id" => "workerflow",
+    "name" => "WorkerFlow",
+    "version" => version,
+    "type" => "general",
+    "description" => "Worker-local workflow plugin for QwenPaw agents and subagents.",
+    "author" => "AgentTeams",
+    "entry" => {
+      "backend" => "plugin.py"
+    },
+    "dependencies" => [],
+    "min_version" => "1.1.7",
+    "meta" => {
+      "category" => "workerflow",
+      "features" => [
+        "worker-internal-workflow",
+        "temporary-agent-lifecycle",
+        "workerflow-mcp"
+      ]
+    }
+  }
+  (staging / "plugin.json").write(
+    JSON.pretty_generate(qwenpaw_manifest) + "\n",
+    mode: "w",
+    encoding: "UTF-8"
+  )
+
+  prune_generated(staging)
+  zip_dir(tmp_root, package_name, out_zip)
+  FileUtils.cp(out_zip, stable_zip)
+end
+
+puts out_zip

--- a/plugins/workerflow/adapters/qwenpaw/uninstall.sh
+++ b/plugins/workerflow/adapters/qwenpaw/uninstall.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v qwenpaw >/dev/null 2>&1; then
+  printf 'y\n' | qwenpaw plugin uninstall workerflow >/dev/null 2>&1 || true
+fi

--- a/plugins/workerflow/mcp/server.py
+++ b/plugins/workerflow/mcp/server.py
@@ -1,0 +1,1506 @@
+#!/usr/bin/env python3
+"""WorkerFlow MCP stdio server."""
+
+from __future__ import annotations
+
+import html
+import ipaddress
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import sys
+import time
+from typing import Any
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+
+
+TOOL_NAMES = ["worker_agentflow"]
+
+TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
+    "worker_agentflow": {
+        "description": (
+            "Manage Worker-local QwenPaw agent lifecycle for internal workflow. "
+            "Use only for list_agents, list_subagents, create_temp_agent, "
+            "delete_temp_agent, cleanup_shared, workflow_run, and workflow_* actions. "
+            "Temporary agents are not TeamHarness Workers."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "list_agents",
+                        "list_subagents",
+                        "create_temp_agent",
+                        "delete_temp_agent",
+                        "cleanup_shared",
+                        "workflow_run",
+                        "workflow_start",
+                        "workflow_update",
+                        "workflow_finish",
+                        "workflow_fail",
+                    ],
+                },
+                "apiBaseUrl": {
+                    "type": "string",
+                    "description": "Optional QwenPaw API base URL. Defaults to QWENPAW_API_BASE_URL or http://127.0.0.1:8088/api.",
+                },
+                "agentId": {
+                    "type": "string",
+                    "description": "Temporary agent id. create_temp_agent generates tmp-workerflow-* when omitted.",
+                },
+                "name": {"type": "string"},
+                "description": {"type": "string"},
+                "workspaceDir": {
+                    "type": "string",
+                    "description": "Optional QwenPaw workspace directory for the temporary agent.",
+                },
+                "templatePath": {
+                    "type": "string",
+                    "description": "Optional external template directory containing AGENTS.md and skills/. Overrides subagent.",
+                },
+                "subagent": {
+                    "type": "string",
+                    "description": "Optional runtime subagent name under the default workspace subagents/<name> directory.",
+                },
+                "sharedRunId": {
+                    "type": "string",
+                    "description": "Optional safe run id for a shared directory under default workspace shared/workerflow/<run-id>.",
+                },
+                "sharedDir": {
+                    "type": "string",
+                    "description": "Optional explicit shared directory. Relative paths resolve from the default workspace.",
+                },
+                "runId": {
+                    "type": "string",
+                    "description": "Workflow run id. Defaults to sharedRunId when omitted.",
+                },
+                "roomId": {
+                    "type": "string",
+                    "description": "Required Matrix DM/current conversation room id for workflow_run and workflow_start.",
+                },
+                "eventId": {
+                    "type": "string",
+                    "description": "Matrix event id to edit for workflow_update, workflow_finish, and workflow_fail.",
+                },
+                "title": {"type": "string"},
+                "input": {
+                    "type": "string",
+                    "description": "Original workflow input to include in generated subagent submit prompts.",
+                },
+                "status": {"type": "string"},
+                "summary": {"type": "string"},
+                "subagents": {
+                    "type": "array",
+                    "items": {"type": "object", "additionalProperties": True},
+                    "description": "Visible subagent rows for the workflow card or workflow_run fan-out plan.",
+                },
+                "nodes": {
+                    "type": "array",
+                    "items": {"type": "object", "additionalProperties": True},
+                    "description": "Optional DAG nodes for workflow_run. Each node may include id, subagent, task, and dependsOn.",
+                },
+                "steps": {
+                    "type": "array",
+                    "items": {"type": "object", "additionalProperties": True},
+                    "description": "Visible workflow step rows for the workflow card.",
+                },
+                "language": {"type": "string"},
+                "skillNames": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional existing QwenPaw skill names for the created agent profile.",
+                },
+                "activeModel": {
+                    "type": "object",
+                    "additionalProperties": True,
+                },
+                "merge": {
+                    "type": "object",
+                    "additionalProperties": True,
+                    "description": "Optional merge instruction stored with workflow_run and included in subagent prompts.",
+                },
+                "cleanupWorkspace": {
+                    "type": "boolean",
+                    "description": "For delete_temp_agent and workflow_finish/fail, remove workspaces only when safely inside QWENPAW_WORKING_DIR/workspaces.",
+                },
+                "dryRun": {
+                    "type": "boolean",
+                    "description": "Return the resolved operation without calling QwenPaw.",
+                },
+            },
+            "required": ["action"],
+            "additionalProperties": True,
+        },
+    },
+}
+
+SAFE_SUBAGENT_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+SAFE_RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+SAFE_TEMP_AGENT_ID_RE = re.compile(r"^tmp-[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+def _require_loopback_api_base(base: str) -> None:
+    parsed = urllib.parse.urlparse(base)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("apiBaseUrl must be an http(s) loopback URL")
+    host = parsed.hostname.lower()
+    if host == "localhost":
+        return
+    try:
+        if ipaddress.ip_address(host).is_loopback:
+            return
+    except ValueError:
+        pass
+    raise ValueError("apiBaseUrl must be an http(s) loopback URL")
+
+
+def _api_base(raw: str | None = None) -> str:
+    explicit = bool((raw or "").strip())
+    base = (
+        (raw or "").strip()
+        or os.getenv("QWENPAW_API_BASE_URL", "").strip()
+        or os.getenv("QWENPAW_BASE_URL", "").strip()
+        or "http://127.0.0.1:8088/api"
+    ).rstrip("/")
+    if not base.endswith("/api"):
+        base = f"{base}/api"
+    if explicit:
+        _require_loopback_api_base(base)
+    return base
+
+
+def _json_request(method: str, base_url: str, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    url = f"{base_url}{path}"
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(url, data=body, method=method)
+    request.add_header("Accept", "application/json")
+    if body is not None:
+        request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            text = response.read().decode("utf-8")
+            return json.loads(text) if text else {}
+    except urllib.error.HTTPError as exc:
+        text = exc.read().decode("utf-8", errors="replace")
+        try:
+            detail = json.loads(text)
+        except json.JSONDecodeError:
+            detail = text
+        raise RuntimeError(f"{method} {path} failed: HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"{method} {path} failed: {exc}") from exc
+
+
+def _qwenpaw_working_dir() -> Path:
+    raw = os.getenv("QWENPAW_WORKING_DIR", "").strip() or os.getenv("COPAW_WORKING_DIR", "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    home = os.getenv("HOME", "").strip()
+    return Path(home).expanduser() / ".qwenpaw" if home else Path.cwd() / ".qwenpaw"
+
+
+def _default_workspace(agent_id: str) -> Path:
+    return _qwenpaw_working_dir() / "workspaces" / agent_id
+
+
+def _default_agent_workspace() -> Path:
+    raw = os.getenv("QWENPAW_DEFAULT_WORKSPACE_DIR", "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    return _default_workspace("default")
+
+
+def _subagents_dir() -> Path:
+    return _default_agent_workspace() / "subagents"
+
+
+def _shared_root() -> Path:
+    return _default_agent_workspace() / "shared" / "workerflow"
+
+
+def _resolve_run_id(raw: Any, fallback: str) -> str:
+    value = str(raw or "").strip() or fallback
+    if not SAFE_RUN_ID_RE.match(value):
+        raise ValueError("sharedRunId must be a safe single path component")
+    return value
+
+
+def _resolve_shared_dir(shared_dir: Any, shared_run_id: Any, fallback_run_id: str) -> Path:
+    raw = str(shared_dir or "").strip()
+    if raw:
+        path = Path(raw).expanduser()
+        if not path.is_absolute():
+            path = _default_agent_workspace() / path
+        return path
+    return _shared_root() / _resolve_run_id(shared_run_id, fallback_run_id)
+
+
+def _shared_plan(agent_id: str, workspace_dir: Path, shared_dir: Path) -> dict[str, Any]:
+    return {
+        "path": str(shared_dir),
+        "inputs": str(shared_dir / "inputs"),
+        "output": str(shared_dir / "outputs" / agent_id),
+        "workspaceLink": str(workspace_dir / "shared"),
+        "metadata": str(workspace_dir / ".workerflow" / "shared.json"),
+    }
+
+
+def _replace_shared_link(link_path: Path, shared_dir: Path) -> dict[str, Any]:
+    if link_path.is_symlink():
+        current = Path(os.readlink(link_path))
+        if not current.is_absolute():
+            current = (link_path.parent / current).resolve()
+        if current.resolve() == shared_dir.resolve():
+            return {"created": False, "path": str(link_path), "target": str(shared_dir), "reason": "already_linked"}
+        link_path.unlink()
+    elif link_path.exists():
+        return {"created": False, "path": str(link_path), "target": str(shared_dir), "reason": "path_exists_not_symlink"}
+
+    os.symlink(shared_dir, link_path)
+    return {"created": True, "path": str(link_path), "target": str(shared_dir)}
+
+
+def _setup_shared_dir(agent_id: str, workspace_dir: Path, shared_dir: Path) -> dict[str, Any]:
+    shared_dir = shared_dir.expanduser().resolve()
+    inputs_dir = shared_dir / "inputs"
+    output_dir = shared_dir / "outputs" / agent_id
+    inputs_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    metadata_dir = workspace_dir / ".workerflow"
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    metadata = {
+        "agentId": agent_id,
+        "sharedPath": str(shared_dir),
+        "inputsPath": str(inputs_dir),
+        "outputPath": str(output_dir),
+    }
+    metadata_path = metadata_dir / "shared.json"
+    metadata_path.write_text(json.dumps(metadata, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    link = _replace_shared_link(workspace_dir / "shared", shared_dir)
+    return {
+        "path": str(shared_dir),
+        "inputs": str(inputs_dir),
+        "output": str(output_dir),
+        "metadata": str(metadata_path),
+        "link": link,
+    }
+
+
+def _safe_cleanup_shared(shared_dir: Path) -> dict[str, Any]:
+    root = _shared_root().resolve()
+    target = shared_dir.expanduser().resolve()
+    try:
+        target.relative_to(root)
+    except ValueError:
+        return {"removed": False, "reason": "shared_dir_outside_workerflow_root", "path": str(target)}
+    if target == root:
+        return {"removed": False, "reason": "refuse_to_remove_shared_root", "path": str(target)}
+    if target.exists():
+        shutil.rmtree(target)
+        return {"removed": True, "path": str(target)}
+    return {"removed": False, "reason": "shared_dir_missing", "path": str(target)}
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _load_runtime_config() -> dict[str, Any]:
+    runtime_config = os.getenv("TEAMHARNESS_RUNTIME_CONFIG", "").strip()
+    if not runtime_config:
+        runtime_config = os.getenv("AGENTTEAMS_MEMBER_RUNTIME_CONFIG", "").strip()
+    if not runtime_config:
+        return {}
+    path = Path(runtime_config).expanduser()
+    if not path.exists():
+        return {}
+    text = path.read_text(encoding="utf-8")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        data = None
+    if isinstance(data, dict):
+        return data
+    try:
+        import yaml
+
+        data = yaml.safe_load(text) or {}
+    except Exception:
+        data = _simple_yaml_sections(text)
+    return data if isinstance(data, dict) else {}
+
+
+def _simple_yaml_sections(text: str) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    section: str | None = None
+    nested_section: str | None = None
+    for line in text.splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        top = re.match(r"^([A-Za-z0-9_]+):\s*(.*)$", line)
+        if top:
+            key, value = top.group(1), top.group(2).strip()
+            if value:
+                data[key] = _yaml_scalar(value)
+                section = None
+                nested_section = None
+            else:
+                data[key] = {}
+                section = key
+                nested_section = None
+            continue
+        nested = re.match(r"^\s{2}([A-Za-z0-9_]+):\s*(.*)$", line)
+        if nested and section and isinstance(data.get(section), dict):
+            key, value = nested.group(1), nested.group(2).strip()
+            if value:
+                data[section][key] = _yaml_scalar(value)
+                nested_section = None
+            else:
+                data[section][key] = {}
+                nested_section = key
+            continue
+        deep = re.match(r"^\s{4}([A-Za-z0-9_]+):\s*(.*)$", line)
+        if deep and section and nested_section and isinstance(data.get(section), dict):
+            parent = data[section].get(nested_section)
+            if isinstance(parent, dict):
+                parent[deep.group(1)] = _yaml_scalar(deep.group(2).strip())
+    return data
+
+
+def _yaml_scalar(value: str) -> Any:
+    if value in {"", "null", "Null", "NULL", "~"}:
+        return ""
+    if value in {"true", "True", "TRUE"}:
+        return True
+    if value in {"false", "False", "FALSE"}:
+        return False
+    if (value.startswith("'") and value.endswith("'")) or (value.startswith('"') and value.endswith('"')):
+        return value[1:-1]
+    return value
+
+
+def _section(data: dict[str, Any], name: str) -> dict[str, Any]:
+    value = data.get(name)
+    return value if isinstance(value, dict) else {}
+
+
+def _matrix_user_id() -> str:
+    explicit = os.getenv("AGENTTEAMS_MATRIX_USER_ID", "").strip()
+    if explicit:
+        return explicit
+    member = _section(_load_runtime_config(), "member")
+    return str(member.get("matrixUserId") or member.get("matrix_user_id") or "").strip()
+
+
+def _workflow_run_id(arguments: dict[str, Any], action: str) -> str:
+    raw = arguments.get("runId") or arguments.get("run_id") or arguments.get("sharedRunId")
+    if raw:
+        return _resolve_run_id(raw, "")
+    shared_dir = str(arguments.get("sharedDir") or "").strip()
+    if shared_dir:
+        return _resolve_run_id(Path(shared_dir).expanduser().name, "")
+    if action in {"workflow_start", "workflow_run"}:
+        return f"run-{uuid.uuid4().hex[:8]}"
+    raise ValueError("runId or sharedRunId is required")
+
+
+def _workflow_state_path(shared_dir: Path) -> Path:
+    return shared_dir / "workflow.json"
+
+
+def _workflow_rows(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    rows: list[dict[str, Any]] = []
+    for item in value:
+        if isinstance(item, dict):
+            rows.append(dict(item))
+        elif item is not None:
+            rows.append({"name": str(item)})
+    return rows
+
+
+def _workflow_row_keys(row: dict[str, Any]) -> set[str]:
+    keys: set[str] = set()
+    for key in ("id", "agentId", "agent_id", "name"):
+        value = str(row.get(key) or "").strip()
+        if value:
+            keys.add(value)
+    return keys
+
+
+def _sync_subagent_rows(subagents: list[dict[str, Any]], steps: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not subagents or not steps:
+        return subagents
+    synced = [dict(row) for row in subagents]
+    by_key: dict[str, int] = {}
+    for index, row in enumerate(synced):
+        for key in _workflow_row_keys(row):
+            by_key[key] = index
+    for step in steps:
+        for key in _workflow_row_keys(step):
+            index = by_key.get(key)
+            if index is None:
+                continue
+            if "status" in step:
+                synced[index]["status"] = step.get("status")
+            if "summary" in step:
+                synced[index]["summary"] = step.get("summary")
+            break
+    return synced
+
+
+def _workflow_done(status: Any) -> bool:
+    return str(status or "").strip().lower() in {"done", "success", "succeeded", "completed"}
+
+
+def _workflow_completed_keys(state: dict[str, Any]) -> set[str]:
+    completed: set[str] = set()
+    for row in _workflow_rows(state.get("steps")) + _workflow_rows(state.get("subagents")) + _workflow_rows(state.get("nodes")):
+        if _workflow_done(row.get("status")):
+            completed.update(_workflow_row_keys(row))
+    return completed
+
+
+def _workflow_rows_by_key(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    by_key: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        for key in _workflow_row_keys(row):
+            by_key.setdefault(key, row)
+    return by_key
+
+
+def _with_upstream_summaries(prompt: str, depends_on: list[str], state: dict[str, Any]) -> str:
+    by_key = _workflow_rows_by_key(_workflow_rows(state.get("steps")) + _workflow_rows(state.get("subagents")))
+    lines: list[str] = []
+    for dep_id in depends_on:
+        row = by_key.get(dep_id) or {}
+        summary = str(row.get("summary") or "").strip()
+        status = str(row.get("status") or "").strip()
+        if summary:
+            lines.append(f"- {dep_id}: {summary}")
+        elif status:
+            lines.append(f"- {dep_id}: {status}")
+    if not lines:
+        return prompt
+    return f"{prompt.rstrip()}\n\nUpstream summaries:\n" + "\n".join(lines)
+
+
+def _mark_workflow_rows_ready(rows: list[dict[str, Any]], ready_ids: set[str]) -> list[dict[str, Any]]:
+    marked: list[dict[str, Any]] = []
+    for row in rows:
+        item = dict(row)
+        if str(item.get("id") or "").strip() in ready_ids:
+            item["status"] = "ready"
+            item["summary"] = "dependencies done; ready for submit"
+        marked.append(item)
+    return marked
+
+
+def _advance_workflow_state(state: dict[str, Any]) -> list[dict[str, Any]]:
+    waiting = _workflow_rows(state.get("waitingInstructions"))
+    if not waiting:
+        state["readyInstructions"] = []
+        return []
+
+    completed = _workflow_completed_keys(state)
+    ready: list[dict[str, Any]] = []
+    still_waiting: list[dict[str, Any]] = []
+    for instruction in waiting:
+        depends_on = [str(item or "").strip() for item in instruction.get("dependsOn") or []]
+        depends_on = [item for item in depends_on if item]
+        if depends_on and all(dep_id in completed for dep_id in depends_on):
+            ready_instruction = dict(instruction)
+            ready_instruction["submitPrompt"] = _with_upstream_summaries(
+                str(ready_instruction.get("submitPrompt") or ""),
+                depends_on,
+                state,
+            )
+            ready.append(ready_instruction)
+        else:
+            still_waiting.append(instruction)
+
+    state["readyInstructions"] = ready
+    if not ready:
+        return []
+
+    state["waitingInstructions"] = still_waiting
+    submit_instructions = _workflow_rows(state.get("submitInstructions"))
+    submitted_ids = {str(item.get("id") or "").strip() for item in submit_instructions}
+    for instruction in ready:
+        instruction_id = str(instruction.get("id") or "").strip()
+        if instruction_id and instruction_id not in submitted_ids:
+            submit_instructions.append(instruction)
+            submitted_ids.add(instruction_id)
+    state["submitInstructions"] = submit_instructions
+
+    ready_ids = {str(instruction.get("id") or "").strip() for instruction in ready}
+    state["nodes"] = _mark_workflow_rows_ready(_workflow_rows(state.get("nodes")), ready_ids)
+    state["subagents"] = _mark_workflow_rows_ready(_workflow_rows(state.get("subagents")), ready_ids)
+    return ready
+
+
+def _workflow_temp_agent_ids(state: dict[str, Any]) -> list[str]:
+    agent_ids: list[str] = []
+    seen: set[str] = set()
+    for row in _workflow_rows(state.get("subagents")) + _workflow_rows(state.get("nodes")):
+        agent_id = str(row.get("agentId") or row.get("agent_id") or "").strip()
+        if not agent_id.startswith("tmp-workerflow-") or not SAFE_TEMP_AGENT_ID_RE.match(agent_id):
+            continue
+        if agent_id not in seen:
+            agent_ids.append(agent_id)
+            seen.add(agent_id)
+    return agent_ids
+
+
+def _cleanup_workflow_temp_agents(state: dict[str, Any], arguments: dict[str, Any]) -> dict[str, Any]:
+    results: list[dict[str, Any]] = []
+    dry_run = bool(arguments.get("dryRun"))
+    for agent_id in _workflow_temp_agent_ids(state):
+        try:
+            deleted = _agentflow(
+                {
+                    "action": "delete_temp_agent",
+                    "apiBaseUrl": arguments.get("apiBaseUrl"),
+                    "agentId": agent_id,
+                    "cleanupWorkspace": bool(arguments.get("cleanupWorkspace")),
+                    "dryRun": dry_run,
+                },
+            )
+            item = {
+                "agentId": agent_id,
+                "ok": True,
+                "deleted": False if dry_run else deleted.get("deleted", True),
+            }
+            if "cleanup" in deleted:
+                item["cleanup"] = deleted["cleanup"]
+            if dry_run:
+                item["planned"] = True
+            results.append(item)
+        except RuntimeError as exc:
+            message = str(exc)
+            if "HTTP 404" in message:
+                results.append({"agentId": agent_id, "ok": True, "deleted": False, "reason": "agent_missing"})
+            else:
+                results.append({"agentId": agent_id, "ok": False, "error": message})
+        except Exception as exc:
+            results.append({"agentId": agent_id, "ok": False, "error": str(exc)})
+    return {
+        "agents": results,
+        "deleted": sum(1 for item in results if item.get("ok") and item.get("deleted") is not False),
+        "missing": sum(1 for item in results if item.get("reason") == "agent_missing"),
+        "failed": sum(1 for item in results if not item.get("ok")),
+    }
+
+
+def _workflow_status(action: str, arguments: dict[str, Any], previous: dict[str, Any]) -> str:
+    explicit = str(arguments.get("status") or "").strip()
+    if explicit:
+        return explicit
+    if action == "workflow_start":
+        return "running"
+    if action == "workflow_finish":
+        return "done"
+    if action == "workflow_fail":
+        return "failed"
+    return str(previous.get("status") or "running")
+
+
+def _merge_workflow_state(action: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    run_id = _workflow_run_id(arguments, action)
+    shared_dir = _resolve_shared_dir(arguments.get("sharedDir"), arguments.get("sharedRunId") or run_id, run_id).expanduser().resolve()
+    previous = _read_json(_workflow_state_path(shared_dir))
+    room_id = str(arguments.get("roomId") or arguments.get("room_id") or previous.get("roomId") or "").strip()
+    event_id = str(arguments.get("eventId") or arguments.get("event_id") or previous.get("eventId") or "").strip()
+    title = str(arguments.get("title") or previous.get("title") or "WorkerFlow").strip()
+    summary = str(arguments.get("summary") or previous.get("summary") or "").strip()
+    subagents = _workflow_rows(arguments.get("subagents")) if "subagents" in arguments else _workflow_rows(previous.get("subagents"))
+    steps = _workflow_rows(arguments.get("steps")) if "steps" in arguments else _workflow_rows(previous.get("steps"))
+    subagents = _sync_subagent_rows(subagents, steps)
+    nodes = _sync_subagent_rows(_workflow_rows(previous.get("nodes")), steps)
+    state = {
+        "runId": run_id,
+        "title": title,
+        "status": _workflow_status(action, arguments, previous),
+        "summary": summary,
+        "roomId": room_id,
+        "eventId": event_id,
+        "coordinator": _matrix_user_id(),
+        "sharedPath": str(shared_dir),
+        "subagents": subagents,
+        "steps": steps,
+        "updatedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    for key in ("phase", "input", "merge", "workflowMode", "submitInstructions", "waitingInstructions"):
+        if key in previous:
+            state[key] = previous[key]
+    if nodes:
+        state["nodes"] = nodes
+    if previous.get("createdAt"):
+        state["createdAt"] = previous["createdAt"]
+    else:
+        state["createdAt"] = state["updatedAt"]
+    return state
+
+
+def _html_cell(value: Any) -> str:
+    return html.escape(str(value or ""))
+
+
+def _workflow_cell_value(row: dict[str, Any], key: str) -> Any:
+    if key == "name":
+        return row.get("name") or row.get("id") or row.get("agentId") or row.get("agent_id")
+    if key == "agentId":
+        return row.get("agentId") or row.get("agent_id") or row.get("id") or row.get("name")
+    return row.get(key)
+
+
+def _workflow_table(rows: list[dict[str, Any]], columns: list[tuple[str, str]]) -> str:
+    if not rows:
+        return ""
+    header = "".join(f"<th>{html.escape(label)}</th>" for _, label in columns)
+    body_rows = []
+    for row in rows:
+        cells = "".join(f"<td>{_html_cell(_workflow_cell_value(row, key))}</td>" for key, _ in columns)
+        body_rows.append(f"<tr>{cells}</tr>")
+    return f"<table><thead><tr>{header}</tr></thead><tbody>{''.join(body_rows)}</tbody></table>"
+
+
+def _workflow_content(state: dict[str, Any]) -> dict[str, Any]:
+    title = str(state.get("title") or "WorkerFlow")
+    run_id = str(state.get("runId") or "")
+    status = str(state.get("status") or "")
+    summary = str(state.get("summary") or "")
+    coordinator = str(state.get("coordinator") or "")
+    shared_path = str(state.get("sharedPath") or "")
+    subagents = _workflow_rows(state.get("subagents"))
+    steps = _workflow_rows(state.get("steps"))
+
+    lines = [f"[WorkerFlow] {run_id}: {status}"]
+    if summary:
+        lines.append(f"Summary: {summary}")
+    if coordinator:
+        lines.append(f"Coordinator: {coordinator}")
+    if shared_path:
+        lines.append(f"Shared: {shared_path}")
+    if subagents:
+        lines.append("Subagents:")
+        for subagent in subagents:
+            label = subagent.get("name") or subagent.get("role") or subagent.get("agentId") or subagent.get("id") or "subagent"
+            subagent_status = subagent.get("status") or ""
+            subagent_summary = subagent.get("summary") or ""
+            lines.append(f"- {label}: {subagent_status} {subagent_summary}".rstrip())
+    if steps:
+        lines.append("Steps:")
+        for step in steps:
+            label = step.get("name") or step.get("id") or "step"
+            step_status = step.get("status") or ""
+            lines.append(f"- {label}: {step_status}".rstrip())
+
+    subagent_table = _workflow_table(
+        subagents,
+        [("name", "Subagent"), ("role", "Role"), ("status", "Status"), ("summary", "Summary")],
+    )
+    step_table = _workflow_table(
+        steps,
+        [("name", "Step"), ("status", "Status"), ("summary", "Summary")],
+    )
+    html_parts = [
+        f"<h3>{html.escape(title)} · {html.escape(run_id)}</h3>",
+        f"<p><strong>Status:</strong> {html.escape(status)}</p>",
+    ]
+    if summary:
+        html_parts.append(f"<p><strong>Summary:</strong> {html.escape(summary)}</p>")
+    if coordinator:
+        html_parts.append(f"<p><strong>Coordinator:</strong> {html.escape(coordinator)}</p>")
+    if shared_path:
+        html_parts.append(f"<p><strong>Shared:</strong> <code>{html.escape(shared_path)}</code></p>")
+    if subagent_table:
+        html_parts.append("<h4>Subagents</h4>")
+        html_parts.append(subagent_table)
+    if step_table:
+        html_parts.append("<h4>Steps</h4>")
+        html_parts.append(step_table)
+
+    return {
+        "msgtype": "m.notice",
+        "body": "\n".join(lines),
+        "format": "org.matrix.custom.html",
+        "formatted_body": "\n".join(html_parts),
+        "hiclaw.workflow": {
+            "type": "workerflow",
+            "runId": run_id,
+            "status": status,
+            "title": title,
+            "summary": summary,
+            "ownerRole": "worker",
+            "ownerAgentId": "default",
+            "coordinator": coordinator,
+            "sharedPath": shared_path,
+            "subagents": subagents,
+            "steps": steps,
+        },
+    }
+
+
+def _workflow_matrix_content(state: dict[str, Any], event_id: str = "") -> dict[str, Any]:
+    content = _workflow_content(state)
+    if not event_id:
+        return content
+    edit_content = dict(content)
+    edit_content["body"] = f"* {content['body']}"
+    edit_content["m.new_content"] = content
+    edit_content["m.relates_to"] = {
+        "rel_type": "m.replace",
+        "event_id": event_id,
+    }
+    return edit_content
+
+
+def _matrix_homeserver() -> str:
+    return str(
+        os.getenv("AGENTTEAMS_MATRIX_URL")
+        or os.getenv("AGENTTEAMS_MATRIX_SERVER")
+        or os.getenv("AGENTTEAMS_MATRIX_HOMESERVER")
+        or ""
+    ).rstrip("/")
+
+
+def _matrix_token() -> str:
+    credentials = _section(_load_runtime_config(), "credentials")
+    token_env = str(credentials.get("matrixTokenEnv") or "AGENTTEAMS_WORKER_MATRIX_TOKEN").strip()
+    for name in (token_env, "AGENTTEAMS_WORKER_MATRIX_TOKEN", "AGENTTEAMS_MATRIX_TOKEN"):
+        if not name:
+            continue
+        value = os.getenv(name, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _matrix_send_content(room_id: str, content: dict[str, Any]) -> str:
+    homeserver = _matrix_homeserver()
+    token = _matrix_token()
+    if not homeserver or not token:
+        raise ValueError(
+            "Matrix homeserver and token are required "
+            "(AGENTTEAMS_MATRIX_URL or alias; runtime credentials.matrixTokenEnv, "
+            "AGENTTEAMS_WORKER_MATRIX_TOKEN, or AGENTTEAMS_MATRIX_TOKEN)"
+        )
+    encoded_room = urllib.parse.quote(room_id, safe="")
+    txn_id = f"workerflow-{os.getpid()}-{int(time.time() * 1000)}"
+    request = urllib.request.Request(
+        f"{homeserver}/_matrix/client/v3/rooms/{encoded_room}/send/m.room.message/{txn_id}",
+        data=json.dumps(content).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="PUT",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8") or "{}")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")[:200]
+        raise RuntimeError(f"Matrix API error: HTTP {exc.code}: {body}") from exc
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise RuntimeError(f"Matrix API error: {exc}") from exc
+    event_id = str(data.get("event_id") or "")
+    if not event_id:
+        raise RuntimeError("Matrix send response missing event_id")
+    return event_id
+
+
+def _workflow(arguments: dict[str, Any], action: str) -> dict[str, Any]:
+    dry_run = bool(arguments.get("dryRun"))
+    state = _merge_workflow_state(action, arguments)
+    ready_instructions = _advance_workflow_state(state) if action == "workflow_update" else []
+    if not state.get("roomId"):
+        raise ValueError("roomId is required; pass the current Matrix DM/conversation room explicitly")
+
+    edit_event_id = "" if action == "workflow_start" else str(state.get("eventId") or "")
+    if action != "workflow_start" and not edit_event_id:
+        raise ValueError("eventId is required for workflow updates unless workflow.json already records it")
+    if action in {"workflow_finish", "workflow_fail"}:
+        state["cleanupTempAgents"] = _cleanup_workflow_temp_agents(state, arguments)
+    content = _workflow_matrix_content(state, edit_event_id)
+    result = {
+        "ok": True,
+        "tool": "worker_agentflow",
+        "action": action,
+        "runId": state["runId"],
+        "roomId": state["roomId"],
+        "eventId": state.get("eventId") or "",
+        "statePath": str(_workflow_state_path(Path(str(state["sharedPath"])))),
+        "content": content,
+    }
+    for key in ("nodes", "submitInstructions", "waitingInstructions", "readyInstructions", "workflowMode"):
+        if key in state:
+            result[key] = state[key]
+    if "cleanupTempAgents" in state:
+        result["cleanupTempAgents"] = state["cleanupTempAgents"]
+    if ready_instructions:
+        result["readyInstructions"] = ready_instructions
+    if dry_run:
+        result["dryRun"] = True
+        return result
+
+    event_id = _matrix_send_content(str(state["roomId"]), content)
+    if action == "workflow_start":
+        state["eventId"] = event_id
+    else:
+        state["lastEditEventId"] = event_id
+    _write_json(_workflow_state_path(Path(str(state["sharedPath"]))), state)
+    result["eventId"] = str(state.get("eventId") or event_id)
+    if action != "workflow_start":
+        result["editEventId"] = event_id
+    return result
+
+
+def _workflow_plan_subagents(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or not value:
+        raise ValueError("workflow_run requires at least one subagent")
+    subagents: list[dict[str, Any]] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise ValueError("workflow_run subagents must be objects")
+        subagent_plan = dict(item)
+        subagent_id = str(subagent_plan.get("id") or f"subagent-{index + 1}").strip()
+        if not SAFE_SUBAGENT_NAME_RE.match(subagent_id):
+            raise ValueError("subagent id must be a safe single path component")
+        subagent = str(subagent_plan.get("subagent") or "").strip()
+        if not subagent:
+            raise ValueError("workflow_run subagent requires subagent")
+        task = str(subagent_plan.get("task") or "").strip()
+        if not task:
+            raise ValueError("workflow_run subagent requires task")
+        subagent_plan["id"] = subagent_id
+        subagent_plan["subagent"] = subagent
+        subagent_plan["task"] = task
+        subagents.append(subagent_plan)
+    return subagents
+
+
+def _workflow_plan_nodes(arguments: dict[str, Any]) -> tuple[list[dict[str, Any]], bool]:
+    raw_nodes = arguments.get("nodes")
+    is_dag = isinstance(raw_nodes, list) and bool(raw_nodes)
+    nodes = _workflow_plan_subagents(raw_nodes if is_dag else arguments.get("subagents"))
+    seen: set[str] = set()
+    node_ids = [node["id"] for node in nodes]
+    for node in nodes:
+        if node["id"] in seen:
+            raise ValueError("workflow_run node ids must be unique")
+        seen.add(node["id"])
+        raw_depends = node.get("dependsOn")
+        if raw_depends is None:
+            raw_depends = node.get("depends_on")
+        depends_on = raw_depends if isinstance(raw_depends, list) else []
+        normalized: list[str] = []
+        for dep in depends_on:
+            dep_id = str(dep or "").strip()
+            if not SAFE_SUBAGENT_NAME_RE.match(dep_id):
+                raise ValueError("workflow_run dependsOn entries must be safe node ids")
+            if dep_id not in node_ids:
+                raise ValueError(f"workflow_run node depends on unknown node: {dep_id}")
+            if dep_id not in normalized:
+                normalized.append(dep_id)
+        node["dependsOn"] = normalized
+    _validate_workflow_dag(nodes)
+    return nodes, is_dag
+
+
+def _validate_workflow_dag(nodes: list[dict[str, Any]]) -> None:
+    by_id = {node["id"]: node for node in nodes}
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(node_id: str) -> None:
+        if node_id in visited:
+            return
+        if node_id in visiting:
+            raise ValueError("workflow_run nodes must not contain dependency cycles")
+        visiting.add(node_id)
+        for dep in by_id[node_id].get("dependsOn") or []:
+            visit(dep)
+        visiting.remove(node_id)
+        visited.add(node_id)
+
+    for node in nodes:
+        visit(node["id"])
+
+
+def _workflow_subagent_agent_id(run_id: str, subagent: dict[str, Any]) -> str:
+    explicit = str(subagent.get("agentId") or subagent.get("agent_id") or "").strip()
+    agent_id = explicit or f"tmp-workerflow-{run_id}-{subagent['id']}"
+    if not SAFE_TEMP_AGENT_ID_RE.match(agent_id):
+        raise ValueError("workflow_run subagent agentId must be a safe tmp-* id")
+    return agent_id
+
+
+def _workflow_submit_prompt(
+    title: str,
+    input_text: str,
+    subagent: dict[str, Any],
+    shared: dict[str, Any],
+    merge: dict[str, Any],
+    dependency_outputs: list[dict[str, str]] | None = None,
+) -> str:
+    lines = [
+        "WorkerFlow subagent task.",
+        "",
+        f"Workflow: {title}",
+        f"Subagent id: {subagent['id']}",
+        f"Subagent: {subagent['subagent']}",
+        f"Task: {subagent['task']}",
+        "",
+        "Input:",
+        input_text,
+        "",
+        "Shared files:",
+        f"- inputs: {shared.get('inputs') or ''}",
+        f"- output: {shared.get('output') or ''}",
+        "",
+        "Write any files only under the output path above. Return a concise structured result.",
+    ]
+    if dependency_outputs:
+        lines.extend(["", "Upstream outputs:"])
+        for item in dependency_outputs:
+            lines.append(f"- {item['id']}: {item['output']}")
+    merge_instruction = str(merge.get("instruction") or "").strip()
+    if merge_instruction:
+        lines.extend(["", f"Merge expectation: {merge_instruction}"])
+    return "\n".join(lines).strip()
+
+
+def _workflow_dependency_outputs(node: dict[str, Any], output_paths: dict[str, str]) -> list[dict[str, str]]:
+    return [{"id": dep_id, "output": output_paths[dep_id]} for dep_id in node.get("dependsOn") or []]
+
+
+def _fail_workflow_run_spawn(
+    arguments: dict[str, Any],
+    run_id: str,
+    start: dict[str, Any],
+    node_rows: list[dict[str, Any]],
+    exc: Exception,
+) -> None:
+    if bool(arguments.get("dryRun")):
+        return
+    try:
+        _workflow(
+            {
+                **arguments,
+                "runId": run_id,
+                "roomId": start.get("roomId"),
+                "eventId": start.get("eventId"),
+                "status": "failed",
+                "summary": f"failed to create subagents: {exc}",
+                "subagents": node_rows,
+                "steps": [
+                    {"name": "Start workflow", "status": "done"},
+                    {"name": "Create subagents", "status": "failed", "summary": str(exc)},
+                    {"name": "Submit subagent tasks", "status": "pending"},
+                    {"name": "Merge results", "status": "pending"},
+                ],
+            },
+            "workflow_fail",
+        )
+    except Exception as cleanup_exc:
+        logger.warning("workflow_run failure compensation failed: %s", cleanup_exc, exc_info=True)
+
+
+def _workflow_run(arguments: dict[str, Any]) -> dict[str, Any]:
+    run_id = _workflow_run_id(arguments, "workflow_run")
+    title = str(arguments.get("title") or "WorkerFlow").strip()
+    input_text = str(arguments.get("input") or "").strip()
+    nodes, is_dag = _workflow_plan_nodes(arguments)
+    merge = arguments.get("merge") if isinstance(arguments.get("merge"), dict) else {}
+    dry_run = bool(arguments.get("dryRun"))
+
+    start = _workflow(
+        {
+            **arguments,
+            "runId": run_id,
+            "status": "spawning",
+            "summary": str(arguments.get("summary") or "creating subagents"),
+            "subagents": [],
+            "steps": [
+                {"name": "Start workflow", "status": "done"},
+                {"name": "Create subagents", "status": "running"},
+                {"name": "Submit subagent tasks", "status": "pending"},
+                {"name": "Merge results", "status": "pending"},
+            ],
+        },
+        "workflow_start",
+    )
+
+    shared_dir = _resolve_shared_dir(arguments.get("sharedDir"), arguments.get("sharedRunId") or run_id, run_id)
+    agent_ids = {node["id"]: _workflow_subagent_agent_id(run_id, node) for node in nodes}
+    output_paths = {
+        node_id: str((shared_dir / "outputs" / agent_id).expanduser())
+        for node_id, agent_id in agent_ids.items()
+    }
+    node_rows: list[dict[str, Any]] = []
+    cleanup_rows: list[dict[str, Any]] = []
+    submit_instructions: list[dict[str, Any]] = []
+    waiting_instructions: list[dict[str, Any]] = []
+    try:
+        for node in nodes:
+            agent_id = agent_ids[node["id"]]
+            display_name = str(node.get("name") or node.get("title") or node["id"])
+            display_role = str(node.get("role") or node.get("title") or node["subagent"])
+
+            def record_created_temp_agent(_agent_id: str, _created: dict[str, Any]) -> None:
+                cleanup_rows.append(
+                    {
+                        "id": node["id"],
+                        "name": display_name,
+                        "agentId": _agent_id,
+                        "role": display_role,
+                        "subagent": node["subagent"],
+                        "task": node["task"],
+                        "status": "failed",
+                        "summary": "created before workflow_run failed",
+                    },
+                )
+
+            create_args: dict[str, Any] = {
+                "action": "create_temp_agent",
+                "apiBaseUrl": arguments.get("apiBaseUrl"),
+                "agentId": agent_id,
+                "name": display_name,
+                "description": str(node.get("description") or f"WorkerFlow subagent {display_name}"),
+                "subagent": node["subagent"],
+                "sharedRunId": run_id,
+                "sharedDir": arguments.get("sharedDir"),
+                "language": node.get("language") or arguments.get("language") or "zh",
+                "dryRun": dry_run,
+                "_createdTempAgent": record_created_temp_agent,
+            }
+            if isinstance(node.get("skillNames"), list):
+                create_args["skillNames"] = node["skillNames"]
+            if isinstance(node.get("activeModel"), dict):
+                create_args["activeModel"] = node["activeModel"]
+            elif isinstance(arguments.get("activeModel"), dict):
+                create_args["activeModel"] = arguments["activeModel"]
+
+            created = _agentflow(create_args)
+            shared = created.get("shared") if isinstance(created.get("shared"), dict) else {}
+            workspace = str(created.get("workspace") or _default_workspace(agent_id))
+            dependency_outputs = _workflow_dependency_outputs(node, output_paths)
+            submit_prompt = _workflow_submit_prompt(title, input_text, node, shared, merge, dependency_outputs)
+            is_ready = not node.get("dependsOn")
+            status = "ready" if is_ready else "waiting"
+            row = {
+                "id": node["id"],
+                "name": display_name,
+                "agentId": agent_id,
+                "role": display_role,
+                "subagent": node["subagent"],
+                "task": node["task"],
+                "dependsOn": node.get("dependsOn") or [],
+                "status": status,
+                "summary": "ready for submit" if is_ready else f"waiting for {', '.join(node['dependsOn'])}",
+                "workspace": workspace,
+                "shared": shared,
+                "submitPrompt": submit_prompt,
+            }
+            node_rows.append(row)
+            for index, cleanup_row in enumerate(cleanup_rows):
+                if cleanup_row.get("agentId") == agent_id:
+                    cleanup_rows[index] = row
+                    break
+            else:
+                if not dry_run:
+                    cleanup_rows.append(row)
+            instruction = {
+                "id": node["id"],
+                "agentId": agent_id,
+                "submitPrompt": submit_prompt,
+                "shared": shared,
+            }
+            if is_ready:
+                submit_instructions.append(instruction)
+            else:
+                instruction["dependsOn"] = node.get("dependsOn") or []
+                waiting_instructions.append(instruction)
+    except Exception as exc:
+        _fail_workflow_run_spawn(arguments, run_id, start, cleanup_rows, exc)
+        raise
+
+    if dry_run:
+        state_path = Path(str(start["statePath"]))
+        return {
+            "ok": True,
+            "tool": "worker_agentflow",
+            "action": "workflow_run",
+            "runId": run_id,
+            "roomId": start["roomId"],
+            "eventId": "",
+            "statePath": str(state_path),
+            "shared": {"path": str(state_path.parent)},
+            "subagents": node_rows,
+            "nodes": node_rows,
+            "submitInstructions": submit_instructions,
+            "waitingInstructions": waiting_instructions,
+            "workflowMode": "dag" if is_dag else "fanout",
+            "dryRun": True,
+        }
+
+    updated = _workflow(
+        {
+            **arguments,
+            "runId": run_id,
+            "status": "ready",
+            "summary": "subagents ready; submit tasks to agents",
+            "subagents": node_rows,
+            "steps": [
+                {"name": "Start workflow", "status": "done"},
+                {"name": "Create subagents", "status": "done"},
+                {"name": "Submit subagent tasks", "status": "ready"},
+                {"name": "Merge results", "status": "pending"},
+            ],
+        },
+        "workflow_update",
+    )
+
+    state_path = Path(str(updated["statePath"]))
+    state = _read_json(state_path)
+    state["phase"] = "ready"
+    state["input"] = input_text
+    state["merge"] = merge
+    state["workflowMode"] = "dag" if is_dag else "fanout"
+    state["nodes"] = node_rows
+    state["submitInstructions"] = submit_instructions
+    state["waitingInstructions"] = waiting_instructions
+    _write_json(state_path, state)
+
+    return {
+        "ok": True,
+        "tool": "worker_agentflow",
+        "action": "workflow_run",
+        "runId": run_id,
+        "roomId": updated["roomId"],
+        "eventId": updated["eventId"],
+        "statePath": str(state_path),
+        "shared": {"path": str(Path(str(state_path)).parent)},
+        "subagents": node_rows,
+        "nodes": node_rows,
+        "submitInstructions": submit_instructions,
+        "waitingInstructions": waiting_instructions,
+        "workflowMode": "dag" if is_dag else "fanout",
+        "dryRun": False,
+    }
+
+
+def _list_subagents() -> list[dict[str, Any]]:
+    root = _subagents_dir()
+    if not root.is_dir():
+        return []
+    result = []
+    for path in sorted(root.iterdir()):
+        if not path.is_dir() or not SAFE_SUBAGENT_NAME_RE.match(path.name):
+            continue
+        skills_dir = path / "skills"
+        skills = []
+        if skills_dir.is_dir():
+            skills = sorted(
+                skill.name
+                for skill in skills_dir.iterdir()
+                if skill.is_dir() and (skill / "SKILL.md").is_file()
+            )
+        result.append({
+            "name": path.name,
+            "path": str(path),
+            "hasAgentsMd": (path / "AGENTS.md").is_file(),
+            "skills": skills,
+        })
+    return result
+
+
+def _resolve_subagent_template(name: str) -> Path:
+    value = name.strip()
+    if not SAFE_SUBAGENT_NAME_RE.match(value):
+        raise ValueError("subagent must be a safe single path component")
+    path = (_subagents_dir() / value).resolve()
+    root = _subagents_dir().resolve()
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("subagent path escapes default workspace subagents directory") from exc
+    if not path.is_dir():
+        raise ValueError(f"subagent not found: {value}")
+    return path
+
+
+def _copy_replace(source: Path, target: Path) -> None:
+    if target.exists():
+        shutil.rmtree(target)
+    shutil.copytree(source, target, ignore=shutil.ignore_patterns("__pycache__", ".DS_Store", "*.pyc"))
+
+
+def _copy_template(template_path: str, workspace_dir: Path) -> dict[str, Any]:
+    if not template_path:
+        return {"copied": [], "skills": [], "enabled": []}
+    template = Path(template_path).expanduser().resolve()
+    if not template.is_dir():
+        raise ValueError(f"templatePath is not a directory: {template}")
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+
+    copied: list[str] = []
+    for name in ("AGENTS.md", "PROFILE.md", "SOUL.md"):
+        source = template / name
+        if source.is_file():
+            shutil.copy2(source, workspace_dir / name)
+            copied.append(name)
+
+    copied_skills: list[str] = []
+    source_skills = template / "skills"
+    target_skills = workspace_dir / "skills"
+    if source_skills.is_dir():
+        target_skills.mkdir(parents=True, exist_ok=True)
+        for source in sorted(source_skills.iterdir()):
+            if source.is_dir() and (source / "SKILL.md").is_file():
+                _copy_replace(source, target_skills / source.name)
+                copied_skills.append(source.name)
+
+    enabled = _reconcile_and_enable_skills(workspace_dir, copied_skills)
+    return {"copied": copied, "skills": copied_skills, "enabled": enabled}
+
+
+def _reconcile_and_enable_skills(workspace_dir: Path, skill_names: list[str]) -> list[str]:
+    if not skill_names:
+        return []
+    try:
+        from qwenpaw.agents.skill_system.registry import reconcile_workspace_manifest
+        from qwenpaw.agents.skill_system.workspace_service import SkillService
+    except ImportError:
+        return []
+
+    reconcile_workspace_manifest(workspace_dir)
+    service = SkillService(workspace_dir)
+    enabled: list[str] = []
+    for name in skill_names:
+        result = service.enable_skill(name)
+        if result.get("success"):
+            enabled.append(name)
+    return enabled
+
+
+def _safe_cleanup_workspace(agent_id: str, workspace_dir: str) -> dict[str, Any]:
+    if not workspace_dir:
+        return {"removed": False, "reason": "missing_workspace"}
+    if not agent_id.startswith("tmp-"):
+        return {"removed": False, "reason": "agent_id_not_temporary"}
+    root = (_qwenpaw_working_dir() / "workspaces").resolve()
+    target = Path(workspace_dir).expanduser().resolve()
+    try:
+        target.relative_to(root)
+    except ValueError:
+        return {"removed": False, "reason": "workspace_outside_qwenpaw_workspaces", "path": str(target)}
+    if target.name != agent_id:
+        return {"removed": False, "reason": "workspace_name_mismatch", "path": str(target)}
+    if target.exists():
+        shutil.rmtree(target)
+        return {"removed": True, "path": str(target)}
+    return {"removed": False, "reason": "workspace_missing", "path": str(target)}
+
+
+def _agentflow(arguments: dict[str, Any]) -> dict[str, Any]:
+    action = str(arguments.get("action") or "").strip()
+    base_url = _api_base(arguments.get("apiBaseUrl"))
+    dry_run = bool(arguments.get("dryRun"))
+
+    if action == "list_agents":
+        if dry_run:
+            return {"ok": True, "tool": "worker_agentflow", "action": action, "apiBaseUrl": base_url}
+        return {"ok": True, "tool": "worker_agentflow", "action": action, "agents": _json_request("GET", base_url, "/agents")}
+
+    if action == "list_subagents":
+        return {"ok": True, "tool": "worker_agentflow", "action": action, "subagents": _list_subagents()}
+
+    if action == "create_temp_agent":
+        agent_id = str(arguments.get("agentId") or f"tmp-workerflow-{uuid.uuid4().hex[:8]}").strip()
+        if not agent_id.startswith("tmp-"):
+            raise ValueError("temporary agent id must start with tmp-")
+        workspace_dir = Path(str(arguments.get("workspaceDir") or _default_workspace(agent_id))).expanduser()
+        template_path = str(arguments.get("templatePath") or "").strip()
+        subagent = str(arguments.get("subagent") or "").strip()
+        if template_path and subagent:
+            raise ValueError("use either templatePath or subagent, not both")
+        if subagent:
+            template_path = str(_resolve_subagent_template(subagent))
+        payload: dict[str, Any] = {
+            "id": agent_id,
+            "name": str(arguments.get("name") or agent_id),
+            "description": str(arguments.get("description") or "Temporary WorkerFlow agent"),
+            "workspace_dir": str(workspace_dir),
+            "language": str(arguments.get("language") or "zh"),
+            "skill_names": arguments.get("skillNames") if isinstance(arguments.get("skillNames"), list) else [],
+        }
+        active_model = arguments.get("activeModel")
+        if isinstance(active_model, dict):
+            payload["active_model"] = active_model
+        shared_dir = _resolve_shared_dir(arguments.get("sharedDir"), arguments.get("sharedRunId"), agent_id)
+        if dry_run:
+            return {
+                "ok": True,
+                "tool": "worker_agentflow",
+                "action": action,
+                "apiBaseUrl": base_url,
+                "payload": payload,
+                "subagent": subagent,
+                "templatePath": template_path,
+                "shared": _shared_plan(agent_id, workspace_dir, shared_dir),
+            }
+        created = _json_request("POST", base_url, "/agents", payload)
+        created_recorder = arguments.get("_createdTempAgent")
+        if callable(created_recorder):
+            created_recorder(agent_id, created)
+        resolved_workspace = Path(str(created.get("workspace_dir") or workspace_dir)).expanduser()
+        template = _copy_template(template_path, resolved_workspace)
+        shared = _setup_shared_dir(agent_id, resolved_workspace, shared_dir)
+        return {
+            "ok": True,
+            "tool": "worker_agentflow",
+            "action": action,
+            "agentId": agent_id,
+            "created": created,
+            "workspace": str(resolved_workspace),
+            "subagent": subagent,
+            "template": template,
+            "shared": shared,
+        }
+
+    if action == "delete_temp_agent":
+        agent_id = str(arguments.get("agentId") or "").strip()
+        if not agent_id:
+            raise ValueError("agentId is required")
+        if not agent_id.startswith("tmp-"):
+            raise ValueError("worker_agentflow only deletes tmp-* temporary agents")
+        workspace_dir = str(arguments.get("workspaceDir") or "").strip()
+        if bool(arguments.get("cleanupWorkspace")) and not workspace_dir:
+            try:
+                profile = _json_request("GET", base_url, f"/agents/{urllib.parse.quote(agent_id)}")
+                workspace_dir = str(profile.get("workspace_dir") or "")
+            except RuntimeError:
+                workspace_dir = ""
+        if dry_run:
+            return {
+                "ok": True,
+                "tool": "worker_agentflow",
+                "action": action,
+                "apiBaseUrl": base_url,
+                "agentId": agent_id,
+                "workspace": workspace_dir,
+            }
+        deleted = _json_request("DELETE", base_url, f"/agents/{urllib.parse.quote(agent_id)}")
+        cleanup = (
+            _safe_cleanup_workspace(agent_id, workspace_dir)
+            if bool(arguments.get("cleanupWorkspace"))
+            else {"removed": False, "reason": "cleanup_disabled"}
+        )
+        return {"ok": True, "tool": "worker_agentflow", "action": action, "agentId": agent_id, "deleted": deleted, "cleanup": cleanup}
+
+    if action == "cleanup_shared":
+        if not str(arguments.get("sharedDir") or "").strip() and not str(arguments.get("sharedRunId") or "").strip():
+            raise ValueError("sharedRunId or sharedDir is required")
+        shared_dir = _resolve_shared_dir(arguments.get("sharedDir"), arguments.get("sharedRunId"), "")
+        if dry_run:
+            return {
+                "ok": True,
+                "tool": "worker_agentflow",
+                "action": action,
+                "shared": {"path": str(shared_dir)},
+            }
+        return {
+            "ok": True,
+            "tool": "worker_agentflow",
+            "action": action,
+            "shared": _safe_cleanup_shared(shared_dir),
+        }
+
+    if action == "workflow_run":
+        return _workflow_run(arguments)
+
+    if action in {"workflow_start", "workflow_update", "workflow_finish", "workflow_fail"}:
+        return _workflow(arguments, action)
+
+    raise ValueError(f"unsupported action: {action}")
+
+
+def _tool_schema(name: str) -> dict[str, Any]:
+    schema = TOOL_SCHEMAS[name]
+    return {"name": name, "description": schema["description"], "inputSchema": schema["inputSchema"]}
+
+
+def _call_tool(name: str, arguments: dict[str, Any] | None = None) -> dict[str, Any]:
+    if name not in TOOL_NAMES:
+        raise ValueError(f"unknown tool: {name}")
+    args = arguments or {}
+    try:
+        result = _agentflow(args)
+    except Exception as exc:  # pylint: disable=broad-except
+        result = {"ok": False, "tool": name, "error": str(exc)}
+    return {"content": [{"type": "text", "text": json.dumps(result, ensure_ascii=False, indent=2)}]}
+
+
+def _handle(request: dict[str, Any]) -> dict[str, Any] | None:
+    method = request.get("method")
+    request_id = request.get("id")
+    if request_id is None:
+        return None
+    try:
+        if method == "initialize":
+            result = {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "workerflow", "version": "0.1.0"},
+            }
+        elif method == "tools/list":
+            result = {"tools": [_tool_schema(name) for name in TOOL_NAMES]}
+        elif method == "tools/call":
+            params = request.get("params") or {}
+            result = _call_tool(str(params.get("name") or ""), params.get("arguments") or {})
+        else:
+            return {"jsonrpc": "2.0", "id": request_id, "error": {"code": -32601, "message": f"method not found: {method}"}}
+        return {"jsonrpc": "2.0", "id": request_id, "result": result}
+    except Exception as exc:  # pylint: disable=broad-except
+        return {"jsonrpc": "2.0", "id": request_id, "error": {"code": -32000, "message": str(exc)}}
+
+
+def main() -> None:
+    for line in sys.stdin:
+        if not line.strip():
+            continue
+        response = _handle(json.loads(line))
+        if response is not None:
+            sys.stdout.write(json.dumps(response, ensure_ascii=False) + "\n")
+            sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/workerflow/plugin.yaml
+++ b/plugins/workerflow/plugin.yaml
@@ -1,0 +1,37 @@
+apiVersion: hiclaw.agentteam/v1alpha1
+kind: AgentTeamPlugin
+metadata:
+  name: workerflow
+  version: 0.1.0
+prompts:
+  team: prompts/team/WORKERFLOW.md
+  agent:
+    worker: prompts/agent/worker.md
+  manager:
+    agents: prompts/manager/AGENTS.md
+    tools: prompts/manager/TOOLS.md
+skills:
+  agent:
+    - id: worker-internal-workflow
+      path: skills/agent/worker-internal-workflow
+      roles: [worker]
+mcp:
+  servers:
+    - id: workerflow
+      transport: stdio
+      command: python
+      args:
+        - mcp/server.py
+      tools:
+        - worker_agentflow
+adapters:
+  - id: qwenpaw
+    path: adapters/qwenpaw
+package:
+  include:
+    - plugin.yaml
+    - prompts/
+    - skills/
+    - mcp/
+    - adapters/
+    - scripts/

--- a/plugins/workerflow/prompts/agent/worker.md
+++ b/plugins/workerflow/prompts/agent/worker.md
@@ -1,0 +1,41 @@
+# Worker Role
+
+You own your assigned work. Use WorkerFlow only to split or isolate parts of
+your own execution.
+
+Choose the smallest path:
+
+- Do the work directly when no subagent is needed.
+- Use QwenPaw native subagents for short same-workspace parallel checks.
+- Use `worker_agentflow` `workflow_run` when visible multi-subagent work needs
+  temporary QwenPaw agents with custom roles, workspaces, `AGENTS.md`, or skill
+  templates.
+- Use `create_temp_agent` directly only when you need manual control outside a
+  dynamic workflow.
+
+You remain responsible for merging subagent results and cleaning temporary
+agents before reporting completion.
+
+When fanning one input out to multiple temporary agents, send the complete
+source input to each subagent unless there is a clear token, privacy, or cost
+reason to narrow it. Let each subagent's `AGENTS.md` decide what to extract.
+
+Temporary subagents should be instructed to start work immediately, without
+greetings, self-introduction, or capability summaries. Ask for a fixed output
+shape when the results will be merged.
+
+For file-based fan-out with temporary agents, use the `shared` directory
+returned by `workflow_run` or `create_temp_agent`. Keep subagent workspaces
+separate; share inputs under `shared/inputs/` and require each subagent to write
+under `shared/outputs/<agent-id>/`.
+
+For visible multi-subagent work in Matrix, the current Worker owns the workflow
+card. Prefer `workflow_run` with the explicit current DM/conversation `roomId`.
+It starts the card, creates temporary agents from `subagents/<name>` templates,
+writes `workflow.json`, and returns `submitInstructions` for immediately ready
+subagents or DAG nodes. When using `nodes` with `dependsOn`, call
+`workflow_update` with done `steps` as upstream nodes finish; if the response
+contains `readyInstructions`, send those prompts immediately through the
+available QwenPaw agent communication tools. Merge the results yourself, then
+finish with `workflow_finish` or `workflow_fail`. Temporary agents should not
+send their own Matrix status. Do not fallback to Team Room or personal room.

--- a/plugins/workerflow/prompts/manager/AGENTS.md
+++ b/plugins/workerflow/prompts/manager/AGENTS.md
@@ -1,0 +1,7 @@
+# WorkerFlow Manager Prompt
+
+WorkerFlow is runtime support for Worker-local workflow execution.
+
+Install the plugin into QwenPaw runtimes that need controlled access to
+temporary agent lifecycle tools. Do not use this plugin to model persistent
+TeamHarness collaboration.

--- a/plugins/workerflow/prompts/manager/TOOLS.md
+++ b/plugins/workerflow/prompts/manager/TOOLS.md
@@ -1,0 +1,39 @@
+# WorkerFlow Tools
+
+The WorkerFlow MCP server exposes `worker_agentflow`.
+
+Supported actions:
+
+- `list_agents`: list QwenPaw agents through the local API.
+- `list_subagents`: list runtime subagent templates under the default
+  workspace `subagents/` directory.
+- `create_temp_agent`: create a bounded temporary QwenPaw agent and optionally
+  copy a default-workspace subagent template or external template containing
+  `AGENTS.md` and `skills/`. The response includes a run-level `shared`
+  directory. Pass the same `sharedRunId` to several temporary agents when they
+  should share input/output files.
+- `delete_temp_agent`: delete a temporary QwenPaw agent and optionally clean
+  its workspace when the path is safe.
+- `cleanup_shared`: remove a shared run directory after the Worker has merged
+  results. It only removes paths under the default workspace
+  `shared/workerflow/` root.
+- `workflow_run`: start a Worker-owned dynamic workflow from a declarative
+  `subagents` fan-out plan or DAG `nodes` plan. It creates the workflow card
+  and temporary agents from default-workspace `subagents/<name>` templates,
+  writes `workflow.json`, and returns `submitInstructions` for dependency-free nodes.
+  Nodes blocked by `dependsOn` are returned as `waitingInstructions`.
+- `workflow_update`: update the same Matrix workflow card with `m.replace`.
+  When `steps` mark dependencies as `done`, the response can include
+  `readyInstructions`; submit those prompts immediately to continue the DAG.
+- `workflow_start`: show a Worker-owned workflow card in the explicit current
+  Matrix DM/conversation `roomId` and return the Matrix `eventId`.
+- `workflow_finish` / `workflow_fail`: finish the card as done or failed.
+
+Workflow cards are sent as the current Worker Matrix user. Temporary agents do
+not send Matrix status directly; the Worker coordinates and updates the card.
+WorkerFlow does not choose or fallback to Team Room or personal room. Pass the
+current DM/conversation `roomId` explicitly.
+
+Prefer `workflow_run` for visible multi-subagent fan-out or a small DAG. Use the
+lower-level `workflow_start`, `create_temp_agent`, `workflow_update`, and
+cleanup actions only when the Worker needs manual control over each phase.

--- a/plugins/workerflow/prompts/team/WORKERFLOW.md
+++ b/plugins/workerflow/prompts/team/WORKERFLOW.md
@@ -1,0 +1,36 @@
+# WorkerFlow Runtime Contract
+
+WorkerFlow is for one Worker to organize its own internal execution. It does
+not create TeamHarness Workers, project DAGs, task rooms, requester reply
+routes, or Leader acceptance state.
+
+Use WorkerFlow only for bounded work owned by the current Worker:
+
+- Native QwenPaw subagents for short internal parallelism.
+- Dynamic workflows that create temporary QwenPaw agents from custom
+  `AGENTS.md` and skill templates under the default workspace
+  `subagents/` directory.
+- Direct execution by the current default agent when no subagent is needed.
+
+Do not present temporary QwenPaw agents as durable team members.
+
+For temporary-agent fan-out, the current Worker remains the coordinator. It
+should prefer `workflow_run`: pass the explicit current DM/conversation
+`roomId`, the source input, and either a `subagents` fan-out plan or DAG
+`nodes` plan.
+`workflow_run` starts the workflow card, creates temporary agents, writes
+`workflow.json`, and returns submit prompts for nodes that are ready now. The
+Worker still sends those prompts through the available QwenPaw agent
+communication tools, waits for upstream outputs before submitting dependent
+nodes, merges the results, marks failed subagents explicitly, and deletes
+temporary agents before reporting completion.
+
+Temporary agents created with `/api/agents` have separate workspaces. When file
+sharing is needed, use the run-level `shared` directory returned by
+`create_temp_agent`, not the default agent workspace as the temporary
+`workspaceDir`.
+
+When WorkerFlow progress should be visible in Matrix, the current Worker may
+publish one workflow card to the explicit current DM/conversation `roomId` and
+edit it as phases change. WorkerFlow does not fallback to Team Room or personal
+room. This does not make temporary agents TeamHarness members.

--- a/plugins/workerflow/scripts/install.sh
+++ b/plugins/workerflow/scripts/install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+export WORKERFLOW_PLUGIN_DIR="${WORKERFLOW_PLUGIN_DIR:-$PLUGIN_DIR}"
+
+if ! command -v qwenpaw >/dev/null 2>&1; then
+  echo "ERROR: qwenpaw command not found" >&2
+  exit 1
+fi
+
+bash "${PLUGIN_DIR}/adapters/qwenpaw/install.sh"

--- a/plugins/workerflow/scripts/uninstall.sh
+++ b/plugins/workerflow/scripts/uninstall.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v qwenpaw >/dev/null 2>&1; then
+  bash "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/adapters/qwenpaw/uninstall.sh"
+fi

--- a/plugins/workerflow/skills/agent/worker-internal-workflow/SKILL.md
+++ b/plugins/workerflow/skills/agent/worker-internal-workflow/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: workerflow-internal-workflow
+description: Use when a QwenPaw-backed Worker needs to decide whether to do work directly, use native subagents for internal parallelism, or create a temporary QwenPaw agent with a custom AGENTS.md and skills.
+---
+
+# Worker Internal Workflow
+
+Use this skill before splitting work inside a single Worker. WorkerFlow is not
+TeamHarness delegation.
+
+## Decision
+
+| Need | Path |
+| --- | --- |
+| Current Worker can do it directly | No subagent |
+| Same Worker needs short parallel inspection | QwenPaw native subagent |
+| Same Worker needs visible fan-out to custom roles, workspaces, `AGENTS.md`, or skills | Dynamic workflow via `worker_agentflow` `workflow_run` |
+| Same Worker needs one manually controlled temporary subagent | `create_temp_agent` directly |
+| Work needs a persistent team member or Leader acceptance | Do not use WorkerFlow; use the team workflow |
+
+## Native Subagent
+
+Use QwenPaw native subagents for short internal parallelism. The current Worker
+still owns the final result.
+
+Do not create a temporary agent when no custom prompt, workspace, or skill set
+is required.
+
+## Temporary QwenPaw Agent
+
+Use `worker_agentflow` with `workflow_run` when a custom AgentSpec-style
+template has already been placed in the default QwenPaw workspace:
+
+```text
+<QWENPAW_WORKING_DIR>/workspaces/default/subagents/<role>/
+  AGENTS.md
+  PROFILE.md        # optional
+  SOUL.md           # optional
+  skills/
+    <skill-id>/
+      SKILL.md
+```
+
+Use `list_subagents` first when you need to discover the templates available in
+the default workspace. Use `create_temp_agent` directly only when you need
+manual control outside a dynamic workflow.
+
+Subagent template rules:
+
+- `AGENTS.md` should tell the temporary agent to begin analysis immediately.
+- `AGENTS.md` should forbid greetings, self-introductions, and capability
+  summaries.
+- `AGENTS.md` should define the subagent's focus area so the Worker can send the
+  complete source input instead of manually slicing the input.
+- When multiple subagent results will be merged, each `AGENTS.md` should require
+  the same fixed output shape.
+
+Dynamic workflow lifecycle:
+
+1. Call `workflow_run` with the explicit current DM/conversation `roomId`,
+   `title`, source `input`, optional `merge.instruction`, and either
+   `subagents` or DAG `nodes`.
+2. Each subagent or node must name a default-workspace template with `subagent`
+   and a bounded `task`.
+3. `workflow_run` starts the Matrix card, creates `tmp-...` subagents, creates the
+   run-level shared directory, stores `workflow.json`, and returns
+   `submitInstructions` for nodes that are ready now.
+4. Send each returned `submitPrompt` to its `agentId` using the available
+   QwenPaw agent communication tools.
+5. When a subagent finishes, call `workflow_update` with a `steps` row whose
+   `id` matches the node id, `status` is `done`, and `summary` contains the
+   short result.
+6. For DAG `nodes`, inspect every `workflow_update` response. If it returns
+   `readyInstructions`, immediately send each returned `submitPrompt` to its
+   `agentId`.
+7. Use `workflow_update` at meaningful phase changes: submitted, running,
+   retrying, merging, cleanup, done, or failed.
+8. Retry a timed-out subagent once when the task is still useful.
+9. Mark subagents that still fail as missing or failed in the merged result.
+10. Merge subagent results into the current Worker's own output.
+11. Delete every temporary agent with `delete_temp_agent`.
+12. Call `workflow_finish` or `workflow_fail`.
+13. After merging, either keep the shared run directory as evidence or remove it
+    with `cleanup_shared`.
+
+Example `workflow_run` input:
+
+```json
+{
+  "action": "workflow_run",
+  "roomId": "!current-dm:example.test",
+  "runId": "run-review-auth",
+  "title": "Review auth module",
+  "input": "Review auth.py for this task...",
+  "subagents": [
+    {
+      "id": "security",
+      "subagent": "security-reviewer",
+      "task": "Check authentication and authorization risks."
+    },
+    {
+      "id": "tests",
+      "subagent": "test-reviewer",
+      "task": "Check test coverage gaps."
+    }
+  ],
+  "merge": {
+    "instruction": "Return one severity-ordered finding list."
+  }
+}
+```
+
+DAG nodes example:
+
+```json
+{
+  "action": "workflow_run",
+  "roomId": "!current-dm:example.test",
+  "runId": "pig-diagnosis-b001",
+  "title": "猪病诊断报告生成",
+  "input": "批次号 B001 的猪病诊断请求...",
+  "nodes": [
+    {
+      "id": "base_info",
+      "name": "基础信息梳理",
+      "role": "基础信息梳理",
+      "subagent": "base-info-agent",
+      "task": "处理基础信息。"
+    },
+    {
+      "id": "feed_cough",
+      "name": "采食与咳喘指标",
+      "role": "采食与咳喘指标",
+      "subagent": "feed-cough-agent",
+      "task": "分析采食及咳嗽波动。"
+    },
+    {
+      "id": "pathogen",
+      "name": "病原线索分析",
+      "role": "病原线索分析",
+      "subagent": "pathogen-agent",
+      "task": "分析病原及亚型。"
+    },
+    {
+      "id": "disease_analysis",
+      "name": "疾病综合研判",
+      "role": "疾病综合研判",
+      "subagent": "disease-analysis-agent",
+      "task": "综合基础信息、采食咳嗽和病原结果，判断猪病。",
+      "dependsOn": ["base_info", "feed_cough", "pathogen"]
+    },
+    {
+      "id": "medication",
+      "name": "用药与处置措施",
+      "role": "用药与处置措施",
+      "subagent": "medication-measures-agent",
+      "task": "基于猪病分析生成药物及措施方案。",
+      "dependsOn": ["disease_analysis"]
+    },
+    {
+      "id": "diagnosis_advice",
+      "name": "诊断建议",
+      "role": "诊断建议",
+      "subagent": "diagnosis-advice-agent",
+      "task": "基于猪病分析生成诊断建议。",
+      "dependsOn": ["disease_analysis"]
+    },
+    {
+      "id": "report",
+      "name": "最终报告汇总",
+      "role": "最终报告汇总",
+      "subagent": "report-agent",
+      "task": "汇总上游结果生成最终诊断报告。",
+      "dependsOn": ["medication", "diagnosis_advice"]
+    }
+  ]
+}
+```
+
+For DAG workflows, `workflow_run` creates every node's temporary agent. Only
+dependency-free nodes appear in `submitInstructions`. Dependent nodes appear in
+`waitingInstructions`. The current Worker is the scheduler: submit ready nodes,
+wait for their replies, call `workflow_update` with done `steps`, then submit
+any downstream `readyInstructions` returned by that update. WorkerFlow uses the
+done step ids as the dependency-completion signal and appends upstream summaries
+to newly unblocked submit prompts.
+
+File sharing:
+
+- Native QwenPaw subagents share the current Worker's workspace.
+- Temporary QwenPaw agents created through `/api/agents` have separate
+  workspaces. Do not point their `workspaceDir` at the default workspace.
+- `workflow_run` and `create_temp_agent` expose a run-level shared directory:
+  `<default-workspace>/shared/workerflow/<sharedRunId>/`.
+- Put input files under `shared/inputs/`.
+- Each subagent writes only under `shared/outputs/<agent-id>/`.
+- The subagent workspace contains `.workerflow/shared.json` and a `shared`
+  symlink for discovery, but prompts should still include the absolute
+  `shared.path`, `shared.inputs`, and `shared.output` returned by the tool.
+- Do not place the shared directory inside a temporary agent workspace, because
+  `cleanupWorkspace` may delete that workspace.
+
+Workflow visibility:
+
+- The current Worker is the Matrix sender for WorkerFlow workflow cards.
+- Temporary agents do not send Matrix status directly.
+- Prefer `workflow_run` for visible multi-subagent work; it creates the first
+  Matrix `m.notice` card and records the returned `eventId`.
+- `workflow_run` and `workflow_start` require an explicit current
+  DM/conversation `roomId`.
+  WorkerFlow does not fallback to Team Room or personal room.
+- Use `workflow_update`, `workflow_finish`, and `workflow_fail` to edit the same
+  card through Matrix `m.replace`.
+- The card state is also stored in
+  `<default-workspace>/shared/workerflow/<run-id>/workflow.json`.
+- Show phase-level changes only: spawning subagents, running, retrying, merging,
+  cleanup, done, or failed.
+- Do not expose full prompts, secrets, raw large inputs, or tool traces in the
+  card. Use shared paths and short summaries.
+
+Fan-out rules:
+
+- Send the full source input to each subagent unless there is a clear token,
+  privacy, or cost reason to narrow it.
+- Let each subagent extract the subset relevant to its `AGENTS.md`.
+- Request a fixed output shape for all subagents when the results need
+  programmatic or low-friction merging.
+- Keep a small ledger of created temporary agent ids so cleanup can run even
+  when one subagent fails.
+- Keep the shared run id in the same ledger when file sharing is used.
+
+Rules:
+
+- Temporary agents are implementation details of the current Worker.
+- Always use `tmp-` ids for temporary agents.
+- Do not store temporary agent ids as TeamHarness workers.
+- Delete temporary agents after the bounded task completes or fails; treat this
+  as a finally step.
+- If the work must survive the current Worker run, use a durable team workflow
+  instead.


### PR DESCRIPTION
## Summary
- add WorkerFlow plugin manifest, prompts, skill, MCP stdio server, and QwenPaw adapter package builder
- install WorkerFlow skills and MCP client into QwenPaw agent workspaces
- add adapter, package, and MCP tests

## Scope
- QwenPaw WorkerFlow adapter only
- OpenHuman remains unchanged and parallel to QwenPaw
- no controller or Helm runtime wiring
- no credential or JWT provisioning changes

## Validation
- uv run --with pytest python -m pytest plugins/tests/workerflow -q
- bash -n plugins/workerflow/adapters/qwenpaw/install.sh plugins/workerflow/adapters/qwenpaw/uninstall.sh plugins/workerflow/scripts/install.sh plugins/workerflow/scripts/uninstall.sh
- ruby -c plugins/workerflow/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb
- git diff --check