### PR TITLE
fix(controller): sync human team room status from teams

### DIFF
--- a/hiclaw-controller/internal/controller/team_controller.go
+++ b/hiclaw-controller/internal/controller/team_controller.go
@@ -223,10 +223,118 @@ func (r *TeamReconciler) deriveTeamWithResolvedIdentities(ctx context.Context, t
 		}
 		derived.Spec.Admin.MatrixUserID = adminActor.MatrixUserID
 	}
+	r.appendAccessibleTeamHumans(ctx, derived)
 	for i := range derived.Spec.HumanMembers {
 		derived.Spec.HumanMembers[i].MatrixUserID = r.resolveHumanMemberMatrixUserID(ctx, t.Namespace, derived.Spec.HumanMembers[i])
 	}
 	return derived
+}
+
+func (r *TeamReconciler) appendAccessibleTeamHumans(ctx context.Context, t *v1beta1.Team) {
+	var humans v1beta1.HumanList
+	if err := r.List(ctx, &humans, client.InNamespace(t.Namespace)); err != nil {
+		log.FromContext(ctx).Error(err, "failed to list humans for accessibleTeams")
+		return
+	}
+
+	seen := make(map[string]struct{}, len(t.Spec.HumanMembers))
+	for _, member := range t.Spec.HumanMembers {
+		if member.Name != "" {
+			seen[member.Name] = struct{}{}
+		}
+		if member.MatrixUserID != "" {
+			seen[member.MatrixUserID] = struct{}{}
+		}
+	}
+	for i := range humans.Items {
+		human := &humans.Items[i]
+		if !containsString(human.Spec.AccessibleTeams, t.Name) {
+			continue
+		}
+		if _, ok := seen[human.Name]; ok {
+			continue
+		}
+		matrixUserID, err := r.resolveHumanMatrixUserID(human)
+		if err != nil {
+			log.FromContext(ctx).Info("human accessibleTeam member not ready",
+				"team", t.Name, "human", human.Name, "err", err.Error())
+			continue
+		}
+		if _, ok := seen[matrixUserID]; ok {
+			continue
+		}
+		t.Spec.HumanMembers = append(t.Spec.HumanMembers, v1beta1.TeamMemberSpec{
+			Name:         human.Name,
+			Role:         "coordinator",
+			MatrixUserID: matrixUserID,
+		})
+		seen[human.Name] = struct{}{}
+		seen[matrixUserID] = struct{}{}
+	}
+}
+
+func (r *TeamReconciler) syncTeamRoomHumanStatuses(ctx context.Context, namespace, teamName, roomID string, members []v1beta1.TeamMemberSpec) {
+	if roomID == "" {
+		return
+	}
+	var humans v1beta1.HumanList
+	if err := r.List(ctx, &humans, client.InNamespace(namespace)); err != nil {
+		log.FromContext(ctx).Error(err, "failed to list humans for team room status sync",
+			"team", teamName, "room", roomID)
+		return
+	}
+
+	desiredNames := make(map[string]struct{}, len(members))
+	desiredMatrixIDs := make(map[string]struct{}, len(members))
+	for _, member := range members {
+		if member.Name != "" {
+			desiredNames[member.Name] = struct{}{}
+		}
+		if member.MatrixUserID != "" {
+			desiredMatrixIDs[member.MatrixUserID] = struct{}{}
+		}
+	}
+
+	logger := log.FromContext(ctx)
+	for i := range humans.Items {
+		human := &humans.Items[i]
+		_, desiredByName := desiredNames[human.Name]
+		_, desiredByMatrixID := desiredMatrixIDs[human.Status.MatrixUserID]
+		desired := desiredByName || desiredByMatrixID || containsString(human.Spec.AccessibleTeams, teamName)
+		hasRoom := containsString(human.Status.Rooms, roomID)
+		if desired == hasRoom {
+			continue
+		}
+
+		base := human.DeepCopy()
+		if desired {
+			human.Status.Rooms = append(human.Status.Rooms, roomID)
+		} else {
+			human.Status.Rooms = removeString(human.Status.Rooms, roomID)
+		}
+		if err := r.Status().Patch(ctx, human, client.MergeFrom(base)); err != nil {
+			logger.Error(err, "failed to sync human team room status",
+				"team", teamName, "human", human.Name, "room", roomID)
+		}
+	}
+}
+
+func (r *TeamReconciler) resolveHumanMatrixUserID(human *v1beta1.Human) (string, error) {
+	if human.Status.MatrixUserID != "" {
+		return human.Status.MatrixUserID, nil
+	}
+	humanProv, ok := r.Provisioner.(service.HumanProvisioner)
+	if !ok {
+		return "", fmt.Errorf("human %s requires HumanProvisioner support", human.Name)
+	}
+	identity, err := humanidentity.ResolveHuman(&human.Spec, human.Name, humanidentity.Deps{Provisioner: humanProv})
+	if err != nil {
+		return "", err
+	}
+	if human.Spec.IdentitySource != nil {
+		return "", fmt.Errorf("human %s uses an external identity source but is not provisioned yet", human.Name)
+	}
+	return identity.MatrixUserID, nil
 }
 
 // resolveHumanMemberMatrixUserID returns the authoritative Matrix user ID for
