### PR TITLE
feat(teamharness): add QwenPaw task trace correlation

### DIFF
--- a/plugins/teamharness/adapters/qwenpaw/plugin.py
+++ b/plugins/teamharness/adapters/qwenpaw/plugin.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import re
 import shutil
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +29,8 @@ REDACTION = "[REDACTED]"
 SENSITIVE_FILE_AUTO_DENY_RULE = "SENSITIVE_FILE_BLOCK"
 TEAMS_CONTEXT_START = "<!-- BEGIN HICLAW RUNTIME TEAM CONTEXT -->"
 TEAMS_CONTEXT_END = "<!-- END HICLAW RUNTIME TEAM CONTEXT -->"
+_TASK_TRACE_MODULE: Any = None
+_TASK_TRACE_REGISTERED: bool = False
 
 _BUILTIN_SANITIZER_PATTERNS: List[tuple[re.Pattern[str], str]] = [
     (re.compile(r"\b(LTAI)[A-Za-z0-9]{12,}"), r"\1****"),
@@ -741,16 +743,255 @@ def install_output_sanitizer_wrapper() -> Dict[str, Any]:
     return {"ok": True, "installed": True, "action": "created"}
 
 
+def _task_trace_module_path() -> Optional[Path]:
+    candidate = PLUGIN_DIR / "task_trace.py"
+    return candidate if candidate.exists() else None
+
+
+def _load_task_trace_module() -> Tuple[Optional[Any], Optional[str]]:
+    global _TASK_TRACE_MODULE
+    if _TASK_TRACE_MODULE is not None:
+        return _TASK_TRACE_MODULE, None
+
+    trace_module_path = _task_trace_module_path()
+    if trace_module_path is None:
+        return None, "task_trace.py not found"
+
+    try:
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("teamharness_qwenpaw_task_trace", trace_module_path)
+        if spec is None or spec.loader is None:
+            return None, "cannot load trace module"
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["teamharness_qwenpaw_task_trace"] = module
+        spec.loader.exec_module(module)
+    except Exception as exc:
+        sys.modules.pop("teamharness_qwenpaw_task_trace", None)
+        return None, str(exc)
+
+    _TASK_TRACE_MODULE = module
+    return module, None
+
+
+def _room_id_from_request_context(context: Any) -> str:
+    if not isinstance(context, dict):
+        return ""
+    for key in ("room_id", "roomId"):
+        room_id = _string(context.get(key))
+        if room_id:
+            return room_id
+    meta = context.get("channel_meta")
+    if isinstance(meta, dict):
+        room_id = _string(meta.get("room_id") or meta.get("roomId"))
+        if room_id:
+            return room_id
+    session_id = _string(context.get("session_id"))
+    if session_id.startswith("matrix:"):
+        return session_id[len("matrix:") :]
+    if _string(context.get("channel")) == "matrix":
+        return _string(context.get("user_id"))
+    return ""
+
+
+def _task_trace_debug_enabled() -> bool:
+    return os.getenv("AGENTTEAMS_TASK_TRACE_DEBUG", "").strip().lower() in {"1", "true", "yes"}
+
+
+def _canonical_task_trace_room(trace_module: Any, room_id: str) -> str:
+    canonicalize = getattr(trace_module, "canonical_room_id", None)
+    if callable(canonicalize):
+        try:
+            return str(canonicalize(room_id) or "").strip()
+        except Exception:
+            return _string(room_id)
+    return _string(room_id)
+
+
+def _refresh_shared_tasks_for_task_trace(trace_module: Any, room_id: str) -> Dict[str, Any]:
+    """Best-effort pull of shared task metadata before tagging a turn span."""
+    room = _canonical_task_trace_room(trace_module, room_id)
+    if not room:
+        return {"ok": True, "action": "skipped", "reason": "missing room"}
+
+    qwenpaw_dir = _qwenpaw_working_dir()
+    if qwenpaw_dir is None:
+        return {"ok": False, "reason": "workspace dir unavailable"}
+
+    shared_dir = _shared_dir()
+    shared_prefix = os.getenv("AGENTTEAMS_SHARED_STORAGE_PREFIX", "").strip().strip("/") or "shared"
+    remote_prefix = f"{shared_prefix}/tasks"
+    local_tasks_dir = shared_dir / "tasks"
+    worker_name = (
+        os.getenv("AGENTTEAMS_WORKER_NAME", "").strip()
+        or os.getenv("AGENTTEAMS_AGENT_NAME", "").strip()
+        or "qwenpaw"
+    )
+
+    try:
+        from qwenpaw_worker.sync import FileSync
+
+        sync = FileSync(
+            endpoint=os.getenv("AGENTTEAMS_FS_ENDPOINT", ""),
+            access_key=os.getenv("AGENTTEAMS_FS_ACCESS_KEY", ""),
+            secret_key=os.getenv("AGENTTEAMS_FS_SECRET_KEY", ""),
+            bucket=os.getenv("AGENTTEAMS_FS_BUCKET", "agentteams-storage"),
+            worker_name=worker_name,
+            local_dir=qwenpaw_dir.parent,
+            shared_dir=shared_dir,
+            shared_prefix=shared_prefix,
+        )
+        sync.mirror_prefix(remote_prefix, local_tasks_dir)
+    except Exception as exc:
+        if _task_trace_debug_enabled():
+            logger.warning(
+                "AgentTeamsTaskSpanProcessor shared tasks refresh failed room=%s remote=%s local=%s error_type=%s error=%s",
+                room,
+                remote_prefix,
+                local_tasks_dir,
+                type(exc).__name__,
+                exc,
+            )
+        return {"ok": False, "reason": str(exc), "remote": remote_prefix}
+
+    if _task_trace_debug_enabled():
+        logger.info(
+            "AgentTeamsTaskSpanProcessor shared tasks refreshed room=%s remote=%s local=%s",
+            room,
+            remote_prefix,
+            local_tasks_dir,
+        )
+    return {"ok": True, "action": "refreshed", "remote": remote_prefix, "local": str(local_tasks_dir)}
+
+
+def install_task_trace_context_wrapper(trace_module: Any) -> Dict[str, Any]:
+    try:
+        from qwenpaw.agents.react_agent import QwenPawAgent
+    except ImportError:
+        return {"ok": True, "installed": False, "reason": "qwenpaw agent API unavailable"}
+    if getattr(QwenPawAgent, "_teamharness_trace_context_installed", False):
+        return {"ok": True, "installed": True, "action": "unchanged"}
+
+    original_call = getattr(QwenPawAgent, "__call__", None)
+    original_reply = getattr(QwenPawAgent, "reply", None)
+    if not callable(original_call) or not callable(original_reply):
+        return {"ok": False, "installed": False, "reason": "qwenpaw agent call API unavailable"}
+
+    def _set_room_context(agent: Any):
+        room_id = _room_id_from_request_context(getattr(agent, "_request_context", {}) or {})
+        return (trace_module.set_current_room(room_id) if room_id else None, room_id)
+
+    def _tag_current_entry_span() -> None:
+        workspace_dir = _qwenpaw_working_dir()
+        if workspace_dir is None:
+            return
+        default_ws = workspace_dir / "workspaces" / "default"
+        tag_pending = getattr(trace_module, "tag_pending_entry_span", None)
+        if callable(tag_pending):
+            get_pending = getattr(trace_module, "get_pending_entry_span", None)
+            if callable(get_pending) and get_pending() is not None:
+                tag_pending(default_ws)
+                return
+        tag_current = getattr(trace_module, "tag_current_entry_span", None)
+        if callable(tag_current):
+            tag_current(default_ws)
+
+    async def _call_with_task_trace_context(self, *args, **kwargs):
+        token, room_id = _set_room_context(self)
+        try:
+            _refresh_shared_tasks_for_task_trace(trace_module, room_id)
+            _tag_current_entry_span()
+            _retry_task_trace_registration(trace_module)
+            return await original_call(self, *args, **kwargs)
+        finally:
+            if token is not None:
+                trace_module.reset_current_room(token)
+
+    async def _reply_with_task_trace_context(self, *args, **kwargs):
+        token, room_id = _set_room_context(self)
+        try:
+            _refresh_shared_tasks_for_task_trace(trace_module, room_id)
+            _tag_current_entry_span()
+            _retry_task_trace_registration(trace_module)
+            return await original_reply(self, *args, **kwargs)
+        finally:
+            if token is not None:
+                trace_module.reset_current_room(token)
+
+    QwenPawAgent.__call__ = _call_with_task_trace_context
+    QwenPawAgent.reply = _reply_with_task_trace_context
+    QwenPawAgent._teamharness_trace_context_installed = True
+    QwenPawAgent._teamharness_trace_original_call = original_call
+    QwenPawAgent._teamharness_trace_original_reply = original_reply
+    return {"ok": True, "installed": True, "action": "created"}
+
+
+def _retry_task_trace_registration(trace_module: Any) -> None:
+    if _TASK_TRACE_REGISTERED:
+        return
+    workspace_dir = _qwenpaw_working_dir()
+    if workspace_dir is None:
+        return
+    result = _register_task_trace_processor(trace_module, workspace_dir / "workspaces" / "default")
+    if result.get("ok"):
+        return
+    reason = str(result.get("reason") or "unknown")
+    logger.info("AgentTeamsTaskSpanProcessor lazy registration skipped: %s", reason)
+
+
+def _register_task_trace_processor(trace_module: Any, workspace_dir: Path) -> Dict[str, Any]:
+    global _TASK_TRACE_REGISTERED
+    if _TASK_TRACE_REGISTERED:
+        return {"ok": True, "processor": "AgentTeamsTaskSpanProcessor", "action": "unchanged"}
+    result = trace_module.register_task_trace_processor(workspace_dir)
+    if isinstance(result, dict) and result.get("ok"):
+        _TASK_TRACE_REGISTERED = True
+    return result if isinstance(result, dict) else {"ok": False, "reason": "invalid registration result"}
+
+
+def install_task_trace_processor() -> Dict[str, Any]:
+    """Register the AgentTeams Task-Trace SpanProcessor on the active TracerProvider."""
+    workspace_dir = _qwenpaw_working_dir()
+    if workspace_dir is None:
+        return {"ok": False, "reason": "workspace dir unavailable"}
+    default_workspace = workspace_dir / "workspaces" / "default"
+
+    module, error = _load_task_trace_module()
+    if module is None:
+        return {"ok": False, "reason": error or "cannot load trace module"}
+
+    try:
+        context_result = install_task_trace_context_wrapper(module)
+        result = _register_task_trace_processor(module, default_workspace)
+        if isinstance(result, dict):
+            result = dict(result)
+            result["context"] = context_result
+            if not result.get("ok"):
+                logger.warning(
+                    "AgentTeamsTaskSpanProcessor not registered: %s",
+                    result.get("reason") or "unknown",
+                )
+        return result
+    except Exception as exc:
+        logger.warning("Failed to register AgentTeamsTaskSpanProcessor: %s", exc)
+        return {"ok": False, "reason": str(exc)}
+
+
 class TeamHarnessPlugin:
     def __init__(self) -> None:
         self.last_apply_result: Dict[str, Any] = {}
         self.sanitizer_result: Dict[str, Any] = {}
+        self.trace_result: Dict[str, Any] = {}
+
+    def _sync_runtime(self) -> Dict[str, Any]:
+        self.last_apply_result = apply_teamharness()
+        self.sanitizer_result = install_output_sanitizer_wrapper()
+        self.trace_result = install_task_trace_processor()
+        return self.last_apply_result
 
     def register(self, api: Any) -> None:
         def sync() -> Dict[str, Any]:
-            self.last_apply_result = apply_teamharness()
-            self.sanitizer_result = install_output_sanitizer_wrapper()
-            return self.last_apply_result
+            return self._sync_runtime()
 
         def shutdown() -> None:
             return None
@@ -776,12 +1017,12 @@ class TeamHarnessPlugin:
                 "ok": True,
                 "lastApply": self.last_apply_result,
                 "sanitizer": self.sanitizer_result,
+                "trace": self.trace_result,
             }
 
         @router.post("/sync")
         def sync_endpoint() -> Dict[str, Any]:
-            self.last_apply_result = apply_teamharness()
-            return self.last_apply_result
+            return self._sync_runtime()
 
         api.register_http_router(router, prefix="/teamharness", tags=["teamharness"])
 

