### PR TITLE
fix(controller): skip unsupported gateway port exposure

### DIFF
--- a/hiclaw-controller/internal/controller/member_reconcile.go
+++ b/hiclaw-controller/internal/controller/member_reconcile.go
@@ -1861,7 +1861,7 @@ func extraHostsForBackend(wb backend.WorkerBackend) []string {
 	return nil
 }
 
-// ReconcileMemberExpose reconciles Higress port exposure for the member.
+// ReconcileMemberExpose reconciles gateway port exposure for the member.
 // Non-fatal: logs and returns current state unchanged on failure. The returned
 // slice overwrites state.ExposedPorts on success.
 func ReconcileMemberExpose(ctx context.Context, d MemberDeps, m MemberContext, state *MemberState) error {
@@ -1871,6 +1871,11 @@ func ReconcileMemberExpose(ctx context.Context, d MemberDeps, m MemberContext, s
 	}
 	exposedPorts, err := d.Provisioner.ReconcileExpose(ctx, m.Name, m.Spec.Expose, m.CurrentExposedPorts)
 	if err != nil {
+		if errors.Is(err, gateway.ErrUnsupportedOp) {
+			log.FromContext(ctx).V(1).Info("gateway provider does not manage exposed ports; skipping", "name", m.Name)
+			state.ExposedPorts = m.CurrentExposedPorts
+			return nil
+		}
 		log.FromContext(ctx).Error(err, "failed to reconcile exposed ports (non-fatal)", "name", m.Name)
 		state.ExposedPorts = m.CurrentExposedPorts
 		return nil

--- a/hiclaw-controller/internal/controller/member_reconcile_test.go
+++ b/hiclaw-controller/internal/controller/member_reconcile_test.go
@@ -156,6 +156,26 @@ func TestCreateMemberContainerDoesNotAddDockerHostGatewayForK8s(t *testing.T) {
 	}
 }
 
+func TestReconcileMemberExposeSkipsUnsupportedGatewayProvider(t *testing.T) {
+	current := []v1beta1.ExposedPortStatus{{Port: 8088, Domain: "console.example.com"}}
+	prov := mocks.NewMockProvisioner()
+	prov.ReconcileExposeFn = func(context.Context, string, []v1beta1.ExposePort, []v1beta1.ExposedPortStatus) ([]v1beta1.ExposedPortStatus, error) {
+		return nil, gateway.ErrUnsupportedOp
+	}
+	state := &MemberState{}
+
+	if err := ReconcileMemberExpose(context.Background(), MemberDeps{Provisioner: prov}, MemberContext{
+		Name:                "alice",
+		Spec:                v1beta1.WorkerSpec{Expose: []v1beta1.ExposePort{{Port: 8088}}},
+		CurrentExposedPorts: current,
+	}, state); err != nil {
+		t.Fatalf("ReconcileMemberExpose err = %v", err)
+	}
+	if len(state.ExposedPorts) != 1 || state.ExposedPorts[0].Port != 8088 || state.ExposedPorts[0].Domain != "console.example.com" {
+		t.Fatalf("ExposedPorts=%+v, want current exposed ports preserved", state.ExposedPorts)
+	}
+}
+
 func TestCreateMemberContainerPassesMemberRoleEnv(t *testing.T) {
 	wb := mocks.NewMockWorkerBackend()
 	state := &MemberState{


### PR DESCRIPTION
## Summary
- treat gateway.ErrUnsupportedOp from port exposure reconciliation as a supported no-op
- preserve the current exposed port status when the selected gateway provider does not manage ports
- update the reconcile comment from Higress-specific wording to gateway-provider wording

## Validation
- git diff --check
- go test ./internal/controller (from hiclaw-controller)

Split from the refreshed internal/open-source diff based on codex/sync-opensource-main-20260701 @ 0bf155a2.