@@ -294,6 +402,7 @@ func (r *TeamReconciler) reconcileTeamLegacy(ctx context.Context, t *v1beta1.Tea
 	}
 	t.Status.TeamRoomID = rooms.TeamRoomID
 	t.Status.LeaderDMRoomID = rooms.LeaderDMRoomID
+	r.syncTeamRoomHumanStatuses(ctx, t.Namespace, t.Name, rooms.TeamRoomID, derivedTeam.Spec.HumanMembers)
 
 	if err := r.Deployer.EnsureTeamStorage(ctx, teamRuntimeName); err != nil {
 		logger.Error(err, "team shared storage init failed (non-fatal)", "name", t.Name, "teamName", teamRuntimeName)
@@ -1028,6 +1137,7 @@ func (r *TeamReconciler) reconcileTeamDecoupled(ctx context.Context, t *v1beta1.
 	}
 	t.Status.TeamRoomID = rooms.TeamRoomID
 	t.Status.LeaderDMRoomID = rooms.LeaderDMRoomID
+	r.syncTeamRoomHumanStatuses(ctx, t.Namespace, t.Name, rooms.TeamRoomID, derivedTeam.Spec.HumanMembers)
 
 	if err := r.Deployer.EnsureTeamStorage(ctx, teamRuntimeName); err != nil {
 		logger.Error(err, "team shared storage init failed (non-fatal)", "name", t.Name, "teamName", teamRuntimeName)
@@ -1672,6 +1782,7 @@ func (r *TeamReconciler) handleDeleteDecoupled(ctx context.Context, t *v1beta1.T
 	logger := log.FromContext(ctx)
 	logger.Info("deleting team (decoupled)", "name", t.Name)
 	teamRuntimeName := t.Spec.EffectiveTeamName(t.Name)
+	r.syncTeamRoomHumanStatuses(ctx, t.Namespace, "", t.Status.TeamRoomID, nil)
 
 	// Revert each member's coordination context to standalone.
 	for _, ref := range t.Spec.WorkerMembers {
@@ -1937,6 +2048,25 @@ func pruneMembers(s *v1beta1.TeamStatus, keep map[string]struct{}) {
 		s.Members[i] = v1beta1.TeamMemberStatus{}
 	}
 	s.Members = filtered
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func removeString(values []string, target string) []string {
+	filtered := values[:0]
+	for _, value := range values {
+		if value != target {
+			filtered = append(filtered, value)
+		}
+	}
+	return filtered
 }
 
 // sortMembers orders Members by Name for stable status patches and

--- a/hiclaw-controller/internal/controller/team_controller_test.go
+++ b/hiclaw-controller/internal/controller/team_controller_test.go
@@ -875,6 +875,83 @@ func TestReconcileTeamDecoupled_QwenPawProjectsRuntimeRoster(t *testing.T) {
 	}
 }
 
+func TestReconcileTeamDecoupled_SyncsAccessibleTeamHumanStatus(t *testing.T) {
+	leaderWorker := &v1beta1.Worker{
+		ObjectMeta: metav1.ObjectMeta{Name: "lead", Namespace: "default"},
+		Spec:       v1beta1.WorkerSpec{Runtime: "qwenpaw", Model: "qwen"},
+		Status: v1beta1.WorkerStatus{
+			Phase:        "Running",
+			MatrixUserID: "@lead:matrix.local",
+			RoomID:       "!room-lead:matrix.local",
+		},
+	}
+	worker1 := &v1beta1.Worker{
+		ObjectMeta: metav1.ObjectMeta{Name: "dev", Namespace: "default"},
+		Spec:       v1beta1.WorkerSpec{Runtime: "qwenpaw", Model: "qwen"},
+		Status: v1beta1.WorkerStatus{
+			Phase:        "Running",
+			MatrixUserID: "@dev:matrix.local",
+			RoomID:       "!room-dev:matrix.local",
+		},
+	}
+	alice := &v1beta1.Human{
+		ObjectMeta: metav1.ObjectMeta{Name: "alice", Namespace: "default"},
+		Spec:       v1beta1.HumanSpec{AccessibleTeams: []string{"team-a"}},
+		Status: v1beta1.HumanStatus{
+			Phase:        "Active",
+			MatrixUserID: "@alice:matrix.local",
+		},
+	}
+	bob := &v1beta1.Human{
+		ObjectMeta: metav1.ObjectMeta{Name: "bob", Namespace: "default"},
+		Status: v1beta1.HumanStatus{
+			Phase:        "Active",
+			MatrixUserID: "@bob:matrix.local",
+			Rooms:        []string{"!team-team-a:localhost", "!room-bob:matrix.local"},
+		},
+	}
+	team := &v1beta1.Team{
+		ObjectMeta: metav1.ObjectMeta{Name: "team-a", Namespace: "default"},
+		Spec: v1beta1.TeamSpec{
+			WorkerMembers: []v1beta1.TeamWorkerRef{
+				{Name: "lead", Role: "team_leader"},
+				{Name: "dev"},
+			},
+		},
+	}
+	rig := newTeamReconcileRig(t, team, leaderWorker, worker1, alice, bob)
+
+	if _, _, err := rig.reconcile("team-a"); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(rig.provisioner.Calls.ProvisionTeamRooms) != 1 {
+		t.Fatalf("ProvisionTeamRooms calls=%d, want 1", len(rig.provisioner.Calls.ProvisionTeamRooms))
+	}
+	members := rig.provisioner.Calls.ProvisionTeamRooms[0].HumanMembers
+	if len(members) != 1 || members[0].Name != "alice" || members[0].MatrixUserID != "@alice:matrix.local" {
+		t.Fatalf("HumanMembers=%+v, want alice from Human.spec.accessibleTeams", members)
+	}
+
+	var aliceOut v1beta1.Human
+	if err := rig.client.Get(context.Background(), types.NamespacedName{Name: "alice", Namespace: "default"}, &aliceOut); err != nil {
+		t.Fatalf("get alice: %v", err)
+	}
+	if !stringSliceContains(aliceOut.Status.Rooms, "!team-team-a:localhost") {
+		t.Fatalf("alice Status.Rooms=%v, want team room", aliceOut.Status.Rooms)
+	}
+
+	var bobOut v1beta1.Human
+	if err := rig.client.Get(context.Background(), types.NamespacedName{Name: "bob", Namespace: "default"}, &bobOut); err != nil {
+		t.Fatalf("get bob: %v", err)
+	}
+	if stringSliceContains(bobOut.Status.Rooms, "!team-team-a:localhost") {
+		t.Fatalf("bob Status.Rooms=%v, want stale team room removed", bobOut.Status.Rooms)
+	}
+	if !stringSliceContains(bobOut.Status.Rooms, "!room-bob:matrix.local") {
+		t.Fatalf("bob Status.Rooms=%v, want unrelated room preserved", bobOut.Status.Rooms)
+	}
+}
+
 func TestReconcileTeamDecoupled_EdgeMergesRuntimeTeamContext(t *testing.T) {
 	ctx := context.Background()
 	edgeMode := v1beta1.DeployModeEdge


### PR DESCRIPTION
## Summary
- treat Human.spec.accessibleTeams as Team human membership input
- sync Team room IDs into matching Human.status.rooms after Team room provisioning
- remove stale Team room status from Humans that are no longer desired Team members

## Validation
- git diff --check
- go test ./internal/controller (from hiclaw-controller)

Split from the refreshed internal/open-source diff based on codex/sync-opensource-main-20260701 @ 0bf155a2.