### PR TITLE
feat(controller): add AGENTTEAMS_MODEL_VISION env to override model-l…

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -5,6 +5,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 ---
 
 - feat(controller): add `AGENTTEAMS_MODEL_VISION` env to override model-level vision capability for custom models not in the built-in presets table (e.g. local multimodal models like `qwen3.6-27b-fp8`).
+- feat(controller): add `AGENTTEAMS_MODEL_REASONING` env to override model-level reasoning capability for custom models not in the built-in presets table.
 
 - feat(qwenpaw): add the QwenPaw worker runtime Python package baseline with runtime config sync, storage sync, heartbeat reporting, Matrix channel overlay, and focused unit tests.
 - fix(controller): surface Kubernetes Pod container failures in Worker backend status and status API responses.

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,6 +4,8 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 
 ---
 
+- feat(controller): add `AGENTTEAMS_MODEL_VISION` env to override model-level vision capability for custom models not in the built-in presets table (e.g. local multimodal models like `qwen3.6-27b-fp8`).
+
 - feat(qwenpaw): add the QwenPaw worker runtime Python package baseline with runtime config sync, storage sync, heartbeat reporting, Matrix channel overlay, and focused unit tests.
 - fix(controller): surface Kubernetes Pod container failures in Worker backend status and status API responses.
 - feat(controller): expose low-cardinality AgentTeams controller metrics and optional Helm ServiceMonitor.