--- a/plugins/teamharness/adapters/qwenpaw/task_trace.py
+++ b/plugins/teamharness/adapters/qwenpaw/task_trace.py
@@ -1,0 +1,561 @@
+"""QwenPaw Task-Trace correlation for AgentTeams.
+
+Provides a QwenPaw OpenTelemetry SpanProcessor that attaches
+``agentteams.task.id`` and ``agentteams.project.id`` to the **entry span** of each
+agent turn trace.
+
+Entry span choice
+-----------------
+LoongSuite/QwenPaw instrumentation creates one trace per user turn with this
+hierarchy (outer -> inner)::
+
+    enter_ai_application_system   <- trace root / GenAI application entry
+      agent_step
+        invoke_agent <name>
+          react step
+            chat / execute_tool / ...
+
+We tag **only** ``enter_ai_application_system`` because:
+
+* It is the trace root - CMS/ARMS filters on root-span attributes efficiently.
+* There is exactly one per turn (same cardinality as a "trace" in the product).
+* ``agent_step`` is nested inside it; tagging both would be redundant.
+
+Task status matching
+--------------------
+The current room/session is the primary correlation key.  A unique project is
+derived from ``shared/tasks/*/meta.json`` records in the room, without requiring
+the worker's local copy of ``shared/projects/<project_id>/meta.json`` to be
+present.  ``assigned`` and ``in_progress`` tasks are then matched by
+``project_id + room_id + assigned_to + status`` so the ACK/work/submit turn's
+entry span is tagged before ``submit_task`` flips status to ``submitted``.
+After submit, the room can still be tagged with ``agentteams.project.id`` but
+not ``agentteams.task.id``.
+
+Session isolation
+-----------------
+A Worker may serve multiple sessions (rooms) concurrently.  Each turn is
+tied to a specific ``room_id`` via :func:`set_current_room` which the Agent
+runtime calls before invoking the turn handler.  The processor reads the
+current room via :func:`get_current_room` and only matches tasks whose
+``room_id`` equals the active room.  This prevents cross-session task tagging.
+
+If the room context is not set, the processor does not guess from active tasks
+because that can cross-tag unrelated sessions.
+
+Debug logging
+-------------
+Set ``AGENTTEAMS_TASK_TRACE_DEBUG=1`` to enable verbose processor logs.
+Default is silent - no I/O overhead on the hot span path.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Debug logging (controlled by AGENTTEAMS_TASK_TRACE_DEBUG env var)
+# ---------------------------------------------------------------------------
+
+_DEBUG_ENABLED: bool = os.getenv("AGENTTEAMS_TASK_TRACE_DEBUG", "").strip() in ("1", "true", "yes")
+
+
+def _trace_log(msg: str, *args: Any) -> None:
+    """Emit debug log only when AGENTTEAMS_TASK_TRACE_DEBUG=1."""
+    if not _DEBUG_ENABLED:
+        return
+    formatted = msg % args if args else msg
+    print(f"[AgentTeamsTaskSpanProcessor] {formatted}", file=sys.stderr, flush=True)
+    logger.info(msg, *args)
+
+
+def _trace_warning(msg: str, *args: Any) -> None:
+    """Report a non-fatal trace-correlation problem."""
+    formatted = msg % args if args else msg
+    if _DEBUG_ENABLED:
+        print(f"[AgentTeamsTaskSpanProcessor] {formatted}", file=sys.stderr, flush=True)
+    logger.warning(msg, *args)
+
+
+def set_trace_debug(enabled: bool) -> None:
+    """Programmatically enable/disable processor debug logging."""
+    global _DEBUG_ENABLED
+    _DEBUG_ENABLED = enabled
+
+# ---------------------------------------------------------------------------
+# Session (room) context propagation
+# ---------------------------------------------------------------------------
+
+_current_room: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "agentteams_current_room", default=""
+)
+
+# Entry span captured in on_start when room context is not yet available.
+# The QwenPawAgent wrapper sets the room and then calls
+# tag_pending_entry_span() to retroactively tag it.
+_pending_entry_span: contextvars.ContextVar[Any] = contextvars.ContextVar(
+    "agentteams_pending_entry_span", default=None
+)
+def set_current_room(room_id: str) -> contextvars.Token[str]:
+    """Set the current Matrix room for this coroutine/thread.
+
+    The Agent runtime must call this before processing each turn so the
+    SpanProcessor can correlate spans with the correct task.
+
+    Returns a token for resetting (useful in try/finally blocks).
+    """
+    return _current_room.set(canonical_room_id(room_id))
+
+
+def get_current_room() -> str:
+    """Return the room_id for the current coroutine/thread, or empty string."""
+    return _current_room.get()
+
+
+def reset_current_room(token: contextvars.Token[str]) -> None:
+    """Reset room context to previous value."""
+    _current_room.reset(token)
+
+
+ATTR_AGENTTEAMS_TASK_ID = "agentteams.task.id"
+ATTR_AGENTTEAMS_PROJECT_ID = "agentteams.project.id"
+
+# Trace root span created by loongsuite-instrumentation-qwenpaw per user turn.
+ENTRY_SPAN_NAME = "enter_ai_application_system"
+
+# assigned: ACK turn (before ack_task); in_progress: work/submit turns.
+_ACTIVE_STATUSES = frozenset({"assigned", "in_progress"})
+
+_CACHE_TTL = 0.0  # retained for API compatibility; entry spans always re-scan meta.json
+_REGISTERED_PROVIDER_IDS: set[int] = set()
+
+
+def is_entry_span(span_name: str) -> bool:
+    """Return True if *span_name* is the per-turn trace entry span."""
+    return span_name == ENTRY_SPAN_NAME
+
+
+def canonical_room_id(room_id: Any) -> str:
+    """Return a stable Matrix room key across TeamHarness/QwenPaw prefixes."""
+    value = str(room_id or "").strip()
+    changed = True
+    while changed:
+        changed = False
+        for prefix in ("matrix:", "room:"):
+            if value.startswith(prefix):
+                value = value[len(prefix) :].strip()
+                changed = True
+    return value
+
+
+def canonical_worker_name(worker_id: Any) -> str:
+    """Normalize Matrix user ids and bare worker names to the worker name."""
+    value = str(worker_id or "").strip()
+    if value.startswith("@"):
+        value = value[1:]
+    if ":" in value:
+        value = value.split(":", 1)[0]
+    return value
+
+
+def _meta_text(meta: dict[str, Any], *keys: str) -> str:
+    """Return the first non-empty string value for *keys* in *meta*."""
+    for key in keys:
+        value = str(meta.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _task_room_id(meta: dict[str, Any]) -> str:
+    return _meta_text(meta, "room_id", "roomId")
+
+
+def _task_assignee(meta: dict[str, Any]) -> str:
+    return _meta_text(meta, "assigned_to", "assignedTo", "assignee")
+
+
+def _task_project_id(meta: dict[str, Any]) -> str:
+    return _meta_text(meta, "project_id", "projectId")
+
+
+def _task_id(meta: dict[str, Any]) -> str:
+    return _meta_text(meta, "task_id", "taskId")
+
+
+def _read_task_metas(workspace_dir: Path) -> list[dict[str, Any]]:
+    tasks_dir = workspace_dir / "shared" / "tasks"
+    if not tasks_dir.is_dir():
+        return []
+    metas: list[dict[str, Any]] = []
+    for entry in sorted(tasks_dir.iterdir(), key=lambda path: path.name):
+        if not entry.is_dir():
+            continue
+        meta_path = entry / "meta.json"
+        if not meta_path.exists():
+            continue
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if isinstance(meta, dict):
+            metas.append(meta)
+    return metas
+
+
+def find_task_trace_context(
+    workspace_dir: Path,
+    *,
+    room_id: str = "",
+) -> dict[str, Any]:
+    """Return project/task context for the current room.
+
+    Project attribution is room-based: all task metas in one room must agree on
+    a single project id.  Task attribution is narrower: among that project and
+    room, exactly one active task may be assigned to ``AGENTTEAMS_WORKER_NAME``.
+    Ambiguous or missing task matches keep project attribution but omit task id.
+    """
+    canonical_room = canonical_room_id(room_id)
+    context: dict[str, Any] = {
+        "project_id": "",
+        "task": None,
+        "reason": "",
+    }
+    if not canonical_room:
+        context["reason"] = "missing room context"
+        return context
+
+    try:
+        room_tasks = [
+            meta for meta in _read_task_metas(workspace_dir)
+            if canonical_room_id(_task_room_id(meta)) == canonical_room
+        ]
+        if not room_tasks:
+            context["reason"] = "no task meta for room"
+            return context
+
+        project_ids = sorted({
+            project_id
+            for meta in room_tasks
+            if (project_id := _task_project_id(meta))
+        })
+        if len(project_ids) != 1:
+            _trace_warning(
+                "task trace project ambiguity room=%s projects=%s matches=%d",
+                canonical_room,
+                ",".join(project_ids) or "(none)",
+                len(room_tasks),
+            )
+            context["reason"] = "project ambiguity"
+            return context
+
+        project_id = project_ids[0]
+        context["project_id"] = project_id
+
+        worker_name = canonical_worker_name(os.getenv("AGENTTEAMS_WORKER_NAME", ""))
+        if not worker_name:
+            context["reason"] = "missing worker name"
+            return context
+
+        active_matches = []
+        for meta in room_tasks:
+            if _task_project_id(meta) != project_id:
+                continue
+            if meta.get("status") not in _ACTIVE_STATUSES:
+                continue
+            assignee = canonical_worker_name(_task_assignee(meta))
+            if assignee == worker_name:
+                active_matches.append(meta)
+
+        if len(active_matches) == 1:
+            task = active_matches[0]
+            context["task"] = task
+            _trace_log(
+                "find_task_trace_context: project_id=%s task_id=%s status=%s "
+                "room_id=%s assignee=%s",
+                project_id,
+                _task_id(task),
+                task.get("status"),
+                _task_room_id(task),
+                _task_assignee(task),
+            )
+            return context
+        if not active_matches:
+            _trace_warning(
+                "task trace active task not found room=%s project_id=%s worker=%s",
+                canonical_room,
+                project_id,
+                worker_name,
+            )
+            context["reason"] = "active task not found"
+            return context
+
+        _trace_warning(
+            "task trace active task ambiguity room=%s project_id=%s worker=%s matches=%d",
+            canonical_room,
+            project_id,
+            worker_name,
+            len(active_matches),
+        )
+        context["reason"] = "active task ambiguity"
+        return context
+    except Exception as exc:
+        _trace_log("find_task_trace_context: unexpected error workspace=%s: %s", workspace_dir, exc)
+        logger.warning("find_task_trace_context failed: %s", exc)
+        context["reason"] = "unexpected error"
+        return context
+
+
+def find_active_task(
+    workspace_dir: Path,
+    *,
+    room_id: str = "",
+) -> dict[str, Any] | None:
+    """Return the current worker's active task for ``room_id``, if unique."""
+    context = find_task_trace_context(workspace_dir, room_id=room_id)
+    task = context.get("task")
+    return task if isinstance(task, dict) else None
+
+
+def register_task_trace_processor(
+    workspace_dir: Path | str,
+    *,
+    cache_ttl: float = _CACHE_TTL,
+) -> dict[str, Any]:
+    """Register :class:`AgentTeamsTaskSpanProcessor` on the active TracerProvider.
+
+    Safe to call even when the OTel SDK is not installed - returns a result
+    dict describing what happened.
+    """
+    try:
+        from opentelemetry import trace as trace_api
+        from opentelemetry.sdk.trace import TracerProvider
+    except ImportError:
+        return {"ok": False, "reason": "opentelemetry SDK unavailable"}
+
+    provider = trace_api.get_tracer_provider()
+
+    # The SDK may wrap the real provider in a ProxyTracerProvider.
+    real = getattr(provider, "_real_provider", None) or provider
+    if not isinstance(real, TracerProvider):
+        return {"ok": False, "reason": "TracerProvider not initialised yet"}
+    if id(real) in _REGISTERED_PROVIDER_IDS:
+        return {"ok": True, "processor": "AgentTeamsTaskSpanProcessor", "action": "unchanged"}
+
+    processor = AgentTeamsTaskSpanProcessor(Path(workspace_dir), cache_ttl=cache_ttl)
+    real.add_span_processor(processor)
+    _REGISTERED_PROVIDER_IDS.add(id(real))
+    # Registration is always logged regardless of debug flag.
+    formatted = (
+        f"[AgentTeamsTaskSpanProcessor] registered workspace={workspace_dir} "
+        f"worker={os.getenv('AGENTTEAMS_WORKER_NAME', '')} entry_span={ENTRY_SPAN_NAME} "
+        f"debug={_DEBUG_ENABLED}"
+    )
+    print(formatted, file=sys.stderr, flush=True)
+    logger.info(
+        "AgentTeamsTaskSpanProcessor registered workspace=%s worker=%s debug=%s",
+        workspace_dir,
+        os.getenv("AGENTTEAMS_WORKER_NAME", ""),
+        _DEBUG_ENABLED,
+    )
+    return {"ok": True, "processor": "AgentTeamsTaskSpanProcessor"}
+
+
+def _span_is_recording(span: Any) -> bool:
+    is_recording = getattr(span, "is_recording", None)
+    if callable(is_recording):
+        return bool(is_recording())
+    return True
+
+
+def tag_entry_span(span: Any, workspace_dir: Path | str, *, room_id: str = "") -> dict[str, Any]:
+    """Attach AgentTeams task attributes to an already-started entry span."""
+    span_name = str(getattr(span, "name", "") or "")
+    if not _span_is_recording(span):
+        return {"ok": False, "reason": "span not recording"}
+    if not is_entry_span(span_name):
+        return {"ok": False, "reason": "not entry span", "span": span_name}
+
+    active_room = room_id or get_current_room()
+    context = find_task_trace_context(Path(workspace_dir), room_id=active_room)
+    project_id = str(context.get("project_id") or "")
+    task = context.get("task")
+    if not project_id:
+        _trace_log(
+            "tag_entry_span: entry span=%s no trace project room=%s reason=%s",
+            span_name,
+            active_room or "(none)",
+            context.get("reason", ""),
+        )
+        return {
+            "ok": False,
+            "reason": context.get("reason", "missing project"),
+            "span": span_name,
+        }
+
+    span.set_attribute(ATTR_AGENTTEAMS_PROJECT_ID, project_id)
+
+    task_id = ""
+    if isinstance(task, dict):
+        task_id = _task_id(task)
+        if task_id:
+            span.set_attribute(ATTR_AGENTTEAMS_TASK_ID, task_id)
+        _trace_log(
+            "tag_entry_span: tagged entry span=%s task_id=%s project_id=%s "
+            "status=%s room=%s",
+            span_name,
+            task_id,
+            project_id,
+            task.get("status"),
+            active_room or "(none)",
+        )
+    else:
+        _trace_log(
+            "tag_entry_span: tagged entry span=%s project_id=%s without task room=%s reason=%s",
+            span_name,
+            project_id,
+            active_room or "(none)",
+            context.get("reason", ""),
+        )
+
+    return {
+        "ok": True,
+        "span": span_name,
+        "project_id": project_id,
+        "task_id": task_id,
+        "reason": context.get("reason", ""),
+    }
+
+
+def tag_current_entry_span(workspace_dir: Path | str, *, room_id: str = "") -> dict[str, Any]:
+    """Attach AgentTeams task attributes to the active OTel entry span, if any.
+
+    First checks the pending entry span saved by the SpanProcessor (for the
+    common case where the current span has moved past the entry span by the
+    time the room context becomes available).  Falls back to the OTel current
+    span.
+    """
+    pending = _pending_entry_span.get()
+    if pending is not None:
+        return tag_pending_entry_span(workspace_dir, room_id=room_id)
+
+    try:
+        from opentelemetry import trace as trace_api
+    except ImportError:
+        return {"ok": False, "reason": "opentelemetry API unavailable"}
+
+    return tag_entry_span(trace_api.get_current_span(), workspace_dir, room_id=room_id)
+
+
+def get_pending_entry_span() -> Any:
+    """Return the entry span saved by on_start, or None."""
+    return _pending_entry_span.get()
+
+
+def clear_pending_entry_span() -> None:
+    """Discard the pending entry span reference."""
+    _pending_entry_span.set(None)
+
+
+def tag_pending_entry_span(workspace_dir: Path | str, *, room_id: str = "") -> dict[str, Any]:
+    """Tag the pending entry span (if any) and clear it.
+
+    Called by the QwenPawAgent wrapper after ``set_current_room`` so the entry
+    span - which was created *before* the room was known - gets tagged with
+    the correct task attributes.
+    """
+    span = _pending_entry_span.get()
+    if span is None:
+        return {"ok": False, "reason": "no pending entry span"}
+    _pending_entry_span.set(None)
+    return tag_entry_span(span, workspace_dir, room_id=room_id)
+
+
+# ---------------------------------------------------------------------------
+# SpanProcessor implementation
+# ---------------------------------------------------------------------------
+
+class AgentTeamsTaskSpanProcessor:
+    """OTel SpanProcessor that tags the per-turn entry span with the AgentTeams task.
+
+    Each entry span reads current ``shared/tasks/*/meta.json`` state.  This
+    keeps submit/cancel transitions authoritative without relying on taskflow
+    tool results to invalidate a local cache.
+    """
+
+    def __init__(self, workspace_dir: Path, *, cache_ttl: float = _CACHE_TTL) -> None:
+        _ = cache_ttl
+        self._workspace_dir = workspace_dir
+
+    def on_start(self, span: Any, parent_context: Any = None) -> None:
+        span_name = str(getattr(span, "name", "") or "")
+        if not _span_is_recording(span):
+            return
+        if not is_entry_span(span_name):
+            return
+
+        room = get_current_room()
+        if room:
+            tag_entry_span(span, self._workspace_dir, room_id=room)
+        else:
+            # Room context is not yet available (will be set by the
+            # QwenPawAgent wrapper).  Stash the span so the wrapper can
+            # tag it once the room is known via tag_pending_entry_span().
+            _pending_entry_span.set(span)
+            _trace_log(
+                "on_start: deferred entry span=%s (room not set yet)",
+                span_name,
+            )
+
+    def on_end(self, span: Any) -> None:
+        span_name = str(getattr(span, "name", "") or "")
+        if not is_entry_span(span_name):
+            return
+        if not _DEBUG_ENABLED:
+            return
+        attrs: dict[str, Any] = {}
+        if hasattr(span, "attributes") and span.attributes:
+            attrs = dict(span.attributes)
+        elif hasattr(span, "_attributes") and span._attributes:
+            attrs = dict(span._attributes)
+        _trace_log(
+            "on_end: entry span=%s agentteams.task.id=%s agentteams.project.id=%s",
+            span_name,
+            attrs.get(ATTR_AGENTTEAMS_TASK_ID),
+            attrs.get(ATTR_AGENTTEAMS_PROJECT_ID),
+        )
+
+    def _on_ending(self, span: Any) -> None:
+        pass
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
+
+    # -- internal -----------------------------------------------------------
+
+    def invalidate_cache(self, room_id: str = "") -> None:
+        """Compatibility no-op; entry spans already re-read meta.json."""
+        return None
+
+    def _get_trace_context(self, room_id: str = "") -> dict[str, Any]:
+        cache_key = canonical_room_id(room_id)
+        context = find_task_trace_context(self._workspace_dir, room_id=cache_key)
+        if not context.get("project_id"):
+            _trace_log(
+                "meta scan: no trace context workspace=%s room=%s reason=%s",
+                self._workspace_dir,
+                room_id or "(none)",
+                context.get("reason", ""),
+            )
+        return context

