### PR TITLE
feat(controller): allow overriding APIG endpoint

### DIFF
--- a/helm/hiclaw/templates/controller/deployment.yaml
+++ b/helm/hiclaw/templates/controller/deployment.yaml
@@ -130,6 +130,10 @@ spec:
               value: {{ include "hiclaw.gateway.internalURL" . | quote }}
             - name: HICLAW_REGION
               value: {{ .Values.gateway.aiGateway.region | quote }}
+            {{- if .Values.gateway.aiGateway.endpoint }}
+            - name: HICLAW_APIG_ENDPOINT
+              value: {{ .Values.gateway.aiGateway.endpoint | quote }}
+            {{- end }}
             - name: HICLAW_GW_GATEWAY_ID
               value: {{ .Values.gateway.aiGateway.gatewayId | quote }}
             - name: HICLAW_GW_MODEL_API_ID

--- a/helm/hiclaw/values.yaml
+++ b/helm/hiclaw/values.yaml
@@ -84,6 +84,7 @@ gateway:
   # Required when provider=ai-gateway:
   aiGateway:
     region: ""                # e.g. "cn-hangzhou"
+    endpoint: ""              # optional APIG OpenAPI endpoint override; empty uses apig.<region>.aliyuncs.com
     gatewayId: ""             # APIG gateway instance id (required)
     modelApiId: ""            # LLM Model API id used for consumer authorization
     envId: ""                 # APIG environment id

--- a/hiclaw-controller/internal/config/config.go
+++ b/hiclaw-controller/internal/config/config.go
@@ -71,6 +71,7 @@ type Config struct {
 	Region string
 
 	// AI Gateway (Alibaba Cloud APIG) — only used when GatewayProvider == "ai-gateway"
+	GWEndpoint   string
 	GWGatewayID  string
 	GWModelAPIID string
 	GWEnvID      string
@@ -312,6 +313,7 @@ func LoadConfig() *Config {
 
 		Region: envOrDefault("HICLAW_REGION", "cn-hangzhou"),
 
+		GWEndpoint:   os.Getenv("HICLAW_APIG_ENDPOINT"),
 		GWGatewayID:  os.Getenv("HICLAW_GW_GATEWAY_ID"),
 		GWModelAPIID: os.Getenv("HICLAW_GW_MODEL_API_ID"),
 		GWEnvID:      os.Getenv("HICLAW_GW_ENV_ID"),
@@ -531,6 +533,7 @@ func (c *Config) STSConfig() credentials.STSConfig {
 func (c *Config) AIGatewayConfig() gateway.AIGatewayConfig {
 	return gateway.AIGatewayConfig{
 		Region:     c.Region,
+		Endpoint:   c.GWEndpoint,
 		GatewayID:  c.GWGatewayID,
 		ModelAPIID: c.GWModelAPIID,
 		EnvID:      c.GWEnvID,

--- a/hiclaw-controller/internal/config/config_test.go
+++ b/hiclaw-controller/internal/config/config_test.go
@@ -153,6 +153,15 @@ func TestLoadConfigPanicsOnInvalidManagerSpec(t *testing.T) {
 	_ = LoadConfig()
 }
 
+func TestLoadConfigAIGatewayEndpointOverride(t *testing.T) {
+	t.Setenv("HICLAW_APIG_ENDPOINT", "apig-vpc.cn-hangzhou.aliyuncs.com")
+
+	cfg := LoadConfig()
+	if cfg.AIGatewayConfig().Endpoint != "apig-vpc.cn-hangzhou.aliyuncs.com" {
+		t.Fatalf("AIGatewayConfig().Endpoint = %q", cfg.AIGatewayConfig().Endpoint)
+	}
+}
+
 func TestLoadConfigPrefersAbstractInfraEnv(t *testing.T) {
 	t.Setenv("HICLAW_KUBE_MODE", "incluster")
 	t.Setenv("HICLAW_AI_GATEWAY_ADMIN_URL", "http://higress-admin.example.com:8001")

--- a/hiclaw-controller/internal/gateway/aigateway.go
+++ b/hiclaw-controller/internal/gateway/aigateway.go
@@ -25,6 +25,7 @@ var ErrUnsupportedOp = errors.New("operation not supported on ai-gateway provide
 // hiclaw AI Model API.
 type AIGatewayConfig struct {
 	Region     string // e.g. "cn-hangzhou"
+	Endpoint   string // optional APIG OpenAPI endpoint override
 	GatewayID  string // APIG gateway instance id
 	ModelAPIID string // LLM Model API id that consumers are bound to
 	EnvID      string // APIG environment id
@@ -75,13 +76,21 @@ func NewAIGatewayClient(cfg AIGatewayConfig, cred credential.Credential) (*AIGat
 	apiCfg := &openapi.Config{}
 	apiCfg.SetCredential(cred).
 		SetRegionId(cfg.Region).
-		SetEndpoint(fmt.Sprintf("apig.%s.aliyuncs.com", cfg.Region))
+		SetEndpoint(apigEndpoint(cfg.Region, cfg.Endpoint))
 
 	cli, err := apig.NewClient(apiCfg)
 	if err != nil {
 		return nil, fmt.Errorf("ai-gateway: create APIG client: %w", err)
 	}
 	return &AIGatewayClient{config: cfg, client: cli}, nil
+}
+
+func apigEndpoint(region, override string) string {
+	override = strings.TrimSpace(override)
+	if override != "" {
+		return override
+	}
+	return fmt.Sprintf("apig.%s.aliyuncs.com", region)
 }
 
 // NewAIGatewayClientWithClient is the testing constructor: it accepts a

--- a/hiclaw-controller/internal/gateway/aigateway_test.go
+++ b/hiclaw-controller/internal/gateway/aigateway_test.go
@@ -1,0 +1,12 @@
+package gateway
+
+import "testing"
+
+func TestAPIGEndpoint(t *testing.T) {
+	if got := apigEndpoint("cn-hangzhou", ""); got != "apig.cn-hangzhou.aliyuncs.com" {
+		t.Fatalf("default endpoint = %q", got)
+	}
+	if got := apigEndpoint("cn-hangzhou", " apig-vpc.cn-hangzhou.aliyuncs.com "); got != "apig-vpc.cn-hangzhou.aliyuncs.com" {
+		t.Fatalf("override endpoint = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add an optional Helm value for the Alibaba Cloud APIG OpenAPI endpoint
- pass the value to the controller as HICLAW_APIG_ENDPOINT for ai-gateway installs
- let the APIG SDK client use the override, falling back to apig.<region>.aliyuncs.com

## Validation
- git diff --check
- go test ./internal/config ./internal/gateway (from hiclaw-controller)

Split from the refreshed internal/open-source diff based on codex/sync-opensource-main-20260701 @ 0bf155a2.