--- a/hiclaw-controller/internal/config/config.go
+++ b/hiclaw-controller/internal/config/config.go
@@ -167,6 +167,7 @@ type Config struct {
 	Runtime            string
 	ModelContextWindow int
 	ModelMaxTokens     int
+	ModelVision        *bool // nil = use model default; overrides model-level vision capability
 
 	// LLM provider (for Gateway initialization)
 	LLMProvider                string
@@ -380,6 +381,7 @@ func LoadConfig() *Config {
 		Runtime:            envOrDefault("HICLAW_RUNTIME", "docker"),
 		ModelContextWindow: envOrDefaultInt("HICLAW_MODEL_CONTEXT_WINDOW", 0),
 		ModelMaxTokens:     envOrDefaultInt("HICLAW_MODEL_MAX_TOKENS", 0),
+		ModelVision:        envOptionalBool("AGENTTEAMS_MODEL_VISION"),
 
 		LLMProvider:                envOrDefault("HICLAW_LLM_PROVIDER", "qwen"),
 		LLMAPIKey:                  os.Getenv("HICLAW_LLM_API_KEY"),
@@ -619,6 +621,17 @@ func envBoolDefault(key string, defaultVal bool) bool {
 	return v == "1" || v == "true" || v == "True" || v == "TRUE"
 }
 
+// envOptionalBool returns nil when the env var is unset, so callers can
+// distinguish "not configured" from "explicitly false".
+func envOptionalBool(key string) *bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return nil
+	}
+	b := v == "1" || v == "true" || v == "True" || v == "TRUE"
+	return &b
+}
+
 func firstNonEmpty(values ...string) string {
 	for _, v := range values {
 		if v != "" {
@@ -840,6 +853,7 @@ func (c *Config) AgentConfig() agentconfig.Config {
 		E2EEEnabled:        c.MatrixE2EE,
 		ModelContextWindow: c.ModelContextWindow,
 		ModelMaxTokens:     c.ModelMaxTokens,
+		ModelVision:        c.ModelVision,
 		CMSTracesEnabled:   c.CMSTracesEnabled,
 		CMSMetricsEnabled:  c.CMSMetricsEnabled,
 		CMSEndpoint:        c.CMSEndpoint,

--- a/hiclaw-controller/internal/config/config.go
+++ b/hiclaw-controller/internal/config/config.go
@@ -168,6 +168,7 @@ type Config struct {
 	ModelContextWindow int
 	ModelMaxTokens     int
 	ModelVision        *bool // nil = use model default; overrides model-level vision capability
+	ModelReasoning     *bool // nil = use model default
 
 	// LLM provider (for Gateway initialization)
 	LLMProvider                string
@@ -382,6 +383,7 @@ func LoadConfig() *Config {
 		ModelContextWindow: envOrDefaultInt("HICLAW_MODEL_CONTEXT_WINDOW", 0),
 		ModelMaxTokens:     envOrDefaultInt("HICLAW_MODEL_MAX_TOKENS", 0),
 		ModelVision:        envOptionalBool("AGENTTEAMS_MODEL_VISION"),
+		ModelReasoning:     envOptionalBool("AGENTTEAMS_MODEL_REASONING"),
 
 		LLMProvider:                envOrDefault("HICLAW_LLM_PROVIDER", "qwen"),
 		LLMAPIKey:                  os.Getenv("HICLAW_LLM_API_KEY"),
@@ -854,6 +856,7 @@ func (c *Config) AgentConfig() agentconfig.Config {
 		ModelContextWindow: c.ModelContextWindow,
 		ModelMaxTokens:     c.ModelMaxTokens,
 		ModelVision:        c.ModelVision,
+		ModelReasoning:     c.ModelReasoning,
 		CMSTracesEnabled:   c.CMSTracesEnabled,
 		CMSMetricsEnabled:  c.CMSMetricsEnabled,
 		CMSEndpoint:        c.CMSEndpoint,


### PR DESCRIPTION
## Problem

Two gaps in `config.go` where `agentconfig.Config` fields were declared but
never wired:

1. **ModelVision**: Custom multimodal models not in the built-in presets
   table (e.g. local `qwen3.6-27b-fp8`) fall through to `vision=false`.
   This is correct for models that genuinely lack vision
   (e.g. `deepseek-v4-pro`), but the preset table cannot know about
   user-defined local multimodal models.

2. **ModelReasoning**: Same pattern — `ModelReasoning *bool` declared in
   `types.go`, handled in `generator.go`, but never connected in `config.go`.

Both fields were always nil, so `resolveModelSpec()` never applied the
overrides.

## Fix

Add `AGENTTEAMS_MODEL_VISION` and `AGENTTEAMS_MODEL_REASONING` env var
support, following the same pattern as `ModelContextWindow` /
`ModelMaxTokens`:

- `Config.ModelVision *bool`, `Config.ModelReasoning *bool` — nil = use
  model default
- `envOptionalBool()` helper — returns nil when env unset (unlike
  `envBoolDefault` which returns a concrete bool)
- Pass through via `AgentConfig()` → `resolveModelSpec()`

## Behavior

PR-A does not change any model's default behavior. It adds override knobs
for deployers to set at Controller startup.

**ModelVision** (`AGENTTEAMS_MODEL_VISION`):

| Scenario | Before | After |
|---|---|---|
| `qwen3.6-27b-fp8` (local multimodal), env not set | `vision=false` ❌ | `vision=false` (unchanged — knob provided but not yet turned) |
| `qwen3.6-27b-fp8`, `AGENTTEAMS_MODEL_VISION=true` | `vision=false` ❌ | `vision=true` ✅ |
| `qwen3.6-plus` (in presets, vision:true), env not set | `vision=true` ✅ | unchanged |
| `deepseek-v4-pro` (no vision support), env not set | `vision=false` ✅ | unchanged (correct; should NOT set this env) |

**ModelReasoning** (`AGENTTEAMS_MODEL_REASONING`):

| Scenario | Before | After |
|---|---|---|
| Any model, env not set | preset default | unchanged |
| Any model, `AGENTTEAMS_MODEL_REASONING=true` | preset default | `reasoning=true` |
| Any model, `AGENTTEAMS_MODEL_REASONING=false` | N/A | `reasoning=false` |

Backward compatible: nil default means "use model default".

## Usage

Deployers set the env vars on the Controller:

    AGENTTEAMS_MODEL_VISION=true
    AGENTTEAMS_MODEL_REASONING=true

Then restart the Controller. All generated model specs will include
`"image"` in their `Input` array (vision) and the specified reasoning
capability.

Note: `AGENTTEAMS_MODEL_VISION` is a global override (same pattern as
`ModelContextWindow` / `ModelMaxTokens`). It affects all models. For
text-only models like DeepSeek this is harmless — their API ignores the
capability declaration. `AGENTTEAMS_MODEL_REASONING` overrides the
reasoning field for all models where the provider supports it.

## Files changed

- `hiclaw-controller/internal/config/config.go`: +17 lines
- `changelog/current.md`: +3 lines

2 commits:
- `71f5ef7` feat(controller): add AGENTTEAMS_MODEL_VISION env
- `28ca8bc` feat(controller): wire ModelReasoning env through config