--- a/plugins/teamharness/mcp/server.py
+++ b/plugins/teamharness/mcp/server.py
@@ -2542,10 +2542,16 @@ def _taskflow(arguments: dict[str, Any]) -> dict[str, Any]:
                 raise ValueError("delegate_task requires leader role")
             project_id = _safe_id(payload.get("projectId") or payload.get("project_id"), "projectId")
             task_id = _safe_id(payload.get("taskId") or payload.get("task_id"), "taskId")
+            assigned_to = str(payload.get("assignedTo") or payload.get("assigned_to") or "").strip()
             room_id = str(payload.get("roomId") or payload.get("room_id") or "")
             if not room_id:
                 raise ValueError("roomId is required")
             project = _read_json(_project_state_path(arguments, project_id))
+            if not assigned_to:
+                for item in project.get("tasks", []):
+                    if isinstance(item, dict) and item.get("task_id") == task_id:
+                        assigned_to = str(item.get("assigned_to") or item.get("assignedTo") or "").strip()
+                        break
             _validate_assignment_room(project, room_id)
             task_dir = _task_dir(arguments, task_id)
             task_dir.mkdir(parents=True, exist_ok=True)
@@ -2559,10 +2565,14 @@ def _taskflow(arguments: dict[str, Any]) -> dict[str, Any]:
                 "status": "assigned",
                 "spec_path": f"shared/tasks/{task_id}/spec.md",
             }
+            if assigned_to:
+                task["assigned_to"] = assigned_to
             if source_room_id:
                 task["source_room_id"] = source_room_id
             _write_task(arguments, task)
             project_task_updates: dict[str, Any] = {"status": "assigned"}
+            if assigned_to:
+                project_task_updates["assigned_to"] = assigned_to
             if source_room_id:
                 project_task_updates["source_room_id"] = source_room_id
             _update_project_task(arguments, project_id, task_id, **project_task_updates)

