### PR TITLE
fix(controller): preserve Manager plugin allow-list across reconciles

### DIFF
--- a/copaw/src/copaw_worker/sync.py
+++ b/copaw/src/copaw_worker/sync.py
@@ -93,7 +93,8 @@ def _merge_openclaw_config(remote_text: str, local_text: str) -> str:
       - models, gateway: replaced from remote when present.
       - channels: deep merge with remote winning leaf conflicts; local-only keys kept.
       - channels.matrix.accessToken: local wins (Worker re-login after restart).
-      - plugins.entries: deep merge with local winning on shared keys; load.paths union.
+      - plugins.entries: deep merge with local winning on shared keys.
+      - plugins.load.paths, plugins.allow: union of remote and local values.
     """
     remote = json.loads(remote_text)
     local = json.loads(local_text)
@@ -130,6 +131,10 @@ def _merge_openclaw_config(remote_text: str, local_text: str) -> str:
             out_load = dict(l_plugins.get("load") or {})
             out_load["paths"] = sorted(set((r_paths or []) + (l_paths or [])))
             out_plugins["load"] = out_load
+        r_allow = r_plugins.get("allow")
+        l_allow = l_plugins.get("allow")
+        if r_allow is not None or l_allow is not None:
+            out_plugins["allow"] = sorted(set((r_allow or []) + (l_allow or [])))
         merged["plugins"] = out_plugins
 
     return json.dumps(merged, indent=2, ensure_ascii=False)

--- a/hermes/src/hermes_worker/sync.py
+++ b/hermes/src/hermes_worker/sync.py
@@ -55,7 +55,8 @@ def _merge_openclaw_config(remote_text: str, local_text: str) -> str:
       - models, gateway: replaced from remote when present.
       - channels: deep merge with remote winning leaf conflicts; local-only keys kept.
       - channels.matrix.accessToken: local wins (Worker re-login after restart).
-      - plugins.entries: deep merge with local winning on shared keys; load.paths union.
+      - plugins.entries: deep merge with local winning on shared keys.
+      - plugins.load.paths, plugins.allow: union of remote and local values.
     """
     remote = json.loads(remote_text)
     local = json.loads(local_text)
@@ -92,6 +93,10 @@ def _merge_openclaw_config(remote_text: str, local_text: str) -> str:
             out_load = dict(l_plugins.get("load") or {})
             out_load["paths"] = sorted(set((r_paths or []) + (l_paths or [])))
             out_plugins["load"] = out_load
+        r_allow = r_plugins.get("allow")
+        l_allow = l_plugins.get("allow")
+        if r_allow is not None or l_allow is not None:
+            out_plugins["allow"] = sorted(set((r_allow or []) + (l_allow or [])))
         merged["plugins"] = out_plugins
 
     return json.dumps(merged, indent=2)

--- a/hiclaw-controller/internal/service/deployer.go
+++ b/hiclaw-controller/internal/service/deployer.go
@@ -1312,6 +1312,11 @@ func (d *Deployer) builtinAgentDir(role, runtime string) string {
 // overrides these to [leader, admin] for team members. WorkerReconciler is
 // team-agnostic and would otherwise revert them to standalone [manager, admin]
 // on every reconcile, breaking team-scoped task delivery.
+//
+// plugins.allow and plugins.load.paths are unioned across the two configs so
+// user-added plugin allow-list entries and extension directories survive
+// reconciles; existing user modifications still win on shared keys because
+// the generated config provides the base.
 func mergeUserPluginConfig(generatedJSON, existingJSON []byte) ([]byte, error) {
 	var generated, existing map[string]interface{}
 	if err := json.Unmarshal(generatedJSON, &generated); err != nil {
@@ -1356,21 +1361,15 @@ func mergeUserPluginConfig(generatedJSON, existingJSON []byte) ([]byte, error) {
 	if genLoad != nil && existLoad != nil {
 		genPaths := toStringSliceCompat(genLoad["paths"])
 		existPaths := toStringSliceCompat(existLoad["paths"])
-		seen := make(map[string]bool, len(genPaths)+len(existPaths))
-		var unionPaths []string
-		for _, p := range genPaths {
-			if !seen[p] {
-				seen[p] = true
-				unionPaths = append(unionPaths, p)
-			}
-		}
-		for _, p := range existPaths {
-			if !seen[p] {
-				seen[p] = true
-				unionPaths = append(unionPaths, p)
-			}
-		}
-		genLoad["paths"] = unionPaths
+		genLoad["paths"] = unionStringSlices(genPaths, existPaths)
+	}
+
+	// Union plugin allow entries so user-added plugin allow-list entries
+	// (e.g. memory-core dreaming schedule) survive reconciles.
+	genAllow := toStringSliceCompat(genPlugins["allow"])
+	existAllow := toStringSliceCompat(existPlugins["allow"])
+	if len(genAllow) > 0 || len(existAllow) > 0 {
+		genPlugins["allow"] = unionStringSlices(genAllow, existAllow)
 	}
 
 	return json.MarshalIndent(generated, "", "  ")
@@ -1471,4 +1470,22 @@ func toStringSliceCompat(v interface{}) []string {
 		return arr
 	}
 	return nil
+}
+
+func unionStringSlices(first, second []string) []string {
+	seen := make(map[string]bool, len(first)+len(second))
+	var result []string
+	for _, item := range first {
+		if !seen[item] {
+			seen[item] = true
+			result = append(result, item)
+		}
+	}
+	for _, item := range second {
+		if !seen[item] {
+			seen[item] = true
+			result = append(result, item)
+		}
+	}
+	return result
 }

--- a/hiclaw-controller/internal/service/deployer_merge_test.go
+++ b/hiclaw-controller/internal/service/deployer_merge_test.go
@@ -113,6 +113,76 @@ func TestMergeUserPluginConfig_PreservesUserAddedPlugins(t *testing.T) {
 	}
 }
 
+func TestMergeUserPluginConfig_UnionsPluginAllowList(t *testing.T) {
+	generated := `{
+		"plugins": {
+			"allow": ["matrix", "memory-core"]
+		}
+	}`
+	existing := `{
+		"plugins": {
+			"allow": ["matrix", "active-memory"]
+		}
+	}`
+
+	merged, err := mergeUserPluginConfig([]byte(generated), []byte(existing))
+	if err != nil {
+		t.Fatalf("merge failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(merged, &result); err != nil {
+		t.Fatalf("unmarshal merged: %v", err)
+	}
+
+	plugins := result["plugins"].(map[string]interface{})
+	allow := plugins["allow"].([]interface{})
+	allowSet := make(map[string]bool)
+	for _, name := range allow {
+		allowSet[name.(string)] = true
+	}
+	for _, expected := range []string{"matrix", "memory-core", "active-memory"} {
+		if !allowSet[expected] {
+			t.Errorf("plugin allow entry %q was lost (got: %v)", expected, allow)
+		}
+	}
+}
+
+func TestMergeUserPluginConfig_PreservesAllowWhenGeneratedMissing(t *testing.T) {
+	generated := `{
+		"plugins": {
+			"entries": { "matrix": { "enabled": true } }
+		}
+	}`
+	existing := `{
+		"plugins": {
+			"allow": ["matrix", "memory-core", "active-memory"]
+		}
+	}`
+
+	merged, err := mergeUserPluginConfig([]byte(generated), []byte(existing))
+	if err != nil {
+		t.Fatalf("merge failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(merged, &result); err != nil {
+		t.Fatalf("unmarshal merged: %v", err)
+	}
+
+	plugins, ok := result["plugins"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("plugins missing from merged result: %v", result)
+	}
+	allow, ok := plugins["allow"].([]interface{})
+	if !ok {
+		t.Fatalf("plugins.allow missing when generated has no allow: %v", plugins)
+	}
+	if len(allow) != 3 {
+		t.Errorf("expected 3 allow entries preserved, got %d: %v", len(allow), allow)
+	}
+}
+
 func TestMergeUserPluginConfig_AddsNewDefaultEntries(t *testing.T) {
 	generated := `{
 		"plugins": {

--- a/shared/lib/merge-openclaw-config.sh
+++ b/shared/lib/merge-openclaw-config.sh
@@ -12,6 +12,7 @@
 #       on shared keys so user customizations (e.g. memory-core dreaming schedule)
 #       survive periodic syncs
 #     - plugins.load.paths: union of both sides
+#     - plugins.allow: union of both sides
 #     - channels: deep merge (remote wins shared keys, local-only keys preserved)
 #     - channels.matrix.accessToken: local wins (Worker re-login)
 #
@@ -56,6 +57,9 @@ merge_openclaw_config() {
                 else . end
               | if ($remote.plugins.load.paths // null) != null or ($local.plugins.load.paths // null) != null then
                   .load = ((.load // {}) | .paths = ([($remote.plugins.load.paths // [])[], ($local.plugins.load.paths // [])[]] | unique))
+                else . end
+              | if ($remote.plugins.allow // null) != null or ($local.plugins.allow // null) != null then
+                  .allow = ([($remote.plugins.allow // [])[], ($local.plugins.allow // [])[]] | unique)
                 else . end
             )
           else . end

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,99 @@
+# AgentTeams Issue TODO
+
+Refreshed 2026-07-08 13:03 UTC. Tracks 17 PRs by `RerankerGuo` on `agentscope-ai/AgentTeams`. CI runs are post-rebase onto current `main` (HEAD `0b562ff`).
+
+## PR Summary Table
+
+| PR | Title | State | Mergeable | CI | Issues pinged |
+|---|---|---|---|---|---|
+| #965 | fix(controller): preserve Manager plugin config | ❌ CLOSED | — | — | #936 / #937 / #938 |
+| #969 | fix(manager): add safe worker deletion wrapper | 🟢 OPEN | MERGEABLE | ✅ 18/18 green | #967 |
+| #970 | fix(manager): avoid restart recovery local failure | 🟢 OPEN | MERGEABLE | ✅ 18/18 green | #952 |
+| #971 | fix(worker): avoid heartbeat sync storm | 🟢 OPEN | MERGEABLE | ❌ SHARD_A copaw/hermes (post-rebase) | #949 |
+| #972 | fix(controller): sync Human worker allowlist | 🟢 OPEN | MERGEABLE | ❌ SHARD_A copaw/hermes | #954 |
+| #973 | fix(config): pass custom model parameters to controller | 🟢 OPEN | MERGEABLE | ❌ SHARD_A copaw/hermes | #961 |
+| #975 | fix(manager): stop repeated diagnostic loops | 🟢 OPEN | MERGEABLE | ❌ SHARD_A copaw/copaw + copaw/hermes | #974 |
+| #976 | docs(team-leader): simplify worker name guidance | 🟢 OPEN | MERGEABLE | ❌ SHARD_A copaw/copaw + openclaw/openclaw | #913 |
+| #977 | docs: add skill format contribution guide | 🟢 OPEN | MERGEABLE | ✅ translate only | #735 |
+| #978 | docs: clarify Element homeserver port | 🟢 OPEN | MERGEABLE | ✅ translate only | #898 |
+| #979 | fix(copaw): retry prompt reads during worker startup | 🟢 OPEN | MERGEABLE | ✅ 18/18 green | #711 / #728 |
+| #980 | docs: clarify Higress AI route matching | 🟢 OPEN | MERGEABLE | ✅ translate only | #867 |
+| #981 | fix(copaw): refresh runtime skill projection | 🟢 OPEN | MERGEABLE | ✅ 18/18 green | #712 |
+| #982 | fix(copaw): guard managed skill cleanup | 🟢 OPEN | MERGEABLE | ✅ 18/18 green | #626 |
+| #983 | fix(worker): keep openclaw config local during sync | 🟢 OPEN | MERGEABLE | ❌ SHARD_A openclaw/openclaw | #809 |
+| #984 | fix(install): surface Higress gateway startup diagnostics | 🟢 OPEN | MERGEABLE | ❌ SHARD_B copaw/hermes (NEW — test-14-git-collab) | #888 |
+| #985 | test: make multi-worker bob setup deterministic | 🟢 OPEN | MERGEABLE | ✅ **18/18 green** — root-cause fix for SHARD_A flake | test infra flake |
+
+## Tier 1: Ready to merge (CI green + ping sent)
+
+All docs-only or already passed full integration. Awaiting maintainer review/merge.
+
+- **#977** — Skill format contribution guide (English + Chinese), linked from Manager guide. Translate-only CI green.
+- **#978** — FAQ entry clarifying `:18088` (Element Web UI) vs `:18080` (Matrix/Higress). Translate-only CI green.
+- **#980** — FAQ entry for #867 (custom AI route matching): warns about unconstrained `default-ai-route` shadowing, recommends explicit `modelPredicates`. Translate-only CI green.
+
+## Tier 2: Rebased + CI green (Tier 2 ping sent)
+
+- **#969** — 18/18 green. Adds `hiclaw delete worker <name>` wrapper that cleans `state.json` / `worker-lifecycle.json` / `workers-registry.json`.
+- **#970** — 18/18 green. Removes top-level `local` in `start-manager-agent.sh` Worker recreation block.
+- **#979** — 18/18 green. Bounded stable UTF-8 reads for `SOUL.md` / `AGENTS.md` during CoPaw startup and re-bridge.
+- **#981** — 18/18 green. Restores CoPaw bridge helpers for workspace → runtime workspace materialization.
+- **#982** — 18/18 green. Managed child-directory guards around CoPaw recursive skill cleanup.
+
+## Tier 3: SHARD_A flake (red, flake analysis sent)
+
+These all failed `integration-tests (llm-interaction, SHARD_A_TESTS, ...)` on `test-06-multi-worker.sh`. Same root cause across runtimes: Manager did not invoke `hiclaw create worker --name bob` in the flaky run — confirmed by inspecting #984's downloaded artifacts (no `hiclaw-worker-bob/` session directory exists; only alice's). #976 is a docs-only PR with the same failure pattern, proving the failure is not branch-local. The flake analysis comments on these PRs link back to #984's investigation.
+
+- **#972** — failed `SHARD_A copaw/hermes`. Human Reconciler → `groupAllowExtra` sync.
+- **#973** — failed `SHARD_A copaw/hermes`. Helm/embedded model-parameter env wiring.
+- **#975** — failed `SHARD_A copaw/copaw` + `copaw/hermes`. Manager diagnostic-loop prompt guidance.
+- **#976** — failed `SHARD_A copaw/copaw` + `openclaw/openclaw`. Docs-only (+14/-64); the openclaw failure here is the strongest evidence the flake is cross-runtime.
+- **#983** — failed `SHARD_A openclaw/openclaw`. `hiclaw-sync` exclude + merge for `openclaw.json`.
+- **#984** — failed `SHARD_A copaw/copaw` + `copaw/hermes` (the original investigation that surfaced the flake).
+
+## Tier 4: Latest rebase results
+
+- **#971** — rebase onto `main` HEAD `0b562ff`; new CI run finished red on the **same** SHARD_A copaw/hermes flake (Manager never invoked `hiclaw create worker --name bob`). Comment posted 2026-07-08 13:03 linking to #985 as the upstream fix.
+- **#984** — re-rebased; SHARD_A is now **passing** on this PR (the bob-determinism fix in #985 may have helped even before #985 merges, by changing the test runner script in main? — actually no, #985 is on a separate branch; the SHARD_A pass is just run-to-run variance). But a NEW failure appeared on **SHARD_B copaw/hermes** → `tests/test-14-git-collab.sh` (the 4-phase non-linear multi-worker git collaboration test, 57 min runtime before failing). This is a separate LLM-driven flake (3 workers, 4 phases, complex branch/path/report invariants). No equivalent deterministic-bypass PR exists for test 14. The PR's own change is shell diagnostics + sysctl FAQ, doesn't touch Manager agent runtime or git ops. Comment posted 2026-07-08 13:03.
+
+## Tier 5: Special — Fixes the SHARD_A flake itself
+
+- **#985** — `test: make multi-worker bob setup deterministic`. Replaces the LLM-driven `matrix_send_message ... create bob` instruction with a direct `hiclaw apply worker --name bob ...` call so the collaboration assertions below measure multi-worker flow, not LLM timing. **This is the upstream fix for the SHARD_A flake affecting #972, #973, #975, #976, #983, #984, and now #971.** Rebased onto current `main`, CI **18/18 green as of 13:00 UTC**, priority ping posted 2026-07-08 13:03.
+
+If #985 merges first, the SHARD_A failures on Tier 3 PRs should disappear on the next CI run. **#985 is now the single highest-priority PR — landing it unblocks 7 other PRs.**
+
+## CLOSED
+
+- **#965** — auto-closed by GitHub at 2026-07-08T05:28:38Z after `head_ref_force_pushed`. A buggy rebase script force-pushed origin/main HEAD `0b562ff` over the PR's source branch, losing the original commit `1820ef3`. Fork was restored to `1820ef3`, but the upstream PR ref stayed stuck at `0b562ff`. `gh pr reopen` fails (no reopen permission; only `pull` on the upstream repo). Original fix shape was: preserve `plugins.allow` / `plugins.entries` / `plugins.load.paths` across controller reconciliation; conflicts in deployer.go (638 lines) and deployer_test.go (1064 lines) due to #998's deployer refactor. To recover: open a new PR from a fresh branch.
+
+## Maintainer Feedback
+
+**No human responses on any PR.** Active merger is `shiyiyue1102` (15 PRs merged in last 30 days; nobody else has merged PRs).
+
+All comments on every PR are either:
+- `github-actions` CI bot reports (CI Metrics Report / Integration Tests Failed summary), or
+- My own ping / flake-analysis comments from 2026-07-08 06:05–07:25 UTC.
+
+## Cron / next-step plan
+
+- All scheduled one-shot crons (`cbde48c7`, `de5e92c1`, `fee24c58`) have been deleted (their fire times passed and the events have all been handled manually in real time).
+- Currently active things to monitor:
+  1. **#985** — already pinged as priority; awaiting maintainer merge.
+  2. **#971, #972, #973, #975, #976, #983** — Tier-3 PRs blocked on #985 merge. After #985 lands, re-running CI on these should clear them.
+  3. **#984** — has a separate SHARD_B (test-14) failure; needs separate investigation or maintainer judgement.
+  4. **#965** — still CLOSED; recovery requires either maintainer reopen or new PR (covered above).
+- No further cron scheduling until maintainer responds or #985 lands.
+- Keep current branch `fix/issue-957-copaw-worker-k8s-startup` untouched.
+
+## Issues from old todo still pending
+
+The original 2026-07-03 todo mentioned several skipped/lower-priority issues. Current status (unchanged unless noted):
+
+- **#947 task progress watchdog** — upstream PR #948 open with assignee; skip.
+- **#957 K8s v1.1.1 controller cannot start v1.1.2 CoPaw worker** — upstream PR #960 open; skip. (Branch `fix/issue-957-copaw-worker-k8s-startup` checked out locally is the user's WIP for this.)
+- **#925 Manager Matrix sync silently stops after Suppressed AbortError** — needs design; skip.
+- **#962 Embedded mode McpBridge not pushed to Envoy via xDS** — upstream base-image issue; skip.
+- **#953 Manager cannot be interrupted while processing a message** — needs design; skip.
+- **#929 Can we only use Alibaba Cloud Bailian models?** — already documented; skip.
+- **#850 Qiniu Cloud returns 308** — assigned, needs reproduction; skip.
+- **#820 Worker renamed during use stops receiving Manager messages** — assigned, needs reproduction; skip.


### PR DESCRIPTION
Replacement for #965 (auto-closed by GitHub after a force-push race on 2026-07-08).

Closes #936 (and the duplicate tracking issues #937, #938).

## Problem

Controller regenerates Manager `openclaw.json` on every reconcile. The generated config emits a default `plugins.allow` list. When an admin customizes `openclaw.json` to register additional plugins via the allow-list (e.g. `active-memory`, `matrix`, `memory-core`), those user-added entries were silently lost on every reconcile because `mergeUserPluginConfig` (and the worker-side `_merge_openclaw_config` / `shared/lib/merge-openclaw-config.sh`) only unioned `plugins.load.paths` but not `plugins.allow`. After a few reconciles the user's installed plugin extension would no longer load — visible as missing plugins in Worker SOUL.md / skills without any explicit error.

## Fix

Extend the existing `plugins.load.paths` union to also union `plugins.allow` in three places:

1. **Controller** — `hiclaw-controller/internal/service/deployer.go`: `mergeUserPluginConfig` now also unions `plugins.allow`, using a new `unionStringSlices` helper extracted from the existing inline dedup loop. Function comment updated to describe both unions.
2. **Worker (CoPaw)** — `copaw/src/copaw_worker/sync.py`: `_merge_openclaw_config` doc and merge block add the `plugins.allow` union.
3. **Worker (Hermes)** — `hermes/src/hermes_worker/sync.py`: same as CoPaw.
4. **Shared shell helper** — `shared/lib/merge-openclaw-config.sh`: `jq` query now also unions `plugins.allow`; header comment lists it alongside `plugins.load.paths`.

## Tests added

In `hiclaw-controller/internal/service/deployer_merge_test.go`:

- `TestMergeUserPluginConfig_UnionsPluginAllowList` — generated + existing each define `plugins.allow` with one shared and one unique entry; verify all three are present after merge.
- `TestMergeUserPluginConfig_PreservesAllowWhenGeneratedMissing` — generated has no `plugins.allow`, existing has 3 entries; verify all 3 are preserved (this is the actual user-visible bug).

## Note vs #965

The original #965 also added `encoding/json` import to `deployer_test.go` (a new file). That import is no longer needed because the new tests live in `deployer_merge_test.go` which already imports `encoding/json`. The original also added the unused `utf8` import; that has been removed in current `main`.