### PR TITLE
feat(qwenpaw): add worker runtime image

### DIFF
--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       targets:
-        description: 'Space-separated list of push targets (default: all). Options: openclaw-base hiclaw-controller embedded manager manager-copaw worker copaw-worker hermes-worker'
+        description: 'Space-separated list of push targets (default: all). Options: openclaw-base hiclaw-controller embedded manager manager-copaw worker copaw-worker hermes-worker qwenpaw-worker'
         required: false
         type: string
         default: 'all'
@@ -83,7 +83,7 @@ jobs:
 
       - name: Build and push multi-arch images
         run: |
-          make push-manager push-manager-copaw push-worker push-copaw-worker push-hermes-worker push-hiclaw-controller push-embedded \
+          make push-manager push-manager-copaw push-worker push-copaw-worker push-hermes-worker push-qwenpaw-worker push-hiclaw-controller push-embedded \
             VERSION=${{ inputs.version }} \
             OPENCLAW_BASE_VERSION=${{ inputs.version }} \
             REGISTRY=${{ env.REGISTRY }} \
@@ -99,6 +99,7 @@ jobs:
           WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-worker
           COPAW_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-copaw-worker
           HERMES_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-hermes-worker
+          QWENPAW_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-qwenpaw-worker
           CONTROLLER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-controller
           EMBEDDED_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-embedded
         run: |
@@ -111,6 +112,7 @@ jobs:
           echo "- Worker: \`${WORKER_IMAGE}:${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- CoPaw Worker: \`${COPAW_WORKER_IMAGE}:${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Hermes Worker: \`${HERMES_WORKER_IMAGE}:${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- QwenPaw Worker: \`${QWENPAW_WORKER_IMAGE}:${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Controller: \`${CONTROLLER_IMAGE}:${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Embedded: \`${EMBEDDED_IMAGE}:${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Base (RC): \`${BASE_IMAGE}:${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
       targets:
-        description: 'Space-separated list of push targets (default: all). Options: openclaw-base hiclaw-controller embedded manager manager-copaw worker copaw-worker hermes-worker'
+        description: 'Space-separated list of push targets (default: all). Options: openclaw-base hiclaw-controller embedded manager manager-copaw worker copaw-worker hermes-worker qwenpaw-worker'
         required: false
         type: string
         default: 'all'
@@ -117,13 +117,15 @@ jobs:
           ${{ steps.meta.outputs.targets == 'all' ||
               contains(steps.meta.outputs.targets, 'worker') ||
               contains(steps.meta.outputs.targets, 'copaw-worker') ||
-              contains(steps.meta.outputs.targets, 'hermes-worker') }}
+              contains(steps.meta.outputs.targets, 'hermes-worker') ||
+              contains(steps.meta.outputs.targets, 'qwenpaw-worker') }}
         run: |
           TARGETS="${{ steps.meta.outputs.targets }}"
           MAKE_TARGETS=""
           if [ "${TARGETS}" = "all" ] || echo "${TARGETS}" | grep -qw worker; then MAKE_TARGETS="${MAKE_TARGETS} push-worker"; fi
           if [ "${TARGETS}" = "all" ] || echo "${TARGETS}" | grep -qw copaw-worker; then MAKE_TARGETS="${MAKE_TARGETS} push-copaw-worker"; fi
           if [ "${TARGETS}" = "all" ] || echo "${TARGETS}" | grep -qw hermes-worker; then MAKE_TARGETS="${MAKE_TARGETS} push-hermes-worker"; fi
+          if [ "${TARGETS}" = "all" ] || echo "${TARGETS}" | grep -qw qwenpaw-worker; then MAKE_TARGETS="${MAKE_TARGETS} push-qwenpaw-worker"; fi
           make ${MAKE_TARGETS} \
             VERSION=${{ steps.meta.outputs.version }} \
             REGISTRY=${{ env.REGISTRY }} \
@@ -141,6 +143,7 @@ jobs:
           WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-worker
           COPAW_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-copaw-worker
           HERMES_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-hermes-worker
+          QWENPAW_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-qwenpaw-worker
           CONTROLLER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-controller
           EMBEDDED_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-embedded
         run: |
@@ -154,6 +157,7 @@ jobs:
           echo "- Worker: \`${WORKER_IMAGE}:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
           echo "- CoPaw Worker: \`${COPAW_WORKER_IMAGE}:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Hermes Worker: \`${HERMES_WORKER_IMAGE}:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- QwenPaw Worker: \`${QWENPAW_WORKER_IMAGE}:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Controller: \`${CONTROLLER_IMAGE}:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Embedded: \`${EMBEDDED_IMAGE}:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Base: \`${OPENCLAW_BASE_IMAGE}:latest\` (pre-built, not rebuilt here)" >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ MANAGER_COPAW_IMAGE  ?= $(REGISTRY)/$(REPO)/hiclaw-manager-copaw
 WORKER_IMAGE         ?= $(REGISTRY)/$(REPO)/hiclaw-worker
 COPAW_WORKER_IMAGE   ?= $(REGISTRY)/$(REPO)/hiclaw-copaw-worker
 HERMES_WORKER_IMAGE  ?= $(REGISTRY)/$(REPO)/hiclaw-hermes-worker
+QWENPAW_WORKER_IMAGE ?= $(REGISTRY)/$(REPO)/hiclaw-qwenpaw-worker
 OPENHUMAN_WORKER_IMAGE ?= $(REGISTRY)/$(REPO)/hiclaw-openhuman-worker
 OPENCLAW_BASE_IMAGE  ?= $(REGISTRY)/$(REPO)/openclaw-base
 CONTROLLER_IMAGE     ?= $(REGISTRY)/$(REPO)/hiclaw-controller
@@ -39,6 +40,7 @@ MANAGER_COPAW_TAG  ?= $(MANAGER_COPAW_IMAGE):$(VERSION)
 WORKER_TAG         ?= $(WORKER_IMAGE):$(VERSION)
 COPAW_WORKER_TAG   ?= $(COPAW_WORKER_IMAGE):$(VERSION)
 HERMES_WORKER_TAG  ?= $(HERMES_WORKER_IMAGE):$(VERSION)
+QWENPAW_WORKER_TAG ?= $(QWENPAW_WORKER_IMAGE):$(VERSION)
 OPENHUMAN_WORKER_TAG ?= $(OPENHUMAN_WORKER_IMAGE):$(VERSION)
 OPENCLAW_BASE_TAG  ?= $(OPENCLAW_BASE_IMAGE):$(VERSION)
 CONTROLLER_TAG     ?= $(CONTROLLER_IMAGE):$(VERSION)
@@ -50,6 +52,7 @@ LOCAL_MANAGER_COPAW  = hiclaw/hiclaw-manager-copaw:$(VERSION)
 LOCAL_WORKER         = hiclaw/worker-agent:$(VERSION)
 LOCAL_COPAW_WORKER   = hiclaw/copaw-worker:$(VERSION)
 LOCAL_HERMES_WORKER  = hiclaw/hermes-worker:$(VERSION)
+LOCAL_QWENPAW_WORKER = hiclaw/qwenpaw-worker:$(VERSION)
 LOCAL_OPENHUMAN_WORKER = hiclaw/openhuman-worker:$(VERSION)
 LOCAL_OPENCLAW_BASE  = hiclaw/openclaw-base:$(VERSION)
 LOCAL_CONTROLLER     = hiclaw/hiclaw-controller:$(VERSION)
@@ -105,8 +108,11 @@ LINES          ?= 50
 # ---------- Phony targets ----------
 
 .PHONY: all build build-openclaw-base build-hiclaw-controller build-embedded build-manager build-manager-copaw build-worker build-copaw-worker build-hermes-worker build-openhuman-worker \
+        build-qwenpaw-worker \
         tag push push-openclaw-base push-hiclaw-controller push-embedded push-manager push-manager-copaw push-worker push-copaw-worker push-hermes-worker push-openhuman-worker \
+        push-qwenpaw-worker \
         push-native push-native-manager push-native-manager-copaw push-native-worker push-native-copaw-worker push-native-hermes-worker push-native-openhuman-worker \
+        push-native-qwenpaw-worker \
         buildx-setup \
         test test-quick test-installed test-embedded \
         install install-embedded uninstall uninstall-embedded replay replay-log \
@@ -121,7 +127,7 @@ all: build
 
 # ---------- Build ----------
 
-build: build-manager build-manager-copaw build-worker build-copaw-worker build-hermes-worker build-openhuman-worker build-hiclaw-controller ## Build all images (base image pulled from registry, not rebuilt locally)
+build: build-manager build-manager-copaw build-worker build-copaw-worker build-hermes-worker build-openhuman-worker build-qwenpaw-worker build-hiclaw-controller ## Build all images (base image pulled from registry, not rebuilt locally)
 
 build-openclaw-base: ## Build OpenClaw base image
 	@echo "==> Building OpenClaw base image: $(LOCAL_OPENCLAW_BASE) (registry: $(HIGRESS_REGISTRY))"
@@ -192,6 +198,15 @@ build-openhuman-worker: ## Build OpenHuman Worker image (Rust + native Matrix)
 		-t $(LOCAL_OPENHUMAN_WORKER) \
 		-f openhuman/Dockerfile .
 
+build-qwenpaw-worker: ## Build QwenPaw Worker image
+	@echo "==> Building QwenPaw Worker image: $(LOCAL_QWENPAW_WORKER) (registry: $(HIGRESS_REGISTRY))"
+	OUT_DIR=dist/adapters/qwenpaw ruby plugins/teamharness/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb plugins/teamharness/plugin.yaml >/dev/null
+	OUT_DIR=dist/adapters/qwenpaw ruby plugins/workerflow/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb plugins/workerflow/plugin.yaml >/dev/null
+	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
+		-f qwenpaw/Dockerfile \
+		-t $(LOCAL_QWENPAW_WORKER) \
+		.
+
 # ---------- Tag ----------
 
 tag: build ## Tag images for registry push
@@ -200,12 +215,14 @@ tag: build ## Tag images for registry push
 	docker tag $(LOCAL_COPAW_WORKER) $(COPAW_WORKER_TAG)
 	docker tag $(LOCAL_HERMES_WORKER) $(HERMES_WORKER_TAG)
 	docker tag $(LOCAL_OPENHUMAN_WORKER) $(OPENHUMAN_WORKER_TAG)
+	docker tag $(LOCAL_QWENPAW_WORKER) $(QWENPAW_WORKER_TAG)
 ifeq ($(PUSH_LATEST),yes)
 	docker tag $(LOCAL_MANAGER) $(MANAGER_IMAGE):latest
 	docker tag $(LOCAL_WORKER) $(WORKER_IMAGE):latest
 	docker tag $(LOCAL_COPAW_WORKER) $(COPAW_WORKER_IMAGE):latest
 	docker tag $(LOCAL_HERMES_WORKER) $(HERMES_WORKER_IMAGE):latest
 	docker tag $(LOCAL_OPENHUMAN_WORKER) $(OPENHUMAN_WORKER_IMAGE):latest
+	docker tag $(LOCAL_QWENPAW_WORKER) $(QWENPAW_WORKER_IMAGE):latest
 	docker tag $(LOCAL_CONTROLLER) $(CONTROLLER_IMAGE):latest
 	@echo "==> Images tagged as $(VERSION) and latest"
 else
@@ -234,7 +251,7 @@ else
 	fi
 endif
 
-push: push-manager push-manager-copaw push-worker push-copaw-worker push-hermes-worker push-hiclaw-controller push-embedded ## Build + push multi-arch images (amd64 + arm64); base image built separately via build-base.yml
+push: push-manager push-manager-copaw push-worker push-copaw-worker push-hermes-worker push-openhuman-worker push-qwenpaw-worker push-hiclaw-controller push-embedded ## Build + push multi-arch images (amd64 + arm64); base image built separately via build-base.yml
 
 push-openclaw-base: buildx-setup ## Build + push multi-arch OpenClaw base image
 	@echo "==> Building + pushing multi-arch OpenClaw base: $(OPENCLAW_BASE_TAG) [$(MULTIARCH_PLATFORMS)]"
@@ -456,6 +473,33 @@ else
 		./hermes/
 endif
 
+push-qwenpaw-worker: buildx-setup ## Build + push multi-arch QwenPaw Worker image
+	@echo "==> Building + pushing multi-arch QwenPaw Worker: $(QWENPAW_WORKER_TAG) [$(MULTIARCH_PLATFORMS)]"
+	OUT_DIR=dist/adapters/qwenpaw ruby plugins/teamharness/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb plugins/teamharness/plugin.yaml >/dev/null
+	OUT_DIR=dist/adapters/qwenpaw ruby plugins/workerflow/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb plugins/workerflow/plugin.yaml >/dev/null
+ifeq ($(IS_PODMAN),1)
+	-podman manifest rm $(QWENPAW_WORKER_TAG) 2>/dev/null
+	$(foreach plat,$(subst $(comma), ,$(MULTIARCH_PLATFORMS)), \
+		echo "  -> Building QwenPaw Worker for $(plat)..." && \
+		podman build --platform $(plat) \
+			$(REGISTRY_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
+			--manifest $(QWENPAW_WORKER_TAG) \
+			-f qwenpaw/Dockerfile . && ) true
+	podman manifest push --all $(QWENPAW_WORKER_TAG) docker://$(QWENPAW_WORKER_TAG)
+	$(if $(PUSH_LATEST), \
+		podman manifest push --all $(QWENPAW_WORKER_TAG) docker://$(QWENPAW_WORKER_IMAGE):latest && \
+		echo "  -> Also pushed :latest tag")
+else
+	docker buildx build \
+		--builder $(BUILDX_BUILDER) \
+		--platform $(MULTIARCH_PLATFORMS) \
+		$(REGISTRY_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
+		-t $(QWENPAW_WORKER_TAG) \
+		$(if $(PUSH_LATEST),-t $(QWENPAW_WORKER_IMAGE):latest) \
+		--push \
+		-f qwenpaw/Dockerfile .
+endif
+
 # ---------- Push native-arch only (dev use) ----------
 # WARNING: Pushing single-arch images will overwrite multi-arch manifests.
 # Only use for local development / testing, never for release.
@@ -470,11 +514,14 @@ push-native: tag ## Push native-arch images (dev only, overwrites multi-arch!)
 	docker push $(COPAW_WORKER_TAG)
 	@echo "==> Pushing Hermes Worker: $(HERMES_WORKER_TAG)"
 	docker push $(HERMES_WORKER_TAG)
+	@echo "==> Pushing QwenPaw Worker: $(QWENPAW_WORKER_TAG)"
+	docker push $(QWENPAW_WORKER_TAG)
 ifeq ($(PUSH_LATEST),yes)
 	docker push $(MANAGER_IMAGE):latest
 	docker push $(WORKER_IMAGE):latest
 	docker push $(COPAW_WORKER_IMAGE):latest
 	docker push $(HERMES_WORKER_IMAGE):latest
+	docker push $(QWENPAW_WORKER_IMAGE):latest
 endif
 
 push-native-manager: build-manager ## Push native-arch Manager only (dev)
@@ -500,6 +547,10 @@ push-native-hermes-worker: build-hermes-worker ## Push native-arch Hermes Worker
 push-native-openhuman-worker: build-openhuman-worker ## Push native-arch OpenHuman Worker only (dev)
 	docker tag $(LOCAL_OPENHUMAN_WORKER) $(OPENHUMAN_WORKER_TAG)
 	docker push $(OPENHUMAN_WORKER_TAG)
+
+push-native-qwenpaw-worker: build-qwenpaw-worker ## Push native-arch QwenPaw Worker only (dev)
+	docker tag $(LOCAL_QWENPAW_WORKER) $(QWENPAW_WORKER_TAG)
+	docker push $(QWENPAW_WORKER_TAG)
 
 # ---------- Test ----------
 

--- a/qwenpaw/Dockerfile
+++ b/qwenpaw/Dockerfile
@@ -1,0 +1,134 @@
+# ============================================================
+# HiClaw QwenPaw Worker - Python-based Container
+# ============================================================
+# Lightweight Python container for running QwenPaw-based Worker Agents.
+# Uses the same MinIO-backed config/sync model as CoPaw workers, but reads
+# controller-projected runtime.yaml as the worker contract.
+#
+# Build args:
+#   HIGRESS_REGISTRY  - base image registry for mc (MinIO Client)
+#   APT_MIRROR        - Debian mirror
+#   PIP_INDEX_URL     - PyPI mirror
+#   QWENPAW_PIP_SPEC  - QwenPaw package spec to install from PyPI
+#   NPM_REGISTRY      - npm mirror
+# ============================================================
+
+ARG HIGRESS_REGISTRY=higress-registry.cn-hangzhou.cr.aliyuncs.com
+
+# ============ Stage 1: mc (MinIO Client) ============
+FROM ${HIGRESS_REGISTRY}/higress/mc:20260216 AS mc
+
+# ============ Final Image ============
+FROM ${HIGRESS_REGISTRY}/higress/python:3.11-slim
+
+ARG APT_MIRROR=
+ARG PIP_INDEX_URL=https://pypi.org/simple/
+ARG PIP_TIMEOUT=300
+ARG QWENPAW_PIP_SPEC=qwenpaw==1.1.11
+ARG NPM_REGISTRY=https://registry.npmjs.org/
+
+RUN if [ -n "${APT_MIRROR}" ]; then \
+        sed -i "s|deb.debian.org|${APT_MIRROR}|g" \
+            /etc/apt/sources.list.d/debian.sources 2>/dev/null || true; \
+    fi && \
+    apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        jq \
+        libjemalloc2 \
+        nodejs \
+        npm \
+        socat \
+        tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+# jemalloc reduces Python memory fragmentation and matches the CoPaw worker base.
+RUN JEMALLOC=$(find /usr/lib -name 'libjemalloc.so.2' -print -quit) \
+    && echo "LD_PRELOAD=${JEMALLOC}" >> /etc/environment \
+    && echo "${JEMALLOC}" > /etc/ld.so.preload
+
+# mc (MinIO Client) - real binary; wrapper installed after shared libs are copied.
+COPY --from=mc /usr/bin/mc /usr/local/bin/mc.bin
+
+# Stage qwenpaw-worker dependency metadata only (src/ copied later for layer caching).
+COPY qwenpaw/pyproject.toml qwenpaw/README.md /tmp/qwenpaw-worker/
+RUN mkdir -p /tmp/qwenpaw-worker/src/qwenpaw_worker && \
+    echo '__version__ = "0.0.0"' > /tmp/qwenpaw-worker/src/qwenpaw_worker/__init__.py
+
+# Single venv: qwenpaw runtime + qwenpaw-worker.
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    python -m venv /opt/venv/qwenpaw \
+    && /opt/venv/qwenpaw/bin/pip install \
+        --retries 5 \
+        --timeout "${PIP_TIMEOUT}" \
+        --index-url "${PIP_INDEX_URL}" \
+        --trusted-host "$(echo ${PIP_INDEX_URL} | sed -E 's|^https?://||;s|/.*||')" \
+        "${QWENPAW_PIP_SPEC}" \
+    && /opt/venv/qwenpaw/bin/pip install \
+        --retries 5 \
+        --timeout "${PIP_TIMEOUT}" \
+        --index-url "${PIP_INDEX_URL}" \
+        --trusted-host "$(echo ${PIP_INDEX_URL} | sed -E 's|^https?://||;s|/.*||')" \
+        /tmp/qwenpaw-worker/
+
+RUN /opt/venv/qwenpaw/bin/pip install \
+        --retries 5 \
+        --timeout "${PIP_TIMEOUT}" \
+        --index-url "${PIP_INDEX_URL}" \
+        --trusted-host "$(echo ${PIP_INDEX_URL} | sed -E 's|^https?://||;s|/.*||')" \
+        "wrapt<2.0" \
+        loongsuite-site-bootstrap==0.6.1 \
+        loongsuite-distro==0.6.0 \
+        loongsuite-otel-util-genai==0.6.1 \
+        loongsuite-instrumentation-qwenpaw==0.6.1 \
+        loongsuite-instrumentation-agentscope==0.6.1 \
+        opentelemetry-exporter-otlp
+
+# Keep Node CLI tooling out of the qwenpaw pip dependency cache key.
+RUN npm config set registry ${NPM_REGISTRY} && \
+    npm install -g mcporter skills @nacos-group/cli@1.1.2 && \
+    rm -rf /root/.npm
+
+# Overlay HiClaw Matrix channel behavior while keeping QwenPaw as the base runtime.
+COPY qwenpaw/src/matrix/ /tmp/qwenpaw-matrix-overlay/
+RUN SITE=/opt/venv/qwenpaw/lib/python3.11/site-packages && \
+    cp -a /tmp/qwenpaw-matrix-overlay/channel.py "$SITE/qwenpaw/app/channels/matrix/channel.py" && \
+    rm -rf /tmp/qwenpaw-matrix-overlay
+
+# Overlay real qwenpaw-worker source without rebuilding the dependency-heavy venv.
+COPY qwenpaw/src/ /tmp/qwenpaw-worker/src/
+RUN SITE=/opt/venv/qwenpaw/lib/python3.11/site-packages && \
+    cp -a /tmp/qwenpaw-worker/src/qwenpaw_worker/* "$SITE/qwenpaw_worker/" && \
+    rm -rf /tmp/qwenpaw-worker
+
+# Opaque QwenPaw plugin artifacts. Each plugin build owns its contents.
+RUN mkdir -p /opt/hiclaw/plugins
+COPY dist/adapters/qwenpaw/teamharness-qwenpaw.zip /opt/hiclaw/plugins/teamharness-qwenpaw.zip
+COPY dist/adapters/qwenpaw/workerflow-qwenpaw.zip /opt/hiclaw/plugins/workerflow-qwenpaw.zip
+COPY qwenpaw/scripts/install-builtin-qwenpaw-plugins.py /tmp/install-builtin-qwenpaw-plugins.py
+RUN /opt/venv/qwenpaw/bin/python /tmp/install-builtin-qwenpaw-plugins.py \
+        --working-dir /opt/hiclaw/qwenpaw-builtin \
+        /opt/hiclaw/plugins/teamharness-qwenpaw.zip \
+        /opt/hiclaw/plugins/workerflow-qwenpaw.zip \
+    && rm -f /tmp/install-builtin-qwenpaw-plugins.py
+
+# Enable QwenPaw's native deferred MCP startup for app workspaces.
+COPY qwenpaw/scripts/patch-qwenpaw-defer-mcp-startup.py /tmp/patch-qwenpaw-defer-mcp-startup.py
+RUN /opt/venv/qwenpaw/bin/python /tmp/patch-qwenpaw-defer-mcp-startup.py && \
+    rm -f /tmp/patch-qwenpaw-defer-mcp-startup.py
+
+COPY --chmod=755 qwenpaw/scripts/qwenpaw-worker-entrypoint.sh /opt/hiclaw/scripts/qwenpaw-worker-entrypoint.sh
+COPY --chmod=755 qwenpaw/scripts/qwenpaw-teamharness-plugin-reload.sh /opt/hiclaw/scripts/qwenpaw-teamharness-plugin-reload.sh
+COPY --from=shared . /opt/hiclaw/scripts/lib/
+
+# mc wrapper: auto-refreshes STS credentials before every mc invocation.
+RUN chmod +x /opt/hiclaw/scripts/lib/mc-wrapper.sh && \
+    ln -sf /opt/hiclaw/scripts/lib/mc-wrapper.sh /usr/local/bin/mc && \
+    ln -sf /opt/venv/qwenpaw/bin/qwenpaw /usr/local/bin/qwenpaw && \
+    ln -sf /opt/venv/qwenpaw/bin/qwenpaw-worker /usr/local/bin/qwenpaw-worker && \
+    ln -sf /opt/hiclaw/scripts/qwenpaw-teamharness-plugin-reload.sh /usr/local/bin/qwenpaw-teamharness-plugin-reload && \
+    mkdir -p /root/hiclaw-fs/agents
+
+WORKDIR /root/hiclaw-fs/agents
+
+ENTRYPOINT ["/opt/hiclaw/scripts/qwenpaw-worker-entrypoint.sh"]

--- a/qwenpaw/README.md
+++ b/qwenpaw/README.md
@@ -1,24 +1,183 @@
 # AgentTeams QwenPaw Worker Runtime
 
-This package contains the QwenPaw worker runtime baseline for AgentTeams.
+This directory contains the AgentTeams managed worker runtime for QwenPaw.
 
-The package owns the local runtime lifecycle:
+QwenPaw is integrated as a worker runtime through two pieces.
 
-- prepare the QwenPaw working directory and default workspace
-- restore and persist eligible worker files through object storage
-- apply `runtime.yaml` model, MCP, Matrix, DingTalk, and AgentSpec package changes
-- maintain local QwenPaw health state and controller readiness/heartbeat reports
-- overlay QwenPaw Matrix behavior for AgentTeams startup readiness, first-sync stability, invite auto-join, and mention compatibility
+The worker daemon owns the managed-runtime lifecycle. The plugin adapter owns
+the QwenPaw-specific mapping of TeamHarness assets and runtime wrappers. Keeping these two
+pieces separate is the main boundary of this integration.
 
-The package intentionally does not wire the runtime into controller/Helm
-selection, build the worker image, package TeamHarness/WorkerFlow adapter
-artifacts, or implement remote-worker credential/JWT flows. Those integration
-surfaces are separate PR scopes.
+## 1. Worker Daemon
 
-## Development
+The worker daemon is the process started by the QwenPaw worker container. Its
+job is to keep local QwenPaw runtime files aligned with the
+controller-projected desired state.
 
-Run the focused unit suite with:
+### 1.1 Lifecycle
+
+- Start from AgentTeams environment variables and worker arguments.
+- Prepare the QwenPaw working directory and default workspace.
+- Prepare image-bundled TeamHarness and WorkerFlow QwenPaw plugin adapters.
+- Start the QwenPaw app process.
+- Stop background tasks and the QwenPaw process on shutdown.
+
+### 1.2 Storage Sync
+
+- Restore worker and shared files from object storage on startup.
+- Persist eligible local runtime changes back to object storage.
+- Exclude credentials, shared projections, logs, tool results,
+  media, file store, and other runtime cache paths from background push.
+
+### 1.3 Desired-State Apply
+
+- Pull and read `agents/{memberName}/runtime/runtime.yaml` from object
+  storage.
+- Run the desired-state apply loop every 5 seconds.
+- Apply model, MCP, channel, TeamHarness prompt asset, and AgentSpec package changes from
+  `runtime.yaml`.
+- Apply `desired.model` to the active QwenPaw agent model.
+- Apply `desired.mcpServers` to `config/mcporter.json` using the mcporter JSON
+  shape, not as QwenPaw MCP clients.
+- Apply `desired.channelPolicy` to QwenPaw Matrix access control.
+- Apply `desired.channels.dingtalk` to the active QwenPaw DingTalk channel.
+  When `streaming_enabled` is true, the worker requires a pre-created
+  DingTalk streaming card template id and switches the current DingTalk runtime
+  config to card streaming mode.
+- Apply AgentSpec package changes inside the same desired-state loop, without
+  restarting the pod.
+- Apply AgentSpec package `config/` files to the active QwenPaw workspace root
+  and package `skills/` to workspace skills, then reconcile QwenPaw `skill.json`.
+
+`desired.mcpServers` and package `mcp.json` are intentionally separate:
+
+- `desired.mcpServers` is controller-projected runtime config and updates
+  `config/mcporter.json` for the `mcporter` CLI.
+- Package `mcp.json` configures QwenPaw-native MCP clients. Its canonical shape
+  matches mcporter config: `{"mcpServers": {"name": {...}}}`. Legacy package
+  shapes (`{"clients": {...}}`, `{"mcp": {"clients": {...}}}`, and top-level
+  server maps) are still read for compatibility.
+  See `../docs/zh-cn/qwenpaw-mcp-json.md` for the user-facing package authoring
+  guide.
+
+### 1.4 Heartbeat
+
+- Maintain local `heartbeat.json` for QwenPaw process/API reachability.
+- Use QwenPaw's native `/api/version` endpoint as the process health probe.
+- Report readiness once to `POST /api/v1/workers/{name}/ready` after QwenPaw
+  becomes reachable.
+- Report periodic heartbeat to `POST /api/v1/workers/{name}/heartbeat`.
+- Use QwenPaw's `GET /api/agents/default/agent-status` runtime status API for
+  `lastActiveAt`: running agents report the current heartbeat time, idle agents
+  report the latest `last_finish_at` / `last_run_at` value.
+- Discover controller reporting config from `AGENTTEAMS_CONTROLLER_URL`,
+  `AGENTTEAMS_AUTH_TOKEN` or `AGENTTEAMS_AUTH_TOKEN_FILE`, and optional
+  `AGENTTEAMS_CLUSTER_ID`.
+- Keep controller reporting as a bypass path: report failures are logged but do
+  not block storage sync, desired-state apply, or QwenPaw runtime loops.
+
+### 1.5 Matrix Channel Overlay
+
+- Apply Matrix channel configuration and access control from `runtime.yaml`
+  through the desired-state update loop.
+- Keep runtime behavior fixes in the QwenPaw Matrix overlay, not in TeamHarness
+  hooks.
+- The overlay preserves QwenPaw Matrix support while adding AgentTeams startup
+  readiness, first-sync stability, invite auto-join, and visible Matrix mention
+  compatibility.
+
+The daemon does not implement TeamHarness collaboration semantics. It triggers
+runtime apply and storage persistence, then delegates TeamHarness-specific
+QwenPaw integration to the adapter.
+
+### 1.6 DingTalk Streaming Card Mode
+
+The worker consumes `desired.channels.dingtalk` from `runtime.yaml`. When
+`streaming_enabled: true`, the worker requires `client_id`, `client_secret`,
+`robot_code`, and `card_template_id`. The card template must be created and
+published in DingTalk Open Platform before the runtime config is applied.
+
+Enabling DingTalk streaming changes the current runtime card configuration to
+the configured streaming template id. Existing DingTalk card templates are not
+deleted from DingTalk, but the runtime stops using the previous custom template
+while streaming remains enabled. If streaming is later disabled and a custom
+card is needed again, configure that card template explicitly.
+
+`filter_thinking` and `filter_tool_messages` remain independent of the
+streaming switch: streaming controls the card transport, while those filters
+control whether reasoning and tool progress are shown by the underlying
+QwenPaw DingTalk channel.
+
+## 2. Plugin Adapter
+
+The default plugin adapters live under `plugins/teamharness/adapters/qwenpaw/`
+and `plugins/workerflow/adapters/qwenpaw/`. They are installed into an
+image-local QwenPaw working directory during Docker build, then prepared in the
+runtime QwenPaw working directory on startup and `runtime.yaml` reapply.
+
+### 2.1 Plugin Package
+
+- Package TeamHarness prompts, skills, MCP assets, and WorkerFlow assets into
+  QwenPaw plugins.
+- Install the packages through `qwenpaw plugin install --force` during Docker
+  image build.
+- Keep the QwenPaw plugin ids as `teamharness` and `workerflow`.
+
+### 2.2 TeamHarness Assets
+
+- Merge TeamHarness role prompts into workspace `TEAMS.md`.
+- Register TeamHarness skills for QwenPaw.
+- Register the TeamHarness MCP server for QwenPaw.
+
+### 2.3 Runtime Wrappers
+
+- Install `TEAMS.md` into each QwenPaw agent workspace and include it in the
+  prompt file list.
+- Redact sensitive tool output through the QwenPaw adapter sanitizer.
+- Keep the sanitizer adapter-private. TeamHarness base plugin does not define
+  runtime-neutral top-level hooks.
+
+## Image Integration Tests
+
+The image integration tests live under `qwenpaw/tests/integration/`. They use a
+real QwenPaw worker image and a real MinIO container, but they do not call a
+paid model API unless the real-model test is explicitly selected.
+
+Enable the image tests with:
 
 ```bash
-PYTHONPATH=qwenpaw/src python -m pytest qwenpaw/tests -q
+AGENTTEAMS_QWENPAW_IMAGE_E2E=1 qwenpaw/tests/integration/test-worker-daemon.sh
+AGENTTEAMS_QWENPAW_IMAGE_E2E=1 qwenpaw/tests/integration/test-sync-minio.sh
+AGENTTEAMS_QWENPAW_IMAGE_E2E=1 qwenpaw/tests/integration/test-update-runtime-config.sh
 ```
+
+Set `AGENTTEAMS_QWENPAW_IMAGE=agentteams/qwenpaw-worker:<tag>` to reuse an existing
+local image. Without that override, the scripts build a fresh image.
+
+- `test-worker-daemon.sh` verifies image startup, entrypoint wiring, QwenPaw API
+  readiness, TeamHarness adapter health, and local heartbeat readiness.
+- `test-sync-minio.sh` verifies startup mirror and background push boundaries
+  against MinIO.
+- `test-update-runtime-config.sh` verifies `runtime.yaml` hot apply for model,
+  MCP, Matrix channel policy, and AgentSpec package changes without restarting
+  the worker container.
+
+### Real Image And Model Test
+
+`qwenpaw/tests/integration/test-real-image-model-api.sh` is the narrow
+end-to-end tracer bullet for this runtime. It builds the QwenPaw worker image,
+starts a real MinIO-backed worker container, writes controller-style
+`runtime.yaml`, applies the model provider through the worker update loop, and
+calls a real model through QwenPaw.
+
+It is opt-in because it builds Docker images and calls a paid model API:
+
+```bash
+AGENTTEAMS_QWENPAW_REAL_MODEL_E2E=1 qwenpaw/tests/integration/test-real-image-model-api.sh
+```
+
+By default the test reads `AGENTTEAMS_LLM_API_KEY`, `AGENTTEAMS_OPENAI_BASE_URL`, and
+`AGENTTEAMS_DEFAULT_MODEL` from `${AGENTTEAMS_ENV_FILE:-$HOME/agentteams-manager.env}`.
+`AGENTTEAMS_QWENPAW_REAL_MODEL_API_KEY`,
+`AGENTTEAMS_QWENPAW_REAL_MODEL_BASE_URL`, and `AGENTTEAMS_QWENPAW_REAL_MODEL` can be
+set only when a test run needs an explicit override.

--- a/qwenpaw/scripts/install-builtin-qwenpaw-plugins.py
+++ b/qwenpaw/scripts/install-builtin-qwenpaw-plugins.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Install bundled QwenPaw plugins into an image-local working directory."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+
+
+MARKER = ".agentteams-builtin-plugin.sha256"
+
+
+def _safe_extract(zip_path: Path, target_dir: Path) -> Path:
+    with zipfile.ZipFile(zip_path) as archive:
+        target_root = target_dir.resolve()
+        for name in archive.namelist():
+            resolved = (target_dir / name).resolve()
+            try:
+                resolved.relative_to(target_root)
+            except ValueError:
+                raise RuntimeError(f"unsafe qwenpaw plugin package path: {name}") from None
+        archive.extractall(target_dir)
+
+    packages = [
+        path
+        for path in target_dir.iterdir()
+        if path.is_dir() and (path / "plugin.json").is_file()
+    ]
+    if len(packages) != 1:
+        raise RuntimeError(f"expected one qwenpaw plugin package in {zip_path}")
+    return packages[0]
+
+
+def _directory_digest(plugin_dir: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(plugin_dir.rglob("*")):
+        if not path.is_file() or path.name == MARKER:
+            continue
+        rel = path.relative_to(plugin_dir).as_posix()
+        digest.update(rel.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _write_markers(working_dir: Path) -> None:
+    plugins_dir = working_dir / "plugins"
+    for plugin_dir in sorted(path for path in plugins_dir.iterdir() if path.is_dir()):
+        marker = plugin_dir / MARKER
+        marker.write_text(_directory_digest(plugin_dir) + "\n", encoding="utf-8")
+
+
+def _install(zip_path: Path, working_dir: Path) -> None:
+    qwenpaw_bin = shutil.which("qwenpaw") or str(Path(sys.executable).with_name("qwenpaw"))
+    env = dict(os.environ)
+    env["QWENPAW_WORKING_DIR"] = str(working_dir)
+    with tempfile.TemporaryDirectory(prefix="qwenpaw-builtin-plugin-") as tmp:
+        package_dir = _safe_extract(zip_path, Path(tmp))
+        subprocess.run([qwenpaw_bin, "plugin", "install", str(package_dir), "--force"], check=True, env=env)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--working-dir", required=True)
+    parser.add_argument("packages", nargs="+")
+    args = parser.parse_args()
+
+    working_dir = Path(args.working_dir)
+    working_dir.mkdir(parents=True, exist_ok=True)
+    for package in args.packages:
+        _install(Path(package), working_dir)
+    _write_markers(working_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/qwenpaw/scripts/patch-qwenpaw-defer-mcp-startup.py
+++ b/qwenpaw/scripts/patch-qwenpaw-defer-mcp-startup.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Enable QwenPaw's native deferred MCP startup for app workspaces."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+MULTI_AGENT_MANAGER_PATCHES = (
+    (
+        """        instance = Workspace(
+            agent_id=agent_id,
+            workspace_dir=agent_ref.workspace_dir,
+        )
+""",
+        """        instance = Workspace(
+            agent_id=agent_id,
+            workspace_dir=agent_ref.workspace_dir,
+            defer_mcp_startup=True,
+        )
+""",
+    ),
+    (
+        """        new_instance = Workspace(
+            agent_id=agent_id,
+            workspace_dir=agent_ref.workspace_dir,
+        )
+""",
+        """        new_instance = Workspace(
+            agent_id=agent_id,
+            workspace_dir=agent_ref.workspace_dir,
+            defer_mcp_startup=True,
+        )
+""",
+    ),
+)
+
+
+SERVICE_FACTORIES_PATCHES = (
+    (
+        """                mcp.init_from_config_background(ws._config.mcp)
+""",
+        """                mcp.init_from_config_background(
+                    ws._config.mcp,
+                    timeout=60.0,
+                )
+""",
+    ),
+)
+
+
+def _apply_patches(source: str, patches, component: str) -> str:
+    patched = source
+    for before, after in patches:
+        if after in patched:
+            continue
+        if before not in patched:
+            raise RuntimeError(
+                f"QwenPaw {component} shape changed; "
+                "cannot enable deferred MCP startup safely",
+            )
+        patched = patched.replace(before, after, 1)
+    return patched
+
+
+def patch_multi_agent_manager_source(source: str) -> str:
+    return _apply_patches(
+        source,
+        MULTI_AGENT_MANAGER_PATCHES,
+        "MultiAgentManager",
+    )
+
+
+def patch_service_factories_source(source: str) -> str:
+    return _apply_patches(
+        source,
+        SERVICE_FACTORIES_PATCHES,
+        "workspace service factories",
+    )
+
+
+def patch_source(source: str) -> str:
+    return patch_multi_agent_manager_source(source)
+
+
+def _patch_file(target: Path, patcher) -> None:
+    source = target.read_text(encoding="utf-8")
+    patched = patcher(source)
+    if patched != source:
+        target.write_text(patched, encoding="utf-8")
+
+
+def main() -> int:
+    app_dir = (
+        Path(sys.prefix)
+        / "lib"
+        / "python3.11"
+        / "site-packages"
+        / "qwenpaw"
+        / "app"
+    )
+    _patch_file(app_dir / "multi_agent_manager.py", patch_source)
+    _patch_file(
+        app_dir / "workspace" / "service_factories.py",
+        patch_service_factories_source,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qwenpaw/scripts/qwenpaw-teamharness-plugin-reload.sh
+++ b/qwenpaw/scripts/qwenpaw-teamharness-plugin-reload.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLUGIN_NAME="teamharness"
+PACKAGE_PATH="${TEAMHARNESS_PLUGIN_PACKAGE:-}"
+PROJECT_DIR="${AGENTTEAMS_PROJECT_DIR:-${AGENTTEAMS_WORKER_HOME:-$(pwd)}}"
+API_BASE="${QWENPAW_API_BASE:-${COPAW_API_BASE:-http://127.0.0.1:${AGENTTEAMS_CONSOLE_PORT:-8088}}}"
+RELOAD_PATH="${TEAMHARNESS_RELOAD_PATH:-/api/teamharness/sync}"
+INSTALLER="auto"
+SKIP_RELOAD=0
+CLEANUP_DIR=""
+
+cleanup() {
+  [ -z "$CLEANUP_DIR" ] || rm -rf "$CLEANUP_DIR"
+}
+trap cleanup EXIT
+
+usage() {
+  cat <<'EOF'
+Usage:
+  qwenpaw-teamharness-plugin-reload.sh [--package PATH] [options]
+
+Installs or updates the TeamHarness plugin for a running QwenPaw worker, then
+triggers the TeamHarness sync endpoint so prompts, skills, and MCP config are
+re-applied to the active agent workspace.
+
+Options:
+  --package PATH       Plugin package or directory. Defaults to
+                       $TEAMHARNESS_PLUGIN_PACKAGE, /opt/hiclaw/plugins/teamharness.tar.gz,
+                       then /opt/hiclaw/plugins/teamharness-qwenpaw.zip.
+  --project-dir DIR    agentteams state directory parent. Defaults to
+                       $AGENTTEAMS_PROJECT_DIR, $AGENTTEAMS_WORKER_HOME, or cwd.
+  --api-base URL       QwenPaw API base. Defaults to $QWENPAW_API_BASE or
+                       http://127.0.0.1:$AGENTTEAMS_CONSOLE_PORT.
+  --reload-path PATH   Reload endpoint path. Defaults to /api/teamharness/sync.
+  --use-agentteams     Force agentteams plugin install/update.
+  --use-qwenpaw        Force qwenpaw plugin install --force.
+  --skip-reload        Install only.
+  -h, --help           Show this help.
+EOF
+}
+
+log() {
+  printf '[teamharness-plugin-reload] %s\n' "$*" >&2
+}
+
+fail() {
+  log "ERROR: $*"
+  exit 1
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --package)
+      [ "$#" -ge 2 ] || fail "--package requires a value"
+      PACKAGE_PATH="$2"
+      shift 2
+      ;;
+    --project-dir)
+      [ "$#" -ge 2 ] || fail "--project-dir requires a value"
+      PROJECT_DIR="$2"
+      shift 2
+      ;;
+    --api-base)
+      [ "$#" -ge 2 ] || fail "--api-base requires a value"
+      API_BASE="$2"
+      shift 2
+      ;;
+    --reload-path)
+      [ "$#" -ge 2 ] || fail "--reload-path requires a value"
+      RELOAD_PATH="$2"
+      shift 2
+      ;;
+    --use-agentteams)
+      INSTALLER="agentteams"
+      shift
+      ;;
+    --use-qwenpaw)
+      INSTALLER="qwenpaw"
+      shift
+      ;;
+    --skip-reload)
+      SKIP_RELOAD=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [ -z "$PACKAGE_PATH" ]; then
+  if [ -e /opt/hiclaw/plugins/teamharness.tar.gz ]; then
+    PACKAGE_PATH="/opt/hiclaw/plugins/teamharness.tar.gz"
+  elif [ -e /opt/hiclaw/plugins/teamharness-qwenpaw.zip ]; then
+    PACKAGE_PATH="/opt/hiclaw/plugins/teamharness-qwenpaw.zip"
+  fi
+fi
+
+[ -n "$PACKAGE_PATH" ] || fail "plugin package is required"
+[ -e "$PACKAGE_PATH" ] || fail "plugin package not found: $PACKAGE_PATH"
+PACKAGE_PATH="$(python3 - "$PACKAGE_PATH" <<'PY'
+from pathlib import Path
+import sys
+
+print(Path(sys.argv[1]).expanduser().resolve())
+PY
+)"
+
+is_qwenpaw_native_package() {
+  local package="$1"
+  if [ -d "$package" ]; then
+    [ -f "$package/plugin.json" ]
+    return
+  fi
+  case "$package" in
+    *.zip) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+extract_qwenpaw_package() {
+  local zip_path="$1"
+  local target_dir="$2"
+  python3 - "$zip_path" "$target_dir" <<'PY'
+from pathlib import Path
+import sys
+import zipfile
+
+zip_path = Path(sys.argv[1])
+target_dir = Path(sys.argv[2])
+target_root = target_dir.resolve()
+
+with zipfile.ZipFile(zip_path) as archive:
+    for name in archive.namelist():
+        resolved = (target_dir / name).resolve()
+        try:
+            resolved.relative_to(target_root)
+        except ValueError:
+            raise SystemExit(f"unsafe qwenpaw plugin package path: {name}")
+    archive.extractall(target_dir)
+
+packages = [
+    path for path in target_dir.iterdir()
+    if path.is_dir() and (path / "plugin.json").is_file()
+]
+if len(packages) != 1:
+    raise SystemExit(f"expected one qwenpaw plugin package in {zip_path}")
+print(packages[0])
+PY
+}
+
+install_with_qwenpaw() {
+  command -v qwenpaw >/dev/null 2>&1 || fail "qwenpaw command not found"
+
+  local package="$1"
+  local package_dir="$package"
+  local tmp_dir=""
+
+  if [ -f "$package" ]; then
+    tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/teamharness-qwenpaw-reload.XXXXXX")"
+    CLEANUP_DIR="$tmp_dir"
+    package_dir="$(extract_qwenpaw_package "$package" "$tmp_dir")"
+  fi
+
+  log "installing QwenPaw plugin package: $package_dir"
+  qwenpaw plugin install "$package_dir" --force
+}
+
+install_with_agentteams() {
+  command -v agentteams >/dev/null 2>&1 || fail "agentteams command not found"
+  mkdir -p "$PROJECT_DIR"
+
+  local action="install"
+  if [ -f "$PROJECT_DIR/.agentteams/plugins/$PLUGIN_NAME/manifest.json" ]; then
+    action="update"
+  fi
+
+  log "running agentteams plugin $action in $PROJECT_DIR"
+  (
+    cd "$PROJECT_DIR"
+    agentteams plugin "$action" "$PLUGIN_NAME" --package "$PACKAGE_PATH"
+  )
+}
+
+install_plugin() {
+  case "$INSTALLER" in
+    qwenpaw)
+      install_with_qwenpaw "$PACKAGE_PATH"
+      ;;
+    agentteams)
+      install_with_agentteams
+      ;;
+    auto)
+      if is_qwenpaw_native_package "$PACKAGE_PATH"; then
+        install_with_qwenpaw "$PACKAGE_PATH"
+      elif command -v agentteams >/dev/null 2>&1; then
+        install_with_agentteams
+      else
+        fail "agentteams is unavailable and package is not a QwenPaw-native plugin: $PACKAGE_PATH"
+      fi
+      ;;
+    *)
+      fail "unknown installer: $INSTALLER"
+      ;;
+  esac
+}
+
+post_reload() {
+  local url="${API_BASE%/}/${RELOAD_PATH#/}"
+  log "triggering agent reload: $url"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsS -X POST "$url" >/dev/null
+    return
+  fi
+  python3 - "$url" <<'PY'
+import sys
+import urllib.request
+
+request = urllib.request.Request(sys.argv[1], data=b"", method="POST")
+with urllib.request.urlopen(request, timeout=30) as response:
+    response.read()
+PY
+}
+
+install_plugin
+
+if [ "$SKIP_RELOAD" -eq 0 ]; then
+  post_reload
+fi
+
+log "done"

--- a/qwenpaw/scripts/qwenpaw-worker-entrypoint.sh
+++ b/qwenpaw/scripts/qwenpaw-worker-entrypoint.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# qwenpaw-worker-entrypoint.sh - QwenPaw Worker Agent container startup.
+# Reads controller-injected environment variables and launches qwenpaw-worker.
+#
+# Environment variables:
+#   AGENTTEAMS_WORKER_NAME   - Worker name (required)
+#   AGENTTEAMS_FS_ENDPOINT   - MinIO/OSS endpoint (required in local mode)
+#   AGENTTEAMS_FS_ACCESS_KEY - MinIO/OSS access key (required in local mode)
+#   AGENTTEAMS_FS_SECRET_KEY - MinIO/OSS secret key (required in local mode)
+#   AGENTTEAMS_RUNTIME       - "k8s" for controller-managed mc-wrapper storage access
+#   TZ                   - Timezone (optional)
+
+set -e
+
+source /opt/hiclaw/scripts/lib/hiclaw-env.sh
+
+WORKER_NAME="${AGENTTEAMS_WORKER_NAME:?AGENTTEAMS_WORKER_NAME is required}"
+WORKER_CR_NAME="${AGENTTEAMS_WORKER_CR_NAME:-${WORKER_NAME}}"
+# Align with CoPaw/openclaw/hermes: HOME == workspace == MinIO mirror root.
+# install_dir is its parent so install_dir/<name> == HOME.
+INSTALL_DIR="/root/hiclaw-fs/agents"
+WORKER_HOME="${AGENTTEAMS_WORKER_HOME:-${INSTALL_DIR}/${WORKER_NAME}}"
+CONSOLE_PORT="${AGENTTEAMS_CONSOLE_PORT:-8088}"
+
+log() {
+    echo "[agentteams-qwenpaw-worker $(date '+%Y-%m-%d %H:%M:%S')] $1"
+}
+
+if [ -n "${TZ}" ] && [ -f "/usr/share/zoneinfo/${TZ}" ]; then
+    ln -sf "/usr/share/zoneinfo/${TZ}" /etc/localtime
+    echo "${TZ}" > /etc/timezone
+    log "Timezone set to ${TZ}"
+fi
+
+if [ "${AGENTTEAMS_RUNTIME:-}" = "k8s" ]; then
+    log "Kubernetes mode: mc-wrapper handles storage credentials"
+    # CLI args are required by qwenpaw-worker but unused by FileSync in k8s mode.
+    FS_ENDPOINT="${AGENTTEAMS_FS_ENDPOINT:-k8s-placeholder}"
+    FS_ACCESS_KEY="${AGENTTEAMS_FS_ACCESS_KEY:-k8s}"
+    FS_SECRET_KEY="${AGENTTEAMS_FS_SECRET_KEY:-k8s}"
+    FS_BUCKET="${AGENTTEAMS_FS_BUCKET:-agentteams-storage}"
+else
+    FS_ENDPOINT="${AGENTTEAMS_FS_ENDPOINT:?AGENTTEAMS_FS_ENDPOINT is required}"
+    FS_ACCESS_KEY="${AGENTTEAMS_FS_ACCESS_KEY:?AGENTTEAMS_FS_ACCESS_KEY is required}"
+    FS_SECRET_KEY="${AGENTTEAMS_FS_SECRET_KEY:?AGENTTEAMS_FS_SECRET_KEY is required}"
+    FS_BUCKET="${AGENTTEAMS_FS_BUCKET:-agentteams-storage}"
+fi
+log "  FS bucket: ${FS_BUCKET}"
+
+mkdir -p "${WORKER_HOME}"
+export HOME="${WORKER_HOME}"
+export AGENTTEAMS_WORKER_HOME="${WORKER_HOME}"
+export AGENTTEAMS_AGENT_NAME="${WORKER_NAME}"
+export AGENTTEAMS_AGENT_ROLE="worker"
+export AGENTTEAMS_AGENT_HOME="${WORKER_HOME}"
+
+# Set QWENPAW_WORKING_DIR before starting; QwenPaw reads it during config/plugin setup.
+export QWENPAW_WORKING_DIR="${WORKER_HOME}/.qwenpaw"
+export AGENT_WORKSPACE="${QWENPAW_WORKING_DIR}/workspaces/default"
+export QWENPAW_SECRET_DIR="${QWENPAW_SECRET_DIR:-${QWENPAW_WORKING_DIR}.secret}"
+export QWENPAW_RUNNING_IN_CONTAINER=true
+export QWENPAW_LOG_LEVEL="${QWENPAW_LOG_LEVEL:-info}"
+
+# Configure LoongSuite observability plugin if tracing is enabled.
+CMS_TRACES_ENABLED="$(echo "${AGENTTEAMS_CMS_TRACES_ENABLED:-false}" | tr '[:upper:]' '[:lower:]')"
+if [ "${CMS_TRACES_ENABLED}" = "true" ]; then
+    log "Configuring CoPaw CMS plugin..."
+    LOONGSUITE_DIR="${HOME}/.loongsuite"
+    mkdir -p "${LOONGSUITE_DIR}"
+
+    cat > "${LOONGSUITE_DIR}/bootstrap-config.json" <<EOF
+{
+  "OTEL_EXPORTER_OTLP_ENDPOINT": "${AGENTTEAMS_CMS_ENDPOINT}",
+  "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+  "OTEL_EXPORTER_OTLP_HEADERS": "x-arms-license-key=${AGENTTEAMS_CMS_LICENSE_KEY},x-arms-project=${AGENTTEAMS_CMS_PROJECT},x-cms-workspace=${AGENTTEAMS_CMS_WORKSPACE}",
+  "OTEL_SERVICE_NAME": "${AGENTTEAMS_CMS_SERVICE_NAME:-agentteams-worker-${WORKER_NAME}}",
+  "OTEL_SEMCONV_STABILITY_OPT_IN": "http,gen_ai_latest_experimental",
+  "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": "SPAN_AND_EVENT",
+  "LOONGSUITE_PYTHON_SITE_BOOTSTRAP": "true",
+  "LOONGSUITE_PYTHON_SITE_BOOTSTRAP_LOG_SUCCESS": "false"
+}
+EOF
+    log "CoPaw CMS plugin configured at ${LOONGSUITE_DIR}/bootstrap-config.json"
+    export LOONGSUITE_PYTHON_SITE_BOOTSTRAP=true
+    export LOONGSUITE_PYTHON_SITE_BOOTSTRAP_LOG_SUCCESS=false
+fi
+
+VENV="/opt/venv/qwenpaw"
+
+CMD_ARGS=(
+    --name "${WORKER_NAME}"
+    --cr-name "${WORKER_CR_NAME}"
+    --fs "${FS_ENDPOINT}"
+    --fs-key "${FS_ACCESS_KEY}"
+    --fs-secret "${FS_SECRET_KEY}"
+    --fs-bucket "${FS_BUCKET}"
+    --install-dir "${INSTALL_DIR}"
+    --console-port "${CONSOLE_PORT}"
+)
+
+log "Starting qwenpaw-worker: ${WORKER_NAME}"
+log "  Worker CR name: ${WORKER_CR_NAME}"
+log "  FS endpoint: ${FS_ENDPOINT}"
+log "  Install dir: ${INSTALL_DIR}"
+log "  Worker home: ${WORKER_HOME}"
+log "  QwenPaw working dir: ${QWENPAW_WORKING_DIR}"
+log "  QwenPaw venv: ${VENV}"
+log "  Console port: ${CONSOLE_PORT}"
+
+exec "${VENV}/bin/qwenpaw-worker" "${CMD_ARGS[@]}"

--- a/qwenpaw/src/matrix/channel.py
+++ b/qwenpaw/src/matrix/channel.py
@@ -1847,7 +1847,7 @@ class MatrixChannel(BaseChannel):
         localpart = self._user_id.split(":")[0].lstrip("@")
         if localpart:
             result = re.sub(
-                rf"^{re.escape(localpart)}\s*:?\s*",
+                rf"^@?{re.escape(localpart)}\s*:?\s*",
                 "",
                 text,
                 flags=re.IGNORECASE,

--- a/qwenpaw/src/qwenpaw_worker/update.py
+++ b/qwenpaw/src/qwenpaw_worker/update.py
@@ -21,7 +21,7 @@ import urllib.request
 import zipfile
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qs, quote, urlencode, urlparse
 
 import yaml
 
@@ -30,6 +30,11 @@ logger = logging.getLogger(__name__)
 DEFAULT_AGENT_ID = "default"
 TEAMS_PROMPT_FILE = "TEAMS.md"
 PACKAGE_PROMPT_FILES = ("AGENTS.md", "SOUL.md")
+PACKAGE_RUNTIME_OWNED_CONFIG_FILES = {Path(TEAMS_PROMPT_FILE)}
+TEAMS_INTERNAL_CONTROL_MARKER = (
+    "<!-- AGENTTEAMS_INTERNAL_CONTROL_FILE: TEAMS.md is managed by "
+    "TeamHarness/QwenPaw runtime; agent packages must not overwrite or delete it. -->"
+)
 TEAMS_CONTEXT_START = "<!-- BEGIN AGENTTEAMS RUNTIME TEAM CONTEXT -->"
 TEAMS_CONTEXT_END = "<!-- END AGENTTEAMS RUNTIME TEAM CONTEXT -->"
 AGENT_IDENTITY_DATA_ENDPOINT_FORMAT = "agentidentitydata.{region_id}.aliyuncs.com"
@@ -942,6 +947,8 @@ class AgentPackageManager:
                 rel = child.relative_to(config_dir)
                 if rel == Path("config/mcporter.json"):
                     continue
+                if rel in PACKAGE_RUNTIME_OWNED_CONFIG_FILES:
+                    continue
                 files.append((child, self.workspace_dir / rel))
         return files
 
@@ -1297,6 +1304,235 @@ class ApplyResult:
     agent_package_dir: Optional[Path]
 
 
+@dataclass(frozen=True)
+class _QwenPawApiResponse:
+    status: int
+    payload: Any
+    text: str
+
+
+class QwenPawModelRuntimeSync:
+    """Sync runtime model state into the running QwenPaw app."""
+
+    def __init__(
+        self,
+        port: int,
+        agent_id: str = DEFAULT_AGENT_ID,
+        timeout: float = 10.0,
+    ) -> None:
+        self.api_root = f"http://127.0.0.1:{port}/api/models"
+        self.agent_id = agent_id
+        self.timeout = timeout
+
+    def __call__(self, runtime_config: MemberRuntimeConfig) -> None:
+        self.sync(runtime_config)
+
+    def sync(self, runtime_config: MemberRuntimeConfig) -> None:
+        started_at = time.monotonic()
+        fields = self._model_fields(runtime_config)
+        if fields is None:
+            return
+        provider_id, model_name, provider_name, base_url, api_key, chat_model = fields
+        if not base_url or not api_key:
+            logger.info(
+                "runtime model sync skipped component=update step=model_runtime_sync event=skip "
+                "generation=%s provider_id=%s model=%s reason=missing_provider_config",
+                runtime_config.generation,
+                provider_id,
+                model_name,
+            )
+            return
+
+        provider_count = self._provider_count(self._request("GET", "").payload)
+        provider_info = self._configure_provider(provider_id, provider_name, base_url, api_key, chat_model)
+        if not self._provider_has_model(provider_info, model_name):
+            provider_info = self._add_model(provider_id, model_name)
+        self._set_active_model(provider_id, model_name)
+        self._verify_active_model(provider_id, model_name)
+        logger.info(
+            "runtime model sync complete component=update step=model_runtime_sync event=complete "
+            "generation=%s provider_id=%s model=%s provider_count=%s changed=%s duration_ms=%s",
+            runtime_config.generation,
+            provider_id,
+            model_name,
+            provider_count,
+            True,
+            _duration_ms(started_at),
+        )
+
+    def _model_fields(self, runtime_config: MemberRuntimeConfig) -> Optional[Tuple[str, str, str, str, str, str]]:
+        model = runtime_config.model
+        provider_id = _string(model.get("providerId") or model.get("provider_id") or model.get("provider"))
+        model_name = _string(model.get("model") or model.get("name"))
+        if not provider_id or not model_name:
+            return None
+        base_url = _string(
+            model.get("baseUrl")
+            or model.get("base_url")
+            or model.get("gatewayUrl")
+            or model.get("gateway_url")
+            or model.get("endpoint")
+            or os.getenv("AGENTTEAMS_AI_GATEWAY_URL")
+        )
+        api_key = _string(model.get("apiKey") or model.get("api_key"))
+        api_key_env = _string(
+            model.get("apiKeyEnv")
+            or model.get("api_key_env")
+            or runtime_config.credentials.get("gatewayKeyEnv")
+            or "AGENTTEAMS_WORKER_GATEWAY_KEY"
+        )
+        if not api_key and api_key_env:
+            api_key = _string(os.getenv(api_key_env))
+        return (
+            provider_id,
+            model_name,
+            _string(model.get("providerName") or model.get("provider_name") or provider_id),
+            self._openai_compatible_base_url(base_url) if base_url else "",
+            api_key,
+            _string(model.get("chatModel") or model.get("chat_model") or "OpenAIChatModel"),
+        )
+
+    def _configure_provider(
+        self,
+        provider_id: str,
+        provider_name: str,
+        base_url: str,
+        api_key: str,
+        chat_model: str,
+    ) -> Dict[str, Any]:
+        payload = {"api_key": api_key, "base_url": base_url, "chat_model": chat_model}
+        path = f"/{quote(provider_id, safe='')}/config"
+        response = self._request("PUT", path, payload, ok_statuses=(200, 404))
+        if response.status == 404:
+            self._request(
+                "POST",
+                "/custom-providers",
+                {
+                    "id": provider_id,
+                    "name": provider_name,
+                    "default_base_url": base_url,
+                    "api_key_prefix": "",
+                    "chat_model": chat_model,
+                    "models": [],
+                },
+                ok_statuses=(200, 201),
+            )
+            response = self._request("PUT", path, payload)
+        return response.payload if isinstance(response.payload, dict) else {}
+
+    def _add_model(self, provider_id: str, model_name: str) -> Dict[str, Any]:
+        response = self._request(
+            "POST",
+            f"/{quote(provider_id, safe='')}/models",
+            {"id": model_name, "name": model_name},
+            ok_statuses=(200, 201, 400, 404, 409, 422),
+        )
+        if response.status >= 400 and not self._already_exists(response.text):
+            raise RuntimeError(
+                f"qwenpaw model runtime sync request failed: POST provider model HTTP {response.status}"
+            )
+        return response.payload if isinstance(response.payload, dict) else {}
+
+    def _set_active_model(self, provider_id: str, model_name: str) -> None:
+        self._request(
+            "PUT",
+            "/active",
+            {
+                "scope": "agent",
+                "agent_id": self.agent_id,
+                "provider_id": provider_id,
+                "model": model_name,
+            },
+        )
+
+    def _verify_active_model(self, provider_id: str, model_name: str) -> None:
+        response = self._request(
+            "GET",
+            f"/active?{urlencode({'scope': 'effective', 'agent_id': self.agent_id})}",
+        )
+        payload = response.payload if isinstance(response.payload, dict) else {}
+        active = payload.get("active_llm") if isinstance(payload.get("active_llm"), dict) else {}
+        actual_provider = _string(active.get("provider_id") or active.get("providerId"))
+        actual_model = _string(active.get("model"))
+        if actual_provider != provider_id or actual_model != model_name:
+            raise RuntimeError("qwenpaw model runtime sync verification failed")
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: Optional[Dict[str, Any]] = None,
+        ok_statuses: Iterable[int] = (200, 201),
+    ) -> _QwenPawApiResponse:
+        body = json.dumps(payload).encode("utf-8") if payload is not None else None
+        headers = {"Accept": "application/json"}
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(
+            f"{self.api_root}{path}",
+            data=body,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                text = response.read().decode("utf-8", errors="replace")
+                return _QwenPawApiResponse(
+                    status=response.status,
+                    payload=self._json_payload(text, response.status),
+                    text=text,
+                )
+        except urllib.error.HTTPError as exc:
+            text = exc.read().decode("utf-8", errors="replace")
+            if exc.code in ok_statuses:
+                return _QwenPawApiResponse(
+                    status=exc.code,
+                    payload=self._json_payload(text, exc.code),
+                    text=text,
+                )
+            raise RuntimeError(
+                f"qwenpaw model runtime sync request failed: {method} {path.split('?', 1)[0]} HTTP {exc.code}"
+            ) from None
+        except urllib.error.URLError as exc:
+            raise RuntimeError(
+                f"qwenpaw model runtime sync request failed: {method} {path.split('?', 1)[0]} "
+                f"{type(exc.reason).__name__}"
+            ) from None
+
+    def _json_payload(self, text: str, status: int) -> Any:
+        if not text:
+            return {}
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as exc:
+            if status >= 400:
+                return {}
+            raise RuntimeError("qwenpaw model runtime sync request failed: invalid JSON response") from exc
+
+    def _provider_count(self, payload: Any) -> int:
+        return len(payload) if isinstance(payload, list) else 0
+
+    def _provider_has_model(self, payload: Dict[str, Any], model_name: str) -> bool:
+        for key in ("models", "extra_models"):
+            value = payload.get(key)
+            if not isinstance(value, list):
+                continue
+            for item in value:
+                if isinstance(item, dict) and _string(item.get("id")) == model_name:
+                    return True
+        return False
+
+    def _already_exists(self, text: str) -> bool:
+        lower = text.lower()
+        return "already" in lower or "exist" in lower or "duplicate" in lower
+
+    def _openai_compatible_base_url(self, base_url: str) -> str:
+        value = base_url.rstrip("/")
+        if value.endswith("/v1"):
+            return value
+        return f"{value}/v1"
+
+
 class RuntimeUpdater:
     """Apply controller-projected runtime desired state inside one worker pod."""
 
@@ -1306,10 +1542,14 @@ class RuntimeUpdater:
         adapter_apply: Optional[Callable[[], None]] = None,
         package_manager: Optional[AgentPackageManager] = None,
         runtime_config_pull: Optional[Callable[[], None]] = None,
+        model_runtime_sync: Optional[Callable[[MemberRuntimeConfig], None]] = None,
+        team_context_renderer: Optional[Callable[[MemberRuntimeConfig], str]] = None,
     ) -> None:
         self.config = config
         self.adapter_apply = adapter_apply
         self.runtime_config_pull = runtime_config_pull
+        self.model_runtime_sync = model_runtime_sync or QwenPawModelRuntimeSync(config.console_port)
+        self.team_context_renderer = team_context_renderer
         self.package_manager = package_manager or AgentPackageManager(
             config.qwenpaw_working_dir / "agent-packages",
             workspace_dir=config.default_workspace_dir,
@@ -1329,7 +1569,8 @@ class RuntimeUpdater:
     ) -> ApplyResult:
         started_at = time.monotonic()
         config = runtime_config or self.load()
-        changed = force or self.current_config is None or config.changed_from(self.current_config)
+        previous = self.current_config
+        changed = force or previous is None or config.changed_from(previous)
         if not changed:
             logger.info(
                 "runtime config apply skipped component=update worker=%s generation=%s changed=%s "
@@ -1344,9 +1585,15 @@ class RuntimeUpdater:
             )
             return ApplyResult(runtime_config=config, changed=False, agent_package_dir=None)
 
+        adapter_should_apply = (
+            reapply_adapter
+            and self.adapter_apply is not None
+            and not self._adapter_neutral_change(config)
+        )
         logger.info(
             "runtime config apply begin component=update worker=%s generation=%s team=%s member=%s role=%s "
-            "force=%s reapply_adapter=%s mcp_server_count=%s channel_names=%s credential_binding_count=%s",
+            "force=%s reapply_adapter=%s adapter_applied=%s mcp_server_count=%s channel_names=%s "
+            "credential_binding_count=%s duration_ms=%s",
             self.config.worker_name,
             config.generation,
             config.team_name,
@@ -1354,9 +1601,11 @@ class RuntimeUpdater:
             config.member_role,
             force,
             reapply_adapter,
+            adapter_should_apply,
             _count_collection(config.mcp_servers),
             _named_keys(config.channels),
             len(config.credential_bindings),
+            _duration_ms(started_at),
         )
         self._apply_member_identity(config)
         self._apply_model(config)
@@ -1369,14 +1618,11 @@ class RuntimeUpdater:
         applied_package = self.package_manager.apply(config)
 
         adapter_applied = False
-        if (
-            reapply_adapter
-            and self.adapter_apply is not None
-            and not self._adapter_neutral_change(config)
-        ):
+        if adapter_should_apply:
             self.adapter_apply()
             adapter_applied = True
 
+        self._sync_model_runtime_if_needed(previous, config)
         self.current_config = config
         logger.info(
             "runtime config apply complete component=update worker=%s generation=%s changed=%s "
@@ -1393,6 +1639,31 @@ class RuntimeUpdater:
             _duration_ms(started_at),
         )
         return ApplyResult(runtime_config=config, changed=True, agent_package_dir=applied_package)
+
+    def _sync_model_runtime_if_needed(
+        self,
+        previous: Optional[MemberRuntimeConfig],
+        config: MemberRuntimeConfig,
+    ) -> None:
+        if previous is None or self.model_runtime_sync is None:
+            return
+        if _stable_json(config.model) == _stable_json(previous.model):
+            return
+        started_at = time.monotonic()
+        try:
+            self.model_runtime_sync(config)
+        except Exception as exc:
+            logger.warning(
+                "runtime model sync failed component=update step=model_runtime_sync event=failed "
+                "worker=%s generation=%s changed=%s error_type=%s safe_error_summary=%s duration_ms=%s",
+                self.config.worker_name,
+                config.generation,
+                True,
+                type(exc).__name__,
+                type(exc).__name__,
+                _duration_ms(started_at),
+            )
+            raise
 
     def _adapter_neutral_change(self, config: MemberRuntimeConfig) -> bool:
         previous = self.current_config
@@ -1424,7 +1695,17 @@ class RuntimeUpdater:
             return
         path = self.config.default_workspace_dir / TEAMS_PROMPT_FILE
         path.parent.mkdir(parents=True, exist_ok=True)
-        existing = path.read_text(encoding="utf-8") if path.exists() else "# TeamHarness Runtime Context\n"
+        if path.exists():
+            existing = path.read_text(encoding="utf-8")
+        else:
+            existing = self._render_full_team_context_prompt(config)
+            if not existing:
+                logger.warning(
+                    "full TeamHarness TEAMS renderer unavailable component=update worker=%s action=fallback",
+                    self.config.worker_name,
+                )
+                existing = "# TeamHarness Runtime Context\n"
+        existing = self._ensure_teams_internal_marker(existing)
         if TEAMS_CONTEXT_START in existing and TEAMS_CONTEXT_END in existing:
             prefix, rest = existing.split(TEAMS_CONTEXT_START, 1)
             _old, suffix = rest.split(TEAMS_CONTEXT_END, 1)
@@ -1434,6 +1715,26 @@ class RuntimeUpdater:
         tmp = path.with_name(f".{path.name}.tmp")
         tmp.write_text(text, encoding="utf-8")
         tmp.replace(path)
+
+    def _render_full_team_context_prompt(self, config: MemberRuntimeConfig) -> str:
+        if self.team_context_renderer is None:
+            return ""
+        try:
+            text = self.team_context_renderer(config)
+        except Exception as exc:
+            logger.warning(
+                "full TeamHarness TEAMS renderer failed component=update worker=%s error_type=%s",
+                self.config.worker_name,
+                type(exc).__name__,
+            )
+            return ""
+        return text if isinstance(text, str) and text.strip() else ""
+
+    def _ensure_teams_internal_marker(self, text: str) -> str:
+        if TEAMS_INTERNAL_CONTROL_MARKER in text:
+            return text
+        body = text.lstrip("\n")
+        return f"{TEAMS_INTERNAL_CONTROL_MARKER}\n{body}" if body else f"{TEAMS_INTERNAL_CONTROL_MARKER}\n"
 
     def _runtime_team_context_block(self, config: MemberRuntimeConfig) -> str:
         facts = config.team_context_facts

--- a/qwenpaw/src/qwenpaw_worker/worker.py
+++ b/qwenpaw/src/qwenpaw_worker/worker.py
@@ -19,7 +19,7 @@ from typing import Optional
 from qwenpaw_worker.config import WorkerConfig, _relative_storage_prefix
 from qwenpaw_worker.heartbeat import WorkerHeartbeat, run_worker_heartbeat_loop
 from qwenpaw_worker.sync import FileSync, push_loop
-from qwenpaw_worker.update import RuntimeUpdater
+from qwenpaw_worker.update import MemberRuntimeConfig, RuntimeUpdater
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +59,11 @@ class Worker:
         self.config = config
         self.sync: Optional[FileSync] = None
         self.heartbeat = WorkerHeartbeat(config.qwenpaw_working_dir / "heartbeat.json")
-        self.updater = RuntimeUpdater(config=config, adapter_apply=self._apply_runtime_adapter)
+        self.updater = RuntimeUpdater(
+            config=config,
+            adapter_apply=self._apply_runtime_adapter,
+            team_context_renderer=self._render_teamharness_context,
+        )
         self._process: Optional[asyncio.subprocess.Process] = None
         self._heartbeat_probe_task: Optional[asyncio.Task] = None
         self._push_task: Optional[asyncio.Task] = None
@@ -670,6 +674,23 @@ class Worker:
             module_name="agentteams_teamharness_qwenpaw_plugin",
             entrypoint_name="apply_teamharness",
         )
+
+    def _render_teamharness_context(self, runtime_config: MemberRuntimeConfig) -> str:
+        plugin_file = self.config.qwenpaw_working_dir / "plugins" / "teamharness" / "plugin.py"
+        if not plugin_file.is_file():
+            return ""
+
+        spec = importlib.util.spec_from_file_location("hiclaw_teamharness_qwenpaw_plugin_renderer", plugin_file)
+        if spec is None or spec.loader is None:
+            return ""
+
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        render = getattr(module, "render_team_context", None)
+        if not callable(render):
+            return ""
+        text = render(runtime_config.raw)
+        return text if isinstance(text, str) else ""
 
     def _apply_workerflow_assets(self) -> dict:
         return self._apply_plugin_assets(

--- a/qwenpaw/tests/integration/lib/qwenpaw-image-e2e.sh
+++ b/qwenpaw/tests/integration/lib/qwenpaw-image-e2e.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Shared helpers for QwenPaw worker image integration tests.
+
+qwenpaw_e2e_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+qwenpaw_e2e_repo_root="$(cd "${qwenpaw_e2e_dir}/../../.." && pwd)"
+
+qwenpaw_e2e_log() {
+    echo "[qwenpaw-image-e2e] $*" >&2
+}
+
+qwenpaw_e2e_fail() {
+    qwenpaw_e2e_log "ERROR: $*"
+    exit 1
+}
+
+qwenpaw_e2e_require_enabled() {
+    if [ "${AGENTTEAMS_QWENPAW_IMAGE_E2E:-}" != "1" ]; then
+        qwenpaw_e2e_log "SKIP: set AGENTTEAMS_QWENPAW_IMAGE_E2E=1 to run QwenPaw image integration tests"
+        exit 0
+    fi
+}
+
+qwenpaw_e2e_require_docker() {
+    command -v docker >/dev/null 2>&1 || qwenpaw_e2e_fail "docker is required"
+    docker info >/dev/null 2>&1 || qwenpaw_e2e_fail "docker daemon is not reachable"
+}
+
+qwenpaw_e2e_init() {
+    local name="$1"
+    QWENPAW_E2E_NAME="${name}"
+    QWENPAW_E2E_VERSION="${AGENTTEAMS_QWENPAW_IMAGE_E2E_VERSION:-${name}-$(date +%s)-$$}"
+    QWENPAW_E2E_IMAGE="${AGENTTEAMS_QWENPAW_IMAGE:-agentteams/qwenpaw-worker:${QWENPAW_E2E_VERSION}}"
+    QWENPAW_E2E_MINIO_IMAGE="${AGENTTEAMS_QWENPAW_IMAGE_E2E_MINIO_IMAGE:-minio/minio:latest}"
+    QWENPAW_E2E_BUCKET="${AGENTTEAMS_QWENPAW_IMAGE_E2E_BUCKET:-agentteams-storage}"
+    QWENPAW_E2E_WORKER_NAME="${AGENTTEAMS_QWENPAW_IMAGE_E2E_WORKER_NAME:-${name}-worker-$$}"
+    QWENPAW_E2E_WORKER_HOME="/root/hiclaw-fs/agents/${QWENPAW_E2E_WORKER_NAME}"
+    QWENPAW_E2E_WORKING_DIR="${QWENPAW_E2E_WORKER_HOME}/.qwenpaw"
+    QWENPAW_E2E_SECRET_DIR="${QWENPAW_E2E_WORKING_DIR}.secret"
+    QWENPAW_E2E_SHARED_DIR="/root/hiclaw-fs/shared"
+    QWENPAW_E2E_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/qwenpaw-${name}.XXXXXX")"
+    QWENPAW_E2E_NETWORK="qwenpaw-${name}-$$"
+    QWENPAW_E2E_MINIO_CONTAINER="qwenpaw-${name}-minio-$$"
+    QWENPAW_E2E_WORKER_CONTAINER="qwenpaw-${name}-worker-$$"
+    mkdir -p "${QWENPAW_E2E_TMP_DIR}/seed"
+    trap qwenpaw_e2e_cleanup EXIT
+}
+
+qwenpaw_e2e_cleanup() {
+    local status=$?
+    if [ "${status}" -ne 0 ] && [ "${AGENTTEAMS_QWENPAW_IMAGE_E2E_KEEP:-}" = "1" ]; then
+        qwenpaw_e2e_log "preserving resources for debugging"
+        qwenpaw_e2e_log "  worker container: ${QWENPAW_E2E_WORKER_CONTAINER}"
+        qwenpaw_e2e_log "  minio container: ${QWENPAW_E2E_MINIO_CONTAINER}"
+        qwenpaw_e2e_log "  docker network: ${QWENPAW_E2E_NETWORK}"
+        qwenpaw_e2e_log "  temp dir: ${QWENPAW_E2E_TMP_DIR}"
+        exit "${status}"
+    fi
+    docker rm -f "${QWENPAW_E2E_WORKER_CONTAINER}" "${QWENPAW_E2E_MINIO_CONTAINER}" >/dev/null 2>&1 || true
+    docker network rm "${QWENPAW_E2E_NETWORK}" >/dev/null 2>&1 || true
+    rm -rf "${QWENPAW_E2E_TMP_DIR}"
+}
+
+qwenpaw_e2e_build_or_use_image() {
+    if [ -n "${AGENTTEAMS_QWENPAW_IMAGE:-}" ]; then
+        qwenpaw_e2e_log "using existing QwenPaw worker image: ${QWENPAW_E2E_IMAGE}"
+        docker image inspect "${QWENPAW_E2E_IMAGE}" >/dev/null 2>&1 || qwenpaw_e2e_fail "image not found: ${QWENPAW_E2E_IMAGE}"
+        return
+    fi
+    if [ "${AGENTTEAMS_QWENPAW_IMAGE_E2E_SKIP_BUILD:-}" = "1" ]; then
+        docker image inspect "${QWENPAW_E2E_IMAGE}" >/dev/null 2>&1 || qwenpaw_e2e_fail "image not found: ${QWENPAW_E2E_IMAGE}"
+        return
+    fi
+    qwenpaw_e2e_log "building QwenPaw worker image: ${QWENPAW_E2E_IMAGE}"
+    make -C "${qwenpaw_e2e_repo_root}" build-qwenpaw-worker VERSION="${QWENPAW_E2E_VERSION}"
+}
+
+qwenpaw_e2e_create_network() {
+    qwenpaw_e2e_log "creating docker network: ${QWENPAW_E2E_NETWORK}"
+    docker network create "${QWENPAW_E2E_NETWORK}" >/dev/null
+}
+
+qwenpaw_e2e_start_minio() {
+    qwenpaw_e2e_log "starting MinIO: ${QWENPAW_E2E_MINIO_CONTAINER}"
+    docker run -d \
+        --name "${QWENPAW_E2E_MINIO_CONTAINER}" \
+        --network "${QWENPAW_E2E_NETWORK}" \
+        --network-alias minio \
+        -e MINIO_ROOT_USER=minioadmin \
+        -e MINIO_ROOT_PASSWORD=minioadmin \
+        "${QWENPAW_E2E_MINIO_IMAGE}" \
+        server /data >/dev/null
+}
+
+qwenpaw_e2e_run_mc() {
+    docker run --rm \
+        --network "${QWENPAW_E2E_NETWORK}" \
+        -v "${QWENPAW_E2E_TMP_DIR}/seed:/tmp/seed:ro" \
+        --entrypoint sh \
+        -e MC_HOST_local="http://minioadmin:minioadmin@minio:9000" \
+        -e AGENTTEAMS_FS_BUCKET="${QWENPAW_E2E_BUCKET}" \
+        -e AGENTTEAMS_WORKER_NAME="${QWENPAW_E2E_WORKER_NAME}" \
+        "${QWENPAW_E2E_IMAGE}" \
+        -lc "$*"
+}
+
+qwenpaw_e2e_wait_for_minio() {
+    local i
+    for i in $(seq 1 60); do
+        if qwenpaw_e2e_run_mc '/usr/local/bin/mc.bin mb --ignore-existing "local/${AGENTTEAMS_FS_BUCKET}" >/dev/null 2>&1'; then
+            return 0
+        fi
+        sleep 2
+    done
+    docker logs "${QWENPAW_E2E_MINIO_CONTAINER}" 2>&1 || true
+    qwenpaw_e2e_fail "minio did not become ready"
+}
+
+qwenpaw_e2e_seed_storage() {
+    qwenpaw_e2e_log "seeding object storage"
+    qwenpaw_e2e_run_mc '/usr/local/bin/mc.bin cp --recursive /tmp/seed/ "local/${AGENTTEAMS_FS_BUCKET}/"' >/dev/null
+}
+
+qwenpaw_e2e_start_worker() {
+    qwenpaw_e2e_log "starting qwenpaw-worker container: ${QWENPAW_E2E_WORKER_CONTAINER}"
+    docker run -d \
+        --name "${QWENPAW_E2E_WORKER_CONTAINER}" \
+        --network "${QWENPAW_E2E_NETWORK}" \
+        -e AGENTTEAMS_WORKER_NAME="${QWENPAW_E2E_WORKER_NAME}" \
+        -e AGENTTEAMS_WORKER_CR_NAME="${QWENPAW_E2E_WORKER_NAME}" \
+        -e AGENTTEAMS_FS_ENDPOINT="http://minio:9000" \
+        -e AGENTTEAMS_FS_ACCESS_KEY=minioadmin \
+        -e AGENTTEAMS_FS_SECRET_KEY=minioadmin \
+        -e AGENTTEAMS_FS_BUCKET="${QWENPAW_E2E_BUCKET}" \
+        -e QWENPAW_LOG_LEVEL="${QWENPAW_LOG_LEVEL:-info}" \
+        "$@" \
+        "${QWENPAW_E2E_IMAGE}" >/dev/null
+}
+
+qwenpaw_e2e_wait_worker_http() {
+    local path="$1"
+    local timeout_seconds="${2:-240}"
+    local elapsed=0
+    while [ "${elapsed}" -lt "${timeout_seconds}" ]; do
+        if docker exec "${QWENPAW_E2E_WORKER_CONTAINER}" curl -sf "http://127.0.0.1:8088${path}" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 3
+        elapsed=$((elapsed + 3))
+    done
+    docker logs --tail 180 "${QWENPAW_E2E_WORKER_CONTAINER}" 2>&1 || true
+    qwenpaw_e2e_fail "worker endpoint did not become ready: ${path}"
+}
+
+qwenpaw_e2e_exec() {
+    docker exec -i \
+        -e HOME="${QWENPAW_E2E_WORKER_HOME}" \
+        -e QWENPAW_WORKING_DIR="${QWENPAW_E2E_WORKING_DIR}" \
+        -e QWENPAW_SECRET_DIR="${QWENPAW_E2E_SECRET_DIR}" \
+        "${QWENPAW_E2E_WORKER_CONTAINER}" \
+        "$@"
+}
+
+qwenpaw_e2e_write_runtime_yaml() {
+    local generation="$1"
+    local target="${QWENPAW_E2E_TMP_DIR}/seed/agents/${QWENPAW_E2E_WORKER_NAME}/runtime/runtime.yaml"
+    mkdir -p "$(dirname "${target}")"
+    cat >"${target}" <<EOF
+metadata:
+  generation: "${generation}"
+team:
+  name: qwenpaw-image-e2e
+member:
+  name: ${QWENPAW_E2E_WORKER_NAME}
+  runtimeName: ${QWENPAW_E2E_WORKER_NAME}
+  runtime: qwenpaw
+  role: worker
+desired:
+  mcpServers: {}
+  channelPolicy: {}
+EOF
+}
+
+qwenpaw_e2e_put_runtime_yaml() {
+    qwenpaw_e2e_run_mc "
+        /usr/local/bin/mc.bin cp \
+            '/tmp/seed/agents/${QWENPAW_E2E_WORKER_NAME}/runtime/runtime.yaml' \
+            'local/${QWENPAW_E2E_BUCKET}/agents/${QWENPAW_E2E_WORKER_NAME}/runtime/runtime.yaml'
+    " >/dev/null
+}

--- a/qwenpaw/tests/integration/test-real-image-model-api.sh
+++ b/qwenpaw/tests/integration/test-real-image-model-api.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# Real QwenPaw worker image + real model API tracer bullet.
+#
+# This test is opt-in because it builds a Docker image and calls a paid model API.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+log() {
+    echo "[qwenpaw-real-e2e] $*" >&2
+}
+
+fail() {
+    log "ERROR: $*"
+    exit 1
+}
+
+if [ "${AGENTTEAMS_QWENPAW_REAL_MODEL_E2E:-}" != "1" ]; then
+    log "SKIP: set AGENTTEAMS_QWENPAW_REAL_MODEL_E2E=1 to build the image and call a real model API"
+    exit 0
+fi
+
+command -v docker >/dev/null 2>&1 || fail "docker is required"
+docker info >/dev/null 2>&1 || fail "docker daemon is not reachable"
+
+ENV_FILE="${AGENTTEAMS_ENV_FILE:-${HOME}/hiclaw-manager.env}"
+
+read_env_file() {
+    key="$1"
+    [ -f "${ENV_FILE}" ] || return 0
+    grep "^${key}=" "${ENV_FILE}" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '\r'
+}
+
+API_KEY="${AGENTTEAMS_QWENPAW_REAL_MODEL_API_KEY:-$(read_env_file AGENTTEAMS_LLM_API_KEY)}"
+[ -n "${API_KEY}" ] || fail "AGENTTEAMS_LLM_API_KEY is required in ${ENV_FILE}"
+
+MODEL="${AGENTTEAMS_QWENPAW_REAL_MODEL:-$(read_env_file AGENTTEAMS_DEFAULT_MODEL)}"
+MODEL="${MODEL:-qwen3.6-plus}"
+BASE_URL="${AGENTTEAMS_QWENPAW_REAL_MODEL_BASE_URL:-$(read_env_file AGENTTEAMS_OPENAI_BASE_URL)}"
+BASE_URL="${BASE_URL:-https://dashscope.aliyuncs.com/compatible-mode/v1}"
+PROVIDER_ID="${AGENTTEAMS_QWENPAW_REAL_MODEL_PROVIDER_ID:-hiclaw-real-model}"
+MINIO_IMAGE="${AGENTTEAMS_QWENPAW_REAL_MODEL_MINIO_IMAGE:-minio/minio:latest}"
+VERSION="${AGENTTEAMS_QWENPAW_REAL_MODEL_IMAGE_VERSION:-qwenpaw-real-e2e-$(date +%s)-$$}"
+WORKER_NAME="${AGENTTEAMS_QWENPAW_REAL_MODEL_WORKER_NAME:-qwenpaw-real-worker-$$}"
+WORKER_HOME="/root/hiclaw-fs/agents/${WORKER_NAME}"
+QWENPAW_WORKING_DIR="${WORKER_HOME}/.qwenpaw"
+QWENPAW_SECRET_DIR="${QWENPAW_WORKING_DIR}.secret"
+BUCKET="${AGENTTEAMS_QWENPAW_REAL_MODEL_BUCKET:-agentteams-storage}"
+
+if [ -n "${AGENTTEAMS_QWENPAW_REAL_MODEL_IMAGE:-}" ]; then
+    IMAGE="${AGENTTEAMS_QWENPAW_REAL_MODEL_IMAGE}"
+else
+    IMAGE="agentteams/qwenpaw-worker:${VERSION}"
+fi
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/qwenpaw-real-e2e.XXXXXX")"
+NETWORK="qwenpaw-real-e2e-$$"
+MINIO_CONTAINER="qwenpaw-real-minio-$$"
+WORKER_CONTAINER="qwenpaw-real-worker-$$"
+
+cleanup() {
+    status=$?
+    if [ "${status}" -ne 0 ] && [ "${AGENTTEAMS_QWENPAW_REAL_MODEL_KEEP:-}" = "1" ]; then
+        log "preserving resources for debugging"
+        log "  worker container: ${WORKER_CONTAINER}"
+        log "  minio container: ${MINIO_CONTAINER}"
+        log "  docker network: ${NETWORK}"
+        log "  temp dir: ${TMP_DIR}"
+        exit "${status}"
+    fi
+    docker rm -f "${WORKER_CONTAINER}" "${MINIO_CONTAINER}" >/dev/null 2>&1 || true
+    docker network rm "${NETWORK}" >/dev/null 2>&1 || true
+    rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+run_mc() {
+    docker run --rm \
+        --network "${NETWORK}" \
+        -v "${TMP_DIR}/seed:/tmp/seed:ro" \
+        --entrypoint sh \
+        -e MC_HOST_local="http://minioadmin:minioadmin@minio:9000" \
+        -e AGENTTEAMS_FS_BUCKET="${BUCKET}" \
+        -e AGENTTEAMS_WORKER_NAME="${WORKER_NAME}" \
+        "${IMAGE}" \
+        -lc "$*"
+}
+
+wait_for_minio() {
+    for _ in $(seq 1 60); do
+        if run_mc '/usr/local/bin/mc.bin mb --ignore-existing "local/${AGENTTEAMS_FS_BUCKET}" >/dev/null 2>&1'; then
+            return 0
+        fi
+        sleep 2
+    done
+    docker logs "${MINIO_CONTAINER}" 2>&1 || true
+    fail "minio did not become ready"
+}
+
+wait_worker_http() {
+    path="$1"
+    timeout_seconds="${2:-180}"
+    elapsed=0
+    while [ "${elapsed}" -lt "${timeout_seconds}" ]; do
+        if docker exec "${WORKER_CONTAINER}" curl -sf "http://127.0.0.1:8088${path}" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 3
+        elapsed=$((elapsed + 3))
+    done
+    docker logs --tail 160 "${WORKER_CONTAINER}" 2>&1 || true
+    fail "worker endpoint did not become ready: ${path}"
+}
+
+if [ -z "${AGENTTEAMS_QWENPAW_REAL_MODEL_IMAGE:-}" ] && [ "${AGENTTEAMS_QWENPAW_REAL_MODEL_SKIP_BUILD:-}" != "1" ]; then
+    log "building QwenPaw worker image: ${IMAGE}"
+    make -C "${REPO_ROOT}" build-qwenpaw-worker VERSION="${VERSION}"
+else
+    log "using existing QwenPaw worker image: ${IMAGE}"
+    docker image inspect "${IMAGE}" >/dev/null 2>&1 || fail "image not found: ${IMAGE}"
+fi
+
+log "creating docker network: ${NETWORK}"
+docker network create "${NETWORK}" >/dev/null
+
+log "starting MinIO: ${MINIO_CONTAINER}"
+docker run -d \
+    --name "${MINIO_CONTAINER}" \
+    --network "${NETWORK}" \
+    --network-alias minio \
+    -e MINIO_ROOT_USER=minioadmin \
+    -e MINIO_ROOT_PASSWORD=minioadmin \
+    "${MINIO_IMAGE}" \
+    server /data >/dev/null
+
+mkdir -p "${TMP_DIR}/seed/agents/${WORKER_NAME}/runtime" "${TMP_DIR}/seed/agents/${WORKER_NAME}"
+cat >"${TMP_DIR}/seed/agents/${WORKER_NAME}/runtime/runtime.yaml" <<EOF
+metadata:
+  generation: "1"
+team:
+  name: qwenpaw-real-model-e2e
+member:
+  name: ${WORKER_NAME}
+  runtimeName: ${WORKER_NAME}
+  runtime: qwenpaw
+  role: worker
+desired:
+  model:
+    providerId: ${PROVIDER_ID}
+    providerName: HiClaw Real Model E2E
+    model: ${MODEL}
+    baseUrl: ${BASE_URL}
+    apiKeyEnv: AGENTTEAMS_QWENPAW_REAL_MODEL_API_KEY
+  mcpServers: {}
+  channelPolicy: {}
+credentials:
+  gatewayKeyEnv: AGENTTEAMS_QWENPAW_REAL_MODEL_API_KEY
+EOF
+cat >"${TMP_DIR}/seed/agents/${WORKER_NAME}/SOUL.md" <<EOF
+# QwenPaw Real Model E2E
+
+Use the configured real model provider.
+EOF
+
+wait_for_minio
+log "seeding runtime.yaml into object storage"
+run_mc "
+    /usr/local/bin/mc.bin cp \
+        '/tmp/seed/agents/${WORKER_NAME}/runtime/runtime.yaml' \
+        'local/${BUCKET}/agents/${WORKER_NAME}/runtime/runtime.yaml' &&
+    /usr/local/bin/mc.bin cp \
+        '/tmp/seed/agents/${WORKER_NAME}/SOUL.md' \
+        'local/${BUCKET}/agents/${WORKER_NAME}/SOUL.md'
+" >/dev/null
+
+log "starting qwenpaw-worker container: ${WORKER_CONTAINER}"
+docker run -d \
+    --name "${WORKER_CONTAINER}" \
+    --network "${NETWORK}" \
+    -e AGENTTEAMS_WORKER_NAME="${WORKER_NAME}" \
+    -e AGENTTEAMS_WORKER_CR_NAME="${WORKER_NAME}" \
+    -e AGENTTEAMS_FS_ENDPOINT="http://minio:9000" \
+    -e AGENTTEAMS_FS_ACCESS_KEY=minioadmin \
+    -e AGENTTEAMS_FS_SECRET_KEY=minioadmin \
+    -e AGENTTEAMS_FS_BUCKET="${BUCKET}" \
+    -e AGENTTEAMS_QWENPAW_REAL_MODEL_API_KEY="${API_KEY}" \
+    -e QWENPAW_LOG_LEVEL="${QWENPAW_LOG_LEVEL:-info}" \
+    "${IMAGE}" >/dev/null
+
+wait_worker_http /api/version 240
+wait_worker_http /api/teamharness/health 240
+
+log "verifying provider config from runtime.yaml"
+docker exec -i \
+    -e HOME="${WORKER_HOME}" \
+    -e QWENPAW_WORKING_DIR="${QWENPAW_WORKING_DIR}" \
+    -e QWENPAW_SECRET_DIR="${QWENPAW_SECRET_DIR}" \
+    -e EXPECTED_PROVIDER="${PROVIDER_ID}" \
+    -e EXPECTED_MODEL="${MODEL}" \
+    -e EXPECTED_BASE_URL="${BASE_URL}" \
+    "${WORKER_CONTAINER}" \
+    /opt/venv/qwenpaw/bin/python - <<'PY'
+import os
+
+from qwenpaw.providers.provider_manager import ProviderManager
+
+expected_provider = os.environ["EXPECTED_PROVIDER"]
+expected_model = os.environ["EXPECTED_MODEL"]
+expected_base = os.environ["EXPECTED_BASE_URL"].rstrip("/")
+if not expected_base.endswith("/v1"):
+    expected_base = f"{expected_base}/v1"
+
+manager = ProviderManager.get_instance()
+active = manager.active_model
+provider = manager.custom_providers.get(expected_provider)
+
+assert active.provider_id == expected_provider, active
+assert active.model == expected_model, active
+assert provider is not None, expected_provider
+assert provider.base_url == expected_base, provider.base_url
+assert bool(provider.api_key), "provider api key missing"
+PY
+
+MARKER="AGENTTEAMS_QWENPAW_REAL_MODEL_E2E_$$_$(date +%s)"
+log "calling real model through qwenpaw agents chat"
+docker exec \
+    -e HOME="${WORKER_HOME}" \
+    -e QWENPAW_WORKING_DIR="${QWENPAW_WORKING_DIR}" \
+    -e QWENPAW_SECRET_DIR="${QWENPAW_SECRET_DIR}" \
+    "${WORKER_CONTAINER}" \
+    /opt/venv/qwenpaw/bin/qwenpaw agents chat \
+    --from-agent tester \
+    --to-agent default \
+    --text "Return exactly this token and no other words: ${MARKER}" \
+    --mode final \
+    --json-output \
+    --base-url http://127.0.0.1:8088 \
+    >"${TMP_DIR}/chat.out" 2>"${TMP_DIR}/chat.err" || {
+        docker logs --tail 160 "${WORKER_CONTAINER}" 2>&1 || true
+        cat "${TMP_DIR}/chat.err" >&2 || true
+        cat "${TMP_DIR}/chat.out" >&2 || true
+        fail "qwenpaw real model chat failed"
+    }
+
+if ! grep -q "${MARKER}" "${TMP_DIR}/chat.out" "${TMP_DIR}/chat.err"; then
+    cat "${TMP_DIR}/chat.err" >&2 || true
+    cat "${TMP_DIR}/chat.out" >&2 || true
+    fail "real model response did not contain marker ${MARKER}"
+fi
+
+log "PASS: image built, worker started, provider configured, real model responded"

--- a/qwenpaw/tests/integration/test-sync-minio.sh
+++ b/qwenpaw/tests/integration/test-sync-minio.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# QwenPaw worker storage sync integration test against real MinIO.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/qwenpaw-image-e2e.sh"
+
+qwenpaw_e2e_require_enabled
+qwenpaw_e2e_require_docker
+qwenpaw_e2e_init "sync-minio"
+qwenpaw_e2e_build_or_use_image
+
+qwenpaw_e2e_write_runtime_yaml "1"
+mkdir -p \
+    "${QWENPAW_E2E_TMP_DIR}/seed/agents/${QWENPAW_E2E_WORKER_NAME}/credentials" \
+    "${QWENPAW_E2E_TMP_DIR}/seed/shared"
+cat >"${QWENPAW_E2E_TMP_DIR}/seed/agents/${QWENPAW_E2E_WORKER_NAME}/remote-start.txt" <<EOF
+from-storage
+EOF
+cat >"${QWENPAW_E2E_TMP_DIR}/seed/agents/${QWENPAW_E2E_WORKER_NAME}/credentials/bootstrap-token" <<EOF
+must-not-mirror
+EOF
+cat >"${QWENPAW_E2E_TMP_DIR}/seed/shared/team-note.md" <<EOF
+# Shared Context
+
+Mirrored at worker startup.
+EOF
+
+qwenpaw_e2e_create_network
+qwenpaw_e2e_start_minio
+qwenpaw_e2e_wait_for_minio
+qwenpaw_e2e_seed_storage
+qwenpaw_e2e_start_worker
+qwenpaw_e2e_wait_worker_http /api/version 240
+
+qwenpaw_e2e_exec sh -lc '
+    grep -q "from-storage" "$HOME/remote-start.txt"
+    test -f "/root/hiclaw-fs/shared/team-note.md"
+    test -L "$HOME/.qwenpaw/workspaces/default/shared"
+    python -c '"'"'from pathlib import Path; import os; p = Path(os.environ["HOME"]) / ".qwenpaw/workspaces/default/shared"; assert p.resolve() == Path("/root/hiclaw-fs/shared").resolve()'"'"'
+    test ! -e "$HOME/credentials/bootstrap-token"
+'
+
+qwenpaw_e2e_exec sh -lc '
+    mkdir -p \
+        "$HOME/credentials" \
+        "$HOME/.qwenpaw/workspaces/default/tool_result" \
+        "$HOME/.qwenpaw/workspaces/default/file_store" \
+        "$HOME/.qwenpaw/workspaces/default/shared/tasks/t-2/workspace" \
+        "$HOME/shared/tasks/t-1"
+    printf "runtime upload\n" > "$HOME/runtime-note.md"
+    printf "workspace upload\n" > "$HOME/.qwenpaw/workspaces/default/integration-sync.md"
+    printf "secret\n" > "$HOME/credentials/local-token"
+    printf "log\n" > "$HOME/.qwenpaw/qwenpaw.log"
+    printf "{}\n" > "$HOME/.qwenpaw/workspaces/default/tool_result/result.json"
+    printf "file\n" > "$HOME/.qwenpaw/workspaces/default/file_store/a.txt"
+    printf "workspace shared\n" > "$HOME/.qwenpaw/workspaces/default/shared/tasks/t-2/workspace/result.md"
+    grep -q "workspace shared" "/root/hiclaw-fs/shared/tasks/t-2/workspace/result.md"
+    printf "team shared\n" > "$HOME/shared/tasks/t-1/result.md"
+'
+
+wait_for_object() {
+    local key="$1"
+    local expected="$2"
+    local i
+    for i in $(seq 1 30); do
+        if qwenpaw_e2e_run_mc "/usr/local/bin/mc.bin cat 'local/${QWENPAW_E2E_BUCKET}/${key}' 2>/dev/null" | grep -q "${expected}"; then
+            return 0
+        fi
+        sleep 2
+    done
+    qwenpaw_e2e_fail "object was not pushed: ${key}"
+}
+
+assert_missing_object() {
+    local key="$1"
+    if qwenpaw_e2e_run_mc "/usr/local/bin/mc.bin stat 'local/${QWENPAW_E2E_BUCKET}/${key}' >/dev/null 2>&1"; then
+        qwenpaw_e2e_fail "excluded object was pushed: ${key}"
+    fi
+}
+
+wait_for_object "agents/${QWENPAW_E2E_WORKER_NAME}/runtime-note.md" "runtime upload"
+wait_for_object "agents/${QWENPAW_E2E_WORKER_NAME}/.qwenpaw/workspaces/default/integration-sync.md" "workspace upload"
+
+assert_missing_object "agents/${QWENPAW_E2E_WORKER_NAME}/credentials/local-token"
+assert_missing_object "agents/${QWENPAW_E2E_WORKER_NAME}/.qwenpaw/qwenpaw.log"
+assert_missing_object "agents/${QWENPAW_E2E_WORKER_NAME}/.qwenpaw/workspaces/default/tool_result/result.json"
+assert_missing_object "agents/${QWENPAW_E2E_WORKER_NAME}/.qwenpaw/workspaces/default/file_store/a.txt"
+assert_missing_object "agents/${QWENPAW_E2E_WORKER_NAME}/shared/tasks/t-1/result.md"
+
+qwenpaw_e2e_log "PASS: startup mirror and background push boundaries verified"

--- a/qwenpaw/tests/integration/test-update-runtime-config.sh
+++ b/qwenpaw/tests/integration/test-update-runtime-config.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# QwenPaw runtime.yaml update integration test.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/qwenpaw-image-e2e.sh"
+
+qwenpaw_e2e_require_enabled
+qwenpaw_e2e_require_docker
+qwenpaw_e2e_init "update-runtime"
+qwenpaw_e2e_build_or_use_image
+
+runtime_yaml="${QWENPAW_E2E_TMP_DIR}/seed/agents/${QWENPAW_E2E_WORKER_NAME}/runtime/runtime.yaml"
+mkdir -p "$(dirname "${runtime_yaml}")" "${QWENPAW_E2E_TMP_DIR}/seed/agents/${QWENPAW_E2E_WORKER_NAME}"
+cat >"${runtime_yaml}" <<EOF
+metadata:
+  generation: "1"
+team:
+  name: qwenpaw-update-e2e
+member:
+  name: ${QWENPAW_E2E_WORKER_NAME}
+  runtimeName: ${QWENPAW_E2E_WORKER_NAME}
+  runtime: qwenpaw
+  role: worker
+desired:
+  model:
+    providerId: hiclaw-update-e2e
+    providerName: HiClaw Update E2E
+    model: qwen-fake-v1
+    baseUrl: https://dashscope.aliyuncs.com/compatible-mode/v1
+    apiKeyEnv: AGENTTEAMS_WORKER_GATEWAY_KEY
+  mcpServers:
+    docs:
+      url: https://gateway.example.com/mcp/docs-v1
+      transport: http
+  channelPolicy:
+    groupAllowExtra:
+      - "!team-v1:matrix.local"
+    dmAllowExtra:
+      - "@admin-v1:matrix.local"
+    groupDenyExtra:
+      - "!blocked-v1:matrix.local"
+    dmDenyExtra:
+      - "@blocked-v1:matrix.local"
+credentials:
+  gatewayKeyEnv: AGENTTEAMS_WORKER_GATEWAY_KEY
+EOF
+cat >"${QWENPAW_E2E_TMP_DIR}/seed/agents/${QWENPAW_E2E_WORKER_NAME}/SOUL.md" <<EOF
+# QwenPaw Update E2E
+
+Apply runtime.yaml desired state.
+EOF
+
+qwenpaw_e2e_create_network
+qwenpaw_e2e_start_minio
+qwenpaw_e2e_wait_for_minio
+qwenpaw_e2e_seed_storage
+qwenpaw_e2e_start_worker -e AGENTTEAMS_WORKER_GATEWAY_KEY=fake-gateway-key
+
+qwenpaw_e2e_wait_worker_http /api/version 240
+qwenpaw_e2e_wait_worker_http /api/teamharness/health 240
+
+qwenpaw_e2e_exec /opt/venv/qwenpaw/bin/python - <<'PY'
+import json
+import os
+from pathlib import Path
+
+from qwenpaw.app.channels.access_control import get_access_control_store
+from qwenpaw.config.config import load_agent_config
+from qwenpaw.providers.provider_manager import ProviderManager
+
+workspace = Path(os.environ["QWENPAW_WORKING_DIR"]) / "workspaces" / "default"
+
+manager = ProviderManager.get_instance()
+assert manager.active_model.provider_id == "hiclaw-update-e2e", manager.active_model
+assert manager.active_model.model == "qwen-fake-v1", manager.active_model
+provider = manager.custom_providers["hiclaw-update-e2e"]
+assert provider.base_url == "https://dashscope.aliyuncs.com/compatible-mode/v1", provider.base_url
+assert provider.api_key == "fake-gateway-key"
+
+mcp = json.loads((workspace / "config" / "mcporter.json").read_text(encoding="utf-8"))
+assert mcp["mcpServers"]["docs"]["url"] == "https://gateway.example.com/mcp/docs-v1"
+assert mcp["mcpServers"]["docs"]["headers"]["Authorization"] == "Bearer fake-gateway-key"
+assert not (workspace / "mcporter-servers.json").exists()
+
+agent_config = load_agent_config("default")
+assert agent_config.channels.matrix.access_control_group is True
+assert agent_config.channels.matrix.access_control_dm is True
+
+acl = get_access_control_store(workspace).get_acl("matrix")
+assert "!team-v1:matrix.local" in acl["whitelist"], acl
+assert "@admin-v1:matrix.local" in acl["whitelist"], acl
+assert "!blocked-v1:matrix.local" in acl["blacklist"], acl
+assert "@blocked-v1:matrix.local" in acl["blacklist"], acl
+PY
+
+started_before="$(docker inspect -f '{{.State.StartedAt}}' "${QWENPAW_E2E_WORKER_CONTAINER}")"
+
+qwenpaw_e2e_exec /opt/venv/qwenpaw/bin/python - <<'PY'
+import json
+from pathlib import Path
+
+root = Path("/tmp/qwenpaw-agent-package-v2")
+(root / "config").mkdir(parents=True, exist_ok=True)
+(root / "skills" / "hot-skill").mkdir(parents=True, exist_ok=True)
+(root / "config" / "AGENTS.md").write_text("# Package Generation 2\n", encoding="utf-8")
+(root / "config" / "SOUL.md").write_text("# Runtime Updated Soul\n", encoding="utf-8")
+(root / "mcp.json").write_text(
+    json.dumps(
+        {
+            "mcpServers": {
+                "package-docs": {
+                    "url": "https://package.example.com/mcp/docs",
+                    "transport": "http",
+                    "description": "Package docs",
+                }
+            }
+        }
+    )
+    + "\n",
+    encoding="utf-8",
+)
+(root / "skills" / "hot-skill" / "SKILL.md").write_text("# Hot Skill\n", encoding="utf-8")
+PY
+
+cat >"${runtime_yaml}" <<EOF
+metadata:
+  generation: "2"
+team:
+  name: qwenpaw-update-e2e
+member:
+  name: ${QWENPAW_E2E_WORKER_NAME}
+  runtimeName: ${QWENPAW_E2E_WORKER_NAME}
+  runtime: qwenpaw
+  role: worker
+desired:
+  agentPackage:
+    ref: file:///tmp/qwenpaw-agent-package-v2
+    name: update-e2e-package
+    version: 2.0.0
+    digest: sha256:update-e2e-v2
+  model:
+    providerId: hiclaw-update-e2e
+    providerName: HiClaw Update E2E
+    model: qwen-fake-v2
+    baseUrl: https://dashscope.aliyuncs.com/compatible-mode/v1
+    apiKeyEnv: AGENTTEAMS_WORKER_GATEWAY_KEY
+  mcpServers:
+    docs:
+      url: https://gateway.example.com/mcp/docs-v2
+      transport: http
+  channelPolicy:
+    groupAllowExtra:
+      - "!team-v2:matrix.local"
+    dmAllowExtra:
+      - "@admin-v2:matrix.local"
+    groupDenyExtra:
+      - "!blocked-v2:matrix.local"
+    dmDenyExtra:
+      - "@blocked-v2:matrix.local"
+credentials:
+  gatewayKeyEnv: AGENTTEAMS_WORKER_GATEWAY_KEY
+EOF
+
+qwenpaw_e2e_put_runtime_yaml
+
+updated="false"
+for _ in $(seq 1 45); do
+    if qwenpaw_e2e_exec /opt/venv/qwenpaw/bin/python - <<'PY'
+import json
+import os
+from pathlib import Path
+
+from qwenpaw.app.channels.access_control import get_access_control_store
+from qwenpaw.config.config import load_agent_config
+from qwenpaw.providers.provider_manager import ProviderManager
+
+workspace = Path(os.environ["QWENPAW_WORKING_DIR"]) / "workspaces" / "default"
+package_root = Path(os.environ["QWENPAW_WORKING_DIR"]) / "agent-packages"
+
+manager = ProviderManager.get_instance()
+assert manager.active_model.provider_id == "hiclaw-update-e2e", manager.active_model
+assert manager.active_model.model == "qwen-fake-v2", manager.active_model
+
+mcp = json.loads((workspace / "config" / "mcporter.json").read_text(encoding="utf-8"))
+assert mcp["mcpServers"]["docs"]["url"] == "https://gateway.example.com/mcp/docs-v2"
+assert not (workspace / "mcporter-servers.json").exists()
+
+agent_config = load_agent_config("default")
+assert agent_config.mcp.clients["package-docs"].url == "https://package.example.com/mcp/docs"
+assert not (workspace / "mcp.json").exists()
+
+acl = get_access_control_store(workspace).get_acl("matrix")
+assert "!team-v2:matrix.local" in acl["whitelist"], acl
+assert "@admin-v2:matrix.local" in acl["whitelist"], acl
+assert "!blocked-v2:matrix.local" in acl["blacklist"], acl
+assert "@blocked-v2:matrix.local" in acl["blacklist"], acl
+
+assert "Package Generation 2" in (workspace / "AGENTS.md").read_text(encoding="utf-8")
+assert (workspace / "skills" / "hot-skill" / "SKILL.md").is_file()
+identity = (package_root / "current.identity").read_text(encoding="utf-8").splitlines()
+assert identity[:4] == [
+    "file:///tmp/qwenpaw-agent-package-v2",
+    "update-e2e-package",
+    "2.0.0",
+    "sha256:update-e2e-v2",
+], identity
+PY
+    then
+        updated="true"
+        break
+    fi
+    sleep 2
+done
+
+[ "${updated}" = "true" ] || qwenpaw_e2e_fail "runtime.yaml update was not applied"
+
+started_after="$(docker inspect -f '{{.State.StartedAt}}' "${QWENPAW_E2E_WORKER_CONTAINER}")"
+[ "${started_before}" = "${started_after}" ] || qwenpaw_e2e_fail "worker container restarted during runtime update"
+
+qwenpaw_e2e_log "PASS: runtime.yaml model, MCP, channel policy, and AgentSpec package hot update verified"

--- a/qwenpaw/tests/integration/test-worker-daemon.sh
+++ b/qwenpaw/tests/integration/test-worker-daemon.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# QwenPaw worker daemon image integration test.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/qwenpaw-image-e2e.sh"
+
+qwenpaw_e2e_require_enabled
+qwenpaw_e2e_require_docker
+qwenpaw_e2e_init "worker-daemon"
+qwenpaw_e2e_build_or_use_image
+
+qwenpaw_e2e_write_runtime_yaml "1"
+mkdir -p "${QWENPAW_E2E_TMP_DIR}/seed/agents/${QWENPAW_E2E_WORKER_NAME}"
+cat >"${QWENPAW_E2E_TMP_DIR}/seed/agents/${QWENPAW_E2E_WORKER_NAME}/SOUL.md" <<EOF
+# QwenPaw Worker Daemon E2E
+
+Start the worker daemon and expose QwenPaw APIs.
+EOF
+
+qwenpaw_e2e_create_network
+qwenpaw_e2e_start_minio
+qwenpaw_e2e_wait_for_minio
+qwenpaw_e2e_seed_storage
+qwenpaw_e2e_start_worker
+
+qwenpaw_e2e_wait_worker_http /api/version 240
+qwenpaw_e2e_wait_worker_http /api/teamharness/health 240
+
+qwenpaw_e2e_exec sh -lc '
+    test -d "$HOME"
+    test -d "$QWENPAW_WORKING_DIR"
+    test -d "$QWENPAW_WORKING_DIR/workspaces/default"
+    test -f "$QWENPAW_WORKING_DIR/heartbeat.json"
+'
+
+for _ in $(seq 1 30); do
+    status="$(
+        qwenpaw_e2e_exec /opt/venv/qwenpaw/bin/python - <<'PY'
+import json
+import os
+from pathlib import Path
+
+path = Path(os.environ["QWENPAW_WORKING_DIR"]) / "heartbeat.json"
+print(json.loads(path.read_text(encoding="utf-8")).get("status", ""))
+PY
+    )"
+    if [ "${status}" = "ready" ]; then
+        break
+    fi
+    sleep 2
+done
+[ "${status}" = "ready" ] || qwenpaw_e2e_fail "worker heartbeat did not become ready"
+
+running="$(docker inspect -f '{{.State.Running}}' "${QWENPAW_E2E_WORKER_CONTAINER}")"
+[ "${running}" = "true" ] || qwenpaw_e2e_fail "worker container is not running"
+
+qwenpaw_e2e_log "PASS: worker daemon started, APIs ready, heartbeat ready"

--- a/qwenpaw/tests/test_defer_mcp_startup_patch.py
+++ b/qwenpaw/tests/test_defer_mcp_startup_patch.py
@@ -1,0 +1,80 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH_SCRIPT = ROOT / "scripts" / "patch-qwenpaw-defer-mcp-startup.py"
+
+
+def _load_patch_script():
+    spec = importlib.util.spec_from_file_location(
+        "_patch_qwenpaw_defer_mcp_startup",
+        PATCH_SCRIPT,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_defer_mcp_startup_patch_is_applied_during_image_build() -> None:
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "patch-qwenpaw-defer-mcp-startup.py" in dockerfile
+    assert "/opt/venv/qwenpaw/bin/python /tmp/patch-qwenpaw-defer-mcp-startup.py" in dockerfile
+    assert dockerfile.index("install-builtin-qwenpaw-plugins.py") < dockerfile.index(
+        "patch-qwenpaw-defer-mcp-startup.py",
+    )
+
+
+def test_defer_mcp_startup_patch_enables_native_workspace_flag() -> None:
+    module = _load_patch_script()
+    source = """
+        instance = Workspace(
+            agent_id=agent_id,
+            workspace_dir=agent_ref.workspace_dir,
+        )
+
+        new_instance = Workspace(
+            agent_id=agent_id,
+            workspace_dir=agent_ref.workspace_dir,
+        )
+"""
+
+    patched = module.patch_source(source)
+
+    assert patched.count("defer_mcp_startup=True") == 2
+    assert patched == module.patch_source(patched)
+
+
+def test_defer_mcp_startup_patch_preserves_mcp_connect_timeout() -> None:
+    module = _load_patch_script()
+    source = """
+            if getattr(ws, "defer_mcp_startup", False):
+                mcp.init_from_config_background(ws._config.mcp)
+                logger.debug(
+                    f"MCP initialization deferred for agent: {ws.agent_id}",
+                )
+"""
+
+    patched = module.patch_service_factories_source(source)
+
+    assert "mcp.init_from_config_background(" in patched
+    assert "timeout=60.0" in patched
+    assert patched == module.patch_service_factories_source(patched)
+
+
+def test_defer_mcp_startup_patch_fails_when_qwenpaw_shape_changes() -> None:
+    module = _load_patch_script()
+
+    with pytest.raises(RuntimeError, match="shape changed"):
+        module.patch_source("instance = Workspace(agent_id=agent_id)\n")
+
+
+def test_defer_mcp_startup_patch_fails_when_service_factory_changes() -> None:
+    module = _load_patch_script()
+
+    with pytest.raises(RuntimeError, match="shape changed"):
+        module.patch_service_factories_source("mcp.init_from_config(config)\n")

--- a/qwenpaw/tests/test_matrix_overlay.py
+++ b/qwenpaw/tests/test_matrix_overlay.py
@@ -16,6 +16,13 @@ def _overlay_source() -> str:
     return OVERLAY.read_text(encoding="utf-8")
 
 
+def test_matrix_overlay_is_installed_by_worker_image() -> None:
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "qwenpaw/src/matrix/" in dockerfile
+    assert "qwenpaw/app/channels/matrix/channel.py" in dockerfile
+
+
 def test_matrix_overlay_preserves_invite_join_and_marks_ready() -> None:
     source = _overlay_source()
 
@@ -1191,6 +1198,30 @@ def test_matrix_control_command_strips_mention_before_enqueue() -> None:
     assert _first_text(channel.enqueued[0]) == "/stop"
 
 
+def test_matrix_control_command_strips_at_localpart_mention_before_enqueue() -> None:
+    channel = _make_inbound_channel()
+    channel._user_id = "@worker:at-cn-ojs4upkyq01"
+
+    asyncio.run(
+        channel._on_room_event(
+            _FakeInboundRoom(),
+            _matrix_event_from(
+                "@24774e777ea409f1bc37ea990615d3a5:at-cn-ojs4upkyq01",
+                "@worker /stop",
+                event_id="~!MnRNwPjGJF2BtzpvWe:at-cn-ojs4upkyq01:m1782979172665.54",
+                content_extra={
+                    "m.mentions": {
+                        "user_ids": ["@worker:at-cn-ojs4upkyq01"],
+                    },
+                },
+            ),
+        ),
+    )
+
+    assert len(channel.enqueued) == 1
+    assert _first_text(channel.enqueued[0]) == "/stop"
+
+
 def test_matrix_double_slash_control_command_normalizes_with_mention() -> None:
     channel = _make_inbound_channel()
 
@@ -1245,6 +1276,14 @@ def test_matrix_bare_stop_not_recognized_without_slash() -> None:
 
     assert len(channel.enqueued) == 1
     assert "/stop" not in _first_text(channel.enqueued[0])
+
+
+def test_matrix_stop_command_requires_mention_in_group() -> None:
+    channel = _make_inbound_channel()
+
+    asyncio.run(channel._on_room_event(_FakeInboundRoom(), _matrix_event("/stop")))
+
+    assert len(channel.enqueued) == 0
 
 
 def test_matrix_control_command_requires_mention_in_group() -> None:

--- a/qwenpaw/tests/test_package_update.py
+++ b/qwenpaw/tests/test_package_update.py
@@ -19,6 +19,7 @@ def _package(
     version: str,
     *,
     materials: bool = False,
+    include_teams: bool = False,
     mcp_servers=None,
     mcp_json=None,
 ) -> Path:
@@ -38,6 +39,8 @@ def _package(
     (config_dir / "AGENTS.md").write_text(f"agent package {version}\n", encoding="utf-8")
     (config_dir / "SOUL.md").write_text(f"soul {version}\n", encoding="utf-8")
     (config_dir / "MEMORY.md").write_text(f"memory {version}\n", encoding="utf-8")
+    if include_teams:
+        (config_dir / "TEAMS.md").write_text(f"teams package {version}\n", encoding="utf-8")
     if materials:
         (config_dir / "BOOTSTRAP.md").write_text(f"bootstrap {version}\n", encoding="utf-8")
         materials_dir = config_dir / "materials"
@@ -903,6 +906,33 @@ def test_agent_package_update_overwrites_runtime_edits_to_package_seed(tmp_path:
 
     assert (workspace_dir / "AGENTS.md").read_text(encoding="utf-8") == "agent package 2\n"
     assert (workspace_dir / "skills" / "code-review" / "SKILL.md").read_text(encoding="utf-8") == "skill 2\n"
+
+
+def test_agent_package_update_does_not_overwrite_runtime_teams_md(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package_v1 = _package(tmp_path, "1", include_teams=True)
+    teams_md = workspace_dir / "TEAMS.md"
+
+    manager.apply(_runtime_config(tmp_path, package_v1, "1"))
+    teams_md.write_text("runtime managed teams\n", encoding="utf-8")
+    manager.apply(_runtime_config(tmp_path, package_v1, "1"))
+
+    assert teams_md.read_text(encoding="utf-8") == "runtime managed teams\n"
+
+
+def test_agent_package_update_does_not_delete_runtime_teams_md_from_old_package(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    manager = AgentPackageManager(tmp_path / "packages", workspace_dir=workspace_dir)
+    package_v1 = _package(tmp_path, "1", include_teams=True)
+    package_v2 = _empty_package(tmp_path, "2")
+    teams_md = workspace_dir / "TEAMS.md"
+
+    manager.apply(_runtime_config(tmp_path, package_v1, "1"))
+    teams_md.write_text("runtime managed teams\n", encoding="utf-8")
+    manager.apply(_runtime_config(tmp_path, package_v2, "2"))
+
+    assert teams_md.read_text(encoding="utf-8") == "runtime managed teams\n"
 
 
 def test_agent_package_update_clears_prompt_files_missing_from_new_package(tmp_path: Path) -> None:

--- a/qwenpaw/tests/test_update.py
+++ b/qwenpaw/tests/test_update.py
@@ -1,15 +1,23 @@
 import asyncio
+import io
 import json
 import logging
 import os
 from pathlib import Path
 import sys
+import tarfile
 import types
+import urllib.error
 
 import pytest
 
 from qwenpaw_worker.config import WorkerConfig
-from qwenpaw_worker.update import MemberRuntimeConfig, RuntimeUpdater
+from qwenpaw_worker.update import (
+    MemberRuntimeConfig,
+    QwenPawModelRuntimeSync,
+    RuntimeUpdater,
+    TEAMS_INTERNAL_CONTROL_MARKER,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -34,6 +42,20 @@ def _config(tmp_path: Path) -> WorkerConfig:
         install_dir=tmp_path / "agents",
         runtime_config_poll_interval=0.01,
     )
+
+
+def _agent_package(tmp_path: Path, version: str, *, include_teams: bool = False) -> Path:
+    source_dir = tmp_path / f"package-src-{version}"
+    config_dir = source_dir / "config"
+    config_dir.mkdir(parents=True)
+    (source_dir / "manifest.json").write_text('{"version":"1.0"}\n', encoding="utf-8")
+    (config_dir / "AGENTS.md").write_text(f"agent package {version}\n", encoding="utf-8")
+    if include_teams:
+        (config_dir / "TEAMS.md").write_text(f"package teams {version}\n", encoding="utf-8")
+    package_path = tmp_path / f"agent-package-{version}.tar.gz"
+    with tarfile.open(package_path, "w:gz") as archive:
+        archive.add(source_dir, arcname=".")
+    return package_path
 
 
 def test_runtime_updater_applies_changed_config_and_reapplies_adapter(tmp_path: Path) -> None:
@@ -490,6 +512,7 @@ old context
 
     text = teams_md.read_text(encoding="utf-8")
     assert "# Static TeamHarness Prompt" in text
+    assert TEAMS_INTERNAL_CONTROL_MARKER in text
     assert "old context" not in text
     assert "## Runtime Team Context" in text
     assert "runtimeName: leader-runtime" in text
@@ -501,6 +524,111 @@ old context
     assert "gatewayKeyEnv" not in text
     assert "AGENTTEAMS_WORKER_MATRIX_TOKEN" not in text
     assert "secret-ish-bucket" not in text
+
+
+def test_runtime_updater_rebuilds_missing_teams_md_with_renderer(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    rendered: list[str] = []
+    adapter_calls: list[str] = []
+
+    def render_team_context(runtime_config: MemberRuntimeConfig) -> str:
+        rendered.append(runtime_config.generation)
+        return """# Full TeamHarness Contract
+
+Use Quick Task and Project Work.
+
+<!-- BEGIN AGENTTEAMS RUNTIME TEAM CONTEXT -->
+old renderer context
+<!-- END AGENTTEAMS RUNTIME TEAM CONTEXT -->
+"""
+
+    updater = RuntimeUpdater(
+        config=config,
+        adapter_apply=lambda: adapter_calls.append("adapter"),
+        package_manager=_NoopPackageManager(),
+        team_context_renderer=render_team_context,
+    )
+
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "team": {"name": "demo-team", "teamRoomId": "!team:matrix.local"},
+                "member": {
+                    "name": "worker-a",
+                    "runtimeName": "worker-a",
+                    "role": "worker",
+                    "runtime": "qwenpaw",
+                },
+            },
+        ),
+        reapply_adapter=False,
+    )
+
+    text = (config.default_workspace_dir / "TEAMS.md").read_text(encoding="utf-8")
+    assert rendered == ["1"]
+    assert adapter_calls == []
+    assert "# Full TeamHarness Contract" in text
+    assert "Use Quick Task and Project Work." in text
+    assert "old renderer context" not in text
+    assert "team.name: demo-team" in text
+    assert TEAMS_INTERNAL_CONTROL_MARKER in text
+
+
+def test_runtime_updater_preserves_teams_md_when_package_changes_without_adapter(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    package_v1 = _agent_package(tmp_path, "1", include_teams=True)
+    package_v2 = _agent_package(tmp_path, "2", include_teams=False)
+    adapter_calls: list[str] = []
+
+    def render_team_context(runtime_config: MemberRuntimeConfig) -> str:
+        return f"""# Full TeamHarness Contract
+
+<!-- BEGIN AGENTTEAMS RUNTIME TEAM CONTEXT -->
+rendered generation {runtime_config.generation}
+<!-- END AGENTTEAMS RUNTIME TEAM CONTEXT -->
+"""
+
+    updater = RuntimeUpdater(
+        config=config,
+        adapter_apply=lambda: adapter_calls.append("adapter"),
+        team_context_renderer=render_team_context,
+    )
+
+    def runtime_config(package_path: Path, version: str, team_name: str) -> MemberRuntimeConfig:
+        return MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": version},
+                "team": {"name": team_name, "teamRoomId": "!team:matrix.local"},
+                "member": {
+                    "name": "worker-a",
+                    "runtimeName": "worker-a",
+                    "role": "worker",
+                    "runtime": "qwenpaw",
+                },
+                "desired": {
+                    "agentPackage": {
+                        "ref": f"file://{package_path}",
+                        "name": "dev-worker",
+                        "version": version,
+                        "digest": f"sha256:{version}",
+                    }
+                },
+            },
+        )
+
+    updater.apply_once(runtime_config=runtime_config(package_v1, "1", "team-one"), reapply_adapter=False)
+    updater.apply_once(runtime_config=runtime_config(package_v2, "2", "team-two"), reapply_adapter=False)
+
+    text = (config.default_workspace_dir / "TEAMS.md").read_text(encoding="utf-8")
+    assert adapter_calls == []
+    assert "# Full TeamHarness Contract" in text
+    assert "team.name: team-two" in text
+    assert "rendered generation" not in text
+    assert "package teams" not in text
+    assert TEAMS_INTERNAL_CONTROL_MARKER in text
 
 
 def test_runtime_updater_applies_desired_model_to_qwenpaw_agent_config(
@@ -638,6 +766,283 @@ def test_runtime_updater_configures_openai_compatible_provider_from_runtime_conf
     assert saved_active["active"].model == "qwen-plus"
     assert saved_agent["default"].active_model.provider_id == "hiclaw-gateway"
     assert saved_agent["default"].active_model.model == "qwen-plus"
+
+
+def test_runtime_updater_syncs_live_qwenpaw_app_only_when_model_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    monkeypatch.setenv("REAL_MODEL_KEY", "real-model-secret")
+    sync_calls: list[tuple[str, str]] = []
+
+    updater = RuntimeUpdater(
+        config=config,
+        package_manager=_NoopPackageManager(),
+        model_runtime_sync=lambda runtime_config: sync_calls.append(
+            (runtime_config.generation, runtime_config.model["model"])
+        ),
+    )
+
+    base_model = {
+        "providerId": "hiclaw-gateway",
+        "model": "qwen-plus",
+        "gatewayUrl": "https://dashscope.aliyuncs.com/compatible-mode",
+        "apiKeyEnv": "REAL_MODEL_KEY",
+    }
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {"model": base_model},
+            },
+        )
+    )
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "2"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {"model": base_model},
+            },
+        )
+    )
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "3"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {"model": {**base_model, "model": "qwen-max"}},
+            },
+        )
+    )
+
+    assert sync_calls == [("3", "qwen-max")]
+
+
+def test_runtime_updater_model_runtime_sync_failure_is_safe_and_retriable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config = _config(tmp_path)
+    monkeypatch.setenv("REAL_MODEL_KEY", "real-model-secret")
+    caplog.set_level(logging.WARNING, logger="qwenpaw_worker.update")
+
+    def fail_sync(_runtime_config: MemberRuntimeConfig) -> None:
+        raise RuntimeError("live sync failed with real-model-secret")
+
+    updater = RuntimeUpdater(
+        config=config,
+        package_manager=_NoopPackageManager(),
+        model_runtime_sync=fail_sync,
+    )
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "model": {
+                        "providerId": "hiclaw-gateway",
+                        "model": "qwen-plus",
+                        "gatewayUrl": "https://dashscope.aliyuncs.com/compatible-mode",
+                        "apiKeyEnv": "REAL_MODEL_KEY",
+                    }
+                },
+            },
+        )
+    )
+
+    with pytest.raises(RuntimeError):
+        updater.apply_once(
+            runtime_config=MemberRuntimeConfig(
+                path=config.runtime_config_path,
+                raw={
+                    "metadata": {"generation": "2"},
+                    "member": {"runtime": "qwenpaw"},
+                    "desired": {
+                        "model": {
+                            "providerId": "hiclaw-gateway",
+                            "model": "qwen-max",
+                            "gatewayUrl": "https://dashscope.aliyuncs.com/compatible-mode",
+                            "apiKeyEnv": "REAL_MODEL_KEY",
+                        }
+                    },
+                },
+            )
+        )
+
+    assert updater.current_config is not None
+    assert updater.current_config.generation == "1"
+    assert "component=update step=model_runtime_sync event=failed" in caplog.text
+    assert "generation=2" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
+    assert "safe_error_summary=RuntimeError" in caplog.text
+    assert "real-model-secret" not in caplog.text
+
+
+def test_model_runtime_sync_calls_qwenpaw_models_api_and_verifies_agent_active(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config = _config(tmp_path)
+    monkeypatch.setenv("REAL_MODEL_KEY", "real-model-secret")
+    caplog.set_level(logging.INFO, logger="qwenpaw_worker.update")
+    calls: list[tuple[str, str, dict]] = []
+
+    class FakeResponse:
+        def __init__(self, status: int, payload):
+            self.status = status
+            self._body = json.dumps(payload).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return self._body
+
+    def fake_urlopen(request, timeout):
+        body = json.loads(request.data.decode("utf-8")) if request.data else {}
+        calls.append((request.get_method(), request.full_url, body))
+        index = len(calls)
+        if index == 1:
+            return FakeResponse(200, [])
+        if index == 2:
+            raise urllib.error.HTTPError(
+                request.full_url,
+                404,
+                "Not Found",
+                {},
+                io.BytesIO(b'{"detail":"Provider not found"}'),
+            )
+        if index == 3:
+            return FakeResponse(
+                201,
+                {"id": "hiclaw-gateway", "models": [], "extra_models": []},
+            )
+        if index == 4:
+            return FakeResponse(
+                200,
+                {"id": "hiclaw-gateway", "models": [], "extra_models": []},
+            )
+        if index == 5:
+            return FakeResponse(
+                201,
+                {
+                    "id": "hiclaw-gateway",
+                    "models": [],
+                    "extra_models": [{"id": "qwen-max", "name": "qwen-max"}],
+                },
+            )
+        if index == 6:
+            return FakeResponse(
+                200,
+                {"active_llm": {"provider_id": "hiclaw-gateway", "model": "qwen-max"}},
+            )
+        return FakeResponse(
+            200,
+            {"active_llm": {"provider_id": "hiclaw-gateway", "model": "qwen-max"}},
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    QwenPawModelRuntimeSync(port=8088).sync(
+        MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "2"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "model": {
+                        "providerId": "hiclaw-gateway",
+                        "providerName": "HiClaw Gateway",
+                        "model": "qwen-max",
+                        "gatewayUrl": "https://dashscope.aliyuncs.com/compatible-mode",
+                        "apiKeyEnv": "REAL_MODEL_KEY",
+                    }
+                },
+            },
+        )
+    )
+
+    assert [(method, url.split("/api/models", 1)[1].split("?", 1)[0]) for method, url, _ in calls] == [
+        ("GET", ""),
+        ("PUT", "/hiclaw-gateway/config"),
+        ("POST", "/custom-providers"),
+        ("PUT", "/hiclaw-gateway/config"),
+        ("POST", "/hiclaw-gateway/models"),
+        ("PUT", "/active"),
+        ("GET", "/active"),
+    ]
+    assert calls[3][2] == {
+        "api_key": "real-model-secret",
+        "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "chat_model": "OpenAIChatModel",
+    }
+    assert calls[5][2] == {
+        "scope": "agent",
+        "agent_id": "default",
+        "provider_id": "hiclaw-gateway",
+        "model": "qwen-max",
+    }
+    assert "component=update step=model_runtime_sync event=complete" in caplog.text
+    assert "generation=2" in caplog.text
+    assert "provider_id=hiclaw-gateway" in caplog.text
+    assert "model=qwen-max" in caplog.text
+    assert "changed=True" in caplog.text
+    assert "real-model-secret" not in caplog.text
+
+
+def test_model_runtime_sync_http_error_does_not_expose_response_body_secret(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config(tmp_path)
+    monkeypatch.setenv("REAL_MODEL_KEY", "real-model-secret")
+
+    def fake_urlopen(request, timeout):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            500,
+            "Server Error",
+            {},
+            io.BytesIO(b'{"detail":"failed with real-model-secret"}'),
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    sync = QwenPawModelRuntimeSync(port=8088)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        sync.sync(
+            MemberRuntimeConfig(
+                path=config.runtime_config_path,
+                raw={
+                    "metadata": {"generation": "2"},
+                    "member": {"runtime": "qwenpaw"},
+                    "desired": {
+                        "model": {
+                            "providerId": "hiclaw-gateway",
+                            "model": "qwen-max",
+                            "gatewayUrl": "https://dashscope.aliyuncs.com/compatible-mode",
+                            "apiKeyEnv": "REAL_MODEL_KEY",
+                        }
+                    },
+                },
+            )
+        )
+
+    assert "real-model-secret" not in str(excinfo.value)
+    assert "HTTP 500" in str(excinfo.value)
 
 
 def test_runtime_updater_writes_mcporter_config_from_desired_mcp_servers(

--- a/qwenpaw/tests/test_worker_lifecycle.py
+++ b/qwenpaw/tests/test_worker_lifecycle.py
@@ -793,6 +793,42 @@ def apply_teamharness():
     assert "prompt" not in caplog.text
 
 
+def test_team_context_renderer_only_calls_render_function(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    plugin_dir = config.qwenpaw_working_dir / "plugins" / "teamharness"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.py").write_text(
+        """
+from pathlib import Path
+
+
+def render_team_context(config):
+    Path(__file__).with_name("rendered.txt").write_text(config["team"]["name"], encoding="utf-8")
+    return "# Rendered TeamHarness Contract\\n" + config["team"]["name"] + "\\n"
+
+
+def apply_teamharness():
+    Path(__file__).with_name("applied.txt").write_text("bad\\n", encoding="utf-8")
+    return {"ok": True}
+""".lstrip(),
+        encoding="utf-8",
+    )
+    runtime_config = MemberRuntimeConfig(
+        path=config.runtime_config_path,
+        raw={
+            "metadata": {"generation": "1"},
+            "team": {"name": "demo-team"},
+            "member": {"runtime": "qwenpaw"},
+        },
+    )
+
+    text = Worker(config)._render_teamharness_context(runtime_config)
+
+    assert text == "# Rendered TeamHarness Contract\ndemo-team\n"
+    assert (plugin_dir / "rendered.txt").read_text(encoding="utf-8") == "demo-team"
+    assert not (plugin_dir / "applied.txt").exists()
+
+
 def test_apply_workerflow_assets_runs_installed_adapter(tmp_path: Path) -> None:
     config = _config(tmp_path)
     plugin_dir = config.qwenpaw_working_dir / "plugins" / "workerflow"


### PR DESCRIPTION
## Summary

- add the QwenPaw worker image, entrypoint, builtin plugin install, and deferred MCP startup patching
- add QwenPaw runtime hot-update behavior for runtime config, TEAMS.md context, model/channel/MCP sync, and package updates
- add Makefile and CI image-build wiring for `hiclaw/qwenpaw-worker`

## Scope

This PR keeps QwenPaw as a parallel worker runtime and does not change OpenHuman, OpenClaw, CoPaw, or Hermes runtime selection.

Explicitly not included here:

- TeamHarness / WorkerFlow adapter implementation changes
- credential/JWT bootstrap helpers
- SchedulerX skill or aliyun CLI additions
- broad naming migration

## Validation

- `git diff --check`
- `make -n build-qwenpaw-worker`
- `uv run --with pytest --with-editable qwenpaw pytest qwenpaw/tests/test_update.py qwenpaw/tests/test_worker_lifecycle.py qwenpaw/tests/test_matrix_overlay.py qwenpaw/tests/test_package_update.py qwenpaw/tests/test_defer_mcp_startup_patch.py`