--- a/plugins/tests/teamharness/test_trace.py
+++ b/plugins/tests/teamharness/test_trace.py
@@ -1,0 +1,1188 @@
+#!/usr/bin/env python3
+"""Tests for AgentTeams Task-Trace correlation (SpanProcessor approach).
+
+Test layers:
+  1. find_active_task        - filesystem scanning + room/worker filtering
+  2. AgentTeamsTaskSpanProcessor - span attribute injection + current meta state
+  3. register integration    - TracerProvider registration
+  4. QwenPaw adapter wiring  - install_task_trace_processor()
+  5. End-to-end scenario     - ack -> tool calls -> submit lifecycle
+  6. Session isolation       - multi-room concurrent task scenarios
+  7. Debug logging control   - AGENTTEAMS_TASK_TRACE_DEBUG toggle
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import asyncio
+import json
+import types
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TRACE_MODULE_PATH = (
+    REPO_ROOT / "plugins" / "teamharness" / "adapters" / "qwenpaw" / "task_trace.py"
+)
+ADAPTER_PATH = REPO_ROOT / "plugins" / "teamharness" / "adapters" / "qwenpaw" / "plugin.py"
+
+
+def _load_trace_module():
+    spec = importlib.util.spec_from_file_location("teamharness_qwenpaw_task_trace", TRACE_MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_adapter_module():
+    spec = importlib.util.spec_from_file_location("teamharness_qwenpaw_adapter", ADAPTER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def workspace(tmp_path: Path) -> Path:
+    ws = tmp_path / "workspaces" / "default"
+    ws.mkdir(parents=True)
+    return ws
+
+
+@pytest.fixture(autouse=True)
+def _reset_room_context(monkeypatch):
+    """Ensure each test starts with no room context and no pending span."""
+    monkeypatch.setenv("AGENTTEAMS_WORKER_NAME", "worker-a")
+    mod = _load_trace_module()
+    token = mod.set_current_room("")
+    mod.clear_pending_entry_span()
+    yield
+    mod.reset_current_room(token)
+    mod.clear_pending_entry_span()
+
+
+def _write_task(workspace: Path, task_id: str, meta: dict, *, write_project: bool = True) -> None:
+    meta = dict(meta)
+    if (
+        meta.get("status") in {"assigned", "in_progress"}
+        and not meta.get("assigned_to")
+        and not meta.get("assignee")
+    ):
+        meta["assigned_to"] = "worker-a"
+    task_dir = workspace / "shared" / "tasks" / task_id
+    task_dir.mkdir(parents=True, exist_ok=True)
+    (task_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+    project_id = str(meta.get("project_id") or "")
+    if not write_project or not project_id:
+        return
+
+    project_dir = workspace / "shared" / "projects" / project_id
+    project_dir.mkdir(parents=True, exist_ok=True)
+    project_path = project_dir / "meta.json"
+    try:
+        project = json.loads(project_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        project = {}
+    if not isinstance(project, dict):
+        project = {}
+    project["project_id"] = project_id
+    tasks = project.get("tasks")
+    if not isinstance(tasks, list):
+        tasks = []
+    node = {"task_id": task_id, "status": meta.get("status")}
+    tasks = [item for item in tasks if not isinstance(item, dict) or item.get("task_id") != task_id]
+    tasks.append(node)
+    project["tasks"] = tasks
+    project_path.write_text(json.dumps(project), encoding="utf-8")
+
+
+def _mock_span(name: str, *, recording: bool = True) -> MagicMock:
+    span = MagicMock()
+    span.is_recording.return_value = recording
+    span.name = name
+    return span
+
+
+def _entry_span(*, recording: bool = True) -> MagicMock:
+    return _mock_span("enter_ai_application_system", recording=recording)
+
+
+def _start_entry_in_room(mod: Any, processor: Any, room_id: str = "!r:m.org") -> MagicMock:
+    token = mod.set_current_room(room_id)
+    try:
+        span = _entry_span()
+        processor.on_start(span)
+        return span
+    finally:
+        mod.reset_current_room(token)
+
+
+# ===================================================================
+# Layer 1: find_active_task
+# ===================================================================
+
+
+class TestFindActiveTask:
+    def test_returns_in_progress_task(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "in_progress",
+        })
+        result = mod.find_active_task(workspace, room_id="!r:m.org")
+        assert result is not None
+        assert result["task_id"] == "t1"
+        assert result["project_id"] == "p1"
+
+    def test_returns_assigned_task(self, workspace: Path) -> None:
+        """ACK turn: assigned tasks are matched so entry span is tagged."""
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "assigned_to": "worker-a",
+            "room_id": "!r:m.org", "status": "assigned",
+        })
+        result = mod.find_active_task(workspace, room_id="!r:m.org")
+        assert result is not None
+        assert result["task_id"] == "t1"
+        assert result["status"] == "assigned"
+
+    def test_ignores_submitted(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "submitted",
+        })
+        assert mod.find_active_task(workspace) is None
+
+    def test_no_tasks_dir(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        assert mod.find_active_task(workspace) is None
+
+    def test_empty_tasks_dir(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        (workspace / "shared" / "tasks").mkdir(parents=True)
+        assert mod.find_active_task(workspace) is None
+
+    def test_corrupt_json_skipped(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        task_dir = workspace / "shared" / "tasks" / "bad"
+        task_dir.mkdir(parents=True)
+        (task_dir / "meta.json").write_text("{invalid", encoding="utf-8")
+        assert mod.find_active_task(workspace) is None
+
+    def test_multiple_tasks_returns_matching_in_progress(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "submitted",
+        })
+        _write_task(workspace, "t2", {
+            "task_id": "t2", "project_id": "p2",
+            "room_id": "!r2:m.org", "status": "in_progress",
+        })
+        result = mod.find_active_task(workspace, room_id="!r2:m.org")
+        assert result is not None
+        assert result["task_id"] == "t2"
+
+    def test_worker_name_without_room_context_does_not_guess(self, workspace: Path, monkeypatch) -> None:
+        mod = _load_trace_module()
+        monkeypatch.setenv("AGENTTEAMS_WORKER_NAME", "worker-a")
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "assigned_to": "worker-a",
+            "room_id": "!room-A:m.org", "status": "in_progress",
+        })
+        _write_task(workspace, "t2", {
+            "task_id": "t2", "project_id": "p2",
+            "assigned_to": "worker-b",
+            "room_id": "!room-B:m.org", "status": "in_progress",
+        })
+        result = mod.find_active_task(workspace)
+        assert result is None
+
+    def test_no_room_or_worker_match_does_not_fallback(self, workspace: Path, monkeypatch) -> None:
+        mod = _load_trace_module()
+        monkeypatch.delenv("AGENTTEAMS_WORKER_NAME", raising=False)
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "assigned_to": "worker-a",
+            "room_id": "!room-A:m.org", "status": "in_progress",
+        })
+        assert mod.find_active_task(workspace) is None
+
+    def test_room_id_exact_match_takes_priority(self, workspace: Path) -> None:
+        """When room_id is specified, it wins over worker-name matching."""
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "assigned_to": "worker-a",
+            "room_id": "!room-A:m.org", "status": "in_progress",
+        })
+        _write_task(workspace, "t2", {
+            "task_id": "t2", "project_id": "p2",
+            "assigned_to": "worker-a",
+            "room_id": "!room-B:m.org", "status": "in_progress",
+        })
+        result = mod.find_active_task(workspace, room_id="!room-B:m.org")
+        assert result is not None
+        assert result["task_id"] == "t2"
+
+    def test_room_id_prefixes_are_canonicalized(self, workspace: Path) -> None:
+        """Trace context and task meta may use matrix:, room:, or bare room ids."""
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "assigned_to": "worker-a",
+            "room_id": "room:!room-A:m.org", "status": "in_progress",
+        })
+
+        bare = mod.find_active_task(workspace, room_id="!room-A:m.org")
+        matrix = mod.find_active_task(workspace, room_id="matrix:!room-A:m.org")
+
+        assert bare is not None
+        assert bare["task_id"] == "t1"
+        assert matrix is not None
+        assert matrix["task_id"] == "t1"
+
+    def test_matrix_assignee_matches_worker_name(self, workspace: Path, monkeypatch) -> None:
+        """Matrix ids such as @worker-a:server match AGENTTEAMS_WORKER_NAME."""
+        mod = _load_trace_module()
+        monkeypatch.setenv("AGENTTEAMS_WORKER_NAME", "worker-a")
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "assigned_to": "@worker-a:m.org",
+            "room_id": "!room-A:m.org", "status": "in_progress",
+        })
+
+        result = mod.find_active_task(workspace, room_id="!room-A:m.org")
+
+        assert result is not None
+        assert result["task_id"] == "t1"
+
+    def test_room_id_ignores_non_matching_tasks(self, workspace: Path) -> None:
+        """With room_id set, tasks from other rooms are not matched."""
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!room-X:m.org", "status": "in_progress",
+        })
+        result = mod.find_active_task(workspace, room_id="!room-Y:m.org")
+        assert result is None
+
+    def test_room_id_with_no_active_in_room(self, workspace: Path) -> None:
+        """When the specified room has no active task, no other room is used."""
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!room-A:m.org", "status": "submitted",
+        })
+        _write_task(workspace, "t2", {
+            "task_id": "t2", "project_id": "p2",
+            "room_id": "!room-B:m.org", "status": "in_progress",
+        })
+        result = mod.find_active_task(workspace, room_id="!room-A:m.org")
+        assert result is None
+
+    def test_project_graph_is_not_required_for_room_task_match(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        _write_task(workspace, "orphan", {
+            "task_id": "orphan", "project_id": "p1",
+            "room_id": "!room-A:m.org", "status": "in_progress",
+        }, write_project=False)
+        result = mod.find_active_task(workspace, room_id="!room-A:m.org")
+        assert result is not None
+        assert result["task_id"] == "orphan"
+
+
+# ===================================================================
+# Layer 2: AgentTeamsTaskSpanProcessor
+# ===================================================================
+
+
+class TestAgentTeamsTaskSpanProcessor:
+    def test_sets_attributes_on_entry_span_only(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "in_progress",
+        })
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+
+        entry = _start_entry_in_room(mod, processor, "!r:m.org")
+        entry.set_attribute.assert_any_call("agentteams.task.id", "t1")
+        entry.set_attribute.assert_any_call("agentteams.project.id", "p1")
+
+        child = _mock_span("chat qwen3-max")
+        processor.on_start(child)
+        child.set_attribute.assert_not_called()
+
+    def test_skips_non_recording_span(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "in_progress",
+        })
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+        span = _entry_span(recording=False)
+
+        processor.on_start(span)
+
+        span.set_attribute.assert_not_called()
+
+    def test_no_attributes_when_no_active_task(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+        span = _entry_span()
+
+        # No room set -> span stashed but not tagged
+        processor.on_start(span)
+        span.set_attribute.assert_not_called()
+
+    def test_room_project_ambiguity_sets_no_attributes(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "in_progress",
+        })
+        _write_task(workspace, "t2", {
+            "task_id": "t2", "project_id": "p2",
+            "room_id": "!r:m.org", "status": "in_progress",
+        })
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+
+        span = _start_entry_in_room(mod, processor, "!r:m.org")
+
+        span.set_attribute.assert_not_called()
+
+    def test_multiple_active_tasks_in_project_sets_project_only(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "in_progress",
+        })
+        _write_task(workspace, "t2", {
+            "task_id": "t2", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "assigned",
+        })
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+
+        span = _start_entry_in_room(mod, processor, "!r:m.org")
+
+        span.set_attribute.assert_called_once_with("agentteams.project.id", "p1")
+
+    def test_entry_span_rereads_current_meta(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "in_progress",
+        })
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace)
+
+        span1 = _start_entry_in_room(mod, processor, "!r:m.org")
+        assert span1.set_attribute.call_count == 2
+
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "submitted",
+        })
+
+        span2 = _start_entry_in_room(mod, processor, "!r:m.org")
+        span2.set_attribute.assert_called_once_with("agentteams.project.id", "p1")
+
+    def test_invalidate_cache_is_noop_with_meta_reread(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "in_progress",
+        })
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace)
+
+        span1 = _start_entry_in_room(mod, processor, "!r:m.org")
+        assert span1.set_attribute.call_count == 2
+
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "submitted",
+        })
+        processor.invalidate_cache()
+
+        span2 = _start_entry_in_room(mod, processor, "!r:m.org")
+        span2.set_attribute.assert_called_once_with("agentteams.project.id", "p1")
+
+    def test_on_end_logs_entry_span_attributes(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        mod.set_trace_debug(True)
+        try:
+            processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+            span = _entry_span()
+            span.attributes = {
+                "agentteams.task.id": "t1",
+                "agentteams.project.id": "p1",
+            }
+            processor.on_end(span)  # should not raise
+        finally:
+            mod.set_trace_debug(False)
+
+    def test_on_end_noop_when_debug_disabled(self, workspace: Path) -> None:
+        """on_end skips attribute reading when debug is off."""
+        mod = _load_trace_module()
+        mod.set_trace_debug(False)
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+        span = _entry_span()
+        span.attributes = {"agentteams.task.id": "t1"}
+        processor.on_end(span)  # should not raise, should not access attributes
+
+    def test_force_flush_and_shutdown(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace)
+        assert processor.force_flush() is True
+        processor.shutdown()  # should not raise
+
+# ===================================================================
+# Layer 3: register_task_trace_processor
+# ===================================================================
+
+
+class TestRegisterTaskTraceProcessor:
+    def test_no_otel_sdk_returns_failure(self, workspace: Path, monkeypatch) -> None:
+        mod = _load_trace_module()
+        original_import = __builtins__.__import__ if hasattr(__builtins__, '__import__') else __import__
+
+        def mock_import(name, *args, **kwargs):
+            if name in ("opentelemetry", "opentelemetry.sdk.trace"):
+                raise ImportError("mocked")
+            return original_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            result = mod.register_task_trace_processor(workspace)
+        assert result["ok"] is False
+        assert "unavailable" in result["reason"]
+
+    def test_registers_on_real_tracer_provider(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+
+        otel_sdk_trace = types.ModuleType("opentelemetry.sdk.trace")
+        TracerProviderClass = type("TracerProvider", (), {"add_span_processor": MagicMock()})
+        otel_sdk_trace.TracerProvider = TracerProviderClass
+
+        provider = TracerProviderClass()
+        provider._real_provider = None
+
+        otel_trace = types.ModuleType("opentelemetry.trace")
+        otel_trace.get_tracer_provider = lambda: provider
+
+        with patch.dict("sys.modules", {
+            "opentelemetry": types.ModuleType("opentelemetry"),
+            "opentelemetry.trace": otel_trace,
+            "opentelemetry.sdk": types.ModuleType("opentelemetry.sdk"),
+            "opentelemetry.sdk.trace": otel_sdk_trace,
+        }):
+            result = mod.register_task_trace_processor(workspace)
+
+        assert result["ok"] is True
+        provider.add_span_processor.assert_called_once()
+        processor = provider.add_span_processor.call_args[0][0]
+        assert type(processor).__name__ == "AgentTeamsTaskSpanProcessor"
+
+
+# ===================================================================
+# Layer 4: QwenPaw adapter install_task_trace_processor
+# ===================================================================
+
+
+class TestAdapterInstallTaskTraceProcessor:
+    def test_extracts_matrix_room_from_request_context(self) -> None:
+        mod = _load_adapter_module()
+        assert mod._room_id_from_request_context({
+            "channel": "matrix",
+            "session_id": "matrix:!room-A:m.org",
+            "user_id": "!room-A:m.org",
+        }) == "!room-A:m.org"
+
+    def test_extracts_room_from_channel_meta_first(self) -> None:
+        mod = _load_adapter_module()
+        assert mod._room_id_from_request_context({
+            "session_id": "matrix:!session-room:m.org",
+            "channel_meta": {"room_id": "!meta-room:m.org"},
+        }) == "!meta-room:m.org"
+
+    def test_context_wrapper_does_not_wrap_acting(self, monkeypatch) -> None:
+        mod = _load_adapter_module()
+
+        class FakeQwenPawAgent:
+            async def __call__(self):
+                return "called"
+
+            async def reply(self):
+                return "replied"
+
+            async def _acting(self, tool_call):
+                return {"ok": True}
+
+        qwenpaw = types.ModuleType("qwenpaw")
+        agents = types.ModuleType("qwenpaw.agents")
+        react_agent = types.ModuleType("qwenpaw.agents.react_agent")
+        react_agent.QwenPawAgent = FakeQwenPawAgent
+        monkeypatch.setitem(sys.modules, "qwenpaw", qwenpaw)
+        monkeypatch.setitem(sys.modules, "qwenpaw.agents", agents)
+        monkeypatch.setitem(sys.modules, "qwenpaw.agents.react_agent", react_agent)
+
+        trace_module = types.SimpleNamespace(
+            set_current_room=MagicMock(return_value=object()),
+            reset_current_room=MagicMock(),
+        )
+
+        original_acting = FakeQwenPawAgent._acting
+        result = mod.install_task_trace_context_wrapper(trace_module)
+        assert result["ok"] is True
+        assert FakeQwenPawAgent._acting is original_acting
+
+    def test_context_wrapper_tags_pending_entry_span(self, tmp_path: Path, monkeypatch) -> None:
+        """Wrapper prefers tag_pending_entry_span when a pending span exists."""
+        qwenpaw_dir = tmp_path / ".qwenpaw"
+        (qwenpaw_dir / "workspaces" / "default").mkdir(parents=True)
+        monkeypatch.setenv("QWENPAW_WORKING_DIR", str(qwenpaw_dir))
+        monkeypatch.delenv("COPAW_WORKING_DIR", raising=False)
+
+        mod = _load_adapter_module()
+
+        class FakeQwenPawAgent:
+            def __init__(self):
+                self._request_context = {"session_id": "matrix:!room-A:m.org"}
+
+            async def __call__(self):
+                return "called"
+
+            async def reply(self):
+                return "replied"
+
+        qwenpaw = types.ModuleType("qwenpaw")
+        agents = types.ModuleType("qwenpaw.agents")
+        react_agent = types.ModuleType("qwenpaw.agents.react_agent")
+        react_agent.QwenPawAgent = FakeQwenPawAgent
+        monkeypatch.setitem(sys.modules, "qwenpaw", qwenpaw)
+        monkeypatch.setitem(sys.modules, "qwenpaw.agents", agents)
+        monkeypatch.setitem(sys.modules, "qwenpaw.agents.react_agent", react_agent)
+
+        pending_span = _entry_span()
+        trace_module = types.SimpleNamespace(
+            set_current_room=MagicMock(return_value=object()),
+            reset_current_room=MagicMock(),
+            tag_current_entry_span=MagicMock(return_value={"ok": True}),
+            tag_pending_entry_span=MagicMock(return_value={"ok": True}),
+            get_pending_entry_span=MagicMock(return_value=pending_span),
+            register_task_trace_processor=MagicMock(return_value={"ok": True}),
+        )
+
+        result = mod.install_task_trace_context_wrapper(trace_module)
+        assert result["ok"] is True
+
+        assert asyncio.run(FakeQwenPawAgent()()) == "called"
+
+        trace_module.set_current_room.assert_called_once_with("!room-A:m.org")
+        trace_module.tag_pending_entry_span.assert_called_once_with(
+            qwenpaw_dir / "workspaces" / "default",
+        )
+        # tag_current_entry_span should NOT be called when pending was used
+        trace_module.tag_current_entry_span.assert_not_called()
+        trace_module.reset_current_room.assert_called_once()
+
+    def test_context_wrapper_refreshes_tasks_before_tagging_pending_span(self, tmp_path: Path, monkeypatch) -> None:
+        qwenpaw_dir = tmp_path / ".qwenpaw"
+        shared_dir = tmp_path / "teams" / "devteam11" / "shared"
+        (qwenpaw_dir / "workspaces" / "default").mkdir(parents=True)
+        shared_dir.mkdir(parents=True)
+        monkeypatch.setenv("QWENPAW_WORKING_DIR", str(qwenpaw_dir))
+        monkeypatch.setenv("TEAMHARNESS_SHARED_DIR", str(shared_dir))
+        monkeypatch.setenv("AGENTTEAMS_SHARED_STORAGE_PREFIX", "teams/devteam11/shared")
+        monkeypatch.setenv("AGENTTEAMS_WORKER_NAME", "worker-a")
+        monkeypatch.setenv("AGENTTEAMS_RUNTIME", "k8s")
+        monkeypatch.delenv("COPAW_WORKING_DIR", raising=False)
+
+        mod = _load_adapter_module()
+        events: list[tuple[Any, ...]] = []
+
+        class FakeFileSync:
+            def __init__(self, **kwargs):
+                events.append(("init", kwargs))
+
+            def mirror_prefix(self, remote_prefix, local_dir):
+                events.append(("mirror", remote_prefix, Path(local_dir)))
+
+        qwenpaw_worker = types.ModuleType("qwenpaw_worker")
+        sync_module = types.ModuleType("qwenpaw_worker.sync")
+        sync_module.FileSync = FakeFileSync
+        monkeypatch.setitem(sys.modules, "qwenpaw_worker", qwenpaw_worker)
+        monkeypatch.setitem(sys.modules, "qwenpaw_worker.sync", sync_module)
+
+        class FakeQwenPawAgent:
+            def __init__(self):
+                self._request_context = {"session_id": "matrix:!room-A:m.org"}
+
+            async def __call__(self):
+                events.append(("call",))
+                return "called"
+
+            async def reply(self):
+                return "replied"
+
+        qwenpaw = types.ModuleType("qwenpaw")
+        agents = types.ModuleType("qwenpaw.agents")
+        react_agent = types.ModuleType("qwenpaw.agents.react_agent")
+        react_agent.QwenPawAgent = FakeQwenPawAgent
+        monkeypatch.setitem(sys.modules, "qwenpaw", qwenpaw)
+        monkeypatch.setitem(sys.modules, "qwenpaw.agents", agents)
+        monkeypatch.setitem(sys.modules, "qwenpaw.agents.react_agent", react_agent)
+
+        trace_module = types.SimpleNamespace(
+            set_current_room=MagicMock(side_effect=lambda room: events.append(("set_room", room)) or object()),
+            reset_current_room=MagicMock(side_effect=lambda token: events.append(("reset",))),
+            tag_current_entry_span=MagicMock(return_value={"ok": True}),
+            tag_pending_entry_span=MagicMock(side_effect=lambda workspace: events.append(("tag_pending", Path(workspace))) or {"ok": True}),
+            get_pending_entry_span=MagicMock(return_value=_entry_span()),
+            register_task_trace_processor=MagicMock(return_value={"ok": True}),
+        )
+
+        result = mod.install_task_trace_context_wrapper(trace_module)
+        assert result["ok"] is True
+
+        assert asyncio.run(FakeQwenPawAgent()()) == "called"
+
+        assert events[:4] == [
+            ("set_room", "!room-A:m.org"),
+            ("init", events[1][1]),
+            ("mirror", "teams/devteam11/shared/tasks", shared_dir / "tasks"),
+            ("tag_pending", qwenpaw_dir / "workspaces" / "default"),
+        ]
+        assert events[-2:] == [("call",), ("reset",)]
+
+    def test_context_wrapper_refresh_failure_does_not_block_turn(self, tmp_path: Path, monkeypatch) -> None:
+        qwenpaw_dir = tmp_path / ".qwenpaw"
+        shared_dir = tmp_path / "shared"
+        (qwenpaw_dir / "workspaces" / "default").mkdir(parents=True)
+        shared_dir.mkdir(parents=True)
+        monkeypatch.setenv("QWENPAW_WORKING_DIR", str(qwenpaw_dir))
+        monkeypatch.setenv("TEAMHARNESS_SHARED_DIR", str(shared_dir))
+        monkeypatch.setenv("AGENTTEAMS_WORKER_NAME", "worker-a")
+        monkeypatch.delenv("COPAW_WORKING_DIR", raising=False)
+
+        mod = _load_adapter_module()
+
+        class FakeFileSync:
+            def __init__(self, **kwargs):
+                pass
+
+            def mirror_prefix(self, remote_prefix, local_dir):
+                raise RuntimeError("storage unavailable")
+
+        qwenpaw_worker = types.ModuleType("qwenpaw_worker")
+        sync_module = types.ModuleType("qwenpaw_worker.sync")
+        sync_module.FileSync = FakeFileSync
+        monkeypatch.setitem(sys.modules, "qwenpaw_worker", qwenpaw_worker)
+        monkeypatch.setitem(sys.modules, "qwenpaw_worker.sync", sync_module)
+
+        class FakeQwenPawAgent:
+            def __init__(self):
+                self._request_context = {"session_id": "matrix:!room-A:m.org"}
+
+            async def __call__(self):
+                return "called"
+
+            async def reply(self):
+                return "replied"
+
+        qwenpaw = types.ModuleType("qwenpaw")
+        agents = types.ModuleType("qwenpaw.agents")
+        react_agent = types.ModuleType("qwenpaw.agents.react_agent")
+        react_agent.QwenPawAgent = FakeQwenPawAgent
+        monkeypatch.setitem(sys.modules, "qwenpaw", qwenpaw)
+        monkeypatch.setitem(sys.modules, "qwenpaw.agents", agents)
+        monkeypatch.setitem(sys.modules, "qwenpaw.agents.react_agent", react_agent)
+
+        trace_module = types.SimpleNamespace(
+            set_current_room=MagicMock(return_value=object()),
+            reset_current_room=MagicMock(),
+            tag_current_entry_span=MagicMock(return_value={"ok": True}),
+            tag_pending_entry_span=MagicMock(return_value={"ok": True}),
+            get_pending_entry_span=MagicMock(return_value=_entry_span()),
+            register_task_trace_processor=MagicMock(return_value={"ok": True}),
+        )
+
+        result = mod.install_task_trace_context_wrapper(trace_module)
+        assert result["ok"] is True
+
+        assert asyncio.run(FakeQwenPawAgent()()) == "called"
+        trace_module.tag_pending_entry_span.assert_called_once_with(
+            qwenpaw_dir / "workspaces" / "default",
+        )
+
+    def test_context_wrapper_falls_back_to_tag_current(self, tmp_path: Path, monkeypatch) -> None:
+        """When no pending span exists, wrapper falls back to tag_current_entry_span."""
+        qwenpaw_dir = tmp_path / ".qwenpaw"
+        (qwenpaw_dir / "workspaces" / "default").mkdir(parents=True)
+        monkeypatch.setenv("QWENPAW_WORKING_DIR", str(qwenpaw_dir))
+        monkeypatch.delenv("COPAW_WORKING_DIR", raising=False)
+
+        mod = _load_adapter_module()
+
+        class FakeQwenPawAgent:
+            def __init__(self):
+                self._request_context = {"session_id": "matrix:!room-A:m.org"}
+
+            async def __call__(self):
+                return "called"
+
+            async def reply(self):
+                return "replied"
+
+        qwenpaw = types.ModuleType("qwenpaw")
+        agents = types.ModuleType("qwenpaw.agents")
+        react_agent = types.ModuleType("qwenpaw.agents.react_agent")
+        react_agent.QwenPawAgent = FakeQwenPawAgent
+        monkeypatch.setitem(sys.modules, "qwenpaw", qwenpaw)
+        monkeypatch.setitem(sys.modules, "qwenpaw.agents", agents)
+        monkeypatch.setitem(sys.modules, "qwenpaw.agents.react_agent", react_agent)
+
+        trace_module = types.SimpleNamespace(
+            set_current_room=MagicMock(return_value=object()),
+            reset_current_room=MagicMock(),
+            tag_current_entry_span=MagicMock(return_value={"ok": True}),
+            tag_pending_entry_span=MagicMock(return_value={"ok": True}),
+            get_pending_entry_span=MagicMock(return_value=None),
+            register_task_trace_processor=MagicMock(return_value={"ok": True}),
+        )
+
+        result = mod.install_task_trace_context_wrapper(trace_module)
+        assert result["ok"] is True
+
+        assert asyncio.run(FakeQwenPawAgent()()) == "called"
+
+        trace_module.tag_pending_entry_span.assert_not_called()
+        trace_module.tag_current_entry_span.assert_called_once_with(
+            qwenpaw_dir / "workspaces" / "default",
+        )
+
+    def test_returns_failure_when_no_workspace(self, monkeypatch) -> None:
+        monkeypatch.delenv("QWENPAW_WORKING_DIR", raising=False)
+        monkeypatch.delenv("COPAW_WORKING_DIR", raising=False)
+        monkeypatch.delenv("TEAMHARNESS_RUNTIME_CONFIG", raising=False)
+        mod = _load_adapter_module()
+        result = mod.install_task_trace_processor()
+        assert result["ok"] is False
+
+    def test_loads_trace_module_and_registers(self, tmp_path: Path, monkeypatch) -> None:
+        qwenpaw_dir = tmp_path / ".qwenpaw"
+        workspace = qwenpaw_dir / "workspaces" / "default"
+        workspace.mkdir(parents=True)
+        monkeypatch.setenv("QWENPAW_WORKING_DIR", str(qwenpaw_dir))
+        monkeypatch.delenv("COPAW_WORKING_DIR", raising=False)
+        monkeypatch.delenv("TEAMHARNESS_RUNTIME_CONFIG", raising=False)
+
+        mod = _load_adapter_module()
+
+        with patch.object(mod, "PLUGIN_DIR", REPO_ROOT / "plugins" / "teamharness" / "adapters" / "qwenpaw"):
+            result = mod.install_task_trace_processor()
+
+        assert isinstance(result, dict)
+        assert "ok" in result
+
+
+# ===================================================================
+# Layer 5: End-to-end task lifecycle scenario
+# ===================================================================
+
+
+class TestEndToEndLifecycle:
+    """Simulates ack -> work -> submit and verifies span attributes at each stage."""
+
+    def test_full_lifecycle(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+
+        # --- No task on disk ---
+        span_before = _entry_span()
+        processor.on_start(span_before)
+        span_before.set_attribute.assert_not_called()
+
+        # --- in_progress: entry span tagged, child spans not ---
+        _write_task(workspace, "task-e2e", {
+            "task_id": "task-e2e",
+            "project_id": "proj-e2e",
+            "room_id": "!room:m.org",
+            "status": "in_progress",
+        })
+        span_working = _start_entry_in_room(mod, processor, "!room:m.org")
+        span_working.set_attribute.assert_any_call("agentteams.task.id", "task-e2e")
+        span_working.set_attribute.assert_any_call("agentteams.project.id", "proj-e2e")
+
+        for _ in range(3):
+            span_tool = _mock_span("execute_tool taskflow")
+            processor.on_start(span_tool)
+            span_tool.set_attribute.assert_not_called()
+
+        # --- After submit: no attributes on entry span ---
+        _write_task(workspace, "task-e2e", {
+            "task_id": "task-e2e",
+            "project_id": "proj-e2e",
+            "room_id": "!room:m.org",
+            "status": "submitted",
+        })
+        span_after = _start_entry_in_room(mod, processor, "!room:m.org")
+        span_after.set_attribute.assert_called_once_with("agentteams.project.id", "proj-e2e")
+
+    def test_ack_turn_tags_entry_span_while_assigned(self, workspace: Path) -> None:
+        """ACK turn: entry span is tagged while task is still assigned."""
+        mod = _load_trace_module()
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+
+        _write_task(workspace, "task-ack", {
+            "task_id": "task-ack",
+            "project_id": "proj-ack",
+            "room_id": "!room:m.org",
+            "status": "assigned",
+        })
+
+        span_ack = _start_entry_in_room(mod, processor, "!room:m.org")
+        span_ack.set_attribute.assert_any_call("agentteams.task.id", "task-ack")
+        span_ack.set_attribute.assert_any_call("agentteams.project.id", "proj-ack")
+
+    def test_submit_turn_still_tagged(self, workspace: Path) -> None:
+        """Submit turn entry span is tagged while task is still in_progress."""
+        mod = _load_trace_module()
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+
+        _write_task(workspace, "task-sub", {
+            "task_id": "task-sub",
+            "project_id": "proj-sub",
+            "room_id": "!room:m.org",
+            "status": "in_progress",
+        })
+
+        span_submit_turn = _start_entry_in_room(mod, processor, "!room:m.org")
+        span_submit_turn.set_attribute.assert_any_call("agentteams.task.id", "task-sub")
+
+        _write_task(workspace, "task-sub", {
+            "task_id": "task-sub",
+            "project_id": "proj-sub",
+            "room_id": "!room:m.org",
+            "status": "submitted",
+        })
+        span_next = _start_entry_in_room(mod, processor, "!room:m.org")
+        span_next.set_attribute.assert_called_once_with("agentteams.project.id", "proj-sub")
+
+
+# ===================================================================
+# Layer 6: Session isolation (multi-room)
+# ===================================================================
+
+
+class TestSessionIsolation:
+    """Verifies that set_current_room correctly routes tasks."""
+
+    def test_room_context_routes_to_correct_task(self, workspace: Path) -> None:
+        """Two tasks in different rooms; room context determines which is matched."""
+        mod = _load_trace_module()
+        _write_task(workspace, "task-room-a", {
+            "task_id": "task-room-a", "project_id": "proj-1",
+            "room_id": "!room-A:m.org", "status": "in_progress",
+        })
+        _write_task(workspace, "task-room-b", {
+            "task_id": "task-room-b", "project_id": "proj-2",
+            "room_id": "!room-B:m.org", "status": "in_progress",
+        })
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+
+        # Turn in room A -> should tag with task-room-a
+        token_a = mod.set_current_room("!room-A:m.org")
+        span_a = _entry_span()
+        processor.on_start(span_a)
+        span_a.set_attribute.assert_any_call("agentteams.task.id", "task-room-a")
+        mod.reset_current_room(token_a)
+
+        # Turn in room B -> should tag with task-room-b
+        token_b = mod.set_current_room("!room-B:m.org")
+        span_b = _entry_span()
+        processor.on_start(span_b)
+        span_b.set_attribute.assert_any_call("agentteams.task.id", "task-room-b")
+        mod.reset_current_room(token_b)
+
+    def test_no_room_context_does_not_fallback_to_any_active(self, workspace: Path) -> None:
+        """Without room context, processor stashes but does not tag."""
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!room:m.org", "status": "in_progress",
+        })
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+
+        span = _entry_span()
+        processor.on_start(span)
+        span.set_attribute.assert_not_called()
+        # Span is stashed for deferred tagging
+        assert mod.get_pending_entry_span() is span
+
+    def test_room_submitted_does_not_cross_tag(self, workspace: Path) -> None:
+        """Room A task submitted; room B task active; room A turn should not tag B."""
+        mod = _load_trace_module()
+        _write_task(workspace, "task-a", {
+            "task_id": "task-a", "project_id": "proj-1",
+            "room_id": "!room-A:m.org", "status": "submitted",
+        })
+        _write_task(workspace, "task-b", {
+            "task_id": "task-b", "project_id": "proj-2",
+            "room_id": "!room-B:m.org", "status": "in_progress",
+        })
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+
+        # Room A turn: task-a is submitted, so task-b from another room must
+        # not be used.
+        token = mod.set_current_room("!room-A:m.org")
+        span = _entry_span()
+        processor.on_start(span)
+        span.set_attribute.assert_called_once_with("agentteams.project.id", "proj-1")
+        mod.reset_current_room(token)
+
+    def test_per_room_context_independence(self, workspace: Path) -> None:
+        """Room context routes each turn independently."""
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!room-A:m.org", "status": "in_progress",
+        })
+        _write_task(workspace, "t2", {
+            "task_id": "t2", "project_id": "p2",
+            "room_id": "!room-B:m.org", "status": "in_progress",
+        })
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace)
+
+        # Resolve room-A
+        token_a = mod.set_current_room("!room-A:m.org")
+        span_a = _entry_span()
+        processor.on_start(span_a)
+        span_a.set_attribute.assert_any_call("agentteams.task.id", "t1")
+        mod.reset_current_room(token_a)
+
+        # Room-B should resolve independently
+        token_b = mod.set_current_room("!room-B:m.org")
+        span_b = _entry_span()
+        processor.on_start(span_b)
+        span_b.set_attribute.assert_any_call("agentteams.task.id", "t2")
+        mod.reset_current_room(token_b)
+
+    def test_submitted_meta_stops_tagging_without_invalidation(self, workspace: Path) -> None:
+        """Current meta status is authoritative on the next entry span."""
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!room-A:m.org", "status": "in_progress",
+        })
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace)
+
+        # Resolve active task
+        token = mod.set_current_room("!room-A:m.org")
+        span = _entry_span()
+        processor.on_start(span)
+        span.set_attribute.assert_any_call("agentteams.task.id", "t1")
+        mod.reset_current_room(token)
+
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!room-A:m.org", "status": "submitted",
+        })
+
+        token = mod.set_current_room("!room-A:m.org")
+        span2 = _entry_span()
+        processor.on_start(span2)
+        span2.set_attribute.assert_called_once_with("agentteams.project.id", "p1")
+        mod.reset_current_room(token)
+
+
+# ===================================================================
+# Layer 7: Deferred entry span tagging (pending span mechanism)
+# ===================================================================
+
+
+class TestDeferredEntrySpanTagging:
+    """Verifies the pending-entry-span mechanism that fixes the room
+    context timing issue.
+
+    Real-world flow:
+      1. Instrumentation creates ``enter_ai_application_system`` span
+         -> on_start fires, room is NOT set yet -> span is stashed
+      2. QwenPawAgent.__call__ wrapper sets room context
+      3. Wrapper calls tag_pending_entry_span() -> stashed span gets tagged
+    """
+
+    def test_on_start_stashes_entry_span_when_room_not_set(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "in_progress",
+        })
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+        span = _entry_span()
+
+        # Room NOT set - span should be stashed, not tagged
+        processor.on_start(span)
+        span.set_attribute.assert_not_called()
+        assert mod.get_pending_entry_span() is span
+
+    def test_tag_pending_entry_span_tags_and_clears(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "in_progress",
+        })
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+        span = _entry_span()
+
+        # on_start without room -> stash
+        processor.on_start(span)
+        assert mod.get_pending_entry_span() is span
+
+        # Now set room and tag the pending span
+        token = mod.set_current_room("!r:m.org")
+        try:
+            result = mod.tag_pending_entry_span(workspace, room_id="!r:m.org")
+        finally:
+            mod.reset_current_room(token)
+
+        assert result["ok"] is True
+        span.set_attribute.assert_any_call("agentteams.task.id", "t1")
+        span.set_attribute.assert_any_call("agentteams.project.id", "p1")
+        # Pending span should be cleared
+        assert mod.get_pending_entry_span() is None
+
+    def test_tag_current_entry_span_prefers_pending(self, workspace: Path) -> None:
+        """tag_current_entry_span should find and tag the pending span
+        even when get_current_span() would return a different (non-entry) span."""
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "in_progress",
+        })
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+        entry = _entry_span()
+
+        # on_start without room -> stash
+        processor.on_start(entry)
+
+        # Set room, then call tag_current_entry_span (the wrapper's path)
+        token = mod.set_current_room("!r:m.org")
+        try:
+            result = mod.tag_current_entry_span(workspace, room_id="!r:m.org")
+        finally:
+            mod.reset_current_room(token)
+
+        assert result["ok"] is True
+        entry.set_attribute.assert_any_call("agentteams.task.id", "t1")
+        assert mod.get_pending_entry_span() is None
+
+    def test_no_pending_span_returns_failure(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        result = mod.tag_pending_entry_span(workspace)
+        assert result["ok"] is False
+        assert "no pending" in result["reason"]
+
+    def test_clear_pending_entry_span(self, workspace: Path) -> None:
+        mod = _load_trace_module()
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace)
+        span = _entry_span()
+        processor.on_start(span)
+        assert mod.get_pending_entry_span() is span
+        mod.clear_pending_entry_span()
+        assert mod.get_pending_entry_span() is None
+
+    def test_on_start_with_room_set_does_not_stash(self, workspace: Path) -> None:
+        """When room is already known, on_start tags immediately (no stash)."""
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "in_progress",
+        })
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+
+        token = mod.set_current_room("!r:m.org")
+        try:
+            span = _entry_span()
+            processor.on_start(span)
+        finally:
+            mod.reset_current_room(token)
+
+        span.set_attribute.assert_any_call("agentteams.task.id", "t1")
+        assert mod.get_pending_entry_span() is None
+
+    def test_full_deferred_lifecycle(self, workspace: Path) -> None:
+        """Simulate the real QwenPaw call flow end-to-end."""
+        mod = _load_trace_module()
+        _write_task(workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "in_progress",
+        })
+        processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+
+        # Step 1: Instrumentation creates entry span (no room yet)
+        entry = _entry_span()
+        processor.on_start(entry)
+        entry.set_attribute.assert_not_called()
+        assert mod.get_pending_entry_span() is entry
+
+        # Step 2: Inner spans are created (agent_step, etc.)
+        inner = _mock_span("agent_step")
+        processor.on_start(inner)
+        inner.set_attribute.assert_not_called()
+
+        # Step 3: Wrapper sets room and tags pending span
+        token = mod.set_current_room("!r:m.org")
+        try:
+            result = mod.tag_pending_entry_span(workspace, room_id="!r:m.org")
+        finally:
+            mod.reset_current_room(token)
+
+        assert result["ok"] is True
+        entry.set_attribute.assert_any_call("agentteams.task.id", "t1")
+        entry.set_attribute.assert_any_call("agentteams.project.id", "p1")
+
+
+# ===================================================================
+# Layer 8: Debug logging control
+# ===================================================================
+
+
+class TestDebugLogging:
+    def test_debug_disabled_by_default(self) -> None:
+        mod = _load_trace_module()
+        # Module level _DEBUG_ENABLED should respect env var at import time
+        # For tests, just verify set_trace_debug works
+        mod.set_trace_debug(False)
+        assert mod._DEBUG_ENABLED is False
+
+    def test_set_trace_debug_enables_logging(self) -> None:
+        mod = _load_trace_module()
+        mod.set_trace_debug(True)
+        assert mod._DEBUG_ENABLED is True
+        mod.set_trace_debug(False)
+
+    def test_trace_log_noop_when_disabled(self, capsys, workspace: Path) -> None:
+        mod = _load_trace_module()
+        mod.set_trace_debug(False)
+        mod._trace_log("this should not appear %s", "hello")
+        captured = capsys.readouterr()
+        assert "this should not appear" not in captured.err
+
+    def test_trace_log_emits_when_enabled(self, capsys, workspace: Path) -> None:
+        mod = _load_trace_module()
+        mod.set_trace_debug(True)
+        try:
+            mod._trace_log("visible message %s", "world")
+            captured = capsys.readouterr()
+            assert "visible message world" in captured.err
+        finally:
+            mod.set_trace_debug(False)

--- a/plugins/tests/teamharness/test_trace_integration.py
+++ b/plugins/tests/teamharness/test_trace_integration.py
@@ -1,0 +1,600 @@
+#!/usr/bin/env python3
+"""Integration tests for AgentTeams Task-Trace correlation.
+
+Uses a real OTel SDK (TracerProvider + InMemorySpanExporter) together with
+the TeamHarness MCP server to verify that ``agentteams.task.id`` and
+``agentteams.project.id`` appear on exported spans at every stage of the task
+lifecycle:  delegate -> ack -> tool calls -> submit -> post-submit.
+
+Prerequisites:
+    pip install opentelemetry-api opentelemetry-sdk
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from contextlib import contextmanager
+from pathlib import Path
+import sys
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# OTel SDK imports - skip entire module when SDK is absent
+# ---------------------------------------------------------------------------
+otel_sdk = pytest.importorskip("opentelemetry.sdk")
+
+from opentelemetry import trace as trace_api
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TRACE_MODULE_PATH = (
+    REPO_ROOT / "plugins" / "teamharness" / "adapters" / "qwenpaw" / "task_trace.py"
+)
+SERVER_MODULE_PATH = REPO_ROOT / "plugins" / "teamharness" / "mcp" / "server.py"
+
+
+def _load_module(name: str, path: Path):
+    module_dir = str(path.parent)
+    inserted = module_dir not in sys.path
+    if inserted:
+        sys.path.insert(0, module_dir)
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if inserted:
+            sys.path.remove(module_dir)
+    return module
+
+
+# ===================================================================
+# Fixtures
+# ===================================================================
+
+
+@pytest.fixture()
+def otel_env(tmp_path: Path):
+    """Set up a fresh OTel TracerProvider + InMemorySpanExporter and
+    install the AgentTeamsTaskSpanProcessor on it.
+
+    Uses the provider directly (via provider.get_tracer) instead of the
+    global set_tracer_provider - avoids the "already set" warning and keeps
+    tests isolated.
+    """
+    workspace = tmp_path / "workspaces" / "default"
+    workspace.mkdir(parents=True)
+    old_worker_name = os.environ.get("AGENTTEAMS_WORKER_NAME")
+    os.environ["AGENTTEAMS_WORKER_NAME"] = "worker-a"
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    trace_mod = _load_module("teamharness_trace", TRACE_MODULE_PATH)
+
+    processor = trace_mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
+    provider.add_span_processor(processor)
+
+    tracer = provider.get_tracer("agentteams.test")
+
+    class Env:
+        pass
+
+    env = Env()
+    env.provider = provider
+    env.exporter = exporter
+    env.tracer = tracer
+    env.workspace = workspace
+    env.trace_mod = trace_mod
+    env.processor = processor
+
+    yield env
+
+    if old_worker_name is None:
+        os.environ.pop("AGENTTEAMS_WORKER_NAME", None)
+    else:
+        os.environ["AGENTTEAMS_WORKER_NAME"] = old_worker_name
+    provider.shutdown()
+
+
+@pytest.fixture()
+def mcp_server(otel_env):
+    """Load the TeamHarness MCP server module with env configured for the
+    test workspace.  Patches _sync_task / _pull_task to avoid real MinIO calls.
+    """
+    old_env = {}
+    env_overrides = {
+        "QWENPAW_WORKING_DIR": str(otel_env.workspace.parent.parent),
+        "AGENTTEAMS_AGENT_ROLE": "worker",
+        "AGENTTEAMS_WORKER_NAME": "worker-a",
+    }
+    env_clear = [
+        "COPAW_WORKING_DIR",
+        "TEAMHARNESS_RUNTIME_CONFIG",
+        "TEAMHARNESS_SHARED_DIR",
+        "AGENTTEAMS_SHARED_STORAGE_PREFIX",
+        "AGENTTEAMS_MATRIX_URL",
+        "AGENTTEAMS_WORKER_MATRIX_TOKEN",
+        "AGENTTEAMS_MATRIX_USER_ID",
+    ]
+    for k, v in env_overrides.items():
+        old_env[k] = os.environ.get(k)
+        os.environ[k] = v
+    for k in env_clear:
+        old_env[k] = os.environ.get(k)
+        os.environ.pop(k, None)
+
+    server = _load_module("teamharness_mcp_server_integ", SERVER_MODULE_PATH)
+
+    # Stub out MinIO sync operations - we only care about local meta.json changes
+    server._sync_task = lambda *a, **kw: True
+    server._pull_task = lambda *a, **kw: True
+
+    yield server
+
+    for k, v in old_env.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+# ===================================================================
+# Helpers
+# ===================================================================
+
+
+def _write_task(workspace: Path, task_id: str, meta: dict, *, write_project: bool = True) -> None:
+    meta = dict(meta)
+    if (
+        meta.get("status") in {"assigned", "in_progress"}
+        and not meta.get("assigned_to")
+        and not meta.get("assignee")
+    ):
+        meta["assigned_to"] = "worker-a"
+    task_dir = workspace / "shared" / "tasks" / task_id
+    task_dir.mkdir(parents=True, exist_ok=True)
+    (task_dir / "meta.json").write_text(
+        json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8",
+    )
+    project_id = str(meta.get("project_id") or "")
+    if not write_project or not project_id:
+        return
+    project_path = workspace / "shared" / "projects" / project_id / "meta.json"
+    project_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        project = json.loads(project_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        project = {}
+    if not isinstance(project, dict):
+        project = {}
+    project["project_id"] = project_id
+    tasks = project.get("tasks")
+    if not isinstance(tasks, list):
+        tasks = []
+    tasks = [item for item in tasks if not isinstance(item, dict) or item.get("task_id") != task_id]
+    tasks.append({"task_id": task_id, "status": meta.get("status")})
+    project["tasks"] = tasks
+    project_path.write_text(
+        json.dumps(project, ensure_ascii=False, indent=2), encoding="utf-8",
+    )
+
+
+def _write_project(workspace: Path, project_id: str, meta: dict) -> None:
+    project_dir = workspace / "shared" / "projects" / project_id
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "meta.json").write_text(
+        json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8",
+    )
+
+
+def _spans_with_task(exporter: InMemorySpanExporter, task_id: str):
+    """Return exported spans that carry the given agentteams.task.id."""
+    return [
+        s for s in exporter.get_finished_spans()
+        if s.attributes and s.attributes.get("agentteams.task.id") == task_id
+    ]
+
+
+def _spans_without_task(exporter: InMemorySpanExporter):
+    """Return exported spans that do NOT carry agentteams.task.id."""
+    return [
+        s for s in exporter.get_finished_spans()
+        if not s.attributes or "agentteams.task.id" not in s.attributes
+    ]
+
+
+def _mcp_call(server, name: str, arguments: dict) -> dict:
+    """Call a TeamHarness MCP tool and return the parsed JSON payload."""
+    result = server.call_tool(name, arguments)
+    text = result["content"][0]["text"]
+    return json.loads(text)
+
+
+@contextmanager
+def _room(trace_mod: Any, room_id: str):
+    token = trace_mod.set_current_room(room_id)
+    try:
+        yield
+    finally:
+        trace_mod.reset_current_room(token)
+
+
+# ===================================================================
+# Integration tests
+# ===================================================================
+
+
+class TestBeforeAck:
+    """Only the task turn entry span carries task attributes."""
+
+    def test_health_span_has_no_task_attrs(self, otel_env) -> None:
+        with otel_env.tracer.start_as_current_span("health-check"):
+            pass  # simulates an Agent turn with no active task
+
+        spans = otel_env.exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert "agentteams.task.id" not in (spans[0].attributes or {})
+
+    def test_assigned_task_entry_span_is_picked_up(self, otel_env) -> None:
+        _write_task(otel_env.workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "assigned",
+        })
+
+        with _room(otel_env.trace_mod, "!r:m.org"):
+            with otel_env.tracer.start_as_current_span("enter_ai_application_system"):
+                with otel_env.tracer.start_as_current_span("llm-call"):
+                    pass
+
+        tagged = _spans_with_task(otel_env.exporter, "t1")
+        assert len(tagged) == 1
+        assert tagged[0].name == "enter_ai_application_system"
+
+    def test_entry_span_started_before_room_context_is_backfilled(self, otel_env) -> None:
+        """Covers OTel wrapping outside the QwenPaw TeamHarness wrapper."""
+        _write_task(otel_env.workspace, "t1", {
+            "task_id": "t1", "project_id": "p1",
+            "room_id": "!r:m.org", "status": "assigned",
+        })
+
+        with otel_env.tracer.start_as_current_span("enter_ai_application_system"):
+            with _room(otel_env.trace_mod, "!r:m.org"):
+                result = otel_env.trace_mod.tag_current_entry_span(otel_env.workspace)
+                assert result["ok"] is True
+
+        tagged = _spans_with_task(otel_env.exporter, "t1")
+        assert len(tagged) == 1
+        assert tagged[0].name == "enter_ai_application_system"
+        assert tagged[0].attributes["agentteams.project.id"] == "p1"
+
+
+class TestAckTask:
+    """After ack_task changes meta.json to in_progress, spans get attributes."""
+
+    def test_spans_after_ack_carry_task_attrs(self, otel_env, mcp_server) -> None:
+        ws = otel_env.workspace
+        project_id = "proj-integ"
+        task_id = "task-integ"
+
+        _write_project(ws, project_id, {
+            "project_id": project_id,
+            "tasks": [{"task_id": task_id, "status": "assigned"}],
+        })
+        _write_task(ws, task_id, {
+            "task_id": task_id,
+            "project_id": project_id,
+            "room_id": "!room:m.org",
+            "status": "assigned",
+            "spec_path": f"shared/tasks/{task_id}/spec.md",
+        })
+        spec_dir = ws / "shared" / "tasks" / task_id
+        (spec_dir / "spec.md").write_text("do something", encoding="utf-8")
+
+        # Simulate: Agent's Entry span starts
+        with _room(otel_env.trace_mod, "!room:m.org"):
+            with otel_env.tracer.start_as_current_span("enter_ai_application_system"):
+                # Agent calls ack_task via MCP - this changes meta.json to in_progress
+                with otel_env.tracer.start_as_current_span("mcp-tool-call"):
+                    payload = _mcp_call(mcp_server, "taskflow", {
+                        "workspaceDir": str(ws),
+                        "action": "ack_task",
+                        "role": "worker",
+                        "payload": {"taskId": task_id},
+                    })
+                    assert payload["ok"] is True
+                    assert payload["task"]["status"] == "in_progress"
+
+                # Subsequent work stays as child spans; only the entry span is tagged.
+                with otel_env.tracer.start_as_current_span("llm-call-post-ack"):
+                    pass
+                with otel_env.tracer.start_as_current_span("tool-call-filesync"):
+                    pass
+
+        # Verify: the entry span carries the assigned task context.
+        tagged = _spans_with_task(otel_env.exporter, task_id)
+        assert len(tagged) == 1
+        assert tagged[0].name == "enter_ai_application_system"
+        assert tagged[0].attributes["agentteams.project.id"] == project_id
+
+
+class TestDuringWork:
+    """The per-turn entry span carries task attributes during work."""
+
+    def test_multiple_turn_entries_tagged(self, otel_env) -> None:
+        ws = otel_env.workspace
+        _write_task(ws, "active-task", {
+            "task_id": "active-task",
+            "project_id": "active-proj",
+            "room_id": "!r:m.org",
+            "status": "in_progress",
+        })
+
+        # Simulate 3 Agent turns
+        for i in range(3):
+            with _room(otel_env.trace_mod, "!r:m.org"):
+                with otel_env.tracer.start_as_current_span("enter_ai_application_system"):
+                    with otel_env.tracer.start_as_current_span(f"llm-{i}"):
+                        pass
+                    with otel_env.tracer.start_as_current_span(f"tool-{i}"):
+                        pass
+
+        all_spans = otel_env.exporter.get_finished_spans()
+        assert len(all_spans) == 9  # 3 turns x (entry + llm + tool)
+
+        tagged = _spans_with_task(otel_env.exporter, "active-task")
+        assert len(tagged) == 3
+        for span in tagged:
+            assert span.name == "enter_ai_application_system"
+            assert span.attributes["agentteams.task.id"] == "active-task"
+            assert span.attributes["agentteams.project.id"] == "active-proj"
+
+    def test_nested_spans_tag_entry_only(self, otel_env) -> None:
+        ws = otel_env.workspace
+        _write_task(ws, "deep-task", {
+            "task_id": "deep-task",
+            "project_id": "deep-proj",
+            "room_id": "!r:m.org",
+            "status": "in_progress",
+        })
+
+        with _room(otel_env.trace_mod, "!r:m.org"):
+            with otel_env.tracer.start_as_current_span("enter_ai_application_system"):
+                with otel_env.tracer.start_as_current_span("llm-call"):
+                    with otel_env.tracer.start_as_current_span("http-request"):
+                        with otel_env.tracer.start_as_current_span("dns-resolve"):
+                            pass
+
+        all_spans = otel_env.exporter.get_finished_spans()
+        assert len(all_spans) == 4
+        tagged = _spans_with_task(otel_env.exporter, "deep-task")
+        assert len(tagged) == 1
+        assert tagged[0].name == "enter_ai_application_system"
+
+
+class TestSubmitTask:
+    """The submit turn is still tagged; subsequent turns are not."""
+
+    def test_submit_turn_tagged_and_next_turn_clean(self, otel_env, mcp_server) -> None:
+        ws = otel_env.workspace
+        project_id = "proj-submit"
+        task_id = "task-submit"
+
+        _write_project(ws, project_id, {
+            "project_id": project_id,
+            "tasks": [{"task_id": task_id, "status": "in_progress"}],
+        })
+        _write_task(ws, task_id, {
+            "task_id": task_id,
+            "project_id": project_id,
+            "room_id": "!room:m.org",
+            "status": "in_progress",
+            "spec_path": f"shared/tasks/{task_id}/spec.md",
+        })
+
+        # --- Submit turn ---
+        with _room(otel_env.trace_mod, "!room:m.org"):
+            with otel_env.tracer.start_as_current_span("enter_ai_application_system"):
+                # Entry span is created BEFORE submit - task is still in_progress
+                with otel_env.tracer.start_as_current_span("mcp-submit"):
+                    submit_result = _mcp_call(mcp_server, "taskflow", {
+                        "workspaceDir": str(ws),
+                        "action": "submit_task",
+                        "role": "worker",
+                        "payload": {
+                            "taskId": task_id,
+                            "summary": "done",
+                            "status": "SUCCESS",
+                            "deliverables": [f"shared/tasks/{task_id}/output.md"],
+                        },
+                    })
+                    assert submit_result["ok"] is True
+
+        # Verify: submit turn entry span is tagged
+        submit_spans = _spans_with_task(otel_env.exporter, task_id)
+        assert len(submit_spans) >= 1
+        entry_names = {s.name for s in submit_spans}
+        assert "enter_ai_application_system" in entry_names
+
+        otel_env.exporter.clear()
+
+        # --- Next turn (after submit) ---
+        with _room(otel_env.trace_mod, "!room:m.org"):
+            with otel_env.tracer.start_as_current_span("enter_ai_application_system"):
+                with otel_env.tracer.start_as_current_span("idle-work"):
+                    pass
+
+        post_spans = otel_env.exporter.get_finished_spans()
+        for span in post_spans:
+            assert "agentteams.task.id" not in (span.attributes or {}), \
+                f"span '{span.name}' should NOT have task attributes after submit"
+
+
+class TestFullLifecycle:
+    """End-to-end: delegate -> ack -> work -> submit -> idle."""
+
+    def test_delegate_ack_work_submit_idle(self, otel_env, mcp_server) -> None:
+        ws = otel_env.workspace
+        project_id = "proj-e2e"
+        task_id = "task-e2e"
+
+        # --- Phase 1: Manager delegates task (leader role) ---
+        _write_project(ws, project_id, {
+            "project_id": project_id,
+            "source_room_id": "!team:m.org",
+            "tasks": [{"task_id": task_id, "status": "ready"}],
+        })
+
+        with otel_env.tracer.start_as_current_span("manager-delegate"):
+            delegate_result = _mcp_call(mcp_server, "taskflow", {
+                "workspaceDir": str(ws),
+                "action": "delegate_task",
+                "role": "leader",
+                "payload": {
+                    "projectId": project_id,
+                    "taskId": task_id,
+                    "roomId": "!worker-room:m.org",
+                    "assignedTo": "worker-a",
+                    "spec": "Build the feature",
+                },
+            })
+            assert delegate_result["ok"] is True
+            assert delegate_result["task"]["assigned_to"] == "worker-a"
+
+        # At this point task status is "assigned" - no spans should be tagged
+        delegate_spans = otel_env.exporter.get_finished_spans()
+        for span in delegate_spans:
+            assert "agentteams.task.id" not in (span.attributes or {})
+
+        otel_env.exporter.clear()
+
+        # --- Phase 2: Worker acks task ---
+        with _room(otel_env.trace_mod, "!worker-room:m.org"):
+            with otel_env.tracer.start_as_current_span("enter_ai_application_system"):
+                _mcp_call(mcp_server, "taskflow", {
+                    "workspaceDir": str(ws),
+                    "action": "ack_task",
+                    "role": "worker",
+                    "payload": {"taskId": task_id},
+                })
+
+                # Post-ack work
+                with otel_env.tracer.start_as_current_span("post-ack-work"):
+                    pass
+
+        ack_tagged = _spans_with_task(otel_env.exporter, task_id)
+        assert len(ack_tagged) == 1
+        otel_env.exporter.clear()
+
+        # --- Phase 3: Worker performs multiple work turns ---
+        for i in range(3):
+            with _room(otel_env.trace_mod, "!worker-room:m.org"):
+                with otel_env.tracer.start_as_current_span("enter_ai_application_system"):
+                    with otel_env.tracer.start_as_current_span(f"llm-{i}"):
+                        pass
+
+        work_spans = otel_env.exporter.get_finished_spans()
+        assert len(work_spans) == 6
+        tagged_work_spans = _spans_with_task(otel_env.exporter, task_id)
+        assert len(tagged_work_spans) == 3
+        for span in tagged_work_spans:
+            assert span.name == "enter_ai_application_system"
+            assert span.attributes["agentteams.task.id"] == task_id
+            assert span.attributes["agentteams.project.id"] == project_id
+        otel_env.exporter.clear()
+
+        # --- Phase 4: Worker submits ---
+        with _room(otel_env.trace_mod, "!worker-room:m.org"):
+            with otel_env.tracer.start_as_current_span("enter_ai_application_system"):
+                submit_result = _mcp_call(mcp_server, "taskflow", {
+                    "workspaceDir": str(ws),
+                    "action": "submit_task",
+                    "role": "worker",
+                    "payload": {
+                        "taskId": task_id,
+                        "summary": "feature built",
+                        "status": "SUCCESS",
+                        "deliverables": [f"shared/tasks/{task_id}/feature.py"],
+                    },
+                })
+                assert submit_result["ok"] is True
+
+        submit_tagged = _spans_with_task(otel_env.exporter, task_id)
+        assert any(s.name == "enter_ai_application_system" for s in submit_tagged)
+        otel_env.exporter.clear()
+
+        # --- Phase 5: Post-submit idle --- no task attributes
+        with _room(otel_env.trace_mod, "!worker-room:m.org"):
+            with otel_env.tracer.start_as_current_span("enter_ai_application_system"):
+                with otel_env.tracer.start_as_current_span("health-check"):
+                    pass
+
+        idle_spans = otel_env.exporter.get_finished_spans()
+        assert len(idle_spans) == 2
+        for span in idle_spans:
+            assert "agentteams.task.id" not in (span.attributes or {})
+
+
+class TestRegisterViaRealProvider:
+    """Verify register_task_trace_processor works with the real OTel SDK."""
+
+    def test_register_and_verify_attributes(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "workspaces" / "default"
+        workspace.mkdir(parents=True)
+
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        old_worker_name = os.environ.get("AGENTTEAMS_WORKER_NAME")
+        os.environ["AGENTTEAMS_WORKER_NAME"] = "worker-a"
+
+        # Temporarily set global provider so register_task_trace_processor() can find it
+        trace_api._TRACER_PROVIDER_SET_ONCE = trace_api.Once()
+        trace_api.set_tracer_provider(provider)
+
+        try:
+            trace_mod = _load_module("teamharness_trace_reg", TRACE_MODULE_PATH)
+            result = trace_mod.register_task_trace_processor(workspace, cache_ttl=0)
+            assert result["ok"] is True
+
+            tracer = provider.get_tracer("test")
+
+            # No task yet - span should be clean
+            with tracer.start_as_current_span("no-task"):
+                pass
+            spans = exporter.get_finished_spans()
+            assert len(spans) == 1
+            assert "agentteams.task.id" not in (spans[0].attributes or {})
+
+            exporter.clear()
+
+            # Write active task - next span should be tagged
+            _write_task(workspace, "reg-task", {
+                "task_id": "reg-task",
+                "project_id": "reg-proj",
+                "room_id": "!r:m.org",
+                "status": "in_progress",
+            })
+
+            with _room(trace_mod, "!r:m.org"):
+                with tracer.start_as_current_span("enter_ai_application_system"):
+                    pass
+            spans = exporter.get_finished_spans()
+            assert len(spans) == 1
+            assert spans[0].attributes["agentteams.task.id"] == "reg-task"
+            assert spans[0].attributes["agentteams.project.id"] == "reg-proj"
+        finally:
+            if old_worker_name is None:
+                os.environ.pop("AGENTTEAMS_WORKER_NAME", None)
+            else:
+                os.environ["AGENTTEAMS_WORKER_NAME"] = old_worker_name
+            trace_api._TRACER_PROVIDER_SET_ONCE = trace_api.Once()
+            provider.shutdown()


### PR DESCRIPTION
Summary: Adds QwenPaw Task-Trace correlation for TeamHarness entry spans, wires the QwenPaw adapter to register the SpanProcessor, and preserves assigned_to metadata during task delegation for trace matching. Validation: uv run --with pytest --with opentelemetry-sdk python -m pytest plugins/tests/teamharness/test_trace.py plugins/tests/teamharness/test_trace_integration.py -q; uv run --with pytest --with pyyaml python -m pytest plugins/tests/teamharness/adapters/qwenpaw/test_adapter.py -q; ruby plugins/tests/teamharness/mcp/tools/test-taskflow.rb; python3 -m compileall -q plugins/teamharness/adapters/qwenpaw plugins/teamharness/mcp/server.py; git diff --check.