### PR TITLE
feat(teamharness): add QwenPaw workerflow integration

### DIFF
--- a/docs/teamharness-boundary-and-contracts.md
+++ b/docs/teamharness-boundary-and-contracts.md
@@ -23,7 +23,7 @@ TeamHarness owns:
 
 TeamHarness does not own:
 
-- Controller generation of `shared/runtime/members/{runtimeName}/runtime.yaml`.
+- Controller generation of `agents/{runtimeName}/runtime/runtime.yaml`.
 - Worker process lifecycle, pod restart, or runtime process supervision.
 - Worker desired-state parsing, polling, apply, or diagnostics.
 - Runtime-neutral top-level hooks.
@@ -40,7 +40,7 @@ TeamHarness does not own:
 Controller to runtime:
 
 - The controller writes non-secret desired state and team facts to
-  `shared/runtime/members/{runtimeName}/runtime.yaml`.
+  `agents/{runtimeName}/runtime/runtime.yaml`.
 - Secrets stay in environment variables, mounted files, or service account
   tokens.
 
@@ -55,8 +55,7 @@ Runtime adapter to TeamHarness:
 
 - The adapter maps TeamHarness prompts, skills, and MCP into a concrete runtime.
 - Runtime-specific hooks live under the adapter implementation, for example
-  `adapters/qwenpaw/hooks/` or `adapters/claude-code/hooks/`, when that runtime
-  integration phase defines them.
+  `adapters/qwenpaw/hooks/`, when that runtime integration phase defines them.
 - Runtime config consumption belongs to the worker/runtime adapter layer, not to
   the TeamHarness plugin package.
 - The adapter should consume controller-written runtime config facts instead of

--- a/docs/teamharness-project-task-runtime-design.md
+++ b/docs/teamharness-project-task-runtime-design.md
@@ -1,0 +1,434 @@
+# TeamHarness Project/Task Runtime 设计方案
+
+本文定义 TeamHarness Project/Task Runtime 的目标设计。设计基于现有
+`projectflow`、`taskflow`、`roomflow`、TEAMS prompt 和 team skills，并向原
+MAGIC/CoPaw 的 `ProjectMeta + TaskMeta + Store Protocol` 模型收敛。
+
+核心目标不是共享 session memory，而是在 Leader 被 Worker、外部
+channel 或后续事件唤醒时，通过持久化 project/task state 恢复上下文，继续验收结果、
+推进 DAG/Loop，并把 requester report 发回 `ProjectMeta.reply_route` 记录的
+原始请求通道。
+
+## 设计原则
+
+- `ProjectMeta.reply_route` 是项目级字段，记录最终回报路线；Task 不复制外部
+  channel 路由。
+- `TaskMeta.room_id` 是委派链路里的 assignment room，记录 Worker 执行任务的
+  内部协作房间。
+- TEAMS 只做三种模式的总索引；具体步骤由 `project-management`、
+  `task-delegation`、`task-execution` 展开。
+- Quick Task 需要 fast tool，避免 Leader 手工拼
+  `create_project -> plan_dag -> ready_nodes -> delegate_task`。
+- 存储协议兼容 CoPaw 的 TaskStore 文件协议，而不是兼容当前 TeamHarness 的
+  `project.json` / `task.json` 轻量实现。
+- 不直接依赖 CoPaw 包；TeamHarness 在 `plugins/teamharness/mcp/` 下维护
+  runtime-neutral 的模型、store 和 MCP tool 语义。
+
+## 1. Task/Project 模型定义与存储实现
+
+### ProjectMeta
+
+`ProjectMeta` 是跨 session 恢复项目上下文的根对象，canonical 存储为
+`shared/projects/{project_id}/meta.json`。
+
+```json
+{
+  "project_id": "demo-project-001",
+  "title": "Demo project",
+  "status": "active",
+  "mode": "project",
+  "plan_type": "dag",
+  "source": "dingtalk",
+  "requester": "dingtalk:user:session",
+  "reply_route": {
+    "channel": "dingtalk",
+    "target_user": "user-id",
+    "target_session": "session-id"
+  },
+  "parent_task_id": null,
+  "created_at": "2026-06-06T00:00:00Z",
+  "updated_at": "2026-06-06T00:00:00Z",
+  "requester_report": {
+    "pending": false,
+    "reason": null,
+    "task_id": null,
+    "report_path": "shared/projects/demo-project-001/result.md",
+    "sent_at": null
+  }
+}
+```
+
+| Field | 说明 |
+| --- | --- |
+| `project_id` | 项目唯一 ID，也是 project 目录名。 |
+| `title` | 项目标题。 |
+| `status` | `active` / `paused` / `completed` / `blocked`。 |
+| `mode` | `quick` 或 `project`，Direct Reply 不创建 Project。 |
+| `plan_type` | `dag` / `loop`，Quick Task 固定为 `dag`。 |
+| `source` | 请求来源，例如 `matrix`、`dingtalk`、`api`。 |
+| `requester` | 人类可读的 requester 标识，保留 CoPaw 原字段语义。 |
+| `reply_route` | 最终 requester report 路由；不得包含 secret。 |
+| `parent_task_id` | 子项目来自上游 task 时记录关联。 |
+| `requester_report` | 是否存在待发送 requester report，以及对应 result/report 路径。 |
+
+### TaskMeta
+
+`TaskMeta` 是 Worker 执行任务的状态对象，canonical 存储为
+`shared/tasks/{task_id}/meta.json`。
+
+```json
+{
+  "task_id": "demo-project-001-01",
+  "project_id": "demo-project-001",
+  "task_title": "Write readiness note",
+  "assigned_to": "@worker-a:matrix.local",
+  "room_id": "!task-room:matrix.local",
+  "status": "assigned",
+  "depends_on": [],
+  "assigned_at": "2026-06-06T00:00:00Z",
+  "acknowledged_at": null,
+  "submitted_at": null,
+  "spec_path": "shared/tasks/demo-project-001-01/spec.md",
+  "result_path": "shared/tasks/demo-project-001-01/result.md"
+}
+```
+
+| Field | 说明 |
+| --- | --- |
+| `task_id` | 任务唯一 ID，也是 task 目录名。 |
+| `project_id` | 所属 Project。 |
+| `task_title` | 任务标题。 |
+| `assigned_to` | Worker 标识。 |
+| `room_id` | assignment room；只表示内部执行房间。 |
+| `status` | `assigned` / `in_progress` / `submitted`。 |
+| `depends_on` | DAG 依赖的 task id 列表。 |
+| `spec_path` | Worker 输入 spec。 |
+| `result_path` | Worker 输出 result。 |
+
+### 状态定义
+
+DAG/Loop plan node status：
+
+| Status | 说明 |
+| --- | --- |
+| `pending` | 在 plan 中，但还没有委派。 |
+| `delegated` | 已写入 TaskMeta/spec，并通知 Worker。 |
+| `completed` | Leader 已接受 result，并更新 project plan。 |
+| `blocked` | Leader 接受 blocker，等待人工决策、重排或终止。 |
+| `revision` | Leader 认为 result 需要修订。 |
+
+TaskMeta status：
+
+| Status | 说明 |
+| --- | --- |
+| `assigned` | Leader 已委派，Worker 尚未 ack。 |
+| `in_progress` | Worker 已 ack，正在执行。 |
+| `submitted` | Worker 已提交 result，等待 Leader check/accept。 |
+
+TaskResult status：
+
+| Status | 说明 |
+| --- | --- |
+| `SUCCESS` | 可直接验收的成功结果。 |
+| `SUCCESS_WITH_NOTES` | 成功但带注意事项。 |
+| `REVISION_NEEDED` | Worker 主动说明需要修订。 |
+| `BLOCKED` | Worker 被阻塞。 |
+| `INTERRUPTED` | Worker 执行被中断。 |
+
+### 存储布局
+
+Canonical layout：
+
+```text
+shared/projects/{project_id}/
+  meta.json
+  plan.md
+  result.md
+
+shared/tasks/{task_id}/
+  meta.json
+  spec.md
+  result.md
+  workspace/
+  deliverables/
+```
+
+CoPaw 协议兼容策略：
+
+- 新实现以 `meta.json` 为唯一 canonical metadata 文件。
+- 不把当前 TeamHarness 的 `project.json` / `task.json` 作为兼容协议。
+- `ProjectMeta` 保持 CoPaw 原字段语义，并以可选字段扩展 `mode`、
+  `plan_type`、`reply_route`、`updated_at`、`requester_report`。
+- `TaskMeta` 保持 CoPaw 原字段语义，尤其保留 `room_id` 作为 assignment room。
+- `plan.md`、`spec.md`、`result.md` 的路径和语义对齐 CoPaw
+  `FileSystemTaskStore`。
+- tool 输入可以接受 camelCase alias，例如 `projectId`、`replyRoute`；落盘字段使用
+  snake_case。
+- DingTalk client secret、access token、webhook signing secret 等不得进入
+  `shared/projects`、`shared/tasks`、room log 或 project report。
+
+### Store Protocol
+
+TeamHarness MCP 内部维护 store protocol，先提供 filesystem 实现：
+
+```text
+read_project_meta(project_id)
+write_project_meta(project_meta)
+read_project_plan(project_id)
+write_project_plan(project_id, plan_markdown)
+read_task_meta(task_id)
+write_task_meta(task_meta)
+read_task_spec(task_id)
+write_task_spec(task_id, spec_markdown)
+read_task_result(task_id)
+write_task_result(task_id, result_markdown)
+list_project_ids()
+```
+
+store protocol 的职责只是读写结构化状态和文档文件，不做 DAG 决策、不发消息、
+不调用外部 channel。
+
+## 2. Task/Project Action 设计与 MCP 工具
+
+### projectflow
+
+`projectflow` 管 Project 生命周期、project plan、结果接受和 requester report
+状态。
+
+| Action | 说明 |
+| --- | --- |
+| `create_project` | 创建 `ProjectMeta`，记录 `reply_route`，不创建 task。 |
+| `create_quick_project` | Quick Task fast tool，一次性创建 quick project、单节点 plan、TaskMeta/spec。 |
+| `resolve_project` | 从 `projectId`、`taskId`、`parentTaskId`、`roomId`、`externalId` 恢复 project context。 |
+| `plan_dag` | 写入或刷新 DAG plan，返回 ready nodes。 |
+| `plan_loop` | 写入或刷新 Loop plan，返回 ready loop nodes。 |
+| `ready_nodes` | 只计算 DAG 可委派节点。 |
+| `ready_loop_nodes` | 只计算 Loop 可委派节点。 |
+| `record_loop_iteration` | 记录 Loop 迭代决策。 |
+| `accept_task_result` | Leader 显式把 checked result 接受到 DAG/Loop plan。 |
+| `pause_project` | 暂停项目。 |
+| `resume_project` | 恢复项目。 |
+| `complete_project` | 完成项目。 |
+| `mark_requester_report_sent` | requester report 发送成功后清理 pending 状态。 |
+
+`create_quick_project` 是 Quick Task 的快速工具。它应完成：
+
+```text
+create ProjectMeta(mode=quick, plan_type=dag)
+write single plan node(status=delegated)
+write TaskMeta(status=assigned, room_id=assignment_room)
+write spec.md
+return project_id, task_id, assignment_room, reply_route
+```
+
+它不负责发送 Worker assignment message，也不负责发送 requester report。消息发送仍由
+`communication` skill 通过对应 channel 工具完成。
+
+`accept_task_result` 是 project 状态推进的唯一入口。`check_task` 返回
+`effective: true` 后，Leader 仍必须显式调用 `accept_task_result`，这样跨 session
+恢复时不会把“result 已提交”和“project 已接受”混在一起。
+
+### taskflow
+
+`taskflow` 只管单个 Task 的委派、ack、提交和结果检查。
+
+| Role | Action | 说明 |
+| --- | --- | --- |
+| Leader | `delegate_task` | 将 ready node 转成 TaskMeta/spec，并设置 plan node 为 `delegated`。 |
+| Leader | `check_task` | 读取 TaskMeta/result，校验 result contract，返回 `effective`，不改 DAG/Loop。 |
+| Worker | `ack_task` | Worker 接受任务，创建 workspace，将 TaskMeta 置为 `in_progress`。 |
+| Worker | `submit_task` | Worker 写 result，将 TaskMeta 置为 `submitted`。 |
+
+`delegate_task` 必须校验：
+
+- task 来自 `ready_nodes` 或 `ready_loop_nodes`。
+- 所有 dependencies 已是 `completed`。
+- `room_id` 是已解析好的 assignment room。
+- 不允许直接从用户请求创建 bare task。
+
+### roomflow
+
+`roomflow` 负责 assignment room 解析或创建：
+
+- Matrix DM 来源的任务可以使用 Team Room 作为 assignment room。
+- DingTalk、Feishu、WeChat、API 等外部 requester channel 来源的任务，使用
+  `create_task_room` 创建内部 task room。
+- assignment room 只进入 `TaskMeta.room_id`；最终 requester report 仍使用
+  `ProjectMeta.reply_route`。
+
+### Event Resume Contract
+
+Worker completion/blocker message 必须包含 task id：
+
+```text
+TASK_COMPLETED: {task_id} - Result: shared/tasks/{task_id}/result.md
+TASK_BLOCKED: {task_id} - Result: shared/tasks/{task_id}/result.md
+```
+
+Leader 收到事件后的固定恢复顺序：
+
+```text
+taskflow check_task(task_id)
+projectflow resolve_project(taskId=task_id)
+projectflow accept_task_result(projectId, taskId, decision)
+communication report through ProjectMeta.reply_route when requester_report.pending
+projectflow mark_requester_report_sent(projectId)
+```
+
+Leader 不从当前 session 猜 project、reply route 或下一步 DAG/Loop。
+
+## 3. 流程组织模式与 TEAMS + Skill 实现
+
+### 渐进式披露
+
+TEAMS 定义三种模式，作为总索引：
+
+```text
+Direct Reply
+Quick Task
+Project Task
+```
+
+TEAMS 只说明何时选择哪种模式、每一步调用哪个 skill，不展开所有 tool payload
+细节。细节由 skills 分层承载。
+
+### Direct Reply
+
+适用场景：
+
+- 普通问答。
+- 澄清。
+- 状态确认。
+- 不需要 Worker、不需要 shared state、不需要后续验收的轻量响应。
+
+流程：
+
+```text
+classify as Direct Reply
+reply in current channel/session
+stop
+```
+
+约束：
+
+- 不创建 Project。
+- 不创建 Task。
+- 不调用 `projectflow` / `taskflow`。
+- 如果来自 DingTalk，就在 DingTalk 当前 session 直接回复。
+
+### Quick Task
+
+适用场景：
+
+- 正好一个 Worker-owned task。
+- 有明确 acceptance criteria。
+- 需要 task spec、Worker result、Leader check 和 requester report。
+- 不需要多节点 DAG、Loop、并行 Worker 或复杂重排。
+
+流程：
+
+```text
+TEAMS selects Quick Task
+project-management calls projectflow create_quick_project
+communication notifies Worker in assignment_room
+worker uses task-execution ack_task / submit_task
+Leader resumes from TASK_COMPLETED task_id
+task-delegation calls check_task
+project-management calls resolve_project + accept_task_result
+communication reports through ProjectMeta.reply_route
+project-management calls mark_requester_report_sent
+```
+
+约束：
+
+- 不再单独调用 `create_project`、`plan_dag`、`ready_nodes`、`delegate_task`。
+- Quick Task 的 fast tool 只创建状态和 spec，不发消息。
+- 如果 check/accept 后发现还需要多任务、修订波次或 Loop，升级为 Project Task。
+
+### Project Task
+
+适用场景：
+
+- 多步骤协作。
+- 多 Worker。
+- DAG dependencies。
+- Loop iteration。
+- 需要持续验收、replan、blocker decision 或最终汇总。
+
+流程：
+
+```text
+TEAMS selects Project Task
+project-management create_project or resolve_project
+project-management plan_dag or plan_loop
+project-management ready_nodes or ready_loop_nodes
+task-delegation resolves assignment_room, using roomflow when needed
+task-delegation calls delegate_task
+communication notifies Worker
+worker uses task-execution ack_task / submit_task
+Leader resumes from TASK_COMPLETED / TASK_BLOCKED task_id
+task-delegation calls check_task
+project-management calls resolve_project + accept_task_result
+project-management decides next ready nodes, loop decision, blocker, or complete_project
+communication reports through ProjectMeta.reply_route when needed
+```
+
+### Skill 分工
+
+| Skill | 职责 | 不负责 |
+| --- | --- | --- |
+| `team-coordination` | 判断 Direct Reply / Quick Task / Project Task，决定 DAG vs Loop。 | 写 project/task state。 |
+| `project-management` | ProjectMeta、Project Resolver、plan、ready nodes、acceptance、requester report pending。 | 写 Worker task spec 的细节和 Worker 执行。 |
+| `task-delegation` | assignment room 解析、`delegate_task`、`check_task`、Worker assignment/completion message contract。 | project 生命周期推进。 |
+| `task-execution` | Worker `ack_task`、执行 spec、`submit_task`、result contract。 | 修改 ProjectMeta 或 plan。 |
+| `communication` | Matrix/Team Room/DM requester report 路由。 | 推断 project context。 |
+| `dingtalk-channel` | DingTalk inbound 识别、保留 `reply_route`、最终回 DingTalk。 | 成为 TeamHarness 内置基础 channel 或保存 DingTalk secret。 |
+
+## 4. Task/Project 兜底策略暂缓
+
+异常 loop 中断后的自驱恢复暂不纳入本阶段设计与实现。
+
+当前阶段只要求主流程具备可恢复上下文：
+
+- Worker completion/blocker 消息必须携带 `taskId`。
+- Leader 收到 task 事件后用 `resolve_project(taskId)` 恢复 ProjectMeta、
+  TaskMeta、plan 和 requester route。
+- Leader 通过 `check_task`、`accept_task_result`、
+  `mark_requester_report_sent` 推进正常项目流程。
+
+不在本阶段定义或实现：
+
+- runtime hook。
+- 外置 continuation/recovery service。
+- active task 扫描。
+- loop 中断后的自动唤醒。
+
+后续如果重新处理异常自驱问题，应作为独立设计进入，而不是混入
+Project/Task canonical state、MCP tool 和 skill 分层的当前阶段。
+
+## 现有实现差距
+
+当前 TeamHarness 已经具备轻量 project/task state 和 `create_quick_project`，但还没有
+完全对齐本设计：
+
+| Area | 当前情况 | 目标 |
+| --- | --- | --- |
+| Canonical state | 主要写 `project.json` / `task.json`。 | 迁移到 CoPaw 协议的 `meta.json`，不保留 TeamHarness legacy 文件作为兼容目标。 |
+| ProjectMeta | 已有 `reply_route` 字段雏形，但不在 CoPaw `meta.json` 协议上。 | 基于 CoPaw `ProjectMeta` 扩展 `reply_route` 和 `requester_report`。 |
+| TaskMeta | 已有 `room_id`。 | 对齐 CoPaw `TaskMeta.room_id`，明确它是 assignment room。 |
+| Plan node status | 当前使用 `planned/assigned/completed` 等轻量状态。 | 收敛到 CoPaw 的 `pending/delegated/completed/blocked/revision`。 |
+| Quick Task | 已有 `create_quick_project` shortcut。 | 明确为 Quick Task fast tool 合约。 |
+| Result acceptance | `check_task` 与 project 推进边界不够完整。 | 新增/明确 `accept_task_result`，由 Leader 显式推进 project。 |
+| Resume | 依赖当前 session 容易丢上下文。 | `resolve_project(taskId)` 返回恢复上下文。 |
+| Requester report | 可能依赖即时 session。 | `requester_report.pending` 进入 ProjectMeta。 |
+| Recovery | 暂缓，不作为当前阶段目标。 | 后续独立设计异常 loop 中断后的自驱恢复。 |
+
+## 推荐落地顺序
+
+1. 先补模型和 store protocol，直接对齐 CoPaw 的 `meta.json` canonical 协议。
+2. 再补 `resolve_project`、`accept_task_result`、`mark_requester_report_sent`。
+3. 固化 `create_quick_project` fast tool 合约，并保证 Quick Task 不重复调用
+   `delegate_task`。
+4. 调整 TEAMS 和 skills 分层：TEAMS 做总索引，skills 展开步骤。
+5. 最后补 DingTalk 手动 E2E：Direct Reply 不创建 state；Quick/Project Task 跨
+   session 能从 task id 恢复 project context，并最终回 DingTalk。

--- a/docs/teamharness-runtime-integration-tdd-plan.md
+++ b/docs/teamharness-runtime-integration-tdd-plan.md
@@ -22,27 +22,75 @@ TDD 目标：
 
 - 本阶段以文档评审作为验收。
 
-## 阶段 2：Plugin 管理逻辑与 CLI 集成
+## 阶段 2：CLI 默认安装和 LoongSuite 标准兼容
 
-先做 plugin 管理逻辑和 CLI 功能，不急着接入具体 TeamHarness 内容。
+先做 TeamHarness 标准包和默认 CLI 安装路径。LoongSuite/Pilot 只作为本地部署兼容入口，
+不作为默认安装器，也不参与集群 QwenPaw worker 生命周期。
 
 先写测试：
 
-- plugin manifest 可以被 CLI 发现、解析和校验。
-- CLI 能执行 plugin list / inspect / install / uninstall 或当前项目已有的等价命令。
-- 安装逻辑能把 plugin asset 复制到约定位置。
-- 重复安装是幂等的。
-- 缺失 manifest、非法 manifest、asset 缺失时有明确错误。
-- uninstall 只移除该 plugin 自己安装的内容，不误删 runtime 或其它 plugin 文件。
+- `teamharness.tar.gz` 包含 `plugin.yaml`、prompts、skills、MCP、adapters 和
+  `scripts/install.sh` / `scripts/uninstall.sh`。
+- `agentteams plugin install/list/update/uninstall` 能以同一个 tarball 作为默认安装路径。
+- CLI 解包到 `.agentteams/` 管理目录，调用 lifecycle script，并记录本地 manifest。
+- 重复安装和 update 使用同一套 lifecycle；uninstall 只清理该 plugin 自己的状态。
+- LoongSuite 兼容定义使用 `deployMode: plugin-probe`，指向
+  `$PILOT_DIR/plugins/teamharness.tar.gz` 和 `$PILOT_DATA/plugins/teamharness`。
+- 模拟 LoongSuite 解包后能执行同一个 `scripts/install.sh`。
+- 用 fake `qwenpaw` / fake `claude` 验证 lifecycle script 会分发到对应 adapter 入口。
+- 包不存在、tarball 非法、install script 失败、manifest name 不匹配时有明确错误。
 
 实现目标：
 
-- plugin 管理逻辑和 CLI 功能可测试、可复用。
-- 本阶段不要求 TeamHarness 业务能力完整，也不要求 runtime adapter 已存在。
+- CLI 是默认安装器。
+- TeamHarness tarball 同时兼容 CLI 和 LoongSuite `plugin-probe` 标准。
+- CLI 和 LoongSuite 不维护两套包结构。
+- 本阶段不要求 TeamHarness 业务能力完整，也不做真实 QwenPaw / Claude Code runtime 调用。
 
 ## 阶段 3：TeamHarness 基础包集成
 
 在 plugin 管理逻辑可用后，再迁移 TeamHarness 基础包。
+
+本阶段的核心是树立 TeamHarness v0.1 的功能边界和契约关系。TeamHarness plugin 只提供团队协作
+基础能力，不承载 worker desired-state apply loop 或 runtime apply 逻辑。
+
+标准资产清单：
+
+- Prompts：
+  - `prompts/team/TEAMS.md`
+  - `prompts/agent/leader.md`
+  - `prompts/agent/worker.md`
+  - `prompts/agent/remote-member.md`
+  - `prompts/manager/AGENTS.md`
+  - `prompts/manager/TOOLS.md`
+  - `prompts/manager/HEARTBEAT.md`
+- Agent skills：
+  - `mcporter`
+  - `find-skills`
+- Team skills：
+  - `organization`
+  - `communication`
+  - `file-sharing`
+  - `team-coordination`
+  - `project-management`
+  - `task-delegation`
+  - `task-execution`
+- MCP tools：
+  - `health`
+  - `message`
+  - `filesync`
+  - `projectflow`
+  - `taskflow`
+
+阶段 3 明确不包含：
+
+- `runtime-config` hook 或 `config-sync` skill。
+- 顶层 runtime-neutral hooks。runtime trigger、payload、拦截和改写能力依赖具体 runtime，放到各 adapter 自己实现。
+- credential guard。凭据访问控制依赖具体 runtime enforcement，先放到 QwenPaw worker/adapter 阶段处理。
+- runtime config 读取、轮询、apply、diagnostics。
+- AgentSpec package 拉取、应用、回滚或热更新。
+- QwenPaw / Claude Code runtime 配置写入。
+- plugin 自己启动 5 秒 loop。
 
 先写测试：
 
@@ -50,13 +98,15 @@ TDD 目标：
 - Team prompt 能表达稳定团队协作契约，不包含实时成员、room、model、package version 或 secret。
 - Role prompt 能区分 leader、worker、remote member 的职责边界。
 - Team skills 覆盖组织关系、沟通、文件共享、任务推进等团队协作能力，并且按角色暴露。
-- MCP tools 覆盖 message、filesync、taskflow、projectflow、runtimehealth 等团队操作，并有参数/权限/错误行为测试。
-- Hooks 覆盖 team context 注入、credential guard、output sanitizer、message route、runtime config 等团队运行态逻辑，并有降级行为测试。
+- MCP tools 覆盖 message、filesync、taskflow、projectflow 等团队操作，并有参数/权限/错误行为测试。
+- `runtimehealth` 不属于 TeamHarness v0.1 plugin。runtime heartbeat diagnostics 留到 worker/runtime 阶段处理。
+- TeamHarness 基础包不声明顶层 hooks；后续 runtime adapter 阶段分别定义 adapter-specific behavior 和测试。
 - TeamHarness 基础包可以通过阶段 2 的 plugin CLI 安装。
 
 实现目标：
 
 - `plugins/teamharness` 作为 runtime-neutral 的团队基础能力包存在。
+- TeamHarness plugin 不出现 `AGENTTEAM_` 旧前缀，不包含 `runtime-config` 或 `config-sync`。
 - 本阶段仍不要求 qwenpaw 或 Claude Code adapter 行为。
 
 ## 阶段 4：QwenPaw Worker + Plugin 集成
@@ -65,17 +115,29 @@ QwenPaw 集成包含两部分：QwenPaw worker runtime 和 TeamHarness QwenPaw a
 
 职责边界：
 
-- Worker 负责启动生命周期、存储恢复、runtime config 轮询、AgentSpec package 拉取与应用、runtime health。
-- QwenPaw adapter/plugin 负责把 TeamHarness prompts、skills、MCP、hooks 和 QwenPaw runtime glue 安装/接入到 QwenPaw。
-- Worker 不承载 TeamHarness 团队协作语义；adapter/plugin 不承载 worker 存储生命周期和 package 轮询。
+- Worker 负责启动生命周期、存储恢复、5 秒 desired-state apply loop、runtime heartbeat 上报。desired-state apply loop 读取 runtime.yaml，并在同一条 apply 路径里处理 model、MCP、channel、TeamHarness prompt asset 和 AgentSpec package 变化。
+- QwenPaw adapter/plugin 负责把 TeamHarness prompts、skills、MCP 和 QwenPaw runtime glue 安装/接入到 QwenPaw；QwenPaw runtime wrappers 由该 adapter 自己定义。
+- Worker 不承载 TeamHarness 团队协作语义；adapter/plugin 不承载 worker 存储生命周期和 desired-state apply loop。
+- `runtime-config` parser/helper 放在 QwenPaw worker/runtime 层，不放在 TeamHarness plugin 里。
+
+QwenPaw adapter runtime wrappers：
+
+- 先读 QwenPaw 源码确认可用 hook/middleware/agent toolkit API，不猜测 trigger 名称或 payload 形状。
+- Runtime-specific 资产和注册逻辑放在 `plugins/teamharness/adapters/qwenpaw/` 下，不放在 TeamHarness 顶层 manifest。
+- Team context：adapter 将 `TEAMS.md` 安装到 QwenPaw agent workspace，并加入 prompt file list；内容合入 TeamHarness team prompt、当前 member role prompt、runtime.yaml 的团队、成员、房间、路由和 AgentSpec package 上下文，不写 secret 或动态任务状态。
+- Output sanitizer：adapter 私有包装 QwenPaw tool result 路径，在工具结果进入模型上下文、消息输出或日志前按 `desired.outputSanitize` 和 credential env 值进行 `[REDACTED]` 替换。
+- Desired-state apply loop、storage sync、runtime heartbeat 上报仍属于 worker，不通过 hook 实现。AgentSpec package 更新是 desired-state apply loop 的一个分支，不是独立 worker loop。
 
 先写测试：
 
 - QwenPaw worker 能读取模拟 controller 写入的 runtime.yaml：
-  `shared/runtime/members/{memberName}/runtime.yaml`
-- runtime.yaml 里的 team/member/storage 事实能被 plugin adapter 使用。
-- worker 能安装/加载 TeamHarness QwenPaw plugin，但不直接实现 plugin 内部 prompt/skill/MCP/hook 逻辑。
+  `agents/{memberName}/runtime/runtime.yaml`
+- QwenPaw worker 每 5 秒检查 runtime.yaml，generation 或 AgentSpec package identity 未变化时不重复 apply。
+- runtime.yaml 里的 team/member/storage/desired 事实能被 worker 标准化，并传给 QwenPaw adapter。
+- worker 能安装/加载 TeamHarness QwenPaw plugin，但不直接实现 plugin 内部 prompt/skill/MCP 或 adapter runtime wrapper 逻辑。
 - adapter 能把 TeamHarness assets 安装进 QwenPaw，且不查询 `hiclaw` CLI。
+- adapter 测试覆盖 workspace `TEAMS.md` prompt asset 和 output sanitizer。二者都是 QwenPaw adapter 私有能力，不进入 TeamHarness 顶层 hook contract。
+- worker 在同一个 desired-state apply loop 中负责 AgentSpec package 拉取、校验、应用和失败保留上一成功版本。
 - worker 失败和 adapter/plugin 失败能分别暴露。
 - 集成测试必须基于 qwenpaw worker 镜像运行，使用真实 QwenPaw runtime 和真实 model 调用验证，不用纯 mock 代替 agent 推理。
 
@@ -89,18 +151,19 @@ QwenPaw 集成包含两部分：QwenPaw worker runtime 和 TeamHarness QwenPaw a
 
 共同模型：
 
-- 二者消费同一套 team/member/desired/storage 契约形状。
+- 二者消费同一套 team/member/desired/storage 契约形状，但消费逻辑属于 runtime/adapter，不属于 TeamHarness plugin。
 - 二者遵守同一套 TeamHarness 协作协议。
 
 预期差异：
 
 - Remote worker 不由 controller 管进程生命周期。
 - Remote worker 不接收 controller 注入的 pod env 或 Kubernetes ServiceAccount mount。
-- Remote worker 不一定像集群托管 worker 一样持续强制应用 CRD 的 model 和 MCP 期望态。
+- Remote worker 不一定像集群托管 worker 一样持续 5 秒强制应用 CRD 的 model、MCP 和 AgentSpec package 期望态。
 
 先写测试：
 
-- Claude Code adapter 能基于模拟 controller 写入的 runtime.yaml 安装 TeamHarness assets。
+- Claude Code adapter 能安装 TeamHarness assets。
+- Claude Code remote runtime 能在本地消费契约形状的 runtime.yaml 或等价配置输入。
 - remote-mode runtime.yaml 不假设 pod lifecycle、controller-managed env 或 Kubernetes mount。
 - cluster-mode 和 remote-mode 的测试显式记录共同点和差异点。
 - 集成测试必须基于真实 Claude Code 本地 runtime 运行，验证本地 plugin/adapter 安装、runtime.yaml 消费和 TeamHarness 协议行为，不用纯 mock 代替本地 runtime。
@@ -109,17 +172,19 @@ QwenPaw 集成包含两部分：QwenPaw worker runtime 和 TeamHarness QwenPaw a
 
 - Claude Code 能作为 remote/runtime adapter 接入 TeamHarness，不改变托管 QwenPaw 语义。
 
-## 阶段 6：热更新设计与测试
+## 阶段 6：Desired-State Apply 深化测试
 
-通过模拟 runtime config 变化测试热更新。
+通过模拟 runtime config 变化深化测试 desired-state apply loop。
+
+AgentSpec package 更新不是独立于 runtime config polling 的另一套机制，而是同一个 worker desired-state apply loop 的 AgentSpec package 分支。它属于 worker/runtime 能力，不属于 TeamHarness plugin。阶段 6 可以在阶段 4 的 QwenPaw worker 基础上深化。
 
 先写测试：
 
-- `metadata.generation` 变化会触发 runtime config apply。
-- generation 不变或 digest 不变时不会重复 apply。
-- `desired.agentPackage.version` 或 `desired.agentPackage.digest` 变化时，会拉取并应用 HiClaw AgentSpec package。
-- 热更新不重启 QwenPaw 进程。
-- 拉取、解包或应用失败时保留上一个成功版本，并暴露 unhealthy diagnostics。
+- `metadata.generation` 变化会触发 desired-state apply。
+- generation 不变且 AgentSpec package identity 不变时不会重复 apply。
+- `desired.agentPackage.version` 或 `desired.agentPackage.digest` 变化时，同一个 apply loop 会拉取并应用 HiClaw AgentSpec package。
+- AgentSpec package apply 不重启 QwenPaw 进程。
+- 拉取、解包或应用失败时保留上一个成功版本，并暴露 not-ready diagnostics。
 
 实现目标：
 

--- a/plugins/teamharness/adapters/qwenpaw/plugin.json
+++ b/plugins/teamharness/adapters/qwenpaw/plugin.json
@@ -3,8 +3,8 @@
   "name": "TeamHarness",
   "version": "0.1.0",
   "type": "general",
-  "description": "HiClaw TeamHarness runtime plugin for QwenPaw.",
-  "author": "HiClaw",
+  "description": "AgentTeams TeamHarness runtime plugin for QwenPaw.",
+  "author": "AgentTeams",
   "entry": {
     "backend": "plugin.py"
   },

--- a/plugins/teamharness/adapters/qwenpaw/plugin.py
+++ b/plugins/teamharness/adapters/qwenpaw/plugin.py
@@ -24,11 +24,15 @@ if not (ASSET_DIR / "plugin.yaml").exists():
     ASSET_DIR = PLUGIN_DIR.parent.parent
 
 TEAMS_PROMPT_FILE = "TEAMS.md"
+TEAMS_INTERNAL_CONTROL_MARKER = (
+    "<!-- AGENTTEAMS_INTERNAL_CONTROL_FILE: TEAMS.md is managed by "
+    "TeamHarness/QwenPaw runtime; agent packages must not overwrite or delete it. -->"
+)
 MCP_CLIENT_ID = "teamharness"
 REDACTION = "[REDACTED]"
 SENSITIVE_FILE_AUTO_DENY_RULE = "SENSITIVE_FILE_BLOCK"
-TEAMS_CONTEXT_START = "<!-- BEGIN HICLAW RUNTIME TEAM CONTEXT -->"
-TEAMS_CONTEXT_END = "<!-- END HICLAW RUNTIME TEAM CONTEXT -->"
+TEAMS_CONTEXT_START = "<!-- BEGIN AGENTTEAMS RUNTIME TEAM CONTEXT -->"
+TEAMS_CONTEXT_END = "<!-- END AGENTTEAMS RUNTIME TEAM CONTEXT -->"
 _TASK_TRACE_MODULE: Any = None
 _TASK_TRACE_REGISTERED: bool = False
 
@@ -60,7 +64,6 @@ _BUILTIN_SANITIZER_PATTERNS: List[tuple[re.Pattern[str], str]] = [
         r"\1********",
     ),
 ]
-
 
 def _read_yaml(path: Path) -> Dict[str, Any]:
     try:
@@ -127,7 +130,7 @@ def _write_json_atomic(path: Path, payload: Dict[str, Any]) -> None:
 
 
 def _shared_dir() -> Path:
-    raw = os.getenv("TEAMHARNESS_SHARED_DIR", "").strip() or os.getenv("HICLAW_SHARED_DIR", "").strip()
+    raw = os.getenv("TEAMHARNESS_SHARED_DIR", "").strip() or os.getenv("AGENTTEAMS_SHARED_DIR", "").strip()
     if raw:
         return Path(raw)
     qwenpaw_dir = os.getenv("QWENPAW_WORKING_DIR", "").strip()
@@ -157,11 +160,11 @@ def render_team_context(config: Dict[str, Any]) -> str:
     channel_policy = _section(desired, "channelPolicy")
     base_prompt = ASSET_DIR / "prompts" / "team" / "TEAMS.md"
     base = base_prompt.read_text(encoding="utf-8").strip() if base_prompt.exists() else ""
-    role = _string(member.get("role") or os.getenv("HICLAW_AGENT_ROLE") or "worker")
+    role = _string(member.get("role") or os.getenv("AGENTTEAMS_AGENT_ROLE") or "worker")
     role_prompt = _role_prompt(role)
     role_text = role_prompt.read_text(encoding="utf-8").strip() if role_prompt and role_prompt.exists() else ""
 
-    lines = []
+    lines = [TEAMS_INTERNAL_CONTROL_MARKER, ""]
     if base:
         lines.append(base)
     else:
@@ -265,7 +268,7 @@ def _credagent_paths() -> List[Path]:
     paths: List[Path] = []
     for _agent_id, workspace_dir in _iter_qwenpaw_agents():
         paths.append(workspace_dir / "config" / "credagent.json")
-    for env_name in ("HICLAW_AGENT_HOME", "HICLAW_WORKER_HOME"):
+    for env_name in ("AGENTTEAMS_AGENT_HOME", "AGENTTEAMS_WORKER_HOME"):
         raw = os.getenv(env_name, "").strip()
         if raw:
             paths.append(Path(raw).expanduser() / "config" / "credagent.json")
@@ -595,7 +598,7 @@ def _enable_workspace_skills(workspace_dir: Path, role: str) -> Dict[str, Any]:
 
 def _install_workspace_assets(agent_id: str, workspace_dir: Path, config: Dict[str, Any]) -> Dict[str, Any]:
     member = _section(config, "member")
-    role = _string(member.get("role") or os.getenv("HICLAW_AGENT_ROLE") or "worker")
+    role = _string(member.get("role") or os.getenv("AGENTTEAMS_AGENT_ROLE") or "worker")
     workspace_dir.mkdir(parents=True, exist_ok=True)
     team_context = _write_team_context(workspace_dir, config)
     prompts = _ensure_prompt_files(agent_id, [TEAMS_PROMPT_FILE])
@@ -653,25 +656,25 @@ def _install_skills() -> Dict[str, Any]:
 
 
 def _mcp_client_env() -> Dict[str, str]:
-    env = {"TEAMHARNESS_SHARED_DIR": str(_shared_dir())}
+    env = {
+        "TEAMHARNESS_SHARED_DIR": str(_shared_dir()),
+        "LOONGSUITE_PYTHON_SITE_BOOTSTRAP_LOG_SUCCESS": "false",
+    }
     for name in (
         "TEAMHARNESS_RUNTIME_CONFIG",
-        "HICLAW_MATRIX_URL",
-        "HICLAW_WORKER_MATRIX_TOKEN",
-        "HICLAW_MATRIX_USER_ID",
-        "HICLAW_WORKER_ROLE",
-        "HICLAW_AGENT_ROLE",
-        "HICLAW_WORKER_NAME",
-        "HICLAW_STORAGE_PREFIX",
-        "HICLAW_SHARED_STORAGE_PREFIX",
-        "HICLAW_FS_BUCKET",
-        "HICLAW_CONTROLLER_URL",
-        "HICLAW_AUTH_TOKEN_FILE",
-        "HICLAW_CLUSTER_ID",
-        "HICLAW_FS_ENDPOINT",
-        "HICLAW_FS_ACCESS_KEY",
-        "HICLAW_FS_SECRET_KEY",
-        "MC_HOST_hiclaw",
+        "AGENTTEAMS_MATRIX_URL",
+        "AGENTTEAMS_WORKER_MATRIX_TOKEN",
+        "AGENTTEAMS_MATRIX_USER_ID",
+        "AGENTTEAMS_WORKER_ROLE",
+        "AGENTTEAMS_AGENT_ROLE",
+        "AGENTTEAMS_WORKER_NAME",
+        "AGENTTEAMS_STORAGE_PREFIX",
+        "AGENTTEAMS_SHARED_STORAGE_PREFIX",
+        "AGENTTEAMS_FS_BUCKET",
+        "AGENTTEAMS_CONTROLLER_URL",
+        "AGENTTEAMS_AUTH_TOKEN_FILE",
+        "AGENTTEAMS_CLUSTER_ID",
+        "AGENTTEAMS_FS_ENDPOINT",
         "QWENPAW_WORKING_DIR",
         "COPAW_WORKING_DIR",
     ):
@@ -721,7 +724,7 @@ def apply_teamharness() -> Dict[str, Any]:
     return {"ok": True, "agents": agents, "skills": skills, "mcp": mcp, "credentialGuard": credential_guard}
 
 
-def install_output_sanitizer_wrapper() -> Dict[str, Any]:
+def install_output_sanitizer_wrapper(api: Any = None) -> Dict[str, Any]:
     try:
         from qwenpaw.agents.react_agent import QwenPawAgent
     except ImportError:
@@ -729,9 +732,7 @@ def install_output_sanitizer_wrapper() -> Dict[str, Any]:
     if getattr(QwenPawAgent, "_teamharness_sanitizer_installed", False):
         return {"ok": True, "installed": True, "action": "unchanged"}
 
-    original = getattr(QwenPawAgent, "_acting", None)
-    if not callable(original):
-        return {"ok": True, "installed": False, "reason": "qwenpaw agent _acting hook unavailable"}
+    original = QwenPawAgent._acting
 
     async def _acting_with_sanitizer(self, tool_call):
         result = await original(self, tool_call)
@@ -744,8 +745,17 @@ def install_output_sanitizer_wrapper() -> Dict[str, Any]:
 
 
 def _task_trace_module_path() -> Optional[Path]:
-    candidate = PLUGIN_DIR / "task_trace.py"
-    return candidate if candidate.exists() else None
+    candidates = [
+        PLUGIN_DIR / "task_trace.py",
+    ]
+    seen = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        if candidate.exists():
+            return candidate
+    return None
 
 
 def _load_task_trace_module() -> Tuple[Optional[Any], Optional[str]]:
@@ -886,12 +896,16 @@ def install_task_trace_context_wrapper(trace_module: Any) -> Dict[str, Any]:
         if workspace_dir is None:
             return
         default_ws = workspace_dir / "workspaces" / "default"
+        # Prefer the pending entry span stashed by on_start (the common path:
+        # entry span was created before room context was available).
         tag_pending = getattr(trace_module, "tag_pending_entry_span", None)
         if callable(tag_pending):
             get_pending = getattr(trace_module, "get_pending_entry_span", None)
             if callable(get_pending) and get_pending() is not None:
                 tag_pending(default_ws)
                 return
+        # Fallback: current span might be the entry span (e.g. room was set
+        # before instrumentation created it).
         tag_current = getattr(trace_module, "tag_current_entry_span", None)
         if callable(tag_current):
             tag_current(default_ws)
@@ -983,15 +997,15 @@ class TeamHarnessPlugin:
         self.sanitizer_result: Dict[str, Any] = {}
         self.trace_result: Dict[str, Any] = {}
 
-    def _sync_runtime(self) -> Dict[str, Any]:
+    def _sync_runtime(self, api: Any) -> Dict[str, Any]:
         self.last_apply_result = apply_teamharness()
-        self.sanitizer_result = install_output_sanitizer_wrapper()
+        self.sanitizer_result = install_output_sanitizer_wrapper(api=api)
         self.trace_result = install_task_trace_processor()
         return self.last_apply_result
 
     def register(self, api: Any) -> None:
         def sync() -> Dict[str, Any]:
-            return self._sync_runtime()
+            return self._sync_runtime(api)
 
         def shutdown() -> None:
             return None
@@ -1022,7 +1036,7 @@ class TeamHarnessPlugin:
 
         @router.post("/sync")
         def sync_endpoint() -> Dict[str, Any]:
-            return self._sync_runtime()
+            return self._sync_runtime(api)
 
         api.register_http_router(router, prefix="/teamharness", tags=["teamharness"])
 

--- a/plugins/teamharness/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb
+++ b/plugins/teamharness/adapters/qwenpaw/scripts/build-qwenpaw-plugin.rb
@@ -93,14 +93,15 @@ Dir.mktmpdir("teamharness-qwenpaw-") do |tmp|
   end
 
   copy_entry(adapter_root, staging, "plugin.py")
+  copy_entry(adapter_root, staging, "task_trace.py")
 
   qwenpaw_manifest = {
     "id" => "teamharness",
     "name" => "TeamHarness",
     "version" => version,
     "type" => "general",
-    "description" => "HiClaw TeamHarness runtime plugin for QwenPaw.",
-    "author" => "HiClaw",
+    "description" => "AgentTeams TeamHarness runtime plugin for QwenPaw.",
+    "author" => "AgentTeams",
     "entry" => {
       "backend" => "plugin.py"
     },

--- a/plugins/teamharness/adapters/qwenpaw/scripts/validate-qwenpaw-plugin.rb
+++ b/plugins/teamharness/adapters/qwenpaw/scripts/validate-qwenpaw-plugin.rb
@@ -4,6 +4,7 @@
 require "json"
 require "open3"
 require "pathname"
+require "tmpdir"
 require "yaml"
 
 abort("usage: validate-qwenpaw-plugin.rb <generated-plugin-dir>") if ARGV.empty?
@@ -23,13 +24,27 @@ def assert_dir(path)
   fail!("missing directory: #{path}") unless path.directory?
 end
 
+def py_compile(path)
+  Dir.mktmpdir("teamharness-pycache-") do |cache_dir|
+    Open3.capture3(
+      { "PYTHONPYCACHEPREFIX" => cache_dir },
+      "python3",
+      "-m",
+      "py_compile",
+      path.to_s
+    )
+  end
+end
+
 assert_dir(package_dir)
 plugin_json = package_dir / "plugin.json"
 plugin_py = package_dir / "plugin.py"
+task_trace_py = package_dir / "task_trace.py"
 asset_dir = package_dir / "teamharness"
 
 assert_file(plugin_json)
 assert_file(plugin_py)
+assert_file(task_trace_py)
 assert_dir(asset_dir)
 
 manifest = JSON.parse(plugin_json.read)
@@ -50,12 +65,23 @@ assert_file(asset_dir / "prompts/agent/worker.md")
 assert_file(asset_dir / "prompts/manager/AGENTS.md")
 assert_file(asset_dir / "skills/team/communication/SKILL.md")
 assert_file(asset_dir / "mcp/server.py")
+assert_file(asset_dir / "mcp/message_tool.py")
+assert_file(asset_dir / "mcp/roomflow_tool.py")
 fail!("top-level hooks must not be packaged for qwenpaw") if (asset_dir / "hooks").exist?
 
-stdout, stderr, status = Open3.capture3("python3", "-m", "py_compile", plugin_py.to_s)
+stdout, stderr, status = py_compile(plugin_py)
 fail!("plugin.py syntax check failed: #{stderr}#{stdout}") unless status.success?
 
-stdout, stderr, status = Open3.capture3("python3", "-m", "py_compile", (asset_dir / "mcp/server.py").to_s)
+stdout, stderr, status = py_compile(task_trace_py)
+fail!("task_trace.py syntax check failed: #{stderr}#{stdout}") unless status.success?
+
+stdout, stderr, status = py_compile(asset_dir / "mcp/server.py")
 fail!("teamharness mcp syntax check failed: #{stderr}#{stdout}") unless status.success?
+
+stdout, stderr, status = py_compile(asset_dir / "mcp/message_tool.py")
+fail!("teamharness message tool syntax check failed: #{stderr}#{stdout}") unless status.success?
+
+stdout, stderr, status = py_compile(asset_dir / "mcp/roomflow_tool.py")
+fail!("teamharness roomflow tool syntax check failed: #{stderr}#{stdout}") unless status.success?
 
 puts "ok: qwenpaw teamharness #{version}"

--- a/plugins/teamharness/adapters/qwenpaw/task_trace.py
+++ b/plugins/teamharness/adapters/qwenpaw/task_trace.py
@@ -7,17 +7,17 @@ agent turn trace.
 Entry span choice
 -----------------
 LoongSuite/QwenPaw instrumentation creates one trace per user turn with this
-hierarchy (outer -> inner)::
+hierarchy (outer → inner)::
 
-    enter_ai_application_system   <- trace root / GenAI application entry
+    enter_ai_application_system   ← trace root / GenAI application entry
       agent_step
         invoke_agent <name>
           react step
-            chat / execute_tool / ...
+            chat / execute_tool / …
 
 We tag **only** ``enter_ai_application_system`` because:
 
-* It is the trace root - CMS/ARMS filters on root-span attributes efficiently.
+* It is the trace root — CMS/ARMS filters on root-span attributes efficiently.
 * There is exactly one per turn (same cardinality as a "trace" in the product).
 * ``agent_step`` is nested inside it; tagging both would be redundant.
 
@@ -46,7 +46,7 @@ because that can cross-tag unrelated sessions.
 Debug logging
 -------------
 Set ``AGENTTEAMS_TASK_TRACE_DEBUG=1`` to enable verbose processor logs.
-Default is silent - no I/O overhead on the hot span path.
+Default is silent — no I/O overhead on the hot span path.
 """
 
 from __future__ import annotations
@@ -332,7 +332,7 @@ def register_task_trace_processor(
 ) -> dict[str, Any]:
     """Register :class:`AgentTeamsTaskSpanProcessor` on the active TracerProvider.
 
-    Safe to call even when the OTel SDK is not installed - returns a result
+    Safe to call even when the OTel SDK is not installed — returns a result
     dict describing what happened.
     """
     try:
@@ -469,7 +469,7 @@ def tag_pending_entry_span(workspace_dir: Path | str, *, room_id: str = "") -> d
     """Tag the pending entry span (if any) and clear it.
 
     Called by the QwenPawAgent wrapper after ``set_current_room`` so the entry
-    span - which was created *before* the room was known - gets tagged with
+    span — which was created *before* the room was known — gets tagged with
     the correct task attributes.
     """
     span = _pending_entry_span.get()

--- a/plugins/teamharness/loongsuite/agents.d/teamharness.json
+++ b/plugins/teamharness/loongsuite/agents.d/teamharness.json
@@ -3,8 +3,8 @@
   "displayName": "TeamHarness",
   "deployMode": "plugin-probe",
   "detection": {
-    "paths": ["~/.qwenpaw", "~/.claude"],
-    "commands": ["qwenpaw", "claude"]
+    "paths": ["~/.qwenpaw"],
+    "commands": ["qwenpaw"]
   },
   "pluginProbe": {
     "source": {

--- a/plugins/teamharness/mcp/message_tool.py
+++ b/plugins/teamharness/mcp/message_tool.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""TeamHarness message MCP tool implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+import time
+from typing import Any, Callable
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+SELF_TRIGGER_MESSAGE_TYPES = {"PROJECT_REQUESTED"}
+TEAMHARNESS_TRIGGER_CONTENT_KEY = "m.teamharness.trigger"
+
+
+@dataclass(frozen=True)
+class MessageToolDeps:
+    reply_route: Callable[[dict[str, Any]], dict[str, Any]]
+    qwenpaw_message: Callable[[dict[str, Any], dict[str, Any], str, str], dict[str, Any]]
+    matrix_target: Callable[[str], tuple[str, str]]
+    mentions: Callable[[str, str], list[str]]
+    ping_pong_error: Callable[[str, list[str]], str | None]
+    matrix_content: Callable[[str, list[str]], dict[str, Any]]
+    record_matrix_outbound_to_session: Callable[[str, str, str | None, str], bool]
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _text(value: Any) -> str:
+    return str(value).strip() if value is not None else ""
+
+
+def _message_object(arguments: dict[str, Any]) -> dict[str, Any]:
+    message = arguments.get("message")
+    if isinstance(message, dict):
+        return message
+    if isinstance(message, str):
+        raw = message.strip()
+        if raw.startswith("{"):
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError:
+                return {}
+            return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _message_text(arguments: dict[str, Any]) -> str:
+    message = arguments.get("message")
+    message_obj = _message_object(arguments)
+    if message_obj:
+        for key in ("text", "body", "message", "content"):
+            value = message_obj.get(key)
+            if value is not None:
+                return str(value)
+        return ""
+    if message is not None:
+        return str(message)
+    return str(arguments.get("text") or arguments.get("body") or "")
+
+
+def _message_type(arguments: dict[str, Any]) -> str:
+    for key in ("type", "messageType", "message_type"):
+        value = arguments.get(key)
+        if value is not None:
+            return _text(value)
+    message = _message_object(arguments)
+    if message:
+        for key in ("type", "messageType", "message_type"):
+            value = message.get(key)
+            if value is not None:
+                return _text(value)
+    return ""
+
+
+def _agent_from(value: Any) -> str:
+    data = _dict(value)
+    for key in ("agent", "agentId", "agent_id", "accountId", "account_id", "runtimeName", "runtime_name", "name"):
+        text = _text(data.get(key))
+        if text:
+            return text
+    return ""
+
+
+def _current_agent(arguments: dict[str, Any]) -> str:
+    for key in ("agentId", "agent_id", "accountId", "account_id"):
+        value = _text(arguments.get(key))
+        if value:
+            return value
+    return _text(os.getenv("AGENTTEAMS_WORKER_NAME")) or "default"
+
+
+def _is_matrix_user_id(value: str) -> bool:
+    text = value.strip()
+    return text.startswith("@") and ":" in text
+
+
+def _session_id_from(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    data = _dict(value)
+    session = data.get("session")
+    if isinstance(session, str):
+        return session.strip()
+    if isinstance(session, dict):
+        for key in (
+            "id",
+            "sessionId",
+            "session_id",
+            "targetSession",
+            "target_session",
+            "sourceSession",
+            "source_session",
+            "roomId",
+            "room_id",
+        ):
+            text = _text(session.get(key))
+            if text:
+                return text
+    for key in (
+        "id",
+        "sessionId",
+        "session_id",
+        "targetSession",
+        "target_session",
+        "sourceSession",
+        "source_session",
+        "roomId",
+        "room_id",
+        "target",
+    ):
+        text = _text(data.get(key))
+        if text:
+            return text
+    return ""
+
+
+def _target_value(arguments: dict[str, Any], route: dict[str, Any]) -> str:
+    for value in (
+        arguments.get("target"),
+        route.get("target"),
+        arguments.get("room_id"),
+        arguments.get("roomId"),
+        route.get("room_id"),
+        route.get("roomId"),
+        route.get("targetRoom"),
+        route.get("target_room"),
+        route.get("targetSession"),
+        route.get("target_session"),
+    ):
+        target = _session_id_from(value)
+        if target:
+            return target
+    return ""
+
+
+def _source_value(arguments: dict[str, Any], route: dict[str, Any]) -> str:
+    for value in (
+        arguments.get("sourceSession"),
+        arguments.get("source_session"),
+        arguments.get("senderSession"),
+        arguments.get("sender_session"),
+        arguments.get("currentSession"),
+        arguments.get("current_session"),
+        route.get("sourceSession"),
+        route.get("source_session"),
+        arguments.get("sender"),
+        arguments.get("source"),
+    ):
+        source = _session_id_from(value)
+        if source:
+            return source
+    return ""
+
+
+def _channel_from(value: Any) -> str:
+    data = _dict(value)
+    for key in ("channel", "channelId", "channel_id"):
+        text = _text(data.get(key)).lower()
+        if text:
+            return text
+    session = data.get("session")
+    if isinstance(session, dict):
+        for key in ("channel", "channelId", "channel_id"):
+            text = _text(session.get(key)).lower()
+            if text:
+                return text
+    return ""
+
+
+def _source_channel(arguments: dict[str, Any], route: dict[str, Any], source_session: str) -> str:
+    for value in (
+        arguments.get("sourceChannel"),
+        arguments.get("source_channel"),
+        arguments.get("senderChannel"),
+        arguments.get("sender_channel"),
+        route.get("sourceChannel"),
+        route.get("source_channel"),
+        arguments.get("sender"),
+        arguments.get("source"),
+    ):
+        channel = _channel_from(value) if isinstance(value, dict) else _text(value).lower()
+        if channel:
+            return channel
+    if _matrix_room_id_from_session(source_session):
+        return "matrix"
+    raw = source_session.strip()
+    if ":" in raw:
+        prefix = raw.split(":", 1)[0].strip().lower()
+        if prefix and not prefix.startswith("!"):
+            return prefix
+    return ""
+
+
+def _matrix_room_id_from_session(value: str) -> str:
+    raw = (value or "").strip()
+    if raw.startswith("matrix:"):
+        raw = raw[len("matrix:") :]
+    if raw.startswith("room:"):
+        raw = raw[len("room:") :]
+    return raw if raw.startswith("!") else ""
+
+
+def _canonical_session(channel: str, session: str) -> str:
+    raw = session.strip()
+    source_channel = channel.strip().lower()
+    if source_channel == "matrix":
+        room_id = _matrix_room_id_from_session(raw)
+        return f"matrix:{room_id}" if room_id else raw
+    if source_channel and raw.startswith(f"{source_channel}:"):
+        return raw
+    return f"{source_channel}:{raw}" if source_channel else raw
+
+
+def _route_bool(route: dict[str, Any], *names: str) -> bool | None:
+    for name in names:
+        if name not in route:
+            continue
+        value = route.get(name)
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            text = value.strip().lower()
+            if text in {"1", "true", "yes", "y", "on"}:
+                return True
+            if text in {"0", "false", "no", "n", "off"}:
+                return False
+        if value is not None:
+            return bool(value)
+    return None
+
+
+def _normalize_reply_route(route: dict[str, Any]) -> dict[str, Any]:
+    channel = _text(route.get("channel")).lower()
+    target_user = _text(
+        route.get("targetUser")
+        or route.get("target_user")
+        or route.get("userId")
+        or route.get("user_id"),
+    )
+    target_session = _text(
+        route.get("targetSession")
+        or route.get("target_session")
+        or route.get("sessionId")
+        or route.get("session_id"),
+    )
+    if channel == "matrix":
+        target = _text(
+            route.get("target")
+            or route.get("roomId")
+            or route.get("room_id")
+            or route.get("targetRoom")
+            or route.get("target_room")
+            or target_session,
+        )
+        room_id = _matrix_room_id_from_session(target)
+        if not room_id:
+            return {}
+        normalized: dict[str, Any] = {
+            "channel": "matrix",
+            "targetSession": room_id,
+        }
+        if target_user:
+            normalized["targetUser"] = target_user
+    else:
+        if not (channel and target_user and target_session):
+            return {}
+        normalized = {
+            "channel": channel,
+            "targetUser": target_user,
+            "targetSession": target_session,
+        }
+    mention_sender = _route_bool(route, "mentionSender", "mention_sender", "atSender", "at_sender")
+    if mention_sender is not None:
+        normalized["mentionSender"] = mention_sender
+    return normalized
+
+
+def _visible_reply_route_error(message_text: str, reply_route: dict[str, Any]) -> str:
+    channel = _text(reply_route.get("channel")).lower()
+    if channel and channel != "matrix" and channel not in message_text:
+        return "PROJECT_REQUESTED message text must include replyRoute.channel so the task-room Leader can pass it to projectflow"
+    target_user = _text(reply_route.get("targetUser") or reply_route.get("target_user"))
+    if channel and channel != "matrix" and target_user and target_user not in message_text:
+        return "PROJECT_REQUESTED message text must include replyRoute.targetUser so the task-room Leader can pass it to projectflow"
+    target_session = _text(reply_route.get("targetSession") or reply_route.get("target_session"))
+    if target_session and target_session not in message_text:
+        return "PROJECT_REQUESTED message text must include replyRoute.targetSession so the task-room Leader can pass it to projectflow"
+    return ""
+
+
+def _self_trigger_intent(
+    arguments: dict[str, Any],
+    route: dict[str, Any],
+    *,
+    channel: str,
+    target_id: str,
+) -> dict[str, Any] | None:
+    message_type = _message_type(arguments)
+    if message_type not in SELF_TRIGGER_MESSAGE_TYPES:
+        return None
+    source_session = _source_value(arguments, route)
+    if not source_session:
+        return None
+    source_channel = _source_channel(arguments, route, source_session)
+    if not source_channel or channel.strip().lower() != "matrix":
+        return None
+    target_session = f"matrix:{target_id}"
+    canonical_source_session = _canonical_session(source_channel, source_session)
+    if canonical_source_session == target_session:
+        return None
+
+    current_agent = _current_agent(arguments)
+    source_agent = _agent_from(arguments.get("sender")) or _agent_from(arguments.get("source")) or current_agent
+    target_agent = _agent_from(arguments.get("target")) or current_agent
+    if source_agent != target_agent:
+        return None
+    if not _is_matrix_user_id(source_agent):
+        return {
+            "status": "invalid",
+            "kind": "self_cross_session",
+            "type": message_type,
+            "error": "PROJECT_REQUESTED sender.agent and agentId must be the current runtime Matrix user id, not a role or workspace name",
+        }
+    reply_route = _normalize_reply_route(route)
+    if not reply_route:
+        return {
+            "status": "invalid",
+            "kind": "self_cross_session",
+            "type": message_type,
+            "error": "PROJECT_REQUESTED requires structured replyRoute with channel and targetSession",
+        }
+
+    return {
+        "status": "requested",
+        "kind": "self_cross_session",
+        "type": message_type,
+        "agentId": target_agent,
+        "sourceChannel": source_channel,
+        "targetChannel": "matrix",
+        "sourceSession": canonical_source_session,
+        "targetSession": target_session,
+        "sourceRoomId": source_session.strip(),
+        "targetRoomId": target_id,
+        "replyRoute": reply_route,
+    }
+
+
+def message(arguments: dict[str, Any], deps: MessageToolDeps) -> dict[str, Any]:
+    action = arguments.get("action") or "send"
+    route = deps.reply_route(arguments)
+    channel = str(arguments.get("channel") or route.get("channel") or "matrix")
+    if action != "send":
+        return {"ok": False, "tool": "message", "error": f"unsupported action: {action}"}
+    message_text = _message_text(arguments)
+    if channel != "matrix":
+        return deps.qwenpaw_message(arguments, route, channel, message_text)
+
+    try:
+        target_kind, target_id = deps.matrix_target(_target_value(arguments, route))
+    except ValueError as exc:
+        return {"ok": False, "tool": "message", "error": str(exc)}
+    if target_kind == "user":
+        return {"ok": False, "tool": "message", "error": "Matrix user targets are not supported yet"}
+
+    mentions = deps.mentions(message_text, target_id)
+    blocked = deps.ping_pong_error(message_text, mentions)
+    if blocked:
+        return {"ok": False, "tool": "message", "error": blocked}
+
+    content = deps.matrix_content(message_text, mentions)
+    trigger = _self_trigger_intent(arguments, route, channel=channel, target_id=target_id)
+    if _message_type(arguments) in SELF_TRIGGER_MESSAGE_TYPES and trigger is None:
+        return {
+            "ok": False,
+            "tool": "message",
+            "action": "send",
+            "channel": "matrix",
+            "target": f"room:{target_id}",
+            "error": "PROJECT_REQUESTED must be sent as a same-agent Matrix self-trigger with sender.session, target room, matching sender.agent/agentId, and structured replyRoute",
+        }
+    if trigger is not None and trigger.get("status") == "invalid":
+        return {
+            "ok": False,
+            "tool": "message",
+            "action": "send",
+            "channel": "matrix",
+            "target": f"room:{target_id}",
+            "trigger": trigger,
+            "error": str(trigger.get("error") or "invalid PROJECT_REQUESTED trigger"),
+        }
+    if trigger is not None:
+        visible_route_error = _visible_reply_route_error(message_text, _dict(trigger.get("replyRoute")))
+        if visible_route_error:
+            return {
+                "ok": False,
+                "tool": "message",
+                "action": "send",
+                "channel": "matrix",
+                "target": f"room:{target_id}",
+                "trigger": trigger,
+                "error": visible_route_error,
+            }
+    if trigger is not None:
+        content = dict(content)
+        content[TEAMHARNESS_TRIGGER_CONTENT_KEY] = dict(trigger)
+    base: dict[str, Any] = {
+        "ok": True,
+        "tool": "message",
+        "action": "send",
+        "channel": "matrix",
+        "target": f"room:{target_id}",
+        "targetKind": "room",
+        "mentions": mentions,
+        "content": content,
+    }
+    if trigger is not None:
+        base["trigger"] = trigger
+    if arguments.get("dryRun"):
+        base["dryRun"] = True
+        return base
+
+    homeserver = os.getenv("AGENTTEAMS_MATRIX_URL", "").rstrip("/")
+    token = os.getenv("AGENTTEAMS_WORKER_MATRIX_TOKEN", "")
+    if not homeserver or not token:
+        return {"ok": False, "tool": "message", "error": "AGENTTEAMS_MATRIX_URL and AGENTTEAMS_WORKER_MATRIX_TOKEN are required"}
+
+    room_id = urllib.parse.quote(target_id, safe="")
+    txn_id = f"teamharness-{os.getpid()}-{int(time.time() * 1000)}"
+    url = f"{homeserver}/_matrix/client/v3/rooms/{room_id}/send/m.room.message/{txn_id}"
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(content).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="PUT",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8") or "{}")
+        base["messageId"] = data.get("event_id")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")[:200]
+        return {"ok": False, "tool": "message", "error": f"Matrix API error: HTTP {exc.code}: {body}"}
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return {"ok": False, "tool": "message", "error": f"Matrix API error: {exc}"}
+    if trigger is not None:
+        trigger["status"] = "sent"
+        trigger["targetCurrentEvent"] = base.get("messageId")
+        base["delivery"] = {"sent": "matrix_self_trigger"}
+        base["context"] = {"via": "matrix_current_event"}
+        return base
+    account_id = str(arguments.get("agentId") or arguments.get("agent_id") or arguments.get("accountId") or arguments.get("account_id") or "default").strip() or "default"
+    try:
+        base["sessionRecorded"] = deps.record_matrix_outbound_to_session(
+            target_id,
+            message_text,
+            base.get("messageId"),
+            account_id,
+        )
+    except Exception:
+        base["sessionRecorded"] = False
+        base["warning"] = "message sent, but local session record failed"
+    return base

--- a/plugins/teamharness/mcp/roomflow_tool.py
+++ b/plugins/teamharness/mcp/roomflow_tool.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""TeamHarness roomflow MCP helper implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any, Callable
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+@dataclass(frozen=True)
+class RoomDescribeDeps:
+    matrix_env: Callable[[str], tuple[str, str]]
+    matrix_user_id: Callable[[], str]
+    canonical_room_id: Callable[[Any], str]
+
+
+def _session_room_id(arguments: dict[str, Any], payload: dict[str, Any], deps: RoomDescribeDeps) -> str:
+    raw = str(
+        payload.get("sessionId")
+        or payload.get("session_id")
+        or payload.get("roomId")
+        or payload.get("room_id")
+        or arguments.get("sessionId")
+        or arguments.get("session_id")
+        or arguments.get("roomId")
+        or arguments.get("room_id")
+        or arguments.get("target")
+        or ""
+    ).strip()
+    if raw.startswith("matrix:"):
+        raw = raw[len("matrix:") :].strip()
+    return deps.canonical_room_id(raw)
+
+
+def _matrix_get_json(path: str, token: str) -> dict[str, Any]:
+    request = urllib.request.Request(
+        path,
+        headers={"Authorization": f"Bearer {token}"},
+        method="GET",
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        data = json.loads(response.read().decode("utf-8") or "{}")
+    return data if isinstance(data, dict) else {}
+
+
+def _matrix_get_json_optional(path: str, token: str) -> dict[str, Any]:
+    try:
+        return _matrix_get_json(path, token)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return {}
+        raise
+
+
+def describe_room(arguments: dict[str, Any], payload: dict[str, Any], deps: RoomDescribeDeps) -> dict[str, Any]:
+    room_id = _session_room_id(arguments, payload, deps)
+    if not room_id:
+        return {"ok": False, "tool": "roomflow", "action": "describe_room", "error": "sessionId or roomId is required"}
+    base: dict[str, Any] = {
+        "ok": True,
+        "tool": "roomflow",
+        "action": "describe_room",
+        "roomId": room_id,
+        "sessionId": f"matrix:{room_id}",
+        "name": "",
+        "topic": "",
+        "tags": {},
+    }
+    if arguments.get("dryRun"):
+        base["dryRun"] = True
+        return base
+    try:
+        homeserver, token = deps.matrix_env("roomflow")
+    except ValueError as exc:
+        return {"ok": False, "tool": "roomflow", "action": "describe_room", "error": str(exc)}
+
+    encoded_room = urllib.parse.quote(room_id, safe="")
+    try:
+        name = _matrix_get_json_optional(
+            f"{homeserver}/_matrix/client/v3/rooms/{encoded_room}/state/m.room.name",
+            token,
+        )
+        topic = _matrix_get_json_optional(
+            f"{homeserver}/_matrix/client/v3/rooms/{encoded_room}/state/m.room.topic",
+            token,
+        )
+        user_id = deps.matrix_user_id()
+        tags: dict[str, Any] = {}
+        if user_id:
+            encoded_user = urllib.parse.quote(user_id, safe="")
+            tag_data = _matrix_get_json_optional(
+                f"{homeserver}/_matrix/client/v3/user/{encoded_user}/rooms/{encoded_room}/tags",
+                token,
+            )
+            raw_tags = tag_data.get("tags")
+            tags = raw_tags if isinstance(raw_tags, dict) else {}
+    except urllib.error.HTTPError as exc:
+        error = exc.read().decode("utf-8", errors="replace")[:200]
+        return {"ok": False, "tool": "roomflow", "action": "describe_room", "error": f"Matrix API error: HTTP {exc.code}: {error}"}
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return {"ok": False, "tool": "roomflow", "action": "describe_room", "error": f"Matrix API error: {exc}"}
+
+    base["name"] = str(name.get("name") or "").strip()
+    base["topic"] = str(topic.get("topic") or "").strip()
+    base["tags"] = tags
+    return base

--- a/plugins/teamharness/mcp/server.py
+++ b/plugins/teamharness/mcp/server.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 import html
 import hashlib
+import datetime
 import json
+import mimetypes
 import os
 from pathlib import Path
 import re
@@ -14,12 +16,16 @@ import sys
 import threading
 import time
 from typing import Any
+import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
 
+from message_tool import MessageToolDeps, message as _message_impl
+from roomflow_tool import RoomDescribeDeps, describe_room as _describe_room_impl
 
-TOOL_NAMES = ["health", "message", "roomflow", "filesync", "projectflow", "taskflow"]
+
+TOOL_NAMES = ["health", "message", "roomflow", "filesync", "artifact", "projectflow", "taskflow"]
 MESSAGE_TOOL_BLOCKED_ROLES = {"worker", "remote-member"}
 MATRIX_USER_RE = re.compile(r"@[a-zA-Z0-9._=+/\-]+:[a-zA-Z0-9.\-]+(?::\d+)?")
 MENTION_LOCAL_CHARS = r"a-zA-Z0-9._=+/\-"
@@ -28,9 +34,34 @@ SHORT_MATRIX_MENTION_RE = re.compile(
 )
 MATRIX_ROOM_RE = re.compile(r"^![^:\s]+:[^\s]+$")
 LOW_INFORMATION_ACKS = {"ack", "acknowledged", "ok", "okay", "done", "received", "收到", "好的", "好"}
-MC_ALIAS = "hiclaw"
+MC_ALIAS = "agentteams"
 UNSAFE_SESSION_FILENAME_RE = re.compile(r'[\\/:*?"<>|]')
 SESSION_WRITE_LOCKS: dict[str, threading.Lock] = {}
+SENSITIVE_ARTIFACT_NAME_RE = re.compile(
+    r"(secret|token|cookie|authorization|private[_-]?key|credential|client[_-]?secret)",
+    re.IGNORECASE,
+)
+SENSITIVE_ARTIFACT_TEXT_RE = [
+    re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----", re.IGNORECASE),
+    re.compile(r"\bAuthorization\s*:\s*(?:Bearer|Basic)\s+\S+", re.IGNORECASE),
+    re.compile(
+        r"\b(?:access[_-]?key[_-]?secret|client[_-]?secret|secret[_-]?key|api[_-]?key|token)\b"
+        r"\s*[:=]\s*['\"]?[A-Za-z0-9_./+=:-]{16,}",
+        re.IGNORECASE,
+    ),
+]
+MATRIX_ATTACHMENT_REL_TYPE = "com.agentteams.attachment"
+MATRIX_ATTACHMENT_CONTEXT_FILE = "teamharness-matrix-context.json"
+MATRIX_ATTACHMENT_CONTEXT_TTL_SECONDS = 30 * 60
+ATTACHMENT_PARENT_EVENT_KEYS = (
+    "parentEventId",
+    "parent_event_id",
+    "attachmentParentEventId",
+    "attachment_parent_event_id",
+    "matrixAttachmentParentEventId",
+    "matrix_attachment_parent_event_id",
+)
+TEXT_ARTIFACT_SAMPLE_BYTES = 256 * 1024
 
 TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
     "health": {
@@ -50,6 +81,11 @@ TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
             "Send a TeamHarness message only when the output must leave the "
             "current runtime conversation: Matrix cross-room sends, external "
             "cross-channel sends, or requester replyRoute/cross-session reports. "
+            "For same-agent Project Work handoff from any requester/source "
+            "session into a Matrix task room, use the PROJECT_REQUESTED "
+            "self-trigger payload with sender.session and target.session; the "
+            "tool sends a Matrix event with a TeamHarness trigger marker so "
+            "the target task room receives it as the current event. "
             "Do not use this tool for normal replies in the current room/session; "
             "answer directly instead."
         ),
@@ -63,20 +99,59 @@ TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
                 },
                 "channel": {
                     "type": "string",
-                    "description": "matrix for Matrix room sends, or an external channel such as dingtalk.",
+                    "description": "Delivery target channel: matrix for Matrix room sends and PROJECT_REQUESTED task-room triggers, or an external channel such as dingtalk for external sends.",
+                },
+                "sender": {
+                    "type": "object",
+                    "description": (
+                        "Source Matrix account and requester/source session for "
+                        "same-agent self-trigger handoff. For PROJECT_REQUESTED, "
+                        "sender.agent must be the current runtime Matrix user id "
+                        "such as @leader:matrix.local, not a role name like "
+                        "leader or a workspace name like default."
+                    ),
+                    "additionalProperties": True,
+                    "properties": {
+                        "agent": {
+                            "type": "string",
+                            "description": (
+                                "Current runtime Matrix user id for the sender, "
+                                "for example @leader:matrix.local. Must match "
+                                "agentId for PROJECT_REQUESTED self-trigger."
+                            ),
+                        },
+                        "session": {
+                            "type": "object",
+                            "additionalProperties": True,
+                            "properties": {
+                                "channel": {"type": "string"},
+                                "id": {"type": "string"},
+                            },
+                        },
+                    },
                 },
                 "target": {
                     "type": "string",
-                    "description": "Matrix room target for cross-room sends, for example room:!room:domain.",
+                    "description": (
+                        "Matrix room target for cross-room sends, for example "
+                        "room:!room:domain. For PROJECT_REQUESTED self-trigger, "
+                        "pass the target task room as a room:!room:domain string."
+                    ),
                 },
                 "replyRoute": {
                     "type": "object",
-                    "description": "Preferred requester route for cross-session reports.",
+                    "description": (
+                        "Structured requester route for cross-session reports. "
+                        "Required for PROJECT_REQUESTED; do not put the route "
+                        "only in message text."
+                    ),
                     "additionalProperties": True,
                     "properties": {
                         "channel": {"type": "string"},
+                        "target": {"type": "string"},
                         "targetUser": {"type": "string"},
                         "targetSession": {"type": "string"},
+                        "mentionSender": {"type": "boolean"},
                     },
                 },
                 "targetUser": {
@@ -87,13 +162,58 @@ TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
                     "type": "string",
                     "description": "External-channel session id; required for non-Matrix sends.",
                 },
+                "agentId": {
+                    "type": "string",
+                    "description": (
+                        "Current runtime Matrix user id, for example "
+                        "@leader:matrix.local. For PROJECT_REQUESTED, this "
+                        "must match sender.agent; do not pass role names such "
+                        "as leader or workspace names such as default."
+                    ),
+                },
+                "type": {
+                    "type": "string",
+                    "enum": ["PROJECT_REQUESTED"],
+                    "description": "Top-level message type alias for trigger messages. PROJECT_REQUESTED is the v1 allowlisted self-trigger type.",
+                },
+                "message": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "required": ["type", "text"],
+                            "additionalProperties": True,
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "enum": ["PROJECT_REQUESTED"],
+                                    "description": "Trigger type. v1 only allows PROJECT_REQUESTED.",
+                                },
+                                "text": {
+                                    "type": "string",
+                                    "description": "Synthetic current-event body to enqueue in the target Matrix task room.",
+                                },
+                            },
+                        },
+                        {"type": "string"},
+                    ],
+                    "description": (
+                        "Message body. For PROJECT_REQUESTED handoff, pass a "
+                        "JSON object with type and text, not a serialized JSON "
+                        "string. Serialized JSON object strings are accepted "
+                        "only for compatibility."
+                    ),
+                },
                 "text": {
                     "type": "string",
-                    "description": "Message text. message and body aliases are also accepted.",
+                    "description": "Plain message text for ordinary cross-room or external sends. message and body aliases are also accepted.",
                 },
                 "dryRun": {
                     "type": "boolean",
                     "description": "Return the resolved payload without sending.",
+                },
+                "mentionSender": {
+                    "type": "boolean",
+                    "description": "For DingTalk requester reports, mention the original sender when session metadata has sender_staff_id.",
                 },
             },
             "additionalProperties": True,
@@ -103,32 +223,41 @@ TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
         "description": (
             "Manage Matrix task rooms for TeamHarness execution-channel "
             "isolation: create a dedicated room for a project or quick task, "
-            "list joined rooms, or archive a task room. Task rooms are internal "
-            "Leader/Worker execution channels, not requester reply channels."
+            "list joined rooms, describe one Matrix room by room name/topic/tags, "
+            "or archive a task room. Task rooms are internal Leader/Worker "
+            "execution channels, not requester reply channels."
         ),
         "inputSchema": {
             "type": "object",
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["create_task_room", "list_rooms", "archive_room"],
+                    "enum": ["create_task_room", "list_rooms", "describe_room", "archive_room"],
                     "description": "Room operation to perform.",
                 },
                 "taskId": {
                     "type": "string",
-                    "description": "Safe task or project id used in the room topic.",
+                    "description": "Safe task id or compatibility project id used when projectId is omitted.",
+                },
+                "projectId": {
+                    "type": "string",
+                    "description": "Safe project id. Project task rooms are named TASK：<projectId> and reused only by this id.",
                 },
                 "name": {
                     "type": "string",
-                    "description": "Human-readable Matrix room name for create_task_room.",
+                    "description": "Human-readable title for create_task_room. When projectId is present, Matrix room name uses TASK：<projectId>.",
                 },
                 "source": {
                     "type": "string",
-                    "description": "Optional requester/source label such as matrix, dingtalk, or wechat. Non-Matrix sources require sourceRoomId.",
+                    "description": "Optional requester/source label such as matrix, dingtalk, or wechat. Source metadata is kept for context only and does not decide task-room reuse.",
                 },
                 "sourceRoomId": {
                     "type": "string",
-                    "description": "Stable external requester room/conversation id. Required for non-Matrix sources; the same source+sourceRoomId reuses the same task room.",
+                    "description": "Optional original requester room/conversation id kept as metadata for project/requester routing.",
+                },
+                "sender": {
+                    "type": "string",
+                    "description": "Optional original external sender identity kept as metadata. It does not decide task-room reuse.",
                 },
                 "topic": {
                     "type": "string",
@@ -145,7 +274,11 @@ TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
                 },
                 "roomId": {
                     "type": "string",
-                    "description": "Matrix room id for archive_room, with or without room: prefix.",
+                    "description": "Matrix room id for describe_room or archive_room, with or without room: prefix.",
+                },
+                "sessionId": {
+                    "type": "string",
+                    "description": "Matrix session id accepted by describe_room, for example matrix:!room:domain.",
                 },
                 "payload": {
                     "type": "object",
@@ -163,7 +296,7 @@ TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
     "filesync": {
         "description": (
             "Explicitly list, stat, pull, or push TeamHarness shared artifacts "
-            "under shared/projects, shared/tasks, or read-only global-shared. "
+            "under shared/ or read-only global-shared. "
             "Use this for deliberate shared file operations, not periodic "
             "workspace sync or runtime package updates."
         ),
@@ -177,7 +310,7 @@ TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
                 },
                 "path": {
                     "type": "string",
-                    "description": "Relative path beginning with shared/projects/, shared/tasks/, or global-shared/.",
+                    "description": "Relative path beginning with shared/ or global-shared/.",
                 },
                 "workspaceDir": {
                     "type": "string",
@@ -201,12 +334,68 @@ TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
             "additionalProperties": True,
         },
     },
+    "artifact": {
+        "description": (
+            "Publish a workspace file to a Matrix room as a standard m.file event. "
+            "Use this for explicit user-visible room files, not shared storage sync. "
+            "The file path must be relative to workspaceDir and must not escape it."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["publish_file"],
+                    "description": "Publish one local workspace file to Matrix media and send an m.file event.",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Workspace-relative file path, for example reports/summary.md or shared/tasks/task-001/result.md.",
+                },
+                "filename": {
+                    "type": "string",
+                    "description": "Optional display filename for the Matrix room file. Defaults to the source basename.",
+                },
+                "target": {
+                    "type": "string",
+                    "description": "Matrix room target, for example room:!room:domain.",
+                },
+                "roomId": {
+                    "type": "string",
+                    "description": "Matrix room id target, with or without room: prefix.",
+                },
+                "parentEventId": {
+                    "type": "string",
+                    "description": "Optional Matrix text event id that this file should attach to.",
+                },
+                "attachmentParentEventId": {
+                    "type": "string",
+                    "description": "Alias for parentEventId.",
+                },
+                "matrixAttachmentParentEventId": {
+                    "type": "string",
+                    "description": "Alias for parentEventId.",
+                },
+                "replyRoute": {
+                    "type": "object",
+                    "description": "Optional Matrix replyRoute whose targetSession identifies the target room.",
+                    "additionalProperties": True,
+                },
+                "workspaceDir": {
+                    "type": "string",
+                    "description": "Runtime workspace containing the file.",
+                },
+            },
+            "additionalProperties": True,
+        },
+    },
     "projectflow": {
         "description": (
-            "Manage durable TeamHarness project state only after Project Work "
-            "mode is selected: create projects, plan or update DAG and Loop "
-            "work, query ready nodes, and record loop iterations. Do not use "
-            "for ordinary direct replies or one-off checks."
+            "Manage durable TeamHarness project state only after Quick Task "
+            "or Project Work mode is selected: create quick projects, create "
+            "projects, plan or update DAG and Loop work, query ready nodes, "
+            "and record loop iterations. Do not use for ordinary direct "
+            "replies or one-off checks."
         ),
         "inputSchema": {
             "type": "object",
@@ -257,6 +446,10 @@ TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
                     "type": "boolean",
                     "description": "For accept_task_result, false records a revision state instead of accepting the result.",
                 },
+                "publishArtifacts": {
+                    "type": "boolean",
+                    "description": "For accept_task_result or complete_project, true explicitly publishes project artifacts immediately. Default is false so callers can publish after the requester report message exists.",
+                },
                 "workspaceDir": {
                     "type": "string",
                     "description": "Runtime workspace containing shared/projects.",
@@ -282,7 +475,7 @@ TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
                 },
                 "action": {
                     "type": "string",
-                    "enum": ["delegate_task", "ack_task", "submit_task", "check_task"],
+                    "enum": ["delegate_task", "ack_task", "submit_task", "check_task", "cancel_task"],
                     "description": "Task lifecycle operation.",
                 },
                 "projectId": {
@@ -310,6 +503,18 @@ TOOL_SCHEMAS: dict[str, dict[str, Any]] = {
                     "type": "array",
                     "description": "Shared deliverable paths included in submit_task.",
                     "items": {"type": "string"},
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Required cancellation reason for cancel_task.",
+                },
+                "replacementTaskId": {
+                    "type": "string",
+                    "description": "Optional replacement task id for cancel_task.",
+                },
+                "assignedTo": {
+                    "type": "string",
+                    "description": "Worker Matrix id or stable member name assigned to delegate_task.",
                 },
                 "workspaceDir": {
                     "type": "string",
@@ -354,6 +559,8 @@ def call_tool(name: str, arguments: dict[str, Any] | None = None) -> dict[str, A
         payload = _roomflow(args)
     elif name == "filesync":
         payload = _filesync(args)
+    elif name == "artifact":
+        payload = _artifact(args)
     elif name == "projectflow":
         payload = _projectflow(args)
     elif name == "taskflow":
@@ -606,10 +813,20 @@ def _route_value(arguments: dict[str, Any], route: dict[str, Any], *names: str) 
     return ""
 
 
+def _route_bool(arguments: dict[str, Any], route: dict[str, Any], *names: str, default: bool = False) -> bool:
+    for name in names:
+        if name in route:
+            return _payload_bool(route.get(name), default)
+        if name in arguments:
+            return _payload_bool(arguments.get(name), default)
+    return default
+
+
 def _qwenpaw_message(arguments: dict[str, Any], route: dict[str, Any], channel: str, message: str) -> dict[str, Any]:
     target_user = _route_value(arguments, route, "targetUser", "target_user", "userId", "user_id")
     target_session = _route_value(arguments, route, "targetSession", "target_session", "sessionId", "session_id")
     agent_id = str(arguments.get("agentId") or arguments.get("agent_id") or arguments.get("accountId") or "default").strip()
+    mention_sender = _route_bool(arguments, route, "mentionSender", "mention_sender", "atSender", "at_sender")
     base: dict[str, Any] = {
         "ok": True,
         "tool": "message",
@@ -621,6 +838,8 @@ def _qwenpaw_message(arguments: dict[str, Any], route: dict[str, Any], channel: 
     }
     if message:
         base["message"] = message
+    if mention_sender:
+        base["mentionSender"] = True
     if not target_user:
         return {"ok": False, "tool": "message", "channel": channel, "error": "targetUser is required for non-Matrix channel sends"}
     if not target_session:
@@ -629,6 +848,45 @@ def _qwenpaw_message(arguments: dict[str, Any], route: dict[str, Any], channel: 
         return {"ok": False, "tool": "message", "channel": channel, "error": "message text is required"}
     if arguments.get("dryRun"):
         base["dryRun"] = True
+        return base
+
+    if channel.strip().lower() == "dingtalk" and mention_sender:
+        mention_result = _send_dingtalk_sender_mention(
+            arguments=arguments,
+            route=route,
+            target_user=target_user,
+            target_session=target_session,
+            account_id=agent_id or "default",
+            message=message,
+        )
+        if mention_result.get("ok"):
+            base["response"] = mention_result.get("response", {})
+            base["senderMentioned"] = True
+            base["mentionedSender"] = mention_result.get("mentionedSender", "")
+            try:
+                base["sessionRecorded"] = _record_outbound_to_session(
+                    channel=channel,
+                    user_id=target_user,
+                    session_id=target_session,
+                    text=message,
+                    message_id=None,
+                    account_id=agent_id or "default",
+                    metadata={
+                        "user_id": target_user,
+                        "session_id": target_session,
+                        "sender_mentioned": True,
+                        "mentioned_sender": mention_result.get("mentionedSender", ""),
+                    },
+                )
+            except Exception:
+                base["sessionRecorded"] = False
+                base["warning"] = "message sent, but local session record failed"
+            return base
+        warning = str(mention_result.get("warning") or mention_result.get("error") or "DingTalk sender mention unavailable")
+        base["ok"] = False
+        base["error"] = warning
+        base["delivery"] = {"failed": "dingtalk_sender_mention_required"}
+        base["senderMentionWarning"] = warning
         return base
 
     api_base = (os.getenv("QWENPAW_API_BASE") or os.getenv("COPAW_API_BASE") or "http://127.0.0.1:8088").rstrip("/")
@@ -672,24 +930,76 @@ def _qwenpaw_message(arguments: dict[str, Any], route: dict[str, Any], channel: 
     return base
 
 
-def _session_safe(name: str) -> str:
-    return UNSAFE_SESSION_FILENAME_RE.sub("--", name)
+def _send_dingtalk_sender_mention(
+    *,
+    arguments: dict[str, Any],
+    route: dict[str, Any],
+    target_user: str,
+    target_session: str,
+    account_id: str,
+    message: str,
+) -> dict[str, Any]:
+    entry = _dingtalk_session_webhook_entry(target_user, target_session, account_id)
+    webhook = str(entry.get("webhook") or "").strip()
+    sender_staff_id = str(entry.get("sender_staff_id") or "").strip()
+    explicit_sender = _route_value(arguments, route, "senderStaffId", "sender_staff_id", "senderUserId", "sender_user_id")
+    conversation_type = str(entry.get("conversation_type") or "").strip().lower()
+
+    if not webhook:
+        return {"ok": False, "warning": "DingTalk session webhook not found; sent without sender mention"}
+    if not sender_staff_id:
+        return {"ok": False, "warning": "DingTalk sender_staff_id not found; sent without sender mention"}
+    if explicit_sender and explicit_sender != sender_staff_id:
+        return {"ok": False, "warning": "DingTalk senderStaffId does not match recorded sender; sent without sender mention"}
+    if conversation_type and conversation_type != "group":
+        return {"ok": False, "warning": "DingTalk sender mention is only applied to group conversations"}
+
+    text = f"@{sender_staff_id}\n{message}"
+    body: dict[str, Any]
+    if len(text) > 3500:
+        body = {
+            "msgtype": "text",
+            "text": {"content": text},
+        }
+    else:
+        body = {
+            "msgtype": "markdown",
+            "markdown": {
+                "title": "TeamHarness report",
+                "text": text,
+            },
+        }
+    body["at"] = {"atUserIds": [sender_staff_id]}
+
+    request = urllib.request.Request(
+        webhook,
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            response_text = response.read().decode("utf-8", errors="replace")
+        data = json.loads(response_text or "{}")
+    except urllib.error.HTTPError as exc:
+        body_text = exc.read().decode("utf-8", errors="replace")[:200]
+        return {"ok": False, "error": f"DingTalk session webhook error: HTTP {exc.code}: {body_text}"}
+    except (json.JSONDecodeError, urllib.error.URLError, TimeoutError, OSError) as exc:
+        return {"ok": False, "error": f"DingTalk session webhook error: {exc}"}
+
+    if not isinstance(data, dict):
+        return {"ok": False, "error": "DingTalk session webhook returned a non-object response"}
+    errcode = data.get("errcode")
+    if errcode not in (None, 0, "0"):
+        return {"ok": False, "error": f"DingTalk session webhook rejected message: {data}"}
+    return {
+        "ok": True,
+        "response": data,
+        "mentionedSender": sender_staff_id,
+    }
 
 
-def _qwenpaw_working_dir() -> Path | None:
-    for name in ("QWENPAW_WORKING_DIR", "COPAW_WORKING_DIR"):
-        raw = os.getenv(name, "").strip()
-        if raw:
-            return Path(raw).expanduser()
-    for name in ("HICLAW_AGENT_HOME", "HICLAW_WORKER_HOME", "HOME"):
-        raw = os.getenv(name, "").strip()
-        if raw:
-            home = Path(raw).expanduser()
-            return home / ".qwenpaw"
-    return None
-
-
-def _channel_session_path(channel: str, user_id: str, session_id: str, account_id: str) -> Path | None:
+def _qwenpaw_workspace_dir(account_id: str) -> Path | None:
     working_dir = _qwenpaw_working_dir()
     if working_dir is None:
         return None
@@ -700,6 +1010,57 @@ def _channel_session_path(channel: str, user_id: str, session_id: str, account_i
         default_workspace = working_dir / "workspaces" / "default"
         if default_workspace.exists():
             workspace_dir = default_workspace
+    return workspace_dir
+
+
+def _dingtalk_session_webhook_entry(target_user: str, target_session: str, account_id: str) -> dict[str, Any]:
+    workspace_dir = _qwenpaw_workspace_dir(account_id)
+    if workspace_dir is None:
+        return {}
+
+    store_path = workspace_dir / "dingtalk_session_webhooks.json"
+    try:
+        store = _read_json(store_path)
+    except Exception:
+        return {}
+
+    keys = []
+    if target_user and target_session:
+        keys.append(f"dingtalk:sw:{target_user}_{target_session}")
+    if target_session:
+        keys.append(f"dingtalk:sw:{target_session}")
+        keys.append(target_session)
+
+    for key in keys:
+        value = store.get(key)
+        if isinstance(value, dict):
+            return dict(value)
+        if isinstance(value, str):
+            return {"webhook": value}
+    return {}
+
+
+def _session_safe(name: str) -> str:
+    return UNSAFE_SESSION_FILENAME_RE.sub("--", name)
+
+
+def _qwenpaw_working_dir() -> Path | None:
+    for name in ("QWENPAW_WORKING_DIR", "COPAW_WORKING_DIR"):
+        raw = os.getenv(name, "").strip()
+        if raw:
+            return Path(raw).expanduser()
+    for name in ("AGENTTEAMS_AGENT_HOME", "AGENTTEAMS_WORKER_HOME", "HOME"):
+        raw = os.getenv(name, "").strip()
+        if raw:
+            home = Path(raw).expanduser()
+            return home / ".qwenpaw"
+    return None
+
+
+def _channel_session_path(channel: str, user_id: str, session_id: str, account_id: str) -> Path | None:
+    workspace_dir = _qwenpaw_workspace_dir(account_id)
+    if workspace_dir is None:
+        return None
 
     filename = f"{_session_safe(user_id)}_{_session_safe(session_id)}.json" if user_id else f"{_session_safe(session_id)}.json"
     channel_dir = _session_safe(channel.strip().lower() or "default")
@@ -788,7 +1149,7 @@ def _record_outbound_to_session(
 
 
 def _record_matrix_outbound_to_session(room_id: str, text: str, message_id: str | None, account_id: str) -> bool:
-    return _record_outbound_to_session(
+    recorded = _record_outbound_to_session(
         channel="matrix",
         user_id=room_id,
         session_id=f"matrix:{room_id}",
@@ -797,55 +1158,296 @@ def _record_matrix_outbound_to_session(room_id: str, text: str, message_id: str 
         account_id=account_id,
         metadata={"room_id": room_id},
     )
+    _write_matrix_attachment_context_parent_event_id(room_id, message_id)
+    return recorded
 
 
 def _message(arguments: dict[str, Any]) -> dict[str, Any]:
-    action = arguments.get("action") or "send"
-    route = _reply_route(arguments)
-    channel = str(route.get("channel") or arguments.get("channel") or "matrix")
-    if action != "send":
-        return {"ok": False, "tool": "message", "error": f"unsupported action: {action}"}
-    if channel != "matrix":
-        message = str(arguments.get("message") or arguments.get("text") or arguments.get("body") or "")
-        return _qwenpaw_message(arguments, route, channel, message)
+    return _message_impl(
+        arguments,
+        MessageToolDeps(
+            reply_route=_reply_route,
+            qwenpaw_message=_qwenpaw_message,
+            matrix_target=_matrix_target,
+            mentions=_mentions,
+            ping_pong_error=_ping_pong_error,
+            matrix_content=_matrix_content,
+            record_matrix_outbound_to_session=_record_matrix_outbound_to_session,
+        ),
+    )
 
-    message = str(arguments.get("message") or arguments.get("text") or arguments.get("body") or "")
-    try:
-        target = arguments.get("target") or arguments.get("room_id") or arguments.get("roomId") or ""
-        target_kind, target_id = _matrix_target(str(target))
-    except ValueError as exc:
-        return {"ok": False, "tool": "message", "error": str(exc)}
-    if target_kind == "user":
-        return {"ok": False, "tool": "message", "error": "Matrix user targets are not supported yet"}
 
-    mentions = _mentions(message, target_id)
-    blocked = _ping_pong_error(message, mentions)
-    if blocked:
-        return {"ok": False, "tool": "message", "error": blocked}
-
-    content = _matrix_content(message, mentions)
-    base: dict[str, Any] = {
-        "ok": True,
-        "tool": "message",
-        "action": "send",
-        "channel": "matrix",
-        "target": f"room:{target_id}",
-        "targetKind": "room",
-        "mentions": mentions,
-        "content": content,
-    }
-    if arguments.get("dryRun"):
-        base["dryRun"] = True
-        return base
-
-    homeserver = os.getenv("HICLAW_MATRIX_URL", "").rstrip("/")
-    token = os.getenv("HICLAW_WORKER_MATRIX_TOKEN", "")
+def _matrix_env(tool: str) -> tuple[str, str]:
+    homeserver = os.getenv("AGENTTEAMS_MATRIX_URL", "").rstrip("/")
+    token = os.getenv("AGENTTEAMS_WORKER_MATRIX_TOKEN", "")
     if not homeserver or not token:
-        return {"ok": False, "tool": "message", "error": "HICLAW_MATRIX_URL and HICLAW_WORKER_MATRIX_TOKEN are required"}
+        raise ValueError("AGENTTEAMS_MATRIX_URL and AGENTTEAMS_WORKER_MATRIX_TOKEN are required")
+    return homeserver, token
 
-    room_id = urllib.parse.quote(target_id, safe="")
-    txn_id = f"teamharness-{os.getpid()}-{int(time.time() * 1000)}"
-    url = f"{homeserver}/_matrix/client/v3/rooms/{room_id}/send/m.room.message/{txn_id}"
+
+def _attachment_parent_event_id(*sources: dict[str, Any]) -> str:
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        for key in ATTACHMENT_PARENT_EVENT_KEYS:
+            value = str(source.get(key) or "").strip()
+            if value:
+                return value
+    return ""
+
+
+def _matrix_attachment_context_path() -> Path | None:
+    raw = os.getenv("TEAMHARNESS_MATRIX_CONTEXT_FILE", "").strip()
+    if raw:
+        return Path(raw)
+    qwenpaw_dir = os.getenv("QWENPAW_WORKING_DIR", "").strip()
+    if qwenpaw_dir:
+        return Path(qwenpaw_dir) / MATRIX_ATTACHMENT_CONTEXT_FILE
+    return None
+
+
+def _matrix_attachment_context_parent_event_id(room_id: str) -> str:
+    path = _matrix_attachment_context_path()
+    if not path or not path.is_file():
+        return ""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    rooms = data.get("rooms")
+    if not isinstance(rooms, dict):
+        return ""
+    record = rooms.get(_canonical_room_id(room_id)) or rooms.get(room_id)
+    if not isinstance(record, dict):
+        return ""
+    try:
+        updated_at = float(record.get("updatedAt") or record.get("updated_at") or 0)
+    except (TypeError, ValueError):
+        updated_at = 0
+    if updated_at and time.time() - updated_at > MATRIX_ATTACHMENT_CONTEXT_TTL_SECONDS:
+        return ""
+    for key in ("attachmentParentEventId", "parentEventId", "eventId", "event_id"):
+        value = str(record.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _write_matrix_attachment_context_parent_event_id(room_id: str, event_id: str | None) -> bool:
+    parent_event_id = str(event_id or "").strip()
+    if not parent_event_id:
+        return False
+    path = _matrix_attachment_context_path()
+    if not path:
+        return False
+    data: dict[str, Any] = {}
+    try:
+        if path.is_file():
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                data = loaded
+    except (OSError, json.JSONDecodeError):
+        data = {}
+    rooms = data.get("rooms")
+    if not isinstance(rooms, dict):
+        rooms = {}
+        data["rooms"] = rooms
+    rooms[_canonical_room_id(room_id)] = {
+        "attachmentParentEventId": parent_event_id,
+        "eventId": parent_event_id,
+        "updatedAt": time.time(),
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(data, ensure_ascii=False, sort_keys=True), encoding="utf-8")
+        tmp.replace(path)
+    except OSError:
+        return False
+    return True
+
+
+def _artifact_publish_result(source_path: str, filename: str = "", parent_event_id: str = "") -> dict[str, Any]:
+    return {
+        "sourcePath": source_path,
+        "filename": filename,
+        "size": None,
+        "mimetype": "",
+        "mxcUri": "",
+        "eventId": "",
+        "parentEventId": parent_event_id,
+        "status": "skipped",
+        "error": "",
+    }
+
+
+def _path_is_under(normalized: str, prefix: str) -> bool:
+    return normalized == prefix or normalized.startswith(f"{prefix}/")
+
+
+def _shared_dir_candidates() -> list[Path]:
+    candidates: list[Path] = []
+    for env_key in ("TEAMHARNESS_SHARED_DIR", "AGENTTEAMS_SHARED_DIR"):
+        raw = os.getenv(env_key, "").strip()
+        if raw:
+            candidates.append(Path(raw).expanduser())
+    return candidates
+
+
+def _artifact_is_under_runtime_shared(workspace: Path, local_path: Path, normalized: str) -> bool:
+    if not _path_is_under(normalized, "shared"):
+        return False
+    candidates = _shared_dir_candidates()
+    if not candidates:
+        return False
+    try:
+        workspace_shared = (workspace / "shared").resolve()
+        local_resolved = local_path.resolve()
+    except (OSError, RuntimeError):
+        return False
+    for shared_dir in candidates:
+        try:
+            shared_resolved = shared_dir.resolve()
+            local_resolved.relative_to(shared_resolved)
+        except (OSError, RuntimeError, ValueError):
+            continue
+        if workspace_shared == shared_resolved:
+            return True
+    return False
+
+
+def _normalize_workspace_artifact_path(raw_path: str) -> tuple[str, bool]:
+    raw = (raw_path or "").strip()
+    if not raw or raw.startswith("/") or "\\" in raw:
+        raise ValueError("artifact path must be a relative workspace path")
+    parts = raw.strip("/").split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ValueError("artifact path must be a relative workspace path without '.', '..', or empty segments")
+    is_directory = raw.endswith("/")
+    normalized = "/".join(parts)
+    if is_directory:
+        normalized += "/"
+    return normalized, is_directory
+
+
+def _resolve_workspace_artifact_path(arguments: dict[str, Any], source_path: str, expected_prefix: str) -> tuple[str, Path]:
+    normalized, is_directory = _normalize_workspace_artifact_path(source_path)
+    if is_directory:
+        raise ValueError("artifact path must be a file")
+    if expected_prefix and not _path_is_under(normalized, expected_prefix):
+        raise ValueError(f"artifact path must be under {expected_prefix}/")
+    workspace = _workspace_dir(arguments)
+    parts = normalized.split("/")
+    local_path = workspace / Path(*parts)
+    try:
+        local_path.resolve().relative_to(workspace.resolve())
+    except ValueError as exc:
+        if _artifact_is_under_runtime_shared(workspace, local_path, normalized):
+            return normalized, local_path
+        raise ValueError("artifact path must stay under workspace shared/") from exc
+    return normalized, local_path
+
+
+def _artifact_mimetype(path: Path) -> str:
+    return mimetypes.guess_type(str(path))[0] or "application/octet-stream"
+
+
+def _artifact_is_text(path: Path, mimetype: str) -> bool:
+    if mimetype.startswith("text/"):
+        return True
+    if mimetype in {
+        "application/json",
+        "application/javascript",
+        "application/xml",
+        "application/x-yaml",
+        "application/yaml",
+        "application/toml",
+    }:
+        return True
+    return path.suffix.lower() in {
+        ".cfg",
+        ".conf",
+        ".css",
+        ".csv",
+        ".html",
+        ".ini",
+        ".js",
+        ".json",
+        ".jsx",
+        ".log",
+        ".md",
+        ".py",
+        ".rb",
+        ".sh",
+        ".sql",
+        ".toml",
+        ".ts",
+        ".tsx",
+        ".txt",
+        ".xml",
+        ".yaml",
+        ".yml",
+    }
+
+
+def _artifact_text_has_sensitive_content(path: Path, mimetype: str) -> bool:
+    if not _artifact_is_text(path, mimetype):
+        return False
+    sample = path.read_bytes()[:TEXT_ARTIFACT_SAMPLE_BYTES]
+    if b"\x00" in sample:
+        return False
+    text = sample.decode("utf-8", errors="replace")
+    return any(pattern.search(text) for pattern in SENSITIVE_ARTIFACT_TEXT_RE)
+
+
+def _matrix_upload_artifact(homeserver: str, token: str, path: Path, filename: str, mimetype: str) -> str:
+    url = f"{homeserver}/_matrix/media/v3/upload?filename={urllib.parse.quote(filename)}"
+    request = urllib.request.Request(
+        url,
+        data=path.read_bytes(),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": mimetype,
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        data = json.loads(response.read().decode("utf-8") or "{}")
+    mxc_uri = str(data.get("content_uri") or "").strip()
+    if not mxc_uri:
+        raise ValueError("Matrix media upload response missing content_uri")
+    return mxc_uri
+
+
+def _matrix_send_file_event(
+    homeserver: str,
+    token: str,
+    room_id: str,
+    filename: str,
+    mxc_uri: str,
+    size: int,
+    mimetype: str,
+    parent_event_id: str = "",
+) -> str:
+    content = {
+        "msgtype": "m.file",
+        "body": filename,
+        "url": mxc_uri,
+        "info": {
+            "size": size,
+            "mimetype": mimetype,
+        },
+    }
+    if parent_event_id:
+        content["m.relates_to"] = {
+            "rel_type": MATRIX_ATTACHMENT_REL_TYPE,
+            "event_id": parent_event_id,
+        }
+    encoded_room_id = urllib.parse.quote(_canonical_room_id(room_id), safe="")
+    txn_id = f"teamharness-file-{os.getpid()}-{int(time.time() * 1000)}-{uuid.uuid4().hex}"
+    url = f"{homeserver}/_matrix/client/v3/rooms/{encoded_room_id}/send/m.room.message/{txn_id}"
     request = urllib.request.Request(
         url,
         data=json.dumps(content).encode("utf-8"),
@@ -855,47 +1457,265 @@ def _message(arguments: dict[str, Any]) -> dict[str, Any]:
         },
         method="PUT",
     )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        data = json.loads(response.read().decode("utf-8") or "{}")
+    event_id = str(data.get("event_id") or "").strip()
+    if not event_id:
+        raise ValueError("Matrix file event response missing event_id")
+    return event_id
+
+
+def _publish_workspace_artifact(
+    arguments: dict[str, Any],
+    *,
+    room_id: str,
+    source_path: str,
+    filename: str,
+    expected_prefix: str,
+    parent_event_id: str = "",
+) -> dict[str, Any]:
+    parent_event_id = str(parent_event_id or "").strip()
+    result = _artifact_publish_result(str(source_path), filename, parent_event_id)
     try:
-        with urllib.request.urlopen(request, timeout=10) as response:
-            data = json.loads(response.read().decode("utf-8") or "{}")
-        base["messageId"] = data.get("event_id")
-    except urllib.error.HTTPError as exc:
-        body = exc.read().decode("utf-8", errors="replace")[:200]
-        return {"ok": False, "tool": "message", "error": f"Matrix API error: HTTP {exc.code}: {body}"}
-    except (urllib.error.URLError, TimeoutError, OSError) as exc:
-        return {"ok": False, "tool": "message", "error": f"Matrix API error: {exc}"}
-    account_id = str(arguments.get("agentId") or arguments.get("agent_id") or arguments.get("accountId") or arguments.get("account_id") or "default").strip() or "default"
+        normalized, path = _resolve_workspace_artifact_path(arguments, str(source_path), expected_prefix)
+        result["sourcePath"] = normalized
+    except ValueError as exc:
+        result["status"] = "failed"
+        result["error"] = str(exc)
+        return result
+
+    if not path.exists():
+        result["status"] = "failed"
+        result["error"] = "artifact file not found"
+        return result
+    if path.is_dir():
+        result["status"] = "failed"
+        result["error"] = "artifact path must be a file"
+        return result
+
+    if SENSITIVE_ARTIFACT_NAME_RE.search(result["sourcePath"]) or SENSITIVE_ARTIFACT_NAME_RE.search(filename):
+        result["status"] = "failed"
+        result["error"] = "artifact appears sensitive and was not published"
+        return result
+
+    size = path.stat().st_size
+    mimetype = _artifact_mimetype(path)
+    result["size"] = size
+    result["mimetype"] = mimetype
+
     try:
-        base["sessionRecorded"] = _record_matrix_outbound_to_session(
-            target_id,
-            message,
-            base.get("messageId"),
-            account_id,
+        if _artifact_text_has_sensitive_content(path, mimetype):
+            result["status"] = "failed"
+            result["error"] = "artifact appears sensitive and was not published"
+            return result
+    except OSError:
+        result["status"] = "failed"
+        result["error"] = "artifact file could not be read"
+        return result
+
+    canonical_room_id = _canonical_room_id(room_id)
+    if not canonical_room_id:
+        result["status"] = "skipped"
+        result["error"] = "Matrix room is unavailable"
+        return result
+    if not parent_event_id:
+        parent_event_id = _matrix_attachment_context_parent_event_id(canonical_room_id)
+        result["parentEventId"] = parent_event_id
+
+    try:
+        homeserver, token = _matrix_env("artifact publish")
+    except ValueError as exc:
+        result["status"] = "skipped"
+        result["error"] = str(exc)
+        return result
+
+    try:
+        mxc_uri = _matrix_upload_artifact(homeserver, token, path, filename, mimetype)
+        event_id = _matrix_send_file_event(
+            homeserver,
+            token,
+            canonical_room_id,
+            filename,
+            mxc_uri,
+            size,
+            mimetype,
+            parent_event_id,
         )
-    except Exception:
-        base["sessionRecorded"] = False
-        base["warning"] = "message sent, but local session record failed"
-    return base
+    except urllib.error.HTTPError as exc:
+        result["status"] = "failed"
+        result["error"] = f"Matrix artifact publish failed: HTTP {exc.code}"
+        return result
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as exc:
+        result["status"] = "failed"
+        result["error"] = f"Matrix artifact publish failed: {exc}"
+        return result
+
+    result["mxcUri"] = mxc_uri
+    result["eventId"] = event_id
+    result["status"] = "published"
+    return result
 
 
-def _matrix_env(tool: str) -> tuple[str, str]:
-    homeserver = os.getenv("HICLAW_MATRIX_URL", "").rstrip("/")
-    token = os.getenv("HICLAW_WORKER_MATRIX_TOKEN", "")
-    if not homeserver or not token:
-        raise ValueError("HICLAW_MATRIX_URL and HICLAW_WORKER_MATRIX_TOKEN are required")
-    return homeserver, token
+def _artifact_room_id(arguments: dict[str, Any]) -> str:
+    route = _reply_route(arguments)
+    target = (
+        arguments.get("target")
+        or arguments.get("roomId")
+        or arguments.get("room_id")
+        or route.get("target")
+        or route.get("roomId")
+        or route.get("room_id")
+        or route.get("targetRoom")
+        or route.get("target_room")
+        or route.get("targetSession")
+        or route.get("target_session")
+        or ""
+    )
+    target_kind, target_id = _matrix_target(str(target))
+    if target_kind != "room":
+        raise ValueError("artifact target must be a Matrix room")
+    return target_id
+
+
+def _artifact(arguments: dict[str, Any]) -> dict[str, Any]:
+    action = str(arguments.get("action") or "publish_file").strip()
+    if action != "publish_file":
+        return {"ok": False, "tool": "artifact", "action": action, "error": f"unsupported action: {action}"}
+    source_path = str(
+        arguments.get("path")
+        or arguments.get("sourcePath")
+        or arguments.get("source_path")
+        or arguments.get("file")
+        or ""
+    ).strip()
+    if not source_path:
+        return {"ok": False, "tool": "artifact", "action": action, "error": "path is required"}
+    filename = str(arguments.get("filename") or arguments.get("displayName") or arguments.get("display_name") or "").strip()
+    if not filename:
+        filename = Path(source_path.rstrip("/")).name or "artifact"
+    try:
+        room_id = _artifact_room_id(arguments)
+    except ValueError as exc:
+        return {"ok": False, "tool": "artifact", "action": action, "error": str(exc)}
+    parent_event_id = (
+        _attachment_parent_event_id(arguments)
+        or _matrix_attachment_context_parent_event_id(room_id)
+    )
+    artifact = _publish_workspace_artifact(
+        arguments,
+        room_id=room_id,
+        source_path=source_path,
+        filename=filename,
+        expected_prefix="",
+        parent_event_id=parent_event_id,
+    )
+    return {
+        "ok": artifact.get("status") == "published",
+        "tool": "artifact",
+        "action": action,
+        "artifact": artifact,
+        "error": artifact.get("error") or "",
+    }
+
+
+def _task_artifact_filename(task_id: str, source_path: str, result_artifact: bool = False) -> str:
+    if result_artifact:
+        suffix = Path(source_path).suffix or ".md"
+        return f"{task_id}-result{suffix}"
+    name = Path(str(source_path).rstrip("/")).name or "artifact"
+    return f"{task_id}-{name}"
+
+
+def _publish_task_artifacts(
+    arguments: dict[str, Any],
+    task: dict[str, Any],
+    task_id: str,
+    deliverables: list[Any],
+    parent_event_id: str = "",
+) -> list[dict[str, Any]]:
+    room_id = str(task.get("room_id") or "")
+    expected_prefix = f"shared/tasks/{task_id}"
+    result_source = f"{expected_prefix}/result.md"
+    artifacts: list[tuple[str, str]] = []
+    try:
+        _normalized_result, result_path = _resolve_workspace_artifact_path(arguments, result_source, expected_prefix)
+        if result_path.is_file():
+            artifacts.append((result_source, _task_artifact_filename(task_id, "result.md", result_artifact=True)))
+    except ValueError:
+        pass
+    seen = {source for source, _filename in artifacts}
+    for item in deliverables:
+        source = str(item or "").strip()
+        if not source:
+            continue
+        try:
+            normalized, is_directory = _normalize_shared_path(source, "stat")
+            seen_key = normalized.rstrip("/") + ("/" if is_directory else "")
+        except ValueError:
+            seen_key = source
+        if seen_key in seen:
+            continue
+        seen.add(seen_key)
+        artifacts.append((source, _task_artifact_filename(task_id, source)))
+    return [
+        _publish_workspace_artifact(
+            arguments,
+            room_id=room_id,
+            source_path=source,
+            filename=filename,
+            expected_prefix=expected_prefix,
+            parent_event_id=parent_event_id,
+        )
+        for source, filename in artifacts
+    ]
+
+
+def _project_artifact_room(project: dict[str, Any], task: dict[str, Any]) -> str:
+    reply_route = project.get("reply_route") if isinstance(project.get("reply_route"), dict) else {}
+    if str(reply_route.get("channel") or "").strip().lower() == "matrix":
+        target_session = str(reply_route.get("target_session") or "").strip()
+        if target_session:
+            return target_session
+    room_id = str(task.get("room_id") or "").strip()
+    if room_id:
+        return room_id
+    source_room_id = str(project.get("source_room_id") or "").strip()
+    if MATRIX_ROOM_RE.fullmatch(_canonical_room_id(source_room_id)):
+        return source_room_id
+    return ""
+
+
+def _publish_project_artifacts(
+    arguments: dict[str, Any],
+    project: dict[str, Any],
+    project_id: str,
+    task_id: str,
+    parent_event_id: str = "",
+) -> list[dict[str, Any]]:
+    task = _read_json(_task_state_path(arguments, task_id)) if task_id else {}
+    source_path = f"shared/projects/{project_id}/result.md"
+    return [
+        _publish_workspace_artifact(
+            arguments,
+            room_id=_project_artifact_room(project, task),
+            source_path=source_path,
+            filename=f"{project_id}-project-result.md",
+            expected_prefix=f"shared/projects/{project_id}",
+            parent_event_id=parent_event_id,
+        )
+    ]
 
 
 def _matrix_user_id() -> str:
-    explicit = os.getenv("HICLAW_MATRIX_USER_ID", "").strip()
+    explicit = os.getenv("AGENTTEAMS_MATRIX_USER_ID", "").strip()
     if explicit:
         return explicit
     member = _section(_load_runtime_config(), "member")
     matrix_user_id = str(member.get("matrixUserId") or member.get("matrix_user_id") or "").strip()
     if matrix_user_id:
         return matrix_user_id
-    name = os.getenv("HICLAW_WORKER_NAME", "").strip()
-    domain = os.getenv("HICLAW_MATRIX_DOMAIN", "").strip()
+    name = os.getenv("AGENTTEAMS_WORKER_NAME", "").strip()
+    domain = os.getenv("AGENTTEAMS_MATRIX_DOMAIN", "").strip()
     if name and domain:
         return f"@{name}:{domain}"
     return ""
@@ -918,6 +1738,80 @@ def _string_list(value: Any) -> list[str]:
     return []
 
 
+def _roomflow_room_meta() -> dict[str, Any]:
+    config = _load_runtime_config()
+    team = _section(config, "team")
+    meta: dict[str, Any] = {
+        "schemaVersion": 1,
+        "roomKind": "task_room",
+        "lifecycle": "ephemeral",
+        "createdBy": "teamharness",
+    }
+    team_name = str(team.get("name") or "").strip()
+    if team_name:
+        meta["teamName"] = team_name
+
+    admin = _section(team, "admin")
+    admin_user_id = str(admin.get("matrixUserId") or admin.get("matrix_user_id") or "").strip()
+    if admin_user_id:
+        admin_meta: dict[str, Any] = {"userId": admin_user_id}
+        admin_name = str(admin.get("name") or admin.get("runtimeName") or admin.get("runtime_name") or "").strip()
+        if admin_name:
+            admin_meta["name"] = admin_name
+        meta["teamAdmin"] = admin_meta
+
+    members = team.get("members")
+    if isinstance(members, list):
+        worker_members: list[dict[str, Any]] = []
+        human_members: list[dict[str, Any]] = []
+        for member in members:
+            if not isinstance(member, dict):
+                continue
+            user_id = str(member.get("matrixUserId") or member.get("matrix_user_id") or "").strip()
+            if not user_id:
+                continue
+            role = str(member.get("role") or "").strip().lower().replace("_", "-")
+            display_name = str(member.get("name") or member.get("runtimeName") or member.get("runtime_name") or "").strip()
+            if role in {"team-leader", "teamleader", "leader"}:
+                if "leaderWorker" not in meta:
+                    leader_meta: dict[str, Any] = {"userId": user_id}
+                    if display_name:
+                        leader_meta["workerName"] = display_name
+                    meta["leaderWorker"] = leader_meta
+                continue
+            if role == "worker":
+                worker_meta: dict[str, Any] = {"userId": user_id}
+                if display_name:
+                    worker_meta["workerName"] = display_name
+                worker_members.append(worker_meta)
+                continue
+            human_meta: dict[str, Any] = {"userId": user_id}
+            if display_name:
+                human_meta["name"] = display_name
+            human_members.append(human_meta)
+        if worker_members:
+            meta["workerMembers"] = worker_members
+        if human_members:
+            meta["humanMembers"] = human_members
+    return meta
+
+
+def _write_matrix_room_meta(room_id: str, content: dict[str, Any]) -> None:
+    homeserver, token = _matrix_env("roomflow")
+    encoded_room = urllib.parse.quote(room_id, safe="")
+    request = urllib.request.Request(
+        f"{homeserver}/_matrix/client/v3/rooms/{encoded_room}/state/room.meta/",
+        data=json.dumps(content).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="PUT",
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        response.read()
+
+
 def _roomflow(arguments: dict[str, Any]) -> dict[str, Any]:
     action = str(arguments.get("action") or "create_task_room")
     payload = _payload(arguments)
@@ -925,19 +1819,41 @@ def _roomflow(arguments: dict[str, Any]) -> dict[str, Any]:
         return _create_task_room(arguments, payload)
     if action == "list_rooms":
         return _list_rooms(arguments)
+    if action == "describe_room":
+        return _describe_room_impl(
+            arguments,
+            payload,
+            RoomDescribeDeps(
+                matrix_env=_matrix_env,
+                matrix_user_id=_matrix_user_id,
+                canonical_room_id=_canonical_room_id,
+            ),
+        )
     if action == "archive_room":
         return _archive_room(arguments, payload)
     return {"ok": False, "tool": "roomflow", "action": action, "error": f"unsupported action: {action}"}
 
 
+def _task_room_name(value: Any) -> str:
+    name = str(value or "").strip()
+    lowered = name.lower()
+    for prefix in ("task:", "task\uff1a"):
+        if lowered.startswith(prefix):
+            name = name[len(prefix) :].strip()
+            break
+    return f"TASK\uff1a{name}" if name else ""
+
+
 def _create_task_room(arguments: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
     try:
-        task_id = _safe_id(payload.get("taskId") or payload.get("projectId"), "taskId")
+        raw_project_id = payload.get("projectId") or payload.get("project_id") or payload.get("taskId")
+        project_id = _safe_id(raw_project_id, "projectId")
     except ValueError as exc:
         return {"ok": False, "tool": "roomflow", "action": "create_task_room", "error": str(exc)}
-    name = str(payload.get("name") or payload.get("title") or "").strip()
+    task_id = project_id
+    name = _task_room_name(project_id)
     if not name:
-        return {"ok": False, "tool": "roomflow", "action": "create_task_room", "error": "name is required"}
+        return {"ok": False, "tool": "roomflow", "action": "create_task_room", "error": "projectId is required"}
     source = str(payload.get("source") or "").strip()
     topic = str(payload.get("topic") or "").strip()
     if not topic:
@@ -963,14 +1879,16 @@ def _create_task_room(arguments: dict[str, Any], payload: dict[str, Any]) -> dic
     }
     if power_users:
         body["power_level_content_override"] = {"users": power_users}
-    binding = _roomflow_source_room_binding(arguments, payload)
+    binding = _roomflow_project_room_binding(arguments, payload, project_id)
     if binding.get("error"):
         return {"ok": False, "tool": "roomflow", "action": "create_task_room", "error": binding["error"]}
+    room_meta = _roomflow_room_meta()
 
     base: dict[str, Any] = {
         "ok": True,
         "tool": "roomflow",
         "action": "create_task_room",
+        "projectId": project_id,
         "taskId": task_id,
         "name": name,
         "source": source,
@@ -978,10 +1896,12 @@ def _create_task_room(arguments: dict[str, Any], payload: dict[str, Any]) -> dic
         "invite": invite,
         "content": body,
     }
-    if binding.get("sourceRoomKey"):
-        base["sourceRoomKey"] = binding["sourceRoomKey"]
+    if binding.get("projectRoomKey"):
+        base["projectRoomKey"] = binding["projectRoomKey"]
     if binding.get("sourceRoomId"):
         base["sourceRoomId"] = binding["sourceRoomId"]
+    if binding.get("sender"):
+        base["sender"] = binding["sender"]
     existing_room_id = _bound_room_id(binding)
     if existing_room_id:
         base["roomId"] = existing_room_id
@@ -992,6 +1912,7 @@ def _create_task_room(arguments: dict[str, Any], payload: dict[str, Any]) -> dic
             return base
         try:
             _ensure_matrix_room_members(existing_room_id, invite)
+            _write_matrix_room_meta(existing_room_id, room_meta)
         except ValueError as exc:
             return {"ok": False, "tool": "roomflow", "action": "create_task_room", "error": str(exc)}
         except urllib.error.HTTPError as exc:
@@ -1031,27 +1952,34 @@ def _create_task_room(arguments: dict[str, Any], payload: dict[str, Any]) -> dic
         return {"ok": False, "tool": "roomflow", "action": "create_task_room", "error": "Matrix createRoom response missing room_id", "response": data}
     base["roomId"] = room_id
     base["target"] = f"room:{room_id}"
-    _write_roomflow_source_room_binding(binding, room_id, base)
+    try:
+        _write_matrix_room_meta(room_id, room_meta)
+    except urllib.error.HTTPError as exc:
+        error = exc.read().decode("utf-8", errors="replace")[:200]
+        return {"ok": False, "tool": "roomflow", "action": "create_task_room", "error": f"Matrix API error: HTTP {exc.code}: {error}"}
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return {"ok": False, "tool": "roomflow", "action": "create_task_room", "error": f"Matrix API error: {exc}"}
+    _write_roomflow_project_room_binding(binding, room_id, base)
     return base
 
 
-def _roomflow_source_room_binding(arguments: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+def _roomflow_project_room_binding(arguments: dict[str, Any], payload: dict[str, Any], project_id: str) -> dict[str, Any]:
     source, source_room_id = _external_source_room_ref(payload)
-    if not source:
-        return {}
-    if not source_room_id:
-        return {"error": "sourceRoomId is required for non-Matrix source task rooms"}
-    source_room_key = f"{source}:{source_room_id}"
+    sender = _external_sender_ref(payload)
+    project_room_key = f"project:{project_id}"
     binding: dict[str, Any] = {
+        "projectId": project_id,
         "source": source,
         "sourceRoomId": source_room_id,
-        "sourceRoomKey": source_room_key,
+        "projectRoomKey": project_room_key,
     }
+    if sender:
+        binding["sender"] = sender
     workspace_dir = _optional_workspace_dir(arguments)
     if not workspace_dir:
-        return {"error": "workspaceDir is required to persist external source task room bindings"}
-    digest = hashlib.sha256(source_room_key.encode("utf-8")).hexdigest()[:16]
-    path = workspace_dir / "shared" / "roomflow" / "source-rooms" / f"{source}-{digest}.json"
+        return binding
+    digest = hashlib.sha256(project_room_key.encode("utf-8")).hexdigest()[:16]
+    path = workspace_dir / "shared" / "roomflow" / "project-rooms" / f"{project_id}-{digest}.json"
     record = _read_json(path)
     binding["path"] = path
     binding["record"] = record
@@ -1065,6 +1993,31 @@ def _external_source_room_ref(payload: dict[str, Any]) -> tuple[str, str]:
     return source, str(payload.get("sourceRoomId") or payload.get("source_room_id") or "").strip()
 
 
+def _external_sender_ref(payload: dict[str, Any]) -> str:
+    for key in (
+        "sender",
+        "senderId",
+        "sender_id",
+        "senderUserId",
+        "sender_user_id",
+        "sourceUserId",
+        "source_user_id",
+        "targetUser",
+        "target_user",
+    ):
+        value = str(payload.get(key) or "").strip()
+        if value:
+            return value
+    route = payload.get("replyRoute") or payload.get("reply_route")
+    if isinstance(route, dict):
+        for key in ("targetUser", "target_user", "sender", "senderId", "sender_id"):
+            value = str(route.get(key) or "").strip()
+            if value:
+                return value
+    requester_route = _reply_route_from_requester(payload.get("requester"))
+    return str(requester_route.get("target_user") or "").strip()
+
+
 def _bound_room_id(binding: dict[str, Any]) -> str:
     record = binding.get("record")
     if not isinstance(record, dict):
@@ -1072,16 +2025,17 @@ def _bound_room_id(binding: dict[str, Any]) -> str:
     return str(record.get("roomId") or record.get("room_id") or "").strip()
 
 
-def _write_roomflow_source_room_binding(binding: dict[str, Any], room_id: str, base: dict[str, Any]) -> None:
+def _write_roomflow_project_room_binding(binding: dict[str, Any], room_id: str, base: dict[str, Any]) -> None:
     path = binding.get("path")
     if not isinstance(path, Path):
         return
     record = dict(binding.get("record") if isinstance(binding.get("record"), dict) else {})
     record.update(
         {
+            "projectId": binding.get("projectId"),
             "source": binding.get("source"),
             "sourceRoomId": binding.get("sourceRoomId"),
-            "sourceRoomKey": binding.get("sourceRoomKey"),
+            "projectRoomKey": binding.get("projectRoomKey"),
             "roomId": room_id,
             "target": f"room:{room_id}",
             "updatedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
@@ -1089,6 +2043,8 @@ def _write_roomflow_source_room_binding(binding: dict[str, Any], room_id: str, b
             "name": base.get("name"),
         }
     )
+    if binding.get("sender"):
+        record["sender"] = binding.get("sender")
     if "createdAt" not in record:
         record["createdAt"] = record["updatedAt"]
     _write_json(path, record)
@@ -1319,7 +2275,7 @@ def _runtime_team_room_id() -> str:
 
 
 def _storage_root_prefix() -> str:
-    return os.getenv("HICLAW_STORAGE_PREFIX", "").strip().strip("/")
+    return os.getenv("AGENTTEAMS_STORAGE_PREFIX", "").strip().strip("/")
 
 
 def _mc_host_url(endpoint: str, access_key: str, secret_key: str) -> str:
@@ -1366,9 +2322,9 @@ def _filesync_mc_env(remote: str) -> tuple[dict[str, str], str | None]:
     if env.get(alias_env):
         return env, None
 
-    endpoint = env.get("HICLAW_FS_ENDPOINT", "").strip()
-    access_key = env.get("HICLAW_FS_ACCESS_KEY", "").strip()
-    secret_key = env.get("HICLAW_FS_SECRET_KEY", "").strip()
+    endpoint = env.get("AGENTTEAMS_FS_ENDPOINT", "").strip()
+    access_key = env.get("AGENTTEAMS_FS_ACCESS_KEY", "").strip()
+    secret_key = env.get("AGENTTEAMS_FS_SECRET_KEY", "").strip()
     if endpoint and access_key and secret_key:
         env[alias_env] = _mc_host_url(endpoint, access_key, secret_key)
         return env, None
@@ -1377,7 +2333,7 @@ def _filesync_mc_env(remote: str) -> tuple[dict[str, str], str | None]:
         return env, None
     return env, (
         f"storage alias {MC_ALIAS} is not configured; missing "
-        "HICLAW_FS_ENDPOINT/HICLAW_FS_ACCESS_KEY/HICLAW_FS_SECRET_KEY"
+        "AGENTTEAMS_FS_ENDPOINT/AGENTTEAMS_FS_ACCESS_KEY/AGENTTEAMS_FS_SECRET_KEY"
     )
 
 
@@ -1399,7 +2355,7 @@ def _default_workspace_dir() -> str:
         working_dir = os.getenv(env_key, "").strip()
         if working_dir:
             return str(Path(working_dir) / "workspaces" / "default")
-    shared_dir = os.getenv("TEAMHARNESS_SHARED_DIR", "").strip() or os.getenv("HICLAW_SHARED_DIR", "").strip()
+    shared_dir = os.getenv("TEAMHARNESS_SHARED_DIR", "").strip() or os.getenv("AGENTTEAMS_SHARED_DIR", "").strip()
     if shared_dir:
         return str(Path(shared_dir).parent)
     return ""
@@ -1407,7 +2363,7 @@ def _default_workspace_dir() -> str:
 
 def _default_shared_prefix() -> str:
     """Derive storage shared prefix from environment or runtime.yaml."""
-    configured = os.getenv("HICLAW_SHARED_STORAGE_PREFIX", "").strip()
+    configured = os.getenv("AGENTTEAMS_SHARED_STORAGE_PREFIX", "").strip()
     if configured:
         return _with_storage_root(configured)
     storage = _section(_load_runtime_config(), "storage")
@@ -1475,11 +2431,8 @@ def _normalize_shared_path(raw_path: str, action: str) -> tuple[str, bool]:
         raise ValueError("path must be a relative shared path without '.', '..', or empty segments")
     if parts[0] not in {"shared", "global-shared"}:
         raise ValueError("path must start with shared/ or global-shared/")
-    # Allow shared/ root for list, but require projects/ or tasks/ for push/pull
-    if parts[0] == "shared" and len(parts) >= 2 and parts[1] not in {"projects", "tasks"}:
-        raise ValueError("shared path must be under shared/projects/ or shared/tasks/")
     if parts[0] == "shared" and action in {"push", "pull"} and len(parts) < 3:
-        raise ValueError("shared push/pull requires a project or task path")
+        raise ValueError("shared push/pull requires a subpath under shared/")
     if parts[0] == "global-shared" and len(parts) < 2:
         raise ValueError("global-shared path must include a subpath")
     is_directory = raw.endswith("/") or (
@@ -1625,8 +2578,10 @@ def _payload(arguments: dict[str, Any]) -> dict[str, Any]:
         "taskId": ("taskId", "task_id"),
         "roomId": ("roomId", "room_id"),
         "sourceRoomId": ("sourceRoomId", "source_room_id"),
+        "sender": ("sender", "senderId", "sender_id", "senderUserId", "sender_user_id", "sourceUserId", "source_user_id"),
         "assignedTo": ("assignedTo", "assigned_to"),
         "dependsOn": ("dependsOn", "depends_on"),
+        "replacementTaskId": ("replacementTaskId", "replacement_task_id"),
     }
     for canonical, keys in aliases.items():
         if any(data.get(key) for key in keys):
@@ -1640,6 +2595,8 @@ def _payload(arguments: dict[str, Any]) -> dict[str, Any]:
     for key in (
         "title", "name", "source", "requester", "spec", "status", "summary", "notes", "topic", "admin",
         "invite", "replyRoute", "reply_route", "accepted", "resultStatus", "result_status", "reason",
+        "cancelReason", "cancel_reason",
+        "targetUser", "target_user",
     ):
         if key not in data and arguments.get(key) is not None:
             data[key] = arguments[key]
@@ -1698,6 +2655,31 @@ def _normalize_reply_route(raw: Any) -> dict[str, str]:
     channel = str(route.get("channel") or "").strip()
     target_user = str(route.get("targetUser") or route.get("target_user") or route.get("userId") or route.get("user_id") or "").strip()
     target_session = str(route.get("targetSession") or route.get("target_session") or route.get("sessionId") or route.get("session_id") or "").strip()
+    if channel.lower() == "matrix":
+        target = str(
+            route.get("target")
+            or route.get("roomId")
+            or route.get("room_id")
+            or route.get("targetRoom")
+            or route.get("target_room")
+            or target_session
+            or ""
+        ).strip()
+        if not target:
+            return {}
+        try:
+            target_kind, target_id = _matrix_target(target)
+        except ValueError:
+            return {}
+        if target_kind != "room":
+            return {}
+        normalized = {
+            "channel": "matrix",
+            "target_session": target_id,
+        }
+        if target_user:
+            normalized["target_user"] = target_user
+        return normalized
     if not (channel and target_user and target_session):
         return {}
     return {
@@ -1709,6 +2691,17 @@ def _normalize_reply_route(raw: Any) -> dict[str, str]:
 
 def _reply_route_from_requester(requester: Any) -> dict[str, str]:
     text = str(requester or "").strip()
+    if text.startswith("matrix:"):
+        try:
+            target_kind, target_id = _matrix_target(text)
+        except ValueError:
+            return {}
+        if target_kind != "room":
+            return {}
+        return {
+            "channel": "matrix",
+            "target_session": target_id,
+        }
     if not text.startswith("dingtalk:"):
         return {}
     parts = text.split(":", 2)
@@ -1728,12 +2721,12 @@ def _source_room_id_from_payload(payload: dict[str, Any], reply_route: dict[str,
 
     route = reply_route if isinstance(reply_route, dict) else {}
     channel = str(route.get("channel") or payload.get("source") or "").strip().lower()
-    if channel and channel != "matrix":
+    if channel:
         return str(route.get("target_session") or "").strip()
 
     requester_route = _reply_route_from_requester(payload.get("requester"))
     channel = str(requester_route.get("channel") or "").strip().lower()
-    if channel and channel != "matrix":
+    if channel:
         return str(requester_route.get("target_session") or "").strip()
     return ""
 
@@ -1767,6 +2760,21 @@ def _validate_assignment_room(project: dict[str, Any], room_id: str) -> None:
             f"{channel} requester tasks require a dedicated task room; "
             "call roomflow create_task_room and pass its roomId"
         )
+
+
+def _validate_task_redelegation(arguments: dict[str, Any], project: dict[str, Any], task_id: str, room_id: str) -> None:
+    if not _external_requester_channel(project):
+        return
+    existing = _read_json(_task_state_path(arguments, task_id))
+    existing_room_id = str(existing.get("room_id") or "").strip()
+    if not existing_room_id:
+        return
+    if _canonical_room_id(existing_room_id) == _canonical_room_id(room_id):
+        return
+    raise ValueError(
+        f"task {task_id} is already delegated to assignment room {existing_room_id}; "
+        f"do not delegate it again to {room_id}"
+    )
 
 
 def _read_json(path: Path, default: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -1906,7 +2914,10 @@ def _write_project_plan(project_dir: Path, project: dict[str, Any]) -> None:
         channel = str(reply_route.get("channel") or "").strip()
         target_user = str(reply_route.get("target_user") or "").strip()
         target_session = str(reply_route.get("target_session") or "").strip()
-        if channel and target_user and target_session:
+        if channel == "matrix" and target_session:
+            target = f"{target_user}/{target_session}" if target_user else target_session
+            lines.append(f"- Reply Route: `{channel}/{target}`")
+        elif channel and target_user and target_session:
             lines.append(f"- Reply Route: `{channel}/{target_user}/{target_session}`")
     loop = project.get("loop") if isinstance(project.get("loop"), dict) else {}
     if plan_type == "loop":
@@ -2040,6 +3051,13 @@ def _payload_bool(value: Any, default: bool) -> bool:
     return default
 
 
+def _payload_bool_field(payload: dict[str, Any], names: tuple[str, ...], default: bool) -> bool:
+    for name in names:
+        if name in payload:
+            return _payload_bool(payload.get(name), default)
+    return default
+
+
 def _accept_task_result(arguments: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
     project_id = _safe_id(payload.get("projectId") or payload.get("project_id"), "projectId")
     task_id = _safe_id(payload.get("taskId") or payload.get("task_id"), "taskId")
@@ -2086,6 +3104,19 @@ def _accept_task_result(arguments: dict[str, Any], payload: dict[str, Any]) -> d
             project["requester_report"] = requester_report
     _write_json(_project_state_path(arguments, project_id), project)
     _write_project_plan(_project_dir(arguments, project_id), project)
+    publish_artifacts = _payload_bool_field(payload, ("publishArtifacts", "publish_artifacts"), False)
+    published_artifacts = (
+        _publish_project_artifacts(
+            arguments,
+            project,
+            project_id,
+            task_id,
+            _attachment_parent_event_id(payload, arguments),
+        )
+        if node_status == "completed" and publish_artifacts else []
+    )
+    requester_report = project.get("requester_report") if isinstance(project.get("requester_report"), dict) else {}
+    requester_report_pending = requester_report.get("pending") is True and requester_report.get("task_id") == task_id
     return {
         "ok": True,
         "tool": "projectflow",
@@ -2094,6 +3125,13 @@ def _accept_task_result(arguments: dict[str, Any], payload: dict[str, Any]) -> d
         "taskId": task_id,
         "nodeStatus": node_status,
         "accepted": node_status == "completed",
+        "publishedArtifacts": published_artifacts,
+        "notificationNeeded": _notification_needed(
+            "accept_task_result",
+            project,
+            summary=f"accept_task_result: {task_id} -> {node_status}",
+            include_reply_route=requester_report_pending,
+        ),
     }
 
 
@@ -2113,6 +3151,46 @@ def _mark_requester_report_sent(arguments: dict[str, Any], payload: dict[str, An
         "action": "mark_requester_report_sent",
         "project": project,
     }
+
+
+def _notification_needed(
+    action: str,
+    project: dict[str, Any],
+    task: dict[str, Any] | None = None,
+    summary: str = "",
+    include_reply_route: bool = True,
+) -> dict[str, Any]:
+    """Build a notificationNeeded hint for the calling agent.
+
+    This does NOT send any message. It returns structured metadata that tells the
+    agent which room to notify and what changed, so the agent can follow up with
+    a message tool call.
+    """
+    project_id = str(project.get("project_id") or "")
+    title = str(project.get("title") or project_id)
+    # Determine best target room
+    target_room = ""
+    if task and str(task.get("room_id") or ""):
+        target_room = str(task["room_id"])
+    elif str(project.get("source_room_id") or ""):
+        target_room = str(project["source_room_id"])
+    reply_route = project.get("reply_route") if include_reply_route and isinstance(project.get("reply_route"), dict) else {}
+    if not target_room and reply_route:
+        target_session = str(reply_route.get("target_session") or "").strip()
+        if target_session:
+            target_room = target_session
+    if not summary:
+        summary = f"{action}: {title}"
+    result: dict[str, Any] = {
+        "event": action,
+        "projectId": project_id,
+        "summary": summary,
+    }
+    if target_room:
+        result["targetRoom"] = target_room
+    if reply_route:
+        result["replyRoute"] = reply_route
+    return result
 
 
 def _projectflow(arguments: dict[str, Any]) -> dict[str, Any]:
@@ -2140,7 +3218,13 @@ def _projectflow(arguments: dict[str, Any]) -> dict[str, Any]:
             project_dir = _project_dir(arguments, project_id)
             _write_json(_project_state_path(arguments, project_id), project)
             _write_project_plan(project_dir, project)
-            return {"ok": True, "tool": "projectflow", "action": action, "project": project}
+            return {
+                "ok": True,
+                "tool": "projectflow",
+                "action": action,
+                "project": project,
+                "notificationNeeded": _notification_needed(action, project),
+            }
 
         if action == "create_quick_project":
             project_id = _project_id_from_payload(arguments, payload)
@@ -2199,6 +3283,7 @@ def _projectflow(arguments: dict[str, Any]) -> dict[str, Any]:
                 "room_id": room_id,
                 "status": "assigned",
                 "spec_path": f"shared/tasks/{task_id}/spec.md",
+                "assigned_to": assigned_to,
             }
             if source_room_id:
                 task["source_room_id"] = source_room_id
@@ -2210,6 +3295,7 @@ def _projectflow(arguments: dict[str, Any]) -> dict[str, Any]:
                 "project": project,
                 "task": task,
                 "synced": _sync_task(arguments, task_id),
+                "notificationNeeded": _notification_needed(action, project, task),
             }
 
         if action == "resolve_project":
@@ -2246,6 +3332,7 @@ def _projectflow(arguments: dict[str, Any]) -> dict[str, Any]:
                 "action": action,
                 "project": project,
                 "readyNodes": _ready_nodes(project),
+                "notificationNeeded": _notification_needed(action, project),
             }
 
         if action == "plan_loop":
@@ -2301,6 +3388,7 @@ def _projectflow(arguments: dict[str, Any]) -> dict[str, Any]:
                 "project": project,
                 "loop": loop,
                 "readyLoopNodes": _ready_loop_nodes(project),
+                "notificationNeeded": _notification_needed(action, project),
             }
 
         if action == "ready_nodes":
@@ -2371,6 +3459,9 @@ def _projectflow(arguments: dict[str, Any]) -> dict[str, Any]:
                 "project": project,
                 "loop": loop,
                 "readyLoopNodes": _ready_loop_nodes(project),
+                "notificationNeeded": _notification_needed(
+                    action, project, summary=f"record_loop_iteration: iteration {iteration} -> {decision}",
+                ),
             }
 
         if action in {"pause_project", "resume_project", "complete_project"}:
@@ -2392,12 +3483,23 @@ def _projectflow(arguments: dict[str, Any]) -> dict[str, Any]:
             project_dir = _project_dir(arguments, project_id)
             _write_json(state_path, project)
             _write_project_plan(project_dir, project)
-            return {
+            result = {
                 "ok": True,
                 "tool": "projectflow",
                 "action": action,
                 "project": project,
             }
+            publish_artifacts = _payload_bool_field(payload, ("publishArtifacts", "publish_artifacts"), False)
+            if action == "complete_project" and publish_artifacts and (project_dir / "result.md").is_file():
+                result["publishedArtifacts"] = _publish_project_artifacts(
+                    arguments,
+                    project,
+                    project_id,
+                    "",
+                    _attachment_parent_event_id(payload, arguments),
+                )
+            result["notificationNeeded"] = _notification_needed(action, project)
+            return result
     except ValueError as exc:
         return {"ok": False, "tool": "projectflow", "action": action, "error": str(exc)}
 
@@ -2416,7 +3518,7 @@ def _normalize_role(role: str) -> str:
 
 
 def _runtime_role() -> str:
-    role = os.getenv("HICLAW_AGENT_ROLE", "").strip() or os.getenv("HICLAW_WORKER_ROLE", "").strip()
+    role = os.getenv("AGENTTEAMS_AGENT_ROLE", "").strip() or os.getenv("AGENTTEAMS_WORKER_ROLE", "").strip()
     if not role:
         role = str(_section(_load_runtime_config(), "member").get("role") or "").strip()
     return _normalize_role(role)
@@ -2443,47 +3545,175 @@ def _load_task(arguments: dict[str, Any], task_id: str) -> dict[str, Any]:
     task = _read_json(_task_state_path(arguments, task_id))
     if not task:
         raise ValueError("task not found")
+    if not task.get("task_id") and task.get("taskId"):
+        task["task_id"] = str(task["taskId"])
     return task
 
 
+def _first_text(*values: Any) -> str:
+    for value in values:
+        text = str(value or "").strip()
+        if text:
+            return text
+    return ""
+
+
+def _utc_timestamp() -> str:
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _project_task_for_meta(arguments: dict[str, Any], task: dict[str, Any]) -> dict[str, Any]:
+    project_id = _first_text(task.get("project_id"), task.get("projectId"))
+    task_id = _first_text(task.get("task_id"), task.get("taskId"))
+    if not project_id or not task_id:
+        return {}
+    project = _read_json(_project_state_path(arguments, project_id))
+    tasks = list(project.get("tasks", []) if isinstance(project.get("tasks"), list) else [])
+    loop = project.get("loop") if isinstance(project.get("loop"), dict) else {}
+    if isinstance(loop.get("tasks"), list):
+        tasks.extend(loop["tasks"])
+    for item in tasks:
+        if isinstance(item, dict) and _first_text(item.get("task_id"), item.get("taskId")) == task_id:
+            return item
+    return {}
+
+
+def _preserve_task_meta_fields(arguments: dict[str, Any], task: dict[str, Any]) -> None:
+    """Keep correlation fields when taskflow writes after a remote pull.
+
+    filesync pull and ack_task can replace local ``meta.json`` with a remote
+    copy that omits ``room_id`` / ``assigned_to``.  Preserve non-empty local
+    values and fall back to the project plan node when still missing.
+    """
+    task_id = _first_text(task.get("task_id"), task.get("taskId"))
+    if not task_id:
+        return
+    existing = _read_json(_task_state_path(arguments, task_id))
+    project_task = _project_task_for_meta(arguments, task)
+    for snake, camel in (
+        ("room_id", "roomId"),
+        ("assigned_to", "assignedTo"),
+        ("project_id", "projectId"),
+    ):
+        if _first_text(task.get(snake), task.get(camel)):
+            continue
+        preserved = _first_text(
+            existing.get(snake),
+            existing.get(camel),
+            project_task.get(snake),
+            project_task.get(camel),
+        )
+        if preserved:
+            task[snake] = preserved
+
+
+def _ensure_console_task_meta(arguments: dict[str, Any], task: dict[str, Any]) -> None:
+    _preserve_task_meta_fields(arguments, task)
+    project_task = _project_task_for_meta(arguments, task)
+    task["task_id"] = _first_text(task.get("task_id"), task.get("taskId"))
+    task["project_id"] = _first_text(task.get("project_id"), task.get("projectId"))
+    task["room_id"] = _first_text(task.get("room_id"), task.get("roomId"))
+    task["spec_path"] = _first_text(task.get("spec_path"), task.get("specPath"))
+    source_room_id = _first_text(task.get("source_room_id"), task.get("sourceRoomId"), project_task.get("source_room_id"))
+    if source_room_id:
+        task["source_room_id"] = source_room_id
+    task["task_title"] = _first_text(
+        task.get("task_title"),
+        task.get("taskTitle"),
+        project_task.get("title"),
+        task.get("title"),
+        task["task_id"],
+    )
+    task["assigned_to"] = _first_text(
+        task.get("assigned_to"),
+        task.get("assignedTo"),
+        project_task.get("assigned_to"),
+        project_task.get("assignedTo"),
+    )
+    task["assigned_at"] = _first_text(
+        task.get("assigned_at"),
+        task.get("assignedAt"),
+        task.get("created_at"),
+        task.get("createdAt"),
+    ) or _utc_timestamp()
+    for snake_key, camel_key in (
+        ("acknowledged_by_role", "acknowledgedByRole"),
+        ("result_status", "resultStatus"),
+        ("result_path", "resultPath"),
+        ("submitted_by_role", "submittedByRole"),
+    ):
+        value = _first_text(task.get(snake_key), task.get(camel_key))
+        if value:
+            task[snake_key] = value
+    for key in (
+        "taskId",
+        "projectId",
+        "roomId",
+        "specPath",
+        "sourceRoomId",
+        "taskTitle",
+        "assignedTo",
+        "assignedAt",
+        "createdAt",
+        "acknowledgedByRole",
+        "resultStatus",
+        "resultPath",
+        "submittedByRole",
+    ):
+        task.pop(key, None)
+
+
 def _write_task(arguments: dict[str, Any], task: dict[str, Any]) -> None:
+    _ensure_console_task_meta(arguments, task)
     _write_json(_task_state_path(arguments, task["task_id"]), task)
 
 
-def _parse_task_result(path: Path) -> tuple[dict[str, Any], list[str]]:
-    result: dict[str, Any] = {"status": "", "summary": "", "deliverables": []}
+ALLOWED_TASK_RESULT_STATUSES = {"SUCCESS", "SUCCESS_WITH_NOTES", "REVISION_NEEDED", "BLOCKED", "FAILED", "PARTIAL"}
+
+
+def _validate_task_deliverables(task_id: str, deliverables: list[Any]) -> list[str]:
+    expected_prefix = f"shared/tasks/{task_id}"
+    normalized_deliverables: list[str] = []
+    for item in deliverables:
+        source = str(item or "").strip()
+        if not source:
+            continue
+        try:
+            normalized, _is_directory = _normalize_workspace_artifact_path(source)
+        except ValueError as exc:
+            raise ValueError(f"deliverables must be workspace-relative paths under {expected_prefix}/") from exc
+        if not _path_is_under(normalized.rstrip("/"), expected_prefix):
+            raise ValueError(f"deliverables must stay under {expected_prefix}/")
+        normalized_deliverables.append(normalized)
+    return normalized_deliverables
+
+
+def _task_result_from_meta(task: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    deliverables = task.get("deliverables")
+    if not isinstance(deliverables, list):
+        deliverables = []
+    result = {
+        "status": str(task.get("result_status") or "").strip(),
+        "summary": str(task.get("summary") or "").strip(),
+        "deliverables": [str(item) for item in deliverables],
+    }
     errors: list[str] = []
-    in_deliverables = False
-    has_deliverables_section = False
-
-    for line in path.read_text(encoding="utf-8").splitlines():
-        stripped = line.strip()
-        status_match = re.match(r"^(?:-\s*)?Status:\s*`?([^`]+?)`?\s*$", stripped, re.IGNORECASE)
-        if status_match:
-            result["status"] = status_match.group(1).strip()
-            continue
-        summary_match = re.match(r"^(?:-\s*)?Summary:\s*(.+?)\s*$", stripped, re.IGNORECASE)
-        if summary_match:
-            result["summary"] = summary_match.group(1).strip()
-            continue
-        if stripped.lower() in {"## deliverables", "deliverables:"}:
-            in_deliverables = True
-            has_deliverables_section = True
-            continue
-        if in_deliverables and stripped.startswith("- "):
-            item = stripped[2:].strip().strip("`")
-            if item:
-                result["deliverables"].append(item)
-
-    status = str(result.get("status") or "").strip()
+    status = result["status"]
     if not status:
         errors.append("missing result status")
-    elif status not in {"SUCCESS", "SUCCESS_WITH_NOTES", "REVISION_NEEDED", "BLOCKED", "FAILED", "PARTIAL"}:
+    elif status not in ALLOWED_TASK_RESULT_STATUSES:
         errors.append(f"invalid result status: {status}")
-    if not str(result.get("summary") or "").strip():
+    if not result["summary"]:
         errors.append("missing result summary")
-    if not has_deliverables_section:
-        errors.append("missing deliverables section")
+    try:
+        _validate_task_deliverables(str(task.get("task_id") or ""), result["deliverables"])
+    except ValueError as exc:
+        errors.append(str(exc))
     return result, errors
 
 
@@ -2500,13 +3730,54 @@ def _sync_task(arguments: dict[str, Any], task_id: str, exclude: list[str] | Non
 
 
 def _pull_task(arguments: dict[str, Any], task_id: str) -> bool:
+    existing = _read_json(_task_state_path(arguments, task_id))
     sync_args = dict(arguments)
     sync_args.update({
         "action": "pull",
         "path": f"shared/tasks/{task_id}",
     })
     result = _filesync(sync_args)
-    return bool(result.get("ok"))
+    if not result.get("ok"):
+        return False
+    if existing:
+        task = _read_json(_task_state_path(arguments, task_id))
+        if task:
+            for snake, camel in (
+                ("room_id", "roomId"),
+                ("assigned_to", "assignedTo"),
+                ("project_id", "projectId"),
+            ):
+                if _first_text(task.get(snake), task.get(camel)):
+                    continue
+                preserved = _first_text(existing.get(snake), existing.get(camel))
+                if preserved:
+                    task[snake] = preserved
+            _write_task(arguments, task)
+    return True
+
+
+TERMINAL_TASK_STATUSES = {"completed", "revision", "blocked", "cancelled"}
+
+
+def _terminal_task_status(arguments: dict[str, Any], task: dict[str, Any], task_id: str) -> str:
+    project_id = str(task.get("project_id") or "")
+    project = _read_json(_project_state_path(arguments, project_id)) if project_id else {}
+    project_tasks = project.get("tasks", []) if isinstance(project.get("tasks"), list) else []
+    loop = project.get("loop") if isinstance(project.get("loop"), dict) else {}
+    loop_tasks = loop.get("tasks", []) if isinstance(loop.get("tasks"), list) else []
+    for node in project_tasks + loop_tasks:
+        if isinstance(node, dict) and node.get("task_id") == task_id:
+            node_status = str(node.get("status") or "")
+            if node_status in TERMINAL_TASK_STATUSES:
+                return node_status
+    task_status = str(task.get("status") or "")
+    return task_status if task_status in TERMINAL_TASK_STATUSES else ""
+
+
+def _require_task_mutable(arguments: dict[str, Any], task: dict[str, Any], task_id: str, action: str) -> None:
+    terminal_status = _terminal_task_status(arguments, task, task_id)
+    if terminal_status:
+        raise ValueError(f"{action} cannot update terminal task: {terminal_status}")
 
 
 def _update_project_task(arguments: dict[str, Any], project_id: str, task_id: str, **updates: Any) -> None:
@@ -2553,6 +3824,19 @@ def _taskflow(arguments: dict[str, Any]) -> dict[str, Any]:
                         assigned_to = str(item.get("assigned_to") or item.get("assignedTo") or "").strip()
                         break
             _validate_assignment_room(project, room_id)
+            _validate_task_redelegation(arguments, project, task_id, room_id)
+            existing_task = _read_json(_task_state_path(arguments, task_id), {"project_id": project_id})
+            _require_task_mutable(arguments, existing_task, task_id, action)
+            assigned_to = str(payload.get("assignedTo") or payload.get("assigned_to") or "").strip()
+            if not assigned_to:
+                tasks = project.get("tasks", []) if isinstance(project.get("tasks"), list) else []
+                loop = project.get("loop") if isinstance(project.get("loop"), dict) else {}
+                if isinstance(loop.get("tasks"), list):
+                    tasks = tasks + loop["tasks"]
+                for item in tasks:
+                    if isinstance(item, dict) and item.get("task_id") == task_id:
+                        assigned_to = str(item.get("assigned_to") or "").strip()
+                        break
             task_dir = _task_dir(arguments, task_id)
             task_dir.mkdir(parents=True, exist_ok=True)
             spec = str(payload.get("spec") or "")
@@ -2569,12 +3853,16 @@ def _taskflow(arguments: dict[str, Any]) -> dict[str, Any]:
                 task["assigned_to"] = assigned_to
             if source_room_id:
                 task["source_room_id"] = source_room_id
+            if assigned_to:
+                task["assigned_to"] = assigned_to
             _write_task(arguments, task)
             project_task_updates: dict[str, Any] = {"status": "assigned"}
             if assigned_to:
                 project_task_updates["assigned_to"] = assigned_to
             if source_room_id:
                 project_task_updates["source_room_id"] = source_room_id
+            if assigned_to:
+                project_task_updates["assigned_to"] = assigned_to
             _update_project_task(arguments, project_id, task_id, **project_task_updates)
             return {
                 "ok": True,
@@ -2582,6 +3870,12 @@ def _taskflow(arguments: dict[str, Any]) -> dict[str, Any]:
                 "action": action,
                 "task": task,
                 "synced": _sync_task(arguments, task_id),
+                "notificationNeeded": _notification_needed(
+                    "delegate_task",
+                    project or {"project_id": project_id},
+                    task,
+                    summary=f"delegate_task: {task_id} assigned to {assigned_to}",
+                ),
             }
 
         if action == "ack_task":
@@ -2590,6 +3884,7 @@ def _taskflow(arguments: dict[str, Any]) -> dict[str, Any]:
             task_id = _safe_id(payload.get("taskId") or payload.get("task_id"), "taskId")
             pulled = _pull_task(arguments, task_id)
             task = _load_task(arguments, task_id)
+            _require_task_mutable(arguments, task, task_id, action)
             task["status"] = "in_progress"
             task["acknowledged_by_role"] = role
             _write_task(arguments, task)
@@ -2611,38 +3906,79 @@ def _taskflow(arguments: dict[str, Any]) -> dict[str, Any]:
                 raise ValueError("submit_task requires worker or remote-member role")
             task_id = _safe_id(payload.get("taskId") or payload.get("task_id"), "taskId")
             task = _load_task(arguments, task_id)
+            _require_task_mutable(arguments, task, task_id, action)
             summary = str(payload.get("summary") or "")
             status = str(payload.get("status") or "SUCCESS")
             deliverables = payload.get("deliverables") or []
             if not isinstance(deliverables, list):
                 raise ValueError("deliverables must be a list")
-            result_lines = [
-                "# Task Result",
-                "",
-                f"- Status: `{status}`",
-                f"- Summary: {summary}",
-                "",
-                "## Deliverables",
-            ]
-            result_lines.extend(f"- `{item}`" for item in deliverables)
+            deliverables = _validate_task_deliverables(task_id, deliverables)
             task_dir = _task_dir(arguments, task_id)
             task_dir.mkdir(parents=True, exist_ok=True)
-            (task_dir / "result.md").write_text("\n".join(result_lines) + "\n", encoding="utf-8")
             task.update({
                 "status": "submitted",
                 "result_status": status,
                 "summary": summary,
-                "deliverables": [str(item) for item in deliverables],
-                "result_path": f"shared/tasks/{task_id}/result.md",
+                "deliverables": deliverables,
                 "submitted_by_role": role,
             })
+            if (task_dir / "result.md").is_file():
+                task["result_path"] = f"shared/tasks/{task_id}/result.md"
+            else:
+                task.pop("result_path", None)
             _write_task(arguments, task)
             _update_project_task(arguments, task.get("project_id", ""), task_id, status="submitted")
+            published_artifacts = _publish_task_artifacts(
+                arguments,
+                task,
+                task_id,
+                deliverables,
+                _attachment_parent_event_id(payload, arguments),
+            )
             return {
                 "ok": True,
                 "tool": "taskflow",
                 "action": action,
                 "task": task,
+                "publishedArtifacts": published_artifacts,
+                "synced": _sync_task(arguments, task_id, exclude=["spec.md", "base/"]),
+                "notificationNeeded": _notification_needed(
+                    "submit_task",
+                    {"project_id": task.get("project_id", "")},
+                    task,
+                    summary=f"submit_task: {task_id} ({status})",
+                ),
+            }
+
+        if action == "cancel_task":
+            if role != "leader":
+                raise ValueError("cancel_task requires leader role")
+            task_id = _safe_id(payload.get("taskId") or payload.get("task_id"), "taskId")
+            task = _load_task(arguments, task_id)
+            project_id = str(task.get("project_id") or "")
+            terminal_status = _terminal_task_status(arguments, task, task_id)
+            if terminal_status:
+                raise ValueError(f"cannot cancel terminal task: {terminal_status}")
+            reason = str(payload.get("reason") or payload.get("cancelReason") or payload.get("cancel_reason") or "").strip()
+            if not reason:
+                raise ValueError("reason is required")
+            replacement_task_id = payload.get("replacementTaskId") or payload.get("replacement_task_id")
+
+            task["status"] = "cancelled"
+            task["cancel_reason"] = reason
+            if replacement_task_id:
+                task["replacement_task_id"] = _safe_id(replacement_task_id, "replacementTaskId")
+            else:
+                task.pop("replacement_task_id", None)
+            _write_task(arguments, task)
+
+            _update_project_task(arguments, project_id, task_id, status="cancelled")
+            return {
+                "ok": True,
+                "tool": "taskflow",
+                "action": action,
+                "task": task,
+                "project": _read_json(_project_state_path(arguments, project_id)) if project_id else {},
                 "synced": _sync_task(arguments, task_id, exclude=["spec.md", "base/"]),
             }
 
@@ -2652,12 +3988,8 @@ def _taskflow(arguments: dict[str, Any]) -> dict[str, Any]:
             task_id = _safe_id(payload.get("taskId") or payload.get("task_id"), "taskId")
             pulled = _pull_task(arguments, task_id)
             task = _load_task(arguments, task_id)
-            result_path = _task_dir(arguments, task_id) / "result.md"
-            if result_path.exists():
-                result, validation_errors = _parse_task_result(result_path)
-            else:
-                result, validation_errors = {}, ["missing result.md"]
-            effective = task.get("status") == "submitted" and result_path.exists() and not validation_errors
+            result, validation_errors = _task_result_from_meta(task)
+            effective = task.get("status") == "submitted" and not validation_errors
             return {
                 "ok": True,
                 "tool": "taskflow",

--- a/plugins/teamharness/plugin.yaml
+++ b/plugins/teamharness/plugin.yaml
@@ -22,15 +22,15 @@ skills:
       path: skills/agent/find-skills
       roles: [leader, worker, manager, remote-member]
   team:
-    - id: organization
-      path: skills/team/organization
-      roles: [leader, worker, manager, remote-member]
     - id: communication
       path: skills/team/communication
       roles: [leader, worker, manager, remote-member]
     - id: file-sharing
       path: skills/team/file-sharing
       roles: [leader, worker, manager, remote-member]
+    - id: roomflow
+      path: skills/team/roomflow
+      roles: [leader]
     - id: team-coordination
       path: skills/team/team-coordination
       roles: [leader]
@@ -55,13 +55,12 @@ mcp:
         - message
         - roomflow
         - filesync
+        - artifact
         - projectflow
         - taskflow
 adapters:
   - id: qwenpaw
     path: adapters/qwenpaw
-  - id: claude-code
-    path: adapters/claude-code
 package:
   include:
     - plugin.yaml

--- a/plugins/teamharness/prompts/agent/leader.md
+++ b/plugins/teamharness/prompts/agent/leader.md
@@ -22,6 +22,15 @@ Classify each incoming message before choosing tools:
 Do not create a project, task, DAG, Loop, or Worker assignment for Direct Reply
 or Lightweight Action requests.
 
+For Project Work received in a requester/source session that should proceed in
+a dedicated task room, create or reuse the Matrix task room and send a
+`PROJECT_REQUESTED` self-trigger with the `message` tool to the same runtime
+Matrix account in that task room. Use the current Matrix user id as the trigger
+identity; do not use role names such as `leader` or workspace names such as
+`default`. Do not call `projectflow` or `taskflow` in the source session after
+that trigger; the task-room Leader session owns durable project creation,
+planning, and delegation.
+
 Keep project direction, task ownership, and requester communication separate.
 Do not treat a worker completion message as automatic project acceptance.
 When a project records a requester `reply_route`, use it for accepted outcomes,

--- a/plugins/teamharness/prompts/agent/remote-member.md
+++ b/plugins/teamharness/prompts/agent/remote-member.md
@@ -2,7 +2,7 @@
 
 You are an external or local agent connected to the team as a member.
 
-You are not acting as a HiClaw-managed Worker.
+You are not acting as an AgentTeams-managed Worker.
 
 Claim only work assigned to your account, keep deliverables in the assigned
 task directory when one exists, and use `task-execution` for task acceptance,

--- a/plugins/teamharness/prompts/team/TEAMS.md
+++ b/plugins/teamharness/prompts/team/TEAMS.md
@@ -2,11 +2,6 @@
 
 This file describes stable collaboration rules for the team.
 
-It is not a status database. Do not store live room IDs, credentials, worker
-phase, task status, current model values, package versions, or transient project
-facts here. Query live state through runtime config, Matrix, shared workspace
-files, or TeamHarness tools.
-
 ## Roles
 
 - The Leader plans work, delegates ready tasks, checks results, updates project
@@ -14,158 +9,175 @@ files, or TeamHarness tools.
 - Workers execute assigned tasks, keep task outputs inside their task
   directory, submit structured results, and report blockers or completion to
   the assigning coordinator.
-- Remote members participate as humans or local coding agents. They should
-  claim work only when directly assigned or explicitly invited.
-- The Manager handles control-plane operations such as team, worker, human,
-  model, MCP, package, and lifecycle management.
 
-## Runtime Agent Boundary
+## Team Worker Coordination
 
-The TeamHarness roster is the authority for team collaboration. Runtime-native
-agents, built-in QA agents, spawned subagents, or tool-level agent lists are
-implementation details of the current runtime. They are not TeamHarness team
-members unless they are explicitly listed in the team roster or assigned through
-TeamHarness team state.
+TeamHarness collaboration is about Workers in the team roster. Coordinate
+Worker work through Matrix task rooms, project/task flow, requester reply
+routes, and the members described by this file.
 
-- Do not present runtime-native agent tools such as `chat_with_agent`,
-  `submit_to_agent`, `spawn_subagent`, or `list_agents` as the normal
-  TeamHarness delegation path.
-- Do not claim that a runtime-native QA agent, default agent, or spawned
-  subagent is a team Worker.
-- For TeamHarness work, delegate through the team room or a dedicated
-  assignment room, project/task flow, requester reply routes, and the members
-  described by this file.
-- Only discuss runtime-native agents when the requester explicitly asks about
-  runtime internals. When answering team questions, explain the TeamHarness
-  roles and member roster instead.
+Do not use internal agent tools such as `chat_with_agent`, `submit_to_agent`,
+`spawn_subagent`, or `list_agents` to coordinate TeamHarness Worker work.
 
-## Rooms
+## Rooms and Channels
 
-- Use the team room for normal team-visible coordination.
-- For project tasks that originate from DingTalk, Feishu, WeChat, or another
-  external requester channel, call `roomflow` `create_task_room` with the
-  channel `source` and the current channel's stable `sourceRoomId` before task
-  delegation. Reuse the returned assignment room for later tasks from the same
-  source room.
-- Never invent, transform, or suffix `sourceRoomId` for task type, worker,
-  retry, or project purpose. For the same DingTalk group, pass exactly the same
-  `sourceRoomId` every time; otherwise TeamHarness treats it as a different
-  external room and may create a different Matrix assignment room.
-- Before assigning work in a reused external assignment room, call `roomflow`
-  again with the same `sourceRoomId` and the complete Matrix user ids for all
-  Workers needed in that room so missing members are invited before the task
-  message is sent.
-- Use the Leader DM for requester-facing private updates when the requester is
-  the team admin.
-- Use project reply routes for requester reports that originated from an
-  external channel or another runtime session.
-- Use worker private rooms only for exceptional recovery or sensitive follow-up.
-- Do not copy every team-room event into a DM. Summarize decisions and outcomes.
+TeamHarness has two collaboration surfaces:
+
+- Source channel / requester room: DingTalk, Feishu, WeChat, or another
+  external channel, or a Matrix room whose `roomflow describe_room` name is
+  a DM or Team room. Use it for user requests, clarifications, and
+  requester-facing replies.
+- Task room: a Matrix room whose `roomflow describe_room` name starts with
+  `TASK：<projectId>`, or whose topic/tags carry a Project/Task marker.
+  Use it to coordinate Workers through project creation, planning, delegation,
+  assignment messages, result submission, checking, acceptance, and project
+  advancement.
+
+For Matrix rooms, do not infer room purpose from joined-room ids alone. If the
+current Matrix room is unclear, load `teamharness-roomflow` and call
+`roomflow describe_room` for that session.
 
 ## Communication Contract
 
 Communication rules apply before selecting a request mode and at every outgoing
 message point in Direct Reply, Quick Task, and Project Work.
 
-Use `teamharness-communication` when the TEAMS.md communication contract needs
-one of these detailed protocols:
+### Matrix Mentions
 
-- Channel / Room Selection Protocol
-- Requester Report Delivery Protocol
-- Message Tool Protocol
+A Matrix `@` is not free-form text. It must resolve to the real Matrix member:
+`m.mentions`, a Matrix mention link, or the full member Matrix user id. A wrong
+`@name` or display name is not a valid assignment, wake-up, completion, or
+blocker mention.
 
-Always apply these rules:
+Use Matrix mentions only when that member must act or when recording task
+completion/blocker status. Do not send mention-only acknowledgements.
+The full Matrix user id mention can wake that member and trigger a reply. Use it
+only when you want that member to respond or take action; use plain names or
+roles in descriptive body text.
 
-- Answer in the current session for ordinary Direct Reply.
-- Use `NO_REPLY` for low-information acknowledgements, self echoes, and
-  non-actionable mention-only messages.
-- Do not let acknowledgements create ping-pong between rooms or agents.
-- Use the Team Room or assignment room for team-visible coordination, not as a
-  requester-facing report destination unless the recorded requester route is
-  exactly that room.
-- Use project `reply_route` for requester-facing reports after accepted project
-  state changes.
-- Use the `message` MCP tool only for cross-room, cross-channel, or
-  cross-session sends.
-- Do not treat Worker assignment, Worker completion, or Team Room status as the
-  requester report unless the recorded requester route is exactly that room.
+### Direct Reply And NO_REPLY
 
-## Request Modes
+Answer in the current session for ordinary Direct Reply. Use `NO_REPLY` for
+low-information acknowledgements, self echoes, and non-actionable mention-only
+messages. Do not let acknowledgements create ping-pong between rooms or agents.
 
-Choose the lightest mode that can safely satisfy the current message.
+### Long Matrix Messages
 
-- Direct Reply: ordinary questions, clarifications, readiness checks, useful
-  acknowledgements, explicit requests for a short answer, or synchronous
-  single-agent checks. Do not involve a Worker or create project/task state.
-- Quick Task: one bounded Worker-owned action with one owner, one expected
-  result, no DAG, and no Loop. Use quick project/task state so the Leader can
-  recover the result, accept or reject it, and report back to the requester.
-- Project Work: multi-member work, durable shared state, deliverables,
-  dependencies, acceptance gates, or follow-up tracking. Use project and task
-  flow only after this mode is selected. Choose DAG for finite dependency work
-  and Loop for iterative work with a stop condition.
+Matrix rooms are for concise coordination, decisions, and summaries. Do not send
+large reports, logs, traces, diffs, generated files, or full task artifacts as
+one direct Matrix text body. Send a short summary with the file name or
+artifact path instead.
 
-## Standard Flow Index
+### Artifacts And Documents
 
-Use this section as the execution index only: pick the large step, load the
-listed skill, then follow the listed skill step for exact tool usage, payload
-shape, and cautions. Do not execute project, task, room, or cross-channel
-actions from this index alone.
+For markdown reports, generated documents, or other task artifacts, write the
+file in the workspace and publish it with the TeamHarness MCP `artifact` tool,
+such as `artifact publish_file`. Do not paste the full artifact as chat text.
 
-Direct Reply mode does not need a dedicated flow. Answer directly in the
-current conversation. If routing is unclear or the reply must leave the current
-session, load `teamharness-communication`
-`## Channel / Room Selection Protocol` before replying.
+### Leader Cross-Room Communication
 
-After any task delegation step, do not continuously poll for the Worker result
-or keep calling check tools in the same Leader turn. The Worker will report
-completion or blockers in the assignment room recorded for that task. When that
-room message or task event reaches the Leader, resume from the submitted-result
-check step in the relevant flow.
+Leaders use the `message` tool only when a message must leave the current
+session: another Matrix room, another runtime session, or an external channel.
+Load `teamharness-communication` for exact routing and message-tool payloads.
 
-### Quick Task Flow
+## Request Modes And Standard Flow
 
-Use for Quick Task mode.
+Choose the lightest mode that can safely satisfy the current message, then
+follow that mode's room-specific flow.
 
-| Role | Purpose | Skill | Skill step |
-| --- | --- | --- | --- |
-| Leader | If the message has task/project/recovery context, restore project state before deciding whether to create new work. | `teamharness-project-management` | `## Project Files` |
-| Leader | Confirm the request is exactly one Worker-owned task. | `teamharness-team-coordination` | `## Choose Execution Mode`, `## Good Task Boundaries` |
-| Leader | Create the quick project and single delegated task state. | `teamharness-project-management` | `## Create Quick Project` |
-| Leader | Send the Worker assignment in the assignment room. | `teamharness-task-delegation` | `## Assignment Message` |
-| Worker | Execute and submit the assigned result. | `teamharness-task-execution` | `## Acknowledge`, `## Execute`, `## Submit`, `## Completion Message` |
-| Leader | Check the submitted result before project acceptance. | `teamharness-task-delegation` | `## Check Submitted Task`, `## Result Contract` |
-| Leader | Accept or reject the checked result. | `teamharness-project-management` | `## Accepting Worker Results` |
-| Leader | Report the accepted result or blocker through the project requester source and reply route. | `teamharness-communication` | `## Requester Report Delivery Protocol` |
+### Direct Reply
 
-Do not use Quick Task for multi-node dependencies, parallel Workers, or Loop
-iterations. Switch to Project Work before continuing if those appear.
+Use for ordinary questions, clarifications, readiness checks, useful
+acknowledgements, explicit requests for a short answer, or synchronous
+single-agent checks.
 
-### Project Work Flow
+In the Source channel / requester room:
 
-Use for Project Work mode.
+- Answer directly in the current session.
+- If the direct result is a markdown report, generated document, or other file,
+  use `artifact publish_file` only for Matrix rooms. For DingTalk, Feishu,
+  WeChat, or other non-Matrix requester channels, send a concise summary plus
+  the relevant `shared/...` artifact path instead.
+- Do not create task room, project state, or task state.
 
-| Role | Purpose | Skill | Skill step |
-| --- | --- | --- | --- |
-| Leader | If the message has task/project/recovery context, restore project state before planning or delegating new work. | `teamharness-project-management` | `## Project Files` |
-| Leader | Choose DAG or Loop and define task boundaries. | `teamharness-team-coordination` | `## Choose Execution Mode`, `## Good Task Boundaries` |
-| Leader | Create project state and plan DAG or Loop. | `teamharness-project-management` | `## Create Project`, `## Plan DAG`, `## Plan Loop` |
-| Leader | Resolve ready work before assignment. | `teamharness-project-management` | `## Ready Nodes` |
-| Leader | Delegate only ready nodes and send the assignment message. | `teamharness-task-delegation` | `## Delegate Only Ready Nodes`, `## Delegate Task`, `## Assignment Message` |
-| Worker | Execute the assigned task. | `teamharness-task-execution` | `## Acknowledge`, `## Execute`, `## Submit`, `## Completion Message` |
-| Leader | Check submitted Worker results before project acceptance. | `teamharness-task-delegation` | `## Check Submitted Task`, `## Result Contract` |
-| Leader | Accept/reject results, advance the plan, and find new ready work. | `teamharness-project-management` | `## Accepting Worker Results`, `## Ready Nodes` |
-| Leader | Report accepted progress or final result through the project requester source and reply route. | `teamharness-communication` | `## Requester Report Delivery Protocol` |
+### Quick Task
 
-The project owns durable context and requester routing. The task owns one
-bounded Worker execution unit. The Leader must accept or reject submitted
-results before project dependencies advance.
+Use for one bounded Worker-owned action with one owner, one expected result, no
+DAG, and no Loop.
+
+In the Source channel / requester room:
+
+- Load `teamharness-roomflow` and use `roomflow create_task_room` to create or
+  reuse the Matrix task room.
+- Load `teamharness-communication` to send the task request message to that
+  task room.
+- Stop in the source session. Do not call `create_quick_project`,
+  `delegate_task`, or send Worker assignment messages there.
+
+In the Task room:
+
+- On the task request message, load `teamharness-project-management` and use
+  `create_quick_project`. It writes the single assigned task state and spec.
+- Load `teamharness-task-delegation` to send the assignment message for that
+  assigned task as a normal reply in the current Task room. Do not call
+  `delegate_task` for Quick Task, and do not use the `message` tool for
+  same-room Worker assignment.
+- When the Worker reports `TASK_COMPLETED`, `TASK_BLOCKED`, or a task result
+  path such as `shared/tasks/{task-id}/result.md`, first resolve project context
+  with `projectflow resolve_project`.
+- Load `teamharness-task-delegation` for `check_task`; then use
+  `teamharness-project-management` for `accept_task_result` or rejection.
+- Publish report files and artifacts with `teamharness-file-sharing` or the
+  `artifact` MCP tool only when the destination supports Matrix room files, and
+  use `teamharness-communication` for the requester report through `replyRoute`.
+
+### Project Work
+
+Use for multi-member work, durable shared state, deliverables, dependencies,
+acceptance gates, or follow-up tracking. Choose DAG for finite dependency work
+and Loop for iterative work with a stop condition.
+
+In the Source channel / requester room:
+
+- Load `teamharness-team-coordination` to confirm Project Work and task
+  boundaries.
+- Load `teamharness-roomflow` and use `roomflow create_task_room` to create or
+  reuse the Matrix task room.
+- Load `teamharness-communication` to send the task request message to that
+  task room.
+- Stop in the source session. Do not call `create_project`, `plan_dag`,
+  `plan_loop`, `delegate_task`, or send Worker assignment messages there.
+
+In the Task room:
+
+- On the task request message, load `teamharness-project-management` to
+  `create_project`, `plan_dag` or `plan_loop`, and find `ready_nodes`.
+- Load `teamharness-task-delegation` to delegate only ready nodes and send
+  assignment messages as normal replies in the current Task room.
+- When a Worker reports `TASK_COMPLETED`, `TASK_BLOCKED`, or a task result path,
+  first extract the task id and resolve project context with
+  `projectflow resolve_project`.
+- Load `teamharness-task-delegation` for `check_task`; then use
+  `teamharness-project-management` for `accept_task_result`, rejection,
+  dependency advancement, more `ready_nodes`, project completion, and requester
+  report state.
+- Publish report files and artifacts with `teamharness-file-sharing` or the
+  `artifact` MCP tool only when the destination supports Matrix room files, and
+  use `teamharness-communication` for requester reports through `replyRoute`.
+
+Only accepted results may advance dependencies or project progress. Use
+`teamharness-communication` for requester-visible progress and final reports.
+After delegating a task, do not keep polling for the Worker result in the same
+turn; resume when a submitted-result event arrives.
 
 ## Shared Workspace
 
 - Use local shared paths in messages and task specs.
 - Use `shared/projects/{project-id}/` for project files.
 - Use `shared/tasks/{task-id}/` for task files and deliverables.
+- Keep important task deliverables in the task directory and list them in
+  `submit_task`; TeamHarness will publish eligible files to the Matrix room as
+  standard file events when Matrix room context is available.
 - Do not expose object storage internals in human-facing messages.
 
 ## Credential Safety

--- a/plugins/teamharness/scripts/install.sh
+++ b/plugins/teamharness/scripts/install.sh
@@ -12,12 +12,7 @@ if command -v qwenpaw >/dev/null 2>&1; then
   ran=1
 fi
 
-if command -v claude >/dev/null 2>&1; then
-  bash "${PLUGIN_DIR}/adapters/claude-code/install.sh"
-  ran=1
-fi
-
 if [ "$ran" -eq 0 ]; then
-  echo "ERROR: no supported TeamHarness local runtime found; expected qwenpaw or claude" >&2
+  echo "ERROR: no supported TeamHarness local runtime found; expected qwenpaw" >&2
   exit 1
 fi

--- a/plugins/teamharness/scripts/uninstall.sh
+++ b/plugins/teamharness/scripts/uninstall.sh
@@ -9,10 +9,6 @@ if command -v qwenpaw >/dev/null 2>&1; then
   bash "${PLUGIN_DIR}/adapters/qwenpaw/uninstall.sh"
 fi
 
-if command -v claude >/dev/null 2>&1; then
-  bash "${PLUGIN_DIR}/adapters/claude-code/uninstall.sh"
-fi
-
 log_file="${TEAMHARNESS_INSTALL_LOG:-}"
 if [ -n "$log_file" ]; then
   mkdir -p "$(dirname "$log_file")"

--- a/plugins/teamharness/skills/team/communication/SKILL.md
+++ b/plugins/teamharness/skills/team/communication/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: teamharness-communication
-description: "Use when TEAMS.md Communication Contract needs detailed routing: Channel / Room Selection Protocol, Requester Report Delivery Protocol, or Message Tool Protocol. It resolves current session vs Team Room vs assignment room vs requester reply_route vs external channel, and explains when to use the message MCP tool. Do not use it to choose Quick Task or Project Work, create rooms, delegate tasks, check results, or accept project state."
+description: "Use for TeamHarness message delivery details after a flow has decided a message must be sent: current-session reply, NO_REPLY, cross-room/cross-channel message tool payloads, PROJECT_REQUESTED task-room handoff, and requester replyRoute reports. Do not use to choose work mode, create rooms, delegate, check, or accept tasks."
 ---
 
 # Communication
@@ -11,9 +11,9 @@ It only handles message delivery protocols. It does not choose Direct Reply,
 Quick Task, or Project Work. It does not create rooms, delegate tasks, check
 Worker results, or accept project state.
 
-For ordinary direct replies and other lightweight one-off answers in the
-current room/session, answer directly. Use the `message` MCP tool only when a
-message must leave the current runtime conversation.
+For ordinary direct replies and lightweight one-off answers in the current
+room/session, answer directly. Use the `message` MCP tool only when a message
+must leave the current runtime conversation.
 
 Use `NO_REPLY` exactly when the current event is a low-information
 acknowledgement, self echo, or non-actionable mention-only message. Do not add
@@ -29,18 +29,19 @@ message should be sent.
 
 1. If the reply belongs in the current runtime session, answer directly.
 2. If a project requester report is needed, prefer the project's `reply_route`.
-3. If the selected destination is the Team Room or assignment room, send there
-   only for team-visible coordination.
+3. Use the Task room for task-visible coordination: task request messages,
+   Worker assignments, Worker completion/blocker reports, and downstream
+   delegation notices.
 4. If the selected destination is an external channel, another Matrix room, or
    another runtime session, use the `message` MCP tool.
 5. If the destination is missing or ambiguous, do not guess. Restore project or
    task state first, or ask for the missing routing detail.
 
-Use the Team Room for normal team-visible coordination. Use the assignment room
-recorded on the task for task-visible coordination. Use a project `reply_route`
-for requester-facing reports.
+Use the Source channel / requester room for direct replies and requester-facing
+reports only when the current session or recorded `reply_route` points there.
+Use a project `reply_route` for requester-facing reports.
 
-Do not treat a Team Room assignment, Worker completion, Worker blocker report,
+Do not treat a Task room assignment, Worker completion, Worker blocker report,
 or downstream delegation as a requester report unless the recorded requester
 route is exactly that current room.
 
@@ -48,10 +49,8 @@ route is exactly that current room.
 
 Use this protocol only after project state says a requester report is needed,
 for example after accepted project progress or a blocker that must be surfaced
-to the requester.
-
-When project state records a pending requester report after an accepted state
-change, delivery is mandatory.
+to the requester. When project state has a pending requester report, delivery
+to that requester route is mandatory.
 
 Prefer `reply_route`:
 
@@ -62,6 +61,21 @@ Prefer `reply_route`:
   "target_session": "aaaaaaaa"
 }
 ```
+
+Matrix DM requester reports use the same route shape, with `targetSession`
+pointing at the original DM room:
+
+```json
+{
+  "channel": "matrix",
+  "target_user": "@admin:matrix.local",
+  "target_session": "!admin-dm:matrix.local"
+}
+```
+
+For Matrix DM-originated projects, `requester=@user` is identity only. It is not
+enough to deliver a requester report after the Leader wakes up in a Task room.
+Use the persisted Matrix `reply_route` and send to its `target_session`.
 
 For legacy projects without `reply_route`, parse `requester` only when it uses a
 known encoding:
@@ -75,14 +89,148 @@ Do not guess missing channel, user, room, or session values. If a legacy Matrix
 requester points at the current room/session, answer directly instead of using
 the `message` tool.
 
-After successful delivery, call `projectflow` `mark_requester_report_sent` when
-the project recorded a pending requester report.
+After successful delivery, return to `teamharness-project-management` to record
+the report as sent; project-management owns project state such as
+`projectflow mark_requester_report_sent`.
 
 ## Message Tool Protocol
 
 Use the `message` MCP tool only for explicit cross-room, cross-channel, or
 cross-session sends. Do not use it for normal replies in the current
 room/session; answer directly instead.
+
+## Task Room Request Message
+
+Use this shape when a Source channel / requester room has created or reused a
+Matrix task room and must hand Quick Task or Project Work to the same Leader in
+that task room.
+
+The message text should be a compact task request, not a Worker assignment and
+not a full project plan. Include enough source context for the task-room Leader
+to create project state and preserve the requester route:
+
+```text
+PROJECT_REQUESTED: <short task or project title>
+
+Requester: <human/source identity>
+Source: <source channel and source session or room>
+ReplyRoute: <recorded requester replyRoute summary>
+TaskRoom: !task-room:matrix.local
+
+Request:
+<1-5 sentence requester ask>
+
+Expected outcome:
+- <deliverable or acceptance point>
+- <report/artifact expectation>
+```
+
+Send it with the `PROJECT_REQUESTED` self-trigger payload below. After the tool
+returns `delivery.sent: "matrix_self_trigger"`, stop in the source session.
+
+### PROJECT_REQUESTED Self Trigger
+
+Use this only for same-agent Quick Task or Project Work handoff from any
+requester/source session, such as DingTalk group, Matrix DM, or another Matrix
+room, into a target Matrix task room. The tool sends a Matrix event with a
+TeamHarness trigger marker; the QwenPaw Matrix channel accepts that marked self
+event as the target room's current event.
+
+Set top-level `channel` to `"matrix"` because the trigger target is the Matrix
+task room. Put the original requester/source channel in `sender.session.channel`.
+Set `sender.agent` and `agentId` to the current runtime Matrix user id, for
+example `@prod-observe-oncall-bot:at-cn-rpg4um9o601`. Do not use role names
+such as `leader`, worker names, or workspace names such as `default`.
+Pass the requester route as structured `replyRoute`. Do not write the route only
+inside `message.text`; the tool rejects `PROJECT_REQUESTED` without structured
+`replyRoute` and does not send the Matrix trigger.
+Also include the route values that the task-room Leader must pass to
+`projectflow` in `message.text`. For Matrix routes, include
+`replyRoute.targetSession`. For external routes such as DingTalk or Feishu,
+include `replyRoute.channel`, `replyRoute.targetUser`, and
+`replyRoute.targetSession`.
+
+Pass `message` as a JSON object. Do not serialize it into a JSON string. The
+object form lets the tool attach the TeamHarness trigger marker; a plain Matrix
+send will be ignored by the target room as the Leader's own ordinary message.
+
+```json
+{
+  "action": "send",
+  "channel": "matrix",
+  "sender": {
+    "agent": "@prod-observe-oncall-bot:at-cn-rpg4um9o601",
+    "session": {
+      "channel": "dingtalk",
+      "id": "ding-group-session-001"
+    }
+  },
+  "target": "room:!task-room:matrix.local",
+  "replyRoute": {
+    "channel": "dingtalk",
+    "targetUser": "sender_001",
+    "targetSession": "ding-group-session-001",
+    "mentionSender": true
+  },
+  "message": {
+    "type": "PROJECT_REQUESTED",
+    "text": "PROJECT_REQUESTED: <request summary>\nReplyRoute: dingtalk/sender_001/ding-group-session-001\nTask room: !task-room:matrix.local"
+  },
+  "agentId": "@prod-observe-oncall-bot:at-cn-rpg4um9o601"
+}
+```
+
+Expected result:
+
+```json
+{
+  "delivery": {"sent": "matrix_self_trigger"},
+  "context": {"via": "matrix_current_event"},
+  "trigger": {"status": "sent"}
+}
+```
+
+After this trigger, stop durable project work in the source session. The target
+task-room Leader session should copy the visible PROJECT_REQUESTED `replyRoute`
+into `projectflow create_quick_project` or `create_project` as
+`payload.replyRoute`; `projectflow` then persists it in the existing project
+`meta.json.reply_route`.
+
+## Requester Report Message
+
+Use `teamharness-project-management` to build the requester-facing report
+content from project state. This skill only handles delivery shape and message
+tool payloads.
+
+Deliver the report produced by `teamharness-project-management` with the
+recorded `replyRoute`:
+
+Requester reports are usually informational. Do not use Matrix mention syntax
+for descriptive owners, executors, reviewers, or participants in the report
+body. Use plain names unless the report intentionally asks that member to
+respond or take action.
+
+```json
+{
+  "action": "send",
+  "replyRoute": {
+    "channel": "dingtalk",
+    "targetUser": "sender_001",
+    "targetSession": "aaaaaaaa"
+  },
+  "text": "<project-management requester report markdown>"
+}
+```
+
+Keep the returned Matrix `messageId` when the requester report is sent to a
+Matrix room. Use that id as `parentEventId` for any immediately published
+report files so the files attach to the report message.
+
+For DingTalk, Feishu, WeChat, or other non-Matrix requester reports, do not
+describe workspace files as chat attachments or visible file cards. The
+`artifact` tool publishes Matrix room files only. If report files exist, include
+the important `shared/...` paths in the report text and say they are available
+from the shared workspace or platform object-storage view.
 
 For cross-session requester reports, pass the recorded `replyRoute`:
 
@@ -98,16 +246,54 @@ For cross-session requester reports, pass the recorded `replyRoute`:
 }
 ```
 
-For Matrix room sends, pass a channel target:
+For Matrix DM requester reports, pass the recorded Matrix route:
+
+```json
+{
+  "action": "send",
+  "replyRoute": {
+    "channel": "matrix",
+    "targetUser": "@admin:matrix.local",
+    "targetSession": "!admin-dm:matrix.local"
+  },
+  "text": "Project A is ready."
+}
+```
+
+For DingTalk requester reports that should notify the original sender, add
+`mentionSender: true`. Use this only with the recorded DingTalk requester route;
+the message tool will use stored session metadata to mention the sender. If the
+recorded DingTalk session webhook or sender metadata is missing, the tool
+returns `ok: false` and does not fall back to normal delivery. Do not mark the
+requester report as sent after that failure.
+
+```json
+{
+  "action": "send",
+  "replyRoute": {
+    "channel": "dingtalk",
+    "targetUser": "sender_001",
+    "targetSession": "aaaaaaaa"
+  },
+  "mentionSender": true,
+  "text": "Project A is ready."
+}
+```
+
+For cross-room Matrix sends, pass a channel target:
 
 ```json
 {
   "action": "send",
   "channel": "matrix",
-  "target": "room:!team-room:matrix.local",
-  "text": "@worker-a:matrix.local TASK_ASSIGNED: task-001 - Please start. Spec: shared/tasks/task-001/spec.md"
+  "target": "room:!source-room:matrix.local",
+  "text": "Project A has moved to the task room. I will report back here when accepted."
 }
 ```
+
+Do not use this for Worker assignment messages in the current Task room. In the
+Task room, send the `TASK_ASSIGNED` line as a normal current-session reply so
+the runtime emits one formatted Matrix event and the Worker is triggered once.
 
 For external channel sends, pass the channel-specific target fields:
 
@@ -121,7 +307,4 @@ For external channel sends, pass the channel-specific target fields:
 }
 ```
 
-Pass a channel target or `replyRoute`, not an object-storage path. Matrix
-mentions are message formatting details: mention a Worker or Leader only when
-the message asks that member to act or records task completion/blocker status.
-Do not send mention-only acknowledgements such as `@worker ok`.
+Pass a channel target or `replyRoute`, not an object-storage path.

--- a/plugins/teamharness/skills/team/file-sharing/SKILL.md
+++ b/plugins/teamharness/skills/team/file-sharing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: teamharness-file-sharing
-description: "Use for TeamHarness shared workspace paths, explicit filesync operations, and shared project/task artifact boundaries."
+description: "Use for TeamHarness shared workspace paths, filesync, artifact publication, and Matrix room file boundaries, including artifact publish_file and task/project deliverables. Do not use for message routing or project state changes."
 ---
 
 # File Sharing
@@ -12,6 +12,39 @@ deliverables, and results belong under `shared/tasks/{task-id}/`.
 
 Do not expose object storage internals in human-facing messages. Use TeamHarness
 filesync tools for explicit shared file operations.
+
+## Shared Files vs Room Files
+
+`shared/...` paths are durable collaboration state. They let Leaders, Workers,
+and recovery flows find the same project/task files.
+
+Matrix room files are UI-visible file events. The room Files panel is populated
+from Matrix `m.file` events, not from text that merely mentions a `shared/...`
+path.
+
+DingTalk, Feishu, WeChat, and other non-Matrix requester channels do not receive
+TeamHarness `artifact publish_file` room files. For those requester reports,
+mention the `shared/...` artifact paths and say they are available from the
+shared workspace or platform object-storage view. Do not tell the requester to
+open a chat file card unless the file was actually published to a Matrix room.
+
+For important task outputs, write the files under `shared/tasks/{task-id}/` and
+list them in `taskflow submit_task` `deliverables`. Worker task deliverables
+must not include `shared/projects/...` paths. For important project reports,
+the Leader writes `shared/projects/{project-id}/result.md` from accepted
+project state before publishing it.
+
+Use `artifact publish_file` when an explicit extra workspace file must become a
+Matrix room file outside the task/project submit flow. The `path` can be any
+workspace-relative file path, not only `shared/...`, but it must not be absolute
+or escape the workspace. Always pass an explicit Matrix room `target` or
+`roomId`. When publishing files for a requester report that was just sent with
+`message` to a Matrix room, pass the returned Matrix `messageId` as
+`parentEventId`.
+
+Do not manually send sensitive files. TeamHarness refuses obvious sensitive
+paths and text content by default, and reports the publish status in
+`publishedArtifacts`.
 
 ## Shared Paths
 
@@ -28,7 +61,7 @@ shared/tasks/{task-id}/result.md
 ```
 
 The Leader owns project files and task specs. Workers own task workspaces,
-deliverables, and submitted results.
+task deliverables, and task results.
 
 ## Filesync
 

--- a/plugins/teamharness/skills/team/project-management/SKILL.md
+++ b/plugins/teamharness/skills/team/project-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: teamharness-project-management
-description: "Use only after Project Work mode is selected, before TeamHarness projectflow calls, project DAG or Loop planning, ready-node resolution, iteration recording, project files, result acceptance, or project progress updates."
+description: "Use when a Leader maintains durable TeamHarness project state for Quick Task or Project Work: create_quick_project, create_project, plan_dag, plan_loop, ready_nodes, resolve_project, accept_task_result, project completion, and requester report state. Do not use to create Matrix task rooms or send messages."
 ---
 
 # Project Management
@@ -28,9 +28,11 @@ Use this skill when acting as Leader for:
 - accepting checked Worker results into project progress
 - project-level status reports
 
-Use `teamharness-team-coordination` first to decide task boundaries. Use
-`teamharness-task-delegation` for individual task specs and Worker result
-checks.
+For Project Work, use `teamharness-team-coordination` first to decide task
+boundaries. If no task room exists yet, use `teamharness-roomflow` and
+`teamharness-communication` before this skill. Use
+`teamharness-task-delegation` for individual task specs, assignment messages,
+and Worker result checks.
 
 ## Project Files
 
@@ -52,6 +54,10 @@ Write a final project result, when needed, to:
 ```text
 shared/projects/{project-id}/result.md
 ```
+
+The Leader owns this project result file. Build it from accepted project state
+and accepted task deliverables; do not ask Workers to write or submit it as a
+task deliverable.
 
 Use `projectflow` to change `meta.json` and `plan.md`; do not hand-edit
 project state unless a tool failure leaves no safe alternative.
@@ -113,49 +119,49 @@ cross-session final report. `channel`, `targetUser`, and `targetSession` must
 come from the current message/session metadata or a trusted runtime query. Do
 not guess them.
 
+For Project Work that should proceed in a dedicated task room, do not call
+`create_project` in the requester/source session. Use
+`teamharness-communication` to send a `PROJECT_REQUESTED` self-trigger from the
+current requester/source session to the same Leader in the target Matrix task
+room first. After the task-room Leader session wakes up, call `create_project`
+there and preserve the original requester route from the visible
+`PROJECT_REQUESTED` request: keep the original `source`, `requester`,
+`sourceRoomId`, and `replyRoute` so final reports can return to the
+DingTalk group, Matrix DM, or other source room that made the request. Do not
+invent missing `replyRoute` values from requester names or prose.
+
 For DingTalk requester compatibility, `requester` may use
 `dingtalk:{user_id}:{session_id}`; TeamHarness derives `reply_route` from that
 value when `replyRoute` is not provided.
 
 ## Create Quick Project
 
-Use `create_quick_project` only after Project Work mode is selected and the work
-is clearly a single Worker task. It is a shortcut for:
+Use `create_quick_project` only after Quick Task mode is selected and the
+Leader is in the Matrix Task room that received the task request message. It is
+a shortcut for:
 
 ```text
-create_project + plan single-node DAG + delegate_task-compatible task spec
+create_project + plan single-node DAG + assigned task spec
 ```
 
-Determine the assignment `roomId` before calling this action. Use the Team Room
-for Matrix DM-originated work. For DingTalk, Feishu, WeChat, or another
-external requester channel, first call `roomflow` `create_task_room` with
-`source` and the current channel metadata's stable `sourceRoomId`; use the
-returned Matrix room id. The same `source` + `sourceRoomId` must map to one
-assignment room and must be reused for later tasks from that external room.
+Do not call this in the requester/source session. If the current session is
+still a DingTalk group, Matrix DM, Team room, or other source room, return to
+`TEAMS.md`: create or reuse the task room with `teamharness-roomflow`, hand the
+request to that room with `teamharness-communication`, and stop in the source
+session.
 
-Do not invent, transform, suffix, or specialize `sourceRoomId` by task, worker,
-retry, or project. If the current DingTalk group already provided
-`sourceRoomId: "uhrz6g=="`, pass exactly `"uhrz6g=="` for every later task from
-that group. Values such as `"uhrz6g==-qa-task"` or `"uhrz6g==-dev-task"` are
-wrong unless they came directly from trusted current channel metadata.
+Before calling this action in the Task room:
 
-When reusing an external assignment room, call `roomflow` before creating or
-delegating task state and pass the complete `invite` list for the Workers who
-must receive work in that room. `roomflow` will return the existing Matrix room
-and invite missing members.
+1. Use the current Matrix task room as `roomId`.
+2. Preserve the original `source`, `requester`, `sourceRoomId`, and `replyRoute`
+   from the task request message. Do not guess route values.
+3. Choose the one Worker owner from the team roster.
+4. Write a bounded task spec that includes the completion report instruction
+   from `teamharness-task-delegation`.
 
-Example assignment room setup for DingTalk:
-
-```json
-{
-  "action": "create_task_room",
-  "taskId": "demo-project-001",
-  "name": "Demo Project",
-  "source": "dingtalk",
-  "sourceRoomId": "<exact current DingTalk group sourceRoomId>",
-  "invite": ["@worker-a:matrix.local", "@worker-b:matrix.local"]
-}
-```
+`teamharness-roomflow` owns task-room creation, project-scoped reuse, source
+metadata capture, and Worker invites. This skill only creates durable project
+and task state after the Task room is already selected.
 
 Example:
 
@@ -166,13 +172,14 @@ Example:
     "title": "Write readiness note",
     "source": "matrix",
     "requester": "@admin:matrix.local",
+    "sourceRoomId": "!admin-dm:matrix.local",
     "assignedTo": "@worker-a:matrix.local",
-    "roomId": "!team-room:matrix.local",
+    "roomId": "!task-room:matrix.local",
     "spec": "# Task\n\nWrite one concise readiness note.",
     "replyRoute": {
       "channel": "matrix",
       "targetUser": "@admin:matrix.local",
-      "targetSession": "!team-room:matrix.local"
+      "targetSession": "!admin-dm:matrix.local"
     }
   }
 }
@@ -348,6 +355,14 @@ To accept a result, call `accept_task_result`:
 `requester_report.pending` in ProjectMeta. Keep unresolved nodes in their current
 state.
 
+Accepting a completed result does not publish the project artifact by default.
+Write or update `shared/projects/{project-id}/result.md` as the Leader when a
+project-level report file is needed. After the requester report message is sent
+to a Matrix requester room, publish `shared/projects/{project-id}/result.md`
+with `artifact publish_file` and set `parentEventId` to the report message id.
+Use `publishArtifacts: true` only when you intentionally want an immediate
+project artifact before the requester report.
+
 Then call `ready_nodes` and delegate any newly ready downstream node with
 `teamharness-task-delegation`.
 
@@ -359,9 +374,17 @@ After the project state changes, close the loop with requester visibility:
 3. Use `teamharness-communication`
    `## Requester Report Delivery Protocol` to deliver the report to the
    requester recorded on the project.
-4. After successful delivery, call `mark_requester_report_sent`.
+4. If the requester report was sent to a Matrix room and
+   `shared/projects/{project-id}/result.md` exists, call `artifact publish_file`
+   for that file with `parentEventId` set to the report message id.
+5. If the requester report was sent to DingTalk, Feishu, WeChat, or another
+   non-Matrix channel, do not claim that a file was attached or published in
+   that channel. In the report text, list the important `shared/...` artifact
+   paths and say they are available from the shared workspace or platform
+   object-storage view.
+6. After successful delivery, call `mark_requester_report_sent`.
 
-Team Room coordination, Worker completion messages, downstream assignment
+Task room coordination, Worker completion messages, downstream assignment
 messages, and tool-call summaries do not count as the requester report. You may
 batch several accepted task results and downstream delegations into one
 requester report, but do not omit the report when accepted project state
@@ -423,11 +446,24 @@ Keep the report envelope consistent across DAG and Loop:
 **<localized deliverables label>**:
 - `<path>` - <what it contains>
 
+For Matrix requester reports, this section may say the report file or artifact
+was published to the requester room only after `artifact publish_file` succeeds.
+For DingTalk, Feishu, WeChat, or other non-Matrix requester reports, say the
+files are available from the shared workspace or platform object-storage view;
+do not say "attached", "uploaded to this chat", "click the file card", or
+"view the file here".
+
 **<localized next steps label>**:
 1. <next DAG transition, next Loop decision, or requester action>
 
 **<localized notes label>**: <blocker, risk, or decision needed; omit section if none>
 ````
+
+In requester-facing reports, owner or executor cells are descriptive text.
+Use plain Worker display names or role names such as `workeraa`, `workerbb`, or
+`WorkerAA`. Do not prefix them with `@`, do not use full Matrix user ids, and do
+not create Matrix mention links unless the report is intentionally asking that
+member to respond or take action.
 
 Use this execution progress shape for DAG reports:
 
@@ -470,6 +506,45 @@ After the requester report is sent, clear the pending flag:
   }
 }
 ```
+
+## Post-Action Notification
+
+State-mutating `projectflow` and `taskflow` operations return a
+`notificationNeeded` field when they succeed. This field is a hint — the tool
+does not send any message automatically. The Leader must act on it.
+
+When `notificationNeeded` is present in the tool result:
+
+1. Check `notificationNeeded.targetRoom`. If it matches the current session
+   room, a direct reply in the current session is sufficient — no cross-room
+   message is needed.
+2. If `targetRoom` is a different room, use the `message` tool to send a brief
+   status update to that room. Use `m.notice`-style concise format:
+   `[ProjectFlow] {event}: {summary}`.
+3. If `notificationNeeded.replyRoute` is present and the event is
+   `accept_task_result` or `complete_project`, this is the requester report
+   trigger — follow the Requester Report Delivery Protocol in
+   `teamharness-communication`.
+4. Do not send a notification if the tool returned `ok: false`.
+5. Do not send duplicate notifications for the same event within a single
+   Leader turn — one notification per state change is sufficient.
+
+The `notificationNeeded` field contains:
+
+```json
+{
+  "event": "create_project",
+  "projectId": "demo-project-001",
+  "summary": "create_project: Demo Project",
+  "targetRoom": "!task-room:matrix.local",
+  "replyRoute": { "channel": "matrix", "targetSession": "..." }
+}
+```
+
+`targetRoom` and `replyRoute` may be absent when no room context is available
+(for example, a bare `create_project` before any task room exists). In that
+case, skip the notification — the assignment message or requester report will
+carry the project context later.
 
 ## Current Boundary
 

--- a/plugins/teamharness/skills/team/roomflow/SKILL.md
+++ b/plugins/teamharness/skills/team/roomflow/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: teamharness-roomflow
+description: "Use for TeamHarness room classification and Matrix task-room setup: roomflow describe_room, roomflow create_task_room, source/requester room vs task room detection, project-scoped task-room reuse, and invite handling. Do not use for projectflow, taskflow, or message delivery."
+---
+
+# Roomflow
+
+Use this skill when a Leader needs to identify the current Matrix room or
+prepare the Matrix task room before Quick Task or Project Work state exists.
+
+## Describe Room
+
+Call `roomflow describe_room` when a Matrix room's purpose is unclear.
+
+Classify from Matrix state:
+
+- Source channel / requester room: external channel, or Matrix room whose name
+  indicates DM or Team room.
+- Task room: Matrix room whose name starts with `TASK：<projectId>`, or
+  whose topic/tags carry a Project/Task marker.
+
+Do not infer room purpose from joined-room IDs alone.
+
+## Create Or Reuse Task Room
+
+From a Source channel / requester room, call `roomflow create_task_room` before
+creating project or task state.
+
+Pass a stable `projectId`. The tool normalizes the Matrix room name to
+`TASK：<projectId>` and reuses task rooms only by that project id.
+
+Pass the current source metadata exactly as received, such as DingTalk
+`sourceRoomId` and `sender`, so project state can keep the requester route.
+Do not use source room or sender identity to decide task-room reuse. Different
+projects from the same DingTalk group or same person still get different task
+rooms.
+
+Pass the complete Matrix user IDs for Workers who must receive or observe work
+in the task room. Use the returned Matrix room as the task room for the
+handoff, project state, task delegation, and Worker completion reports.

--- a/plugins/teamharness/skills/team/task-delegation/SKILL.md
+++ b/plugins/teamharness/skills/team/task-delegation/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: teamharness-task-delegation
-description: "Use only after Project Work mode is selected, when a TeamHarness Leader delegates ready project nodes, writes task specs, checks Worker results, and routes completion or blocker messages."
+description: "Use when a Leader turns ready Quick Task or Project Work state into Worker task instructions, sends assignment messages, checks submitted results, and defines completion/blocker report contracts. Do not use to create projects, create rooms, or execute Worker tasks."
 ---
 
 # Task Delegation
 
-Use this skill when acting as Leader to create and delegate task specs.
+Use this skill when acting as Leader to create Project Work task specs, send
+assignment messages, and check submitted Worker results.
 
 Each delegated task should have a task id, owner, scope, expected deliverables,
 acceptance criteria, and blocker reporting path. Write task instructions to the
@@ -29,34 +30,34 @@ project progress.
 
 ## Delegate Only Ready Nodes
 
-Within Project Work, do not create bare tasks directly from a user request.
-First create or update a project DAG, then delegate a ready project node
-returned by `projectflow` `readyNodes`, or create/update a Loop and delegate a
-ready project node returned by `readyLoopNodes`.
+Use `delegate_task` only for Project Work nodes that are ready in project
+state. Do not create bare tasks directly from a user request. First create or
+update a project DAG, then delegate a ready project node returned by
+`projectflow` `readyNodes`, or create/update a Loop and delegate a ready
+project node returned by `readyLoopNodes`.
 
-For a single-task Project Work item, `projectflow` `create_quick_project` may be
-used instead. It already writes `shared/tasks/{task-id}/meta.json`,
+For Quick Task, `projectflow` `create_quick_project` is used instead. It
+already writes `shared/tasks/{task-id}/meta.json`,
 `shared/tasks/{task-id}/spec.md`, and marks the task `assigned`; do not call
 `delegate_task` again for that task. After it returns `ok: true`, send the same
 assignment message you would send after `delegate_task`.
 
 Before delegation:
 
-1. Read `TEAMS.md` for the Worker Matrix ID and Team Room ID.
+1. Resolve the Worker Matrix ID or stable member name from the team roster.
 2. Confirm the node came from `readyNodes` or `readyLoopNodes`.
 3. Write a bounded task spec through `taskflow`. The spec must include the
    completion report instruction below.
-4. Mention the assigned Worker in the assignment room only after
-   `delegate_task` succeeds. Use the Team Room for Matrix DM-originated work,
-   or the assignment room returned by `roomflow` for external requester channels.
-   For external channels, `roomflow` must receive the stable `sourceRoomId` from
-   the current channel metadata so repeated tasks from that source room reuse
-   one Matrix assignment room.
-5. Do not create task-specific or worker-specific `sourceRoomId` values. Reuse
-   the exact external `sourceRoomId` from the current requester room. Before
-   sending the assignment message, call `roomflow` with that same `sourceRoomId`
-   and include the assigned Worker in `invite`; include any other Workers who
-   need to observe or work in the same assignment room.
+4. Keep Worker deliverables under `shared/tasks/{task-id}/...`. Do not ask a
+   Worker to write or submit `shared/projects/...`; project reports are Leader
+   owned.
+5. Use the current Matrix Task room for the assignment. Do not fall back to
+   the requester/source session.
+6. Mention the assigned Worker in the Task room only after
+   `delegate_task` succeeds.
+
+`teamharness-roomflow` owns task-room creation, reuse, external source binding,
+and Worker invites before Project Work reaches this skill.
 
 ## Delegate Task
 
@@ -69,8 +70,8 @@ Call `taskflow` with `role: "leader"` and pass `payload` as an object:
   "payload": {
     "projectId": "demo-project-001",
     "taskId": "demo-project-001-01",
-    "roomId": "room:!team-room:matrix.local",
-    "spec": "# Task demo-project-001-01\n\n## Context\nExplain why this task exists.\n\n## Expected Result\nCreate deliverables under shared/tasks/demo-project-001-01/ and submit a result with STATUS, SUMMARY, and DELIVERABLES.\n\n## Acceptance Criteria\n- The result addresses the task scope.\n- Deliverables are listed in result.md.\n\n## Completion Report\nAfter `taskflow submit_task` returns `ok: true`, reply in the current assignment room and mention the Leader Matrix user from `TEAMS.md`:\n\n<Leader Matrix user from TEAMS.md> TASK_COMPLETED: demo-project-001-01 - Result: shared/tasks/demo-project-001-01/result.md\n\nDo not use `NO_REPLY` after a successful task submission.\n"
+    "roomId": "room:!task-room:matrix.local",
+    "spec": "# Task demo-project-001-01\n\n## Context\nExplain why this task exists.\n\n## Expected Result\nCreate deliverables under shared/tasks/demo-project-001-01/ and submit a result with STATUS, SUMMARY, and DELIVERABLES.\n\n## Acceptance Criteria\n- The result addresses the task scope.\n- Deliverables are listed in result.md.\n\n## Completion Report\nAfter `taskflow submit_task` returns `ok: true`, reply in the current Task room and mention the exact Leader Matrix user from this task context:\n\n<Leader Matrix user> TASK_COMPLETED: demo-project-001-01 - Result: shared/tasks/demo-project-001-01/result.md\n\nDo not use `NO_REPLY` after a successful task submission.\n"
   }
 }
 ```
@@ -93,9 +94,9 @@ and result path adjusted for the actual task:
 ## Completion Report
 
 After `taskflow submit_task` returns `ok: true`, reply in the current assignment
-room and mention the Leader Matrix user from `TEAMS.md`:
+room and mention the exact Leader Matrix user from this task context:
 
-<Leader Matrix user from TEAMS.md> TASK_COMPLETED: demo-project-001-01 - Result: shared/tasks/demo-project-001-01/result.md
+<Leader Matrix user> TASK_COMPLETED: demo-project-001-01 - Result: shared/tasks/demo-project-001-01/result.md
 
 Do not use `NO_REPLY` after a successful task submission.
 ```
@@ -105,12 +106,16 @@ still make the Leader mention requirement explicit.
 
 ## Assignment Message
 
-After `delegate_task` returns `ok: true`, use `teamharness-communication` to
-mention the Worker in the assignment room:
+After `delegate_task` or `create_quick_project` returns `ok: true`, send a
+normal current-session reply in the Task room and mention the Worker:
 
 ```text
 @worker-a:matrix.local TASK_ASSIGNED: demo-project-001-01 - Please start this task. Spec: shared/tasks/demo-project-001-01/spec.md
 ```
+
+Do not use the `message` tool for this same-room assignment. The direct Task
+room reply is the trigger; using `message` plus a direct mention can trigger the
+Worker twice.
 
 Do not ask the Worker to edit project files. Do not ask several Workers to own
 the same task directory.
@@ -147,6 +152,12 @@ DELIVERABLES:
 - shared/tasks/{task-id}/path
 ```
 
+For report-style tasks, the Worker may write the full report directly to
+`shared/tasks/{task-id}/result.md` before calling `submit_task`. The tool
+records structured status in task metadata and does not create or rewrite
+`result.md`. Do not treat `result.md` as only a short envelope when it is the
+expected deliverable.
+
 Accepted statuses are:
 
 - `SUCCESS`
@@ -156,3 +167,23 @@ Accepted statuses are:
 
 Submitting a result ends that Worker task. If more work is needed, create a new
 project node and delegate a new task.
+
+## Post-Action Notification
+
+`delegate_task` and `submit_task` return a `notificationNeeded` field when they
+succeed. This field is a structured hint — the tool does not send any message
+automatically.
+
+For `delegate_task`: the assignment message in the Task room (see Assignment
+Message above) already serves as the notification. No additional cross-room
+notification is needed unless the `notificationNeeded.targetRoom` differs from
+the current Task room.
+
+For `submit_task`: the Worker completion message in the Task room already serves
+as the notification to the Leader. The `notificationNeeded` field confirms the
+target room for this report.
+
+The Leader should check `notificationNeeded` after accepting a task result to
+determine whether a requester report or downstream notification is due. See
+`teamharness-project-management` Post-Action Notification for the full
+protocol.

--- a/plugins/teamharness/skills/team/task-execution/SKILL.md
+++ b/plugins/teamharness/skills/team/task-execution/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: teamharness-task-execution
-description: "Use when a TeamHarness Worker or remote member receives an assigned task, acknowledges it, executes it, submits a result, or reports blockers."
+description: "Use when a Worker receives TASK_ASSIGNED, acknowledges the task, works inside shared/tasks/{task-id}/, submits with taskflow submit_task, publishes deliverables through submit_task, and reports TASK_COMPLETED or blockers in the Task room."
 ---
 
 # Task Execution
@@ -10,7 +10,7 @@ Use this skill when executing assigned work as a Worker or remote member.
 Claim only tasks assigned to you. Read the task spec, keep deliverables in the
 task directory, ask focused blocker questions, and submit a structured result.
 
-Do not change project-level state unless the task spec explicitly authorizes it.
+Do not change project-level state or project result files.
 
 Do not use this skill or taskflow for readiness checks, direct questions, or
 explicit requests to reply with specific text. Answer those directly in the
@@ -47,7 +47,9 @@ shared/projects/{project-id}/plan.md
 shared/projects/{project-id}/result.md
 ```
 
-unless the task spec explicitly tells you to.
+If a task spec asks you to write or submit `shared/projects/...`, report that
+boundary conflict to the Leader. Put Worker-owned deliverables under
+`shared/tasks/{task-id}/...`; the Leader owns project-level reports.
 
 ## Acknowledge
 
@@ -83,6 +85,16 @@ Keep all deliverables under the task directory. If you need private notes, use:
 shared/tasks/{task-id}/workspace/
 ```
 
+Use meaningful filenames for deliverables. Prefer names that describe the
+artifact's purpose, such as `analysis.md`, `trace-summary.log`, or
+`patch-notes.md`; avoid vague names like `output.md` when there are multiple
+files.
+
+For report-style tasks whose expected output is `shared/tasks/{task-id}/result.md`,
+write the full report content to that file before calling `submit_task`.
+`submit_task` records structured status in task metadata and does not create or
+rewrite `result.md`.
+
 If blocked, submit a `BLOCKED` result instead of silently waiting.
 
 ## Submit
@@ -114,13 +126,25 @@ Use one of:
 Submitting ends the task. Do not keep editing the old task after submission
 unless the Leader assigns a new task.
 
+If you already wrote a detailed `shared/tasks/{task-id}/result.md`, include that
+path in `deliverables`; do not replace the report with only a short summary.
+Do not include `shared/projects/...` paths in `deliverables`.
+
+When Matrix room context is available, `submit_task` automatically publishes
+`shared/tasks/{task-id}/result.md` and eligible deliverable files under the
+current task directory as Matrix `m.file` events. Check `publishedArtifacts` in
+the tool result for published, skipped, or failed artifact status. Do not upload
+task artifacts manually with `message` just to make them appear in the room
+file panel.
+
 ## Completion Message
 
 After `submit_task` returns `ok: true`, send a normal text message in the
-current assignment room and mention the Leader:
+current Task room and mention the Leader with the exact Matrix user id or
+resolvable mention from the task spec:
 
 ```text
-@leader:matrix.local TASK_COMPLETED: demo-project-001-01 - Result: shared/tasks/demo-project-001-01/result.md
+@leader-user:matrix.local TASK_COMPLETED: demo-project-001-01 - Result: shared/tasks/demo-project-001-01/result.md
 ```
 
 If the task spec gives an exact completion line, preserve that line exactly and
@@ -131,5 +155,5 @@ include one short summary sentence. A tool call, tool-output thread, or
 For blockers:
 
 ```text
-@leader:matrix.local BLOCKED: demo-project-001-01 - <short blocker summary>
+@leader-user:matrix.local BLOCKED: demo-project-001-01 - <short blocker summary>
 ```

--- a/plugins/teamharness/skills/team/team-coordination/SKILL.md
+++ b/plugins/teamharness/skills/team/team-coordination/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: teamharness-team-coordination
-description: "Use before a TeamHarness Leader chooses task boundaries, dependency shape, ownership, acceptance criteria, or follow-up work."
+description: "Use when a Leader must choose Project Work boundaries, owners, dependency shape, DAG vs Loop, acceptance criteria, or follow-up strategy. Do not use for Quick Task execution after the mode is already selected."
 ---
 
 # Team Coordination

--- a/plugins/tests/teamharness/adapters/qwenpaw/test_adapter.py
+++ b/plugins/tests/teamharness/adapters/qwenpaw/test_adapter.py
@@ -77,7 +77,7 @@ desired:
     keywords: [internal-token]
     envRefs: [EXTRA_SECRET]
 credentials:
-  matrixTokenEnv: HICLAW_WORKER_MATRIX_TOKEN
+  matrixTokenEnv: AGENTTEAMS_WORKER_MATRIX_TOKEN
 """,
         encoding="utf-8",
     )
@@ -106,26 +106,26 @@ def test_mcp_client_env_includes_sts_refresh_inputs(monkeypatch, tmp_path: Path)
     module = _load_plugin()
     shared_dir = tmp_path / "shared"
     monkeypatch.setenv("TEAMHARNESS_SHARED_DIR", str(shared_dir))
-    monkeypatch.setenv("HICLAW_CONTROLLER_URL", "http://controller.example.test")
-    monkeypatch.setenv("HICLAW_AUTH_TOKEN_FILE", "/var/run/secrets/hiclaw/token")
-    monkeypatch.setenv("HICLAW_CLUSTER_ID", "cluster-a")
-    monkeypatch.setenv("HICLAW_FS_ENDPOINT", "https://oss.example.test")
-    monkeypatch.setenv("HICLAW_FS_ACCESS_KEY", "static-ak")
-    monkeypatch.setenv("HICLAW_FS_SECRET_KEY", "static-sk")
-    monkeypatch.setenv("MC_HOST_hiclaw", "https://temporary@example.test")
+    monkeypatch.setenv("AGENTTEAMS_CONTROLLER_URL", "http://controller.example.test")
+    monkeypatch.setenv("AGENTTEAMS_AUTH_TOKEN_FILE", "/var/run/secrets/agentteams/token")
+    monkeypatch.setenv("AGENTTEAMS_CLUSTER_ID", "cluster-a")
+    monkeypatch.setenv("AGENTTEAMS_FS_ENDPOINT", "https://oss.example.test")
+    monkeypatch.setenv("AGENTTEAMS_FS_ACCESS_KEY", "static-ak")
+    monkeypatch.setenv("AGENTTEAMS_FS_SECRET_KEY", "static-sk")
+    monkeypatch.setenv("MC_HOST_agentteams", "https://temporary@example.test")
     monkeypatch.setenv("QWENPAW_WORKING_DIR", str(tmp_path / ".qwenpaw"))
 
     env = module._mcp_client_env()
 
     assert env["TEAMHARNESS_SHARED_DIR"] == str(shared_dir)
-    assert env["HICLAW_CONTROLLER_URL"] == "http://controller.example.test"
-    assert env["HICLAW_AUTH_TOKEN_FILE"] == "/var/run/secrets/hiclaw/token"
-    assert env["HICLAW_CLUSTER_ID"] == "cluster-a"
-    assert env["HICLAW_FS_ENDPOINT"] == "https://oss.example.test"
-    assert env["HICLAW_FS_ACCESS_KEY"] == "static-ak"
-    assert env["HICLAW_FS_SECRET_KEY"] == "static-sk"
-    assert env["MC_HOST_hiclaw"] == "https://temporary@example.test"
+    assert env["AGENTTEAMS_CONTROLLER_URL"] == "http://controller.example.test"
+    assert env["AGENTTEAMS_AUTH_TOKEN_FILE"] == "/var/run/secrets/agentteams/token"
+    assert env["AGENTTEAMS_CLUSTER_ID"] == "cluster-a"
+    assert env["AGENTTEAMS_FS_ENDPOINT"] == "https://oss.example.test"
     assert env["QWENPAW_WORKING_DIR"] == str(tmp_path / ".qwenpaw")
+    assert "AGENTTEAMS_FS_ACCESS_KEY" not in env
+    assert "AGENTTEAMS_FS_SECRET_KEY" not in env
+    assert "MC_HOST_agentteams" not in env
 
 
 def test_teamharness_installs_workspace_teams_md_without_overwriting_agentspec(tmp_path: Path, monkeypatch) -> None:
@@ -144,8 +144,8 @@ def test_teamharness_installs_workspace_teams_md_without_overwriting_agentspec(t
     monkeypatch.setenv("TEAMHARNESS_RUNTIME_CONFIG", str(runtime_config))
     monkeypatch.setenv("TEAMHARNESS_SHARED_DIR", str(shared_dir))
     monkeypatch.setenv("QWENPAW_WORKSPACE_DIR", str(workspace_dir))
-    monkeypatch.setenv("HICLAW_AGENT_HOME", str(agent_home))
-    monkeypatch.setenv("HICLAW_WORKER_MATRIX_TOKEN", "matrix-secret-value")
+    monkeypatch.setenv("AGENTTEAMS_AGENT_HOME", str(agent_home))
+    monkeypatch.setenv("AGENTTEAMS_WORKER_MATRIX_TOKEN", "matrix-secret-value")
 
     result = module.apply_teamharness()
 
@@ -158,8 +158,14 @@ def test_teamharness_installs_workspace_teams_md_without_overwriting_agentspec(t
     assert "qa-runtime" in text
     assert "!team:matrix.local" in text
     assert "dev-worker" in text
+    assert module.TEAMS_INTERNAL_CONTROL_MARKER in text
     assert "Worker Role" in text
     assert "Matrix Reply Discipline" in text
+    assert "Long Matrix Messages" in text
+    assert "roomflow describe_room" in text
+    assert "TASK：<projectId>" in text
+    assert "Matrix Mentions" in text
+    assert "artifact publish_file" in text
     assert "matrix-secret-value" not in text
     assert not (shared_dir / "TEAMS.md").exists()
     assert (workspace_dir / "AGENTS.md").read_text(encoding="utf-8") == "agentspec agents\n"
@@ -239,6 +245,16 @@ def test_teamharness_enables_role_skills_in_workspace(tmp_path: Path, monkeypatc
     assert (workspace_dir / "skills" / "teamharness-task-execution" / "SKILL.md").is_file()
     assert (workspace_dir / "skills" / "teamharness-communication" / "SKILL.md").is_file()
     assert not (workspace_dir / "skills" / "teamharness-task-delegation").exists()
+    task_execution_text = (
+        workspace_dir / "skills" / "teamharness-task-execution" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    assert "automatically publishes" in task_execution_text
+    assert "publishedArtifacts" in task_execution_text
+    file_sharing_text = (
+        workspace_dir / "skills" / "teamharness-file-sharing" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    assert "artifact publish_file" in file_sharing_text
+    assert "workspace-relative file path" in file_sharing_text
     manifest = json.loads((workspace_dir / "skill.json").read_text(encoding="utf-8"))
     assert manifest["skills"]["teamharness-task-execution"]["enabled"] is True
     assert "teamharness-task-delegation" not in manifest["skills"]
@@ -250,7 +266,7 @@ def test_sanitizer_redacts_keywords_and_env_values(tmp_path: Path, monkeypatch) 
     _runtime_yaml(runtime_config)
 
     monkeypatch.setenv("TEAMHARNESS_RUNTIME_CONFIG", str(runtime_config))
-    monkeypatch.setenv("HICLAW_WORKER_MATRIX_TOKEN", "matrix-secret-value")
+    monkeypatch.setenv("AGENTTEAMS_WORKER_MATRIX_TOKEN", "matrix-secret-value")
     monkeypatch.setenv("EXTRA_SECRET", "extra-secret-value")
 
     text = module.sanitize_text(
@@ -372,26 +388,61 @@ def test_private_tool_result_wrapper_redacts_text_blocks(tmp_path: Path, monkeyp
     assert result["content"][0]["text"] == "[REDACTED]"
 
 
-def test_output_sanitizer_skips_when_qwenpaw_private_acting_missing(monkeypatch) -> None:
+def test_teamharness_http_sync_reinstalls_runtime_hooks(monkeypatch) -> None:
     module = _load_plugin()
+    calls = []
 
-    class QwenPawAgent:
-        pass
+    monkeypatch.setattr(module, "apply_teamharness", lambda: {"ok": True, "applied": True})
+    monkeypatch.setattr(
+        module,
+        "install_output_sanitizer_wrapper",
+        lambda api=None: calls.append(("sanitizer", api)) or {"ok": True, "installed": True},
+    )
 
-    react_agent_module = types.ModuleType("qwenpaw.agents.react_agent")
-    react_agent_module.QwenPawAgent = QwenPawAgent
-    monkeypatch.setitem(sys.modules, "qwenpaw", types.ModuleType("qwenpaw"))
-    monkeypatch.setitem(sys.modules, "qwenpaw.agents", types.ModuleType("qwenpaw.agents"))
-    monkeypatch.setitem(sys.modules, "qwenpaw.agents.react_agent", react_agent_module)
+    class APIRouter:
+        def __init__(self):
+            self.routes = {}
 
-    result = module.install_output_sanitizer_wrapper()
+        def get(self, path):
+            def decorator(func):
+                self.routes[("GET", path)] = func
+                return func
 
-    assert result == {
-        "ok": True,
-        "installed": False,
-        "reason": "qwenpaw agent _acting hook unavailable",
-    }
-    assert not hasattr(QwenPawAgent, "_teamharness_sanitizer_installed")
+            return decorator
+
+        def post(self, path):
+            def decorator(func):
+                self.routes[("POST", path)] = func
+                return func
+
+            return decorator
+
+    fastapi_module = types.ModuleType("fastapi")
+    fastapi_module.APIRouter = APIRouter
+    monkeypatch.setitem(sys.modules, "fastapi", fastapi_module)
+
+    class Api:
+        def __init__(self):
+            self.routers = {}
+
+        def register_startup_hook(self, *_args, **_kwargs):
+            pass
+
+        def register_shutdown_hook(self, *_args, **_kwargs):
+            pass
+
+        def register_http_router(self, router, prefix, tags):
+            self.routers[prefix] = router
+
+    api = Api()
+    plugin = module.TeamHarnessPlugin()
+    plugin.register(api)
+
+    result = api.routers["/teamharness"].routes[("POST", "/sync")]()
+
+    assert result == {"ok": True, "applied": True}
+    assert calls == [("sanitizer", api)]
+    assert plugin.sanitizer_result == {"ok": True, "installed": True}
 
 
 def test_mcp_client_receives_matrix_env_for_message_tool(tmp_path: Path, monkeypatch) -> None:
@@ -434,12 +485,12 @@ def test_mcp_client_receives_matrix_env_for_message_tool(tmp_path: Path, monkeyp
     monkeypatch.setitem(sys.modules, "qwenpaw.config.config", config_module)
     monkeypatch.setenv("TEAMHARNESS_SHARED_DIR", str(shared_dir))
     monkeypatch.setenv("TEAMHARNESS_RUNTIME_CONFIG", "/root/hiclaw-fs/shared/runtime/members/worker-a/runtime.yaml")
-    monkeypatch.setenv("HICLAW_MATRIX_URL", "http://matrix.local")
-    monkeypatch.setenv("HICLAW_WORKER_MATRIX_TOKEN", "matrix-token")
-    monkeypatch.setenv("HICLAW_WORKER_ROLE", "worker")
-    monkeypatch.setenv("HICLAW_WORKER_NAME", "worker-a")
-    monkeypatch.setenv("HICLAW_STORAGE_PREFIX", "hiclaw/hiclaw-storage")
-    monkeypatch.setenv("HICLAW_FS_BUCKET", "hiclaw-storage")
+    monkeypatch.setenv("AGENTTEAMS_MATRIX_URL", "http://matrix.local")
+    monkeypatch.setenv("AGENTTEAMS_WORKER_MATRIX_TOKEN", "matrix-token")
+    monkeypatch.setenv("AGENTTEAMS_WORKER_ROLE", "worker")
+    monkeypatch.setenv("AGENTTEAMS_WORKER_NAME", "worker-a")
+    monkeypatch.setenv("AGENTTEAMS_STORAGE_PREFIX", "hiclaw/hiclaw-storage")
+    monkeypatch.setenv("AGENTTEAMS_FS_BUCKET", "hiclaw-storage")
 
     result = module._ensure_mcp_client("default", workspace_dir)
 
@@ -449,10 +500,11 @@ def test_mcp_client_receives_matrix_env_for_message_tool(tmp_path: Path, monkeyp
     client = agent_config.mcp.clients["teamharness"]
     assert client.command == sys.executable
     assert client.env["TEAMHARNESS_SHARED_DIR"] == str(shared_dir)
+    assert client.env["LOONGSUITE_PYTHON_SITE_BOOTSTRAP_LOG_SUCCESS"] == "false"
     assert client.env["TEAMHARNESS_RUNTIME_CONFIG"] == "/root/hiclaw-fs/shared/runtime/members/worker-a/runtime.yaml"
-    assert client.env["HICLAW_MATRIX_URL"] == "http://matrix.local"
-    assert client.env["HICLAW_WORKER_MATRIX_TOKEN"] == "matrix-token"
-    assert client.env["HICLAW_WORKER_ROLE"] == "worker"
-    assert client.env["HICLAW_WORKER_NAME"] == "worker-a"
-    assert client.env["HICLAW_STORAGE_PREFIX"] == "hiclaw/hiclaw-storage"
-    assert client.env["HICLAW_FS_BUCKET"] == "hiclaw-storage"
+    assert client.env["AGENTTEAMS_MATRIX_URL"] == "http://matrix.local"
+    assert client.env["AGENTTEAMS_WORKER_MATRIX_TOKEN"] == "matrix-token"
+    assert client.env["AGENTTEAMS_WORKER_ROLE"] == "worker"
+    assert client.env["AGENTTEAMS_WORKER_NAME"] == "worker-a"
+    assert client.env["AGENTTEAMS_STORAGE_PREFIX"] == "hiclaw/hiclaw-storage"
+    assert client.env["AGENTTEAMS_FS_BUCKET"] == "hiclaw-storage"

--- a/plugins/tests/teamharness/adapters/qwenpaw/test_package.py
+++ b/plugins/tests/teamharness/adapters/qwenpaw/test_package.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 import zipfile
 from pathlib import Path
 
@@ -29,7 +30,11 @@ def test_build_qwenpaw_native_plugin_package(tmp_path: Path) -> None:
     result = subprocess.run(
         ["ruby", str(BUILD_SCRIPT), str(MANIFEST)],
         cwd=REPO_ROOT,
-        env={**os.environ, "OUT_DIR": str(tmp_path)},
+        env={
+            **os.environ,
+            "OUT_DIR": str(tmp_path),
+            "PYTHONPYCACHEPREFIX": str(tmp_path / "pycache"),
+        },
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -46,11 +51,16 @@ def test_build_qwenpaw_native_plugin_package(tmp_path: Path) -> None:
         names = set(archive.namelist())
         assert f"{root}/plugin.json" in names
         assert f"{root}/plugin.py" in names
+        assert f"{root}/task_trace.py" in names
         assert f"{root}/teamharness/plugin.yaml" in names
+        assert f"{root}/teamharness/trace.py" not in names
         assert f"{root}/teamharness/prompts/team/TEAMS.md" in names
         assert f"{root}/teamharness/prompts/agent/worker.md" in names
         assert f"{root}/teamharness/skills/team/communication/SKILL.md" in names
+        assert f"{root}/teamharness/skills/team/roomflow/SKILL.md" in names
         assert f"{root}/teamharness/mcp/server.py" in names
+        assert f"{root}/teamharness/mcp/message_tool.py" in names
+        assert f"{root}/teamharness/mcp/roomflow_tool.py" in names
         assert not any(name.startswith(f"{root}/teamharness/hooks/") for name in names)
         communication_skill = archive.read(f"{root}/teamharness/skills/team/communication/SKILL.md").decode("utf-8")
         project_skill = archive.read(f"{root}/teamharness/skills/team/project-management/SKILL.md").decode("utf-8")
@@ -62,8 +72,36 @@ def test_build_qwenpaw_native_plugin_package(tmp_path: Path) -> None:
         assert "payload` as a JSON object" in project_skill
 
         manifest = json.loads(archive.read(f"{root}/plugin.json"))
+        extract_dir = tmp_path / "extract"
+        archive.extractall(extract_dir)
 
     assert manifest["id"] == "teamharness"
     assert manifest["version"] == version
     assert manifest["entry"]["backend"] == "plugin.py"
     assert "periodic-sync" not in manifest["meta"]["features"]
+
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import importlib.util, json; "
+                f"path = {str(extract_dir / root / 'plugin.py')!r}; "
+                "spec = importlib.util.spec_from_file_location('teamharness_pkg', path); "
+                "mod = importlib.util.module_from_spec(spec); "
+                "spec.loader.exec_module(mod); "
+                "print(json.dumps(mod.install_task_trace_processor()))"
+            ),
+        ],
+        env={
+            **os.environ,
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "QWENPAW_WORKING_DIR": str(tmp_path / ".qwenpaw"),
+        },
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    trace_result = json.loads(probe.stdout)
+    assert trace_result.get("reason") != "task_trace.py not found"

--- a/plugins/tests/teamharness/mcp/test-server.rb
+++ b/plugins/tests/teamharness/mcp/test-server.rb
@@ -37,7 +37,7 @@ python_test = <<~PY
       "params": {},
   })["result"]["tools"]
   names = [tool["name"] for tool in tools]
-  expected = ["health", "message", "roomflow", "filesync", "projectflow", "taskflow"]
+  expected = ["health", "message", "roomflow", "filesync", "artifact", "projectflow", "taskflow"]
   if names != expected:
       raise AssertionError(f"unexpected tools: {names!r}")
 

--- a/plugins/tests/teamharness/mcp/tools/test-artifact.rb
+++ b/plugins/tests/teamharness/mcp/tools/test-artifact.rb
@@ -1,0 +1,191 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "pathname"
+require "tmpdir"
+
+repo_root = Pathname.new(__dir__).join("../../../../..").expand_path
+mcp_dir = repo_root / "plugins/teamharness/mcp"
+
+def fail!(message)
+  warn "ERROR: #{message}"
+  exit 1
+end
+
+Dir.mktmpdir("teamharness-artifact-") do |dir|
+  root = Pathname.new(dir)
+  workspace = root / "workspace"
+
+  python_test = <<~PY
+    import http.server
+    import json
+    import os
+    import pathlib
+    import socketserver
+    import sys
+    import threading
+    import urllib.parse
+
+    sys.path.insert(0, str(pathlib.Path("#{mcp_dir}")))
+    from server import call_tool
+
+    workspace = pathlib.Path("#{workspace}")
+    report = workspace / "reports/demo.txt"
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text("demo report\\n", encoding="utf-8")
+
+    matrix = {"uploads": [], "events": []}
+
+    class MatrixHandler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, format, *args):
+            return
+
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length)
+            parsed = urllib.parse.urlparse(self.path)
+            if parsed.path != "/_matrix/media/v3/upload":
+                self.send_response(404)
+                self.end_headers()
+                return
+            query = urllib.parse.parse_qs(parsed.query)
+            filename = query.get("filename", ["artifact"])[0]
+            matrix["uploads"].append({
+                "filename": filename,
+                "body": body.decode("utf-8", errors="replace"),
+                "auth": self.headers.get("Authorization"),
+                "content_type": self.headers.get("Content-Type"),
+            })
+            payload = {"content_uri": f"mxc://example.test/{len(matrix['uploads'])}-{filename}"}
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(payload).encode("utf-8"))
+
+        def do_PUT(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length)
+            parsed = urllib.parse.urlparse(self.path)
+            if "/send/m.room.message/" not in parsed.path:
+                self.send_response(404)
+                self.end_headers()
+                return
+            matrix["events"].append({
+                "path": parsed.path,
+                "auth": self.headers.get("Authorization"),
+                "content": json.loads(body.decode("utf-8") or "{}"),
+            })
+            payload = {"event_id": f"$artifact-event-{len(matrix['events'])}"}
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(payload).encode("utf-8"))
+
+    class MatrixServer(socketserver.ThreadingTCPServer):
+        allow_reuse_address = True
+        daemon_threads = True
+
+    matrix_server = MatrixServer(("127.0.0.1", 0), MatrixHandler)
+    matrix_thread = threading.Thread(target=matrix_server.serve_forever, daemon=True)
+    matrix_thread.start()
+    os.environ["AGENTTEAMS_MATRIX_URL"] = f"http://127.0.0.1:{matrix_server.server_address[1]}"
+    os.environ["AGENTTEAMS_WORKER_MATRIX_TOKEN"] = "test-token"
+    context_file = workspace / ".teamharness-matrix-context.json"
+    os.environ["TEAMHARNESS_MATRIX_CONTEXT_FILE"] = str(context_file)
+
+    def payload(args):
+        result = call_tool("artifact", args)
+        return json.loads(result["content"][0]["text"])
+
+    published = payload({
+        "workspaceDir": str(workspace),
+        "action": "publish_file",
+        "path": "reports/demo.txt",
+        "target": "room:!room:example.test",
+        "filename": "demo-report.txt",
+        "parentEventId": "$parent-text",
+    })
+    if not published.get("ok"):
+        raise AssertionError(f"artifact publish_file failed: {published!r}")
+    artifact = published.get("artifact") or {}
+    if artifact.get("status") != "published":
+        raise AssertionError(f"artifact was not published: {published!r}")
+    if artifact.get("sourcePath") != "reports/demo.txt" or artifact.get("filename") != "demo-report.txt":
+        raise AssertionError(f"artifact metadata mismatch: {published!r}")
+    if not artifact.get("mxcUri") or not artifact.get("eventId"):
+        raise AssertionError(f"artifact missing Matrix references: {published!r}")
+    if artifact.get("parentEventId") != "$parent-text":
+        raise AssertionError(f"artifact missing parent event reference: {published!r}")
+    if matrix["uploads"][-1].get("body") != "demo report\\n":
+        raise AssertionError(f"uploaded body mismatch: {matrix['uploads']!r}")
+    event = matrix["events"][-1]["content"]
+    if event.get("msgtype") != "m.file" or event.get("body") != "demo-report.txt":
+        raise AssertionError(f"Matrix file event mismatch: {event!r}")
+    if event.get("m.relates_to") != {"rel_type": "com.agentteams.attachment", "event_id": "$parent-text"}:
+        raise AssertionError(f"Matrix file event missing attachment relation: {event!r}")
+    if not event.get("url") or not (event.get("info") or {}).get("size"):
+        raise AssertionError(f"Matrix file event missing metadata: {event!r}")
+
+    context_file.write_text(json.dumps({
+        "rooms": {
+            "!room:example.test": {
+                "attachmentParentEventId": "$context-parent",
+                "updatedAt": __import__("time").time(),
+            }
+        }
+    }), encoding="utf-8")
+    context_published = payload({
+        "workspaceDir": str(workspace),
+        "action": "publish_file",
+        "path": "reports/demo.txt",
+        "target": "room:!room:example.test",
+        "filename": "context-demo-report.txt",
+    })
+    if not context_published.get("ok"):
+        raise AssertionError(f"context artifact publish_file failed: {context_published!r}")
+    context_artifact = context_published.get("artifact") or {}
+    if context_artifact.get("parentEventId") != "$context-parent":
+        raise AssertionError(f"context artifact missing inferred parent event reference: {context_published!r}")
+    context_event = matrix["events"][-1]["content"]
+    if context_event.get("m.relates_to") != {"rel_type": "com.agentteams.attachment", "event_id": "$context-parent"}:
+        raise AssertionError(f"context Matrix file event missing attachment relation: {context_event!r}")
+
+    outside = payload({
+        "workspaceDir": str(workspace),
+        "action": "publish_file",
+        "path": "../outside.txt",
+        "target": "room:!room:example.test",
+    })
+    if outside.get("ok") or "relative" not in str(outside.get("error", "")).lower():
+        raise AssertionError(f"workspace escape should fail clearly: {outside!r}")
+
+    secret = workspace / "reports/secret-note.txt"
+    secret.write_text("token=abcdefghijklmnopqrstuvwxyz1234567890\\n", encoding="utf-8")
+    secret_result = payload({
+        "workspaceDir": str(workspace),
+        "action": "publish_file",
+        "path": "reports/secret-note.txt",
+        "target": "room:!room:example.test",
+    })
+    if secret_result.get("ok") or "sensitive" not in str(secret_result.get("error", "")).lower():
+        raise AssertionError(f"sensitive artifact should fail clearly: {secret_result!r}")
+    if any(upload.get("filename") == "secret-note.txt" for upload in matrix["uploads"]):
+        raise AssertionError(f"sensitive artifact should not upload: {matrix['uploads']!r}")
+
+    matrix_server.shutdown()
+    matrix_server.server_close()
+
+    print(json.dumps({
+        "ok": True,
+        "filename": artifact["filename"],
+        "eventId": artifact["eventId"],
+    }, ensure_ascii=False))
+  PY
+
+  stdout, stderr, status = Open3.capture3("python3", "-", stdin_data: python_test, chdir: repo_root.to_s)
+  fail!(["teamharness artifact MCP test failed", stderr, stdout].reject(&:empty?).join("\n")) unless status.success?
+
+  puts JSON.pretty_generate(JSON.parse(stdout))
+end

--- a/plugins/tests/teamharness/mcp/tools/test-filesync.rb
+++ b/plugins/tests/teamharness/mcp/tools/test-filesync.rb
@@ -23,11 +23,11 @@ Dir.mktmpdir("teamharness-filesync-") do |dir|
   (bin_dir / "mc").write(<<~SH)
     #!/usr/bin/env bash
     printf '%s\\n' "$*" >> "#{log_path}"
-    printf 'ENV MC_HOST_hiclaw=%s\\n' "${MC_HOST_hiclaw:-}" >> "#{log_path}"
+    printf 'ENV MC_HOST_agentteams=%s\\n' "${MC_HOST_agentteams:-}" >> "#{log_path}"
     case "$*" in
-      *"hiclaw/hiclaw-storage"*)
-        if [ -z "${MC_HOST_hiclaw:-}" ]; then
-          echo "missing MC_HOST_hiclaw" >&2
+      *"agentteams/hiclaw-storage"*)
+        if [ -z "${MC_HOST_agentteams:-}" ]; then
+          echo "missing MC_HOST_agentteams" >&2
           exit 3
         fi
         ;;
@@ -88,6 +88,20 @@ Dir.mktmpdir("teamharness-filesync-") do |dir|
         raise AssertionError(f"remote path mismatch: {dry!r}")
     if dry.get("command") != ["mc", "mirror", "mock/shared/projects/demo/", "#{workspace}/shared/projects/demo", "--overwrite"]:
         raise AssertionError(f"dry-run command mismatch: {dry!r}")
+
+    board_dry = payload({
+        "action": "pull",
+        "path": "shared/board/aone-feed",
+        "dryRun": True,
+    })
+    if not board_dry.get("ok"):
+        raise AssertionError(f"shared board dry-run pull failed: {board_dry!r}")
+    if board_dry.get("path") != "shared/board/aone-feed/":
+        raise AssertionError(f"shared board path was not normalized: {board_dry!r}")
+    if board_dry.get("localPath") != "#{workspace}/shared/board/aone-feed":
+        raise AssertionError(f"shared board local path mismatch: {board_dry!r}")
+    if board_dry.get("remotePath") != "mock/shared/board/aone-feed/":
+        raise AssertionError(f"shared board remote path mismatch: {board_dry!r}")
 
     blocked_global_push = payload({
         "action": "push",
@@ -170,14 +184,14 @@ Dir.mktmpdir("teamharness-filesync-") do |dir|
         encoding="utf-8",
     )
     os.environ["TEAMHARNESS_RUNTIME_CONFIG"] = str(runtime_config)
-    os.environ["HICLAW_STORAGE_PREFIX"] = "hiclaw/hiclaw-storage"
+    os.environ["AGENTTEAMS_STORAGE_PREFIX"] = "agentteams/hiclaw-storage"
     from_runtime = payload_without_storage({
         "workspaceDir": "#{workspace}",
         "action": "list",
         "path": "shared/tasks/demo",
         "dryRun": True,
     })
-    if from_runtime.get("remotePath") != "hiclaw/hiclaw-storage/teams/demo-team/shared/tasks/demo/":
+    if from_runtime.get("remotePath") != "agentteams/hiclaw-storage/teams/demo-team/shared/tasks/demo/":
         raise AssertionError(f"runtime storage prefix mismatch: {from_runtime!r}")
 
     runtime_result = pathlib.Path("#{workspace}") / "shared/tasks/runtime-push/result.md"
@@ -190,7 +204,7 @@ Dir.mktmpdir("teamharness-filesync-") do |dir|
     })
     if not pushed_runtime.get("ok"):
         raise AssertionError(f"runtime-prefix push failed: {pushed_runtime!r}")
-    if pushed_runtime.get("remotePath") != "hiclaw/hiclaw-storage/teams/demo-team/shared/tasks/runtime-push/":
+    if pushed_runtime.get("remotePath") != "agentteams/hiclaw-storage/teams/demo-team/shared/tasks/runtime-push/":
         raise AssertionError(f"runtime-prefix push remote mismatch: {pushed_runtime!r}")
 
     print(json.dumps({
@@ -208,9 +222,9 @@ Dir.mktmpdir("teamharness-filesync-") do |dir|
 
   env = {
     "PATH" => "#{bin_dir}:#{ENV.fetch("PATH", "")}",
-    "HICLAW_FS_ENDPOINT" => "https://oss.example.test",
-    "HICLAW_FS_ACCESS_KEY" => "access-key",
-    "HICLAW_FS_SECRET_KEY" => "secret-key"
+    "AGENTTEAMS_FS_ENDPOINT" => "https://oss.example.test",
+    "AGENTTEAMS_FS_ACCESS_KEY" => "access-key",
+    "AGENTTEAMS_FS_SECRET_KEY" => "secret-key"
   }
   stdout, stderr, status = Open3.capture3(env, "python3", "-", stdin_data: python_test, chdir: repo_root.to_s)
   fail!(["teamharness filesync MCP test failed", stderr, stdout].reject(&:empty?).join("\n")) unless status.success?
@@ -232,10 +246,10 @@ Dir.mktmpdir("teamharness-filesync-") do |dir|
     "stat mock/shared/tasks/t-001/result.md"
   )
   fail!("runtime-prefix mc mirror was not called: #{commands.inspect}") unless commands.include?(
-    "mirror #{workspace}/shared/tasks/runtime-push/ hiclaw/hiclaw-storage/teams/demo-team/shared/tasks/runtime-push/ --overwrite"
+    "mirror #{workspace}/shared/tasks/runtime-push/ agentteams/hiclaw-storage/teams/demo-team/shared/tasks/runtime-push/ --overwrite"
   )
-  fail!("runtime-prefix mc mirror did not receive MC_HOST_hiclaw: #{commands.inspect}") unless commands.any? do |line|
-    line.start_with?("ENV MC_HOST_hiclaw=https://access-key:secret-key@oss.example.test")
+  fail!("runtime-prefix mc mirror did not receive MC_HOST_agentteams: #{commands.inspect}") unless commands.any? do |line|
+    line.start_with?("ENV MC_HOST_agentteams=https://access-key:secret-key@oss.example.test")
   end
 
   puts JSON.pretty_generate(JSON.parse(stdout).merge("mcCommands" => commands))

--- a/plugins/tests/teamharness/mcp/tools/test-message.rb
+++ b/plugins/tests/teamharness/mcp/tools/test-message.rb
@@ -34,6 +34,7 @@ Dir.mktmpdir("teamharness-message-") do |_dir|
         def do_PUT(self):
             length = int(self.headers.get("Content-Length", "0"))
             body = self.rfile.read(length).decode("utf-8")
+            captured["put_count"] = captured.get("put_count", 0) + 1
             captured["path"] = self.path
             captured["auth"] = self.headers.get("Authorization")
             captured["body"] = json.loads(body)
@@ -47,10 +48,17 @@ Dir.mktmpdir("teamharness-message-") do |_dir|
         def do_POST(self):
             length = int(self.headers.get("Content-Length", "0"))
             body = self.rfile.read(length).decode("utf-8")
-            captured["qwenpaw_path"] = self.path
-            captured["qwenpaw_agent"] = self.headers.get("X-Agent-Id")
-            captured["qwenpaw_body"] = json.loads(body)
-            payload = json.dumps({"success": True, "message": "sent"}).encode("utf-8")
+            if self.path == "/api/messages/send":
+                captured["qwenpaw_count"] = captured.get("qwenpaw_count", 0) + 1
+                captured["qwenpaw_path"] = self.path
+                captured["qwenpaw_agent"] = self.headers.get("X-Agent-Id")
+                captured["qwenpaw_body"] = json.loads(body)
+                payload = json.dumps({"success": True, "message": "sent"}).encode("utf-8")
+            else:
+                captured["dingtalk_webhook_count"] = captured.get("dingtalk_webhook_count", 0) + 1
+                captured["dingtalk_webhook_path"] = self.path
+                captured["dingtalk_webhook_body"] = json.loads(body)
+                payload = json.dumps({"errcode": 0, "errmsg": "ok"}).encode("utf-8")
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(payload)))
@@ -215,17 +223,293 @@ Dir.mktmpdir("teamharness-message-") do |_dir|
     if dingtalk_dry.get("targetUser") != "sender_001" or dingtalk_dry.get("targetSession") != "aaaaaaaa":
         raise AssertionError(f"dingtalk dry-run target mismatch: {dingtalk_dry!r}")
 
+    matrix_route_dry = payload({
+        "action": "send",
+        "replyRoute": {
+            "channel": "matrix",
+            "targetUser": "@admin:example.test",
+            "targetSession": "!dm-room:example.test",
+        },
+        "text": "Project A is ready.",
+        "dryRun": True,
+    })
+    if not matrix_route_dry.get("ok"):
+        raise AssertionError(f"matrix replyRoute dry-run failed: {matrix_route_dry!r}")
+    if matrix_route_dry.get("target") != "room:!dm-room:example.test":
+        raise AssertionError(f"matrix replyRoute target mismatch: {matrix_route_dry!r}")
+    if matrix_route_dry.get("targetKind") != "room":
+        raise AssertionError(f"matrix replyRoute target kind mismatch: {matrix_route_dry!r}")
+
     import os
-    os.environ["HICLAW_MATRIX_URL"] = f"http://127.0.0.1:{server.server_address[1]}"
-    os.environ["HICLAW_WORKER_MATRIX_TOKEN"] = "test-token"
-    os.environ["HICLAW_MATRIX_USER_ID"] = "@sender:example.test"
+    os.environ["AGENTTEAMS_MATRIX_URL"] = f"http://127.0.0.1:{server.server_address[1]}"
+    os.environ["AGENTTEAMS_WORKER_MATRIX_TOKEN"] = "test-token"
+    os.environ["AGENTTEAMS_MATRIX_USER_ID"] = "@sender:example.test"
     os.environ["QWENPAW_API_BASE"] = f"http://127.0.0.1:{server.server_address[1]}"
     home_dir = pathlib.Path("#{_dir}") / "home"
     qwenpaw_dir = home_dir / ".qwenpaw"
     (qwenpaw_dir / "workspaces" / "default").mkdir(parents=True, exist_ok=True)
+    context_file = pathlib.Path("#{_dir}") / "teamharness-matrix-context.json"
+    os.environ["TEAMHARNESS_MATRIX_CONTEXT_FILE"] = str(context_file)
     os.environ.pop("QWENPAW_WORKING_DIR", None)
     os.environ.pop("COPAW_WORKING_DIR", None)
     os.environ["HOME"] = str(home_dir)
+    def session_safe(value):
+        return re.sub(r'[\\\\/:*?"<>|]', "--", value)
+
+    put_count_before_trigger = captured.get("put_count", 0)
+    trigger_intent = payload({
+        "action": "send",
+        "channel": "matrix",
+        "sender": {
+            "agent": "@leader:example.test",
+            "session": {
+                "channel": "matrix",
+                "id": "!leader-dm:example.test",
+            },
+        },
+        "target": "room:!task-room:example.test",
+        "message": {
+            "type": "PROJECT_REQUESTED",
+            "text": "PROJECT_REQUESTED: req-123\\nReplyRoute: matrix/@admin:example.test/!leader-dm:example.test\\nContext: shared/roomflow/project-requests/req-123/request.md",
+        },
+        "replyRoute": {
+            "channel": "matrix",
+            "targetUser": "@admin:example.test",
+            "targetSession": "!leader-dm:example.test",
+        },
+        "agentId": "@leader:example.test",
+    })
+    if not trigger_intent.get("ok"):
+        raise AssertionError(f"self trigger intent failed: {trigger_intent!r}")
+    if captured.get("put_count", 0) != put_count_before_trigger + 1:
+        raise AssertionError(f"self trigger should send one Matrix PUT: {captured!r}")
+    if trigger_intent.get("delivery", {}).get("sent") != "matrix_self_trigger":
+        raise AssertionError(f"self trigger delivery mismatch: {trigger_intent!r}")
+    if trigger_intent.get("context", {}).get("via") != "matrix_current_event":
+        raise AssertionError(f"self trigger context mismatch: {trigger_intent!r}")
+    trigger = trigger_intent.get("trigger") or {}
+    if trigger.get("status") != "sent" or trigger.get("type") != "PROJECT_REQUESTED":
+        raise AssertionError(f"self trigger status mismatch: {trigger_intent!r}")
+    if trigger.get("targetCurrentEvent") != "$event1":
+        raise AssertionError(f"self trigger event mismatch: {trigger_intent!r}")
+    if trigger.get("sourceSession") != "matrix:!leader-dm:example.test":
+        raise AssertionError(f"self trigger source mismatch: {trigger_intent!r}")
+    if trigger.get("targetSession") != "matrix:!task-room:example.test":
+        raise AssertionError(f"self trigger target mismatch: {trigger_intent!r}")
+    marker = captured["body"].get("m.teamharness.trigger") or {}
+    if marker.get("kind") != "self_cross_session" or marker.get("type") != "PROJECT_REQUESTED":
+        raise AssertionError(f"self trigger marker mismatch: {captured!r}")
+    if marker.get("targetRoomId") != "!task-room:example.test":
+        raise AssertionError(f"self trigger marker target mismatch: {captured!r}")
+    if marker.get("replyRoute") != {
+        "channel": "matrix",
+        "targetUser": "@admin:example.test",
+        "targetSession": "!leader-dm:example.test",
+    }:
+        raise AssertionError(f"self trigger replyRoute marker mismatch: {captured!r}")
+
+    put_count_before_hidden_route = captured.get("put_count", 0)
+    hidden_route_trigger = payload({
+        "action": "send",
+        "channel": "matrix",
+        "sender": {
+            "agent": "@leader:example.test",
+            "session": {
+                "channel": "matrix",
+                "id": "!leader-dm:example.test",
+            },
+        },
+        "target": "room:!task-room:example.test",
+        "message": {
+            "type": "PROJECT_REQUESTED",
+            "text": "PROJECT_REQUESTED: hidden route",
+        },
+        "replyRoute": {
+            "channel": "matrix",
+            "targetSession": "!leader-dm:example.test",
+        },
+        "agentId": "@leader:example.test",
+    })
+    if hidden_route_trigger.get("ok"):
+        raise AssertionError(f"PROJECT_REQUESTED with hidden replyRoute should fail: {hidden_route_trigger!r}")
+    if "targetSession" not in hidden_route_trigger.get("error", ""):
+        raise AssertionError(f"PROJECT_REQUESTED hidden replyRoute error mismatch: {hidden_route_trigger!r}")
+    if captured.get("put_count", 0) != put_count_before_hidden_route:
+        raise AssertionError(f"PROJECT_REQUESTED hidden replyRoute must not send Matrix PUT: {captured!r}")
+    trigger_session_path = (
+        qwenpaw_dir
+        / "workspaces"
+        / "default"
+        / "sessions"
+        / "matrix"
+        / f"{session_safe('!task-room:example.test')}_{session_safe('matrix:!task-room:example.test')}.json"
+    )
+    if trigger_session_path.exists():
+        raise AssertionError(f"self trigger should not write session file: {trigger_session_path}")
+
+    put_count_before_dingtalk_trigger = captured.get("put_count", 0)
+    dingtalk_trigger = payload({
+        "action": "send",
+        "channel": "matrix",
+        "sender": {
+            "agent": "@leader:example.test",
+            "session": {
+                "channel": "dingtalk",
+                "id": "ding-group-session-001",
+            },
+        },
+        "target": "room:!task-room:example.test",
+        "message": {
+            "type": "PROJECT_REQUESTED",
+            "text": "PROJECT_REQUESTED: dingtalk req\\nRequester route: dingtalk/sender_001/ding-group-session-001",
+        },
+        "replyRoute": {
+            "channel": "dingtalk",
+            "targetUser": "sender_001",
+            "targetSession": "ding-group-session-001",
+            "mentionSender": True,
+        },
+        "agentId": "@leader:example.test",
+    })
+    if not dingtalk_trigger.get("ok"):
+        raise AssertionError(f"dingtalk source trigger failed: {dingtalk_trigger!r}")
+    if captured.get("put_count", 0) != put_count_before_dingtalk_trigger + 1:
+        raise AssertionError(f"dingtalk source trigger should send one Matrix PUT: {captured!r}")
+    dingtalk_trigger_intent = dingtalk_trigger.get("trigger") or {}
+    if dingtalk_trigger_intent.get("status") != "sent":
+        raise AssertionError(f"dingtalk source trigger status mismatch: {dingtalk_trigger!r}")
+    if dingtalk_trigger_intent.get("sourceChannel") != "dingtalk":
+        raise AssertionError(f"dingtalk source channel mismatch: {dingtalk_trigger!r}")
+    if dingtalk_trigger_intent.get("sourceSession") != "dingtalk:ding-group-session-001":
+        raise AssertionError(f"dingtalk source session mismatch: {dingtalk_trigger!r}")
+    if dingtalk_trigger_intent.get("targetSession") != "matrix:!task-room:example.test":
+        raise AssertionError(f"dingtalk target session mismatch: {dingtalk_trigger!r}")
+    if dingtalk_trigger_intent.get("replyRoute") != {
+        "channel": "dingtalk",
+        "targetUser": "sender_001",
+        "targetSession": "ding-group-session-001",
+        "mentionSender": True,
+    }:
+        raise AssertionError(f"dingtalk reply route mismatch: {dingtalk_trigger!r}")
+
+    put_count_before_hidden_target_user = captured.get("put_count", 0)
+    hidden_target_user_trigger = payload({
+        "action": "send",
+        "channel": "matrix",
+        "sender": {
+            "agent": "@leader:example.test",
+            "session": {
+                "channel": "dingtalk",
+                "id": "ding-group-session-001",
+            },
+        },
+        "target": "room:!task-room:example.test",
+        "message": {
+            "type": "PROJECT_REQUESTED",
+            "text": "PROJECT_REQUESTED: hidden target user\\nRequester route: dingtalk/ding-group-session-001",
+        },
+        "replyRoute": {
+            "channel": "dingtalk",
+            "targetUser": "sender_001",
+            "targetSession": "ding-group-session-001",
+        },
+        "agentId": "@leader:example.test",
+    })
+    if hidden_target_user_trigger.get("ok"):
+        raise AssertionError(f"PROJECT_REQUESTED with hidden targetUser should fail: {hidden_target_user_trigger!r}")
+    if "targetUser" not in hidden_target_user_trigger.get("error", ""):
+        raise AssertionError(f"PROJECT_REQUESTED hidden targetUser error mismatch: {hidden_target_user_trigger!r}")
+    if captured.get("put_count", 0) != put_count_before_hidden_target_user:
+        raise AssertionError(f"PROJECT_REQUESTED hidden targetUser must not send Matrix PUT: {captured!r}")
+
+    put_count_before_missing_route = captured.get("put_count", 0)
+    missing_route_trigger = payload({
+        "action": "send",
+        "channel": "matrix",
+        "sender": {
+            "agent": "@leader:example.test",
+            "session": {
+                "channel": "dingtalk",
+                "id": "ding-group-session-001",
+            },
+        },
+        "target": "room:!task-room:example.test",
+        "message": {
+            "type": "PROJECT_REQUESTED",
+            "text": "PROJECT_REQUESTED: missing route",
+        },
+        "agentId": "@leader:example.test",
+    })
+    if missing_route_trigger.get("ok"):
+        raise AssertionError(f"PROJECT_REQUESTED without replyRoute should fail: {missing_route_trigger!r}")
+    if "replyRoute" not in missing_route_trigger.get("error", ""):
+        raise AssertionError(f"PROJECT_REQUESTED missing replyRoute error mismatch: {missing_route_trigger!r}")
+    if captured.get("put_count", 0) != put_count_before_missing_route:
+        raise AssertionError(f"PROJECT_REQUESTED missing replyRoute must not send Matrix PUT: {captured!r}")
+
+    put_count_before_role_agent = captured.get("put_count", 0)
+    role_agent_trigger = payload({
+        "action": "send",
+        "channel": "matrix",
+        "sender": {
+            "agent": "default",
+            "session": {
+                "channel": "dingtalk",
+                "id": "ding-group-session-001",
+            },
+        },
+        "target": "room:!task-room:example.test",
+        "message": {
+            "type": "PROJECT_REQUESTED",
+            "text": "PROJECT_REQUESTED: role agent\\nRequester route: dingtalk/ding-group-session-001",
+        },
+        "replyRoute": {
+            "channel": "dingtalk",
+            "targetUser": "sender_001",
+            "targetSession": "ding-group-session-001",
+        },
+        "agentId": "default",
+    })
+    if role_agent_trigger.get("ok"):
+        raise AssertionError(f"PROJECT_REQUESTED with role/workspace agent id should fail: {role_agent_trigger!r}")
+    if "Matrix user id" not in role_agent_trigger.get("error", ""):
+        raise AssertionError(f"PROJECT_REQUESTED role/workspace agent error mismatch: {role_agent_trigger!r}")
+    if captured.get("put_count", 0) != put_count_before_role_agent:
+        raise AssertionError(f"PROJECT_REQUESTED role/workspace agent must not send Matrix PUT: {captured!r}")
+
+    put_count_before_string_trigger = captured.get("put_count", 0)
+    string_trigger = payload({
+        "action": "send",
+        "channel": "matrix",
+        "sender": {
+            "agent": "@leader:example.test",
+            "session": {
+                "channel": "matrix",
+                "id": "!leader-dm:example.test",
+            },
+        },
+        "target": "room:!task-room:example.test",
+        "message": json.dumps({
+            "type": "PROJECT_REQUESTED",
+            "text": "PROJECT_REQUESTED: string req\\nRequester route: matrix/!leader-dm:example.test",
+        }),
+        "replyRoute": {
+            "channel": "matrix",
+            "targetSession": "!leader-dm:example.test",
+        },
+        "agentId": "@leader:example.test",
+    })
+    if not string_trigger.get("ok"):
+        raise AssertionError(f"string self trigger failed: {string_trigger!r}")
+    if captured.get("put_count", 0) != put_count_before_string_trigger + 1:
+        raise AssertionError(f"string self trigger should send one Matrix PUT: {captured!r}")
+    if string_trigger.get("delivery", {}).get("sent") != "matrix_self_trigger":
+        raise AssertionError(f"string self trigger delivery mismatch: {string_trigger!r}")
+    if captured["body"].get("body") != "PROJECT_REQUESTED: string req\\nRequester route: matrix/!leader-dm:example.test":
+        raise AssertionError(f"string self trigger body mismatch: {captured!r}")
+    string_marker = captured["body"].get("m.teamharness.trigger") or {}
+    if string_marker.get("kind") != "self_cross_session" or string_marker.get("type") != "PROJECT_REQUESTED":
+        raise AssertionError(f"string self trigger marker mismatch: {captured!r}")
 
     sent = payload({
         "action": "send",
@@ -243,9 +527,6 @@ Dir.mktmpdir("teamharness-message-") do |_dir|
         raise AssertionError(f"send path mismatch: {captured!r}")
     if captured["body"].get("body") != "Project is ready.":
         raise AssertionError(f"body mismatch: {captured!r}")
-    def session_safe(value):
-        return re.sub(r'[\\\\/:*?"<>|]', "--", value)
-
     session_path = (
         qwenpaw_dir
         / "workspaces"
@@ -271,6 +552,10 @@ Dir.mktmpdir("teamharness-message-") do |_dir|
         "source": "message_tool_outbound",
     }:
         raise AssertionError(f"session metadata mismatch: {recorded_msg!r}")
+    context = json.loads(context_file.read_text(encoding="utf-8"))
+    room_context = context.get("rooms", {}).get("!room:example.test") or {}
+    if room_context.get("attachmentParentEventId") != "$event1":
+        raise AssertionError(f"message send should update attachment context: {context!r}")
 
     dingtalk_sent = payload({
         "action": "send",
@@ -280,7 +565,6 @@ Dir.mktmpdir("teamharness-message-") do |_dir|
         "text": "Project A is ready.",
         "agentId": "default",
     })
-    server.shutdown()
     if not dingtalk_sent.get("ok"):
         raise AssertionError(f"dingtalk send failed: {dingtalk_sent!r}")
     if dingtalk_sent.get("sessionRecorded") is not True:
@@ -322,7 +606,98 @@ Dir.mktmpdir("teamharness-message-") do |_dir|
     }:
         raise AssertionError(f"dingtalk session metadata mismatch: {dingtalk_msg!r}")
 
-    os.environ["HICLAW_AGENT_ROLE"] = "worker"
+    qwenpaw_body_before_missing = captured.get("qwenpaw_body")
+    dingtalk_mention_missing = payload({
+        "action": "send",
+        "channel": "dingtalk",
+        "targetUser": "sender_002",
+        "targetSession": "bbbbbbbb",
+        "mentionSender": True,
+        "text": "Project B is ready.",
+        "agentId": "default",
+    })
+    if dingtalk_mention_missing.get("ok"):
+        raise AssertionError(f"dingtalk mention missing webhook should fail: {dingtalk_mention_missing!r}")
+    if "session webhook not found" not in dingtalk_mention_missing.get("error", ""):
+        raise AssertionError(f"dingtalk mention missing webhook error missing: {dingtalk_mention_missing!r}")
+    if dingtalk_mention_missing.get("delivery", {}).get("failed") != "dingtalk_sender_mention_required":
+        raise AssertionError(f"dingtalk mention missing webhook delivery mismatch: {dingtalk_mention_missing!r}")
+    if captured.get("qwenpaw_body") != qwenpaw_body_before_missing:
+        raise AssertionError(f"dingtalk mention missing webhook must not fall back to qwenpaw API: {captured!r}")
+
+    webhook_store = qwenpaw_dir / "workspaces" / "default" / "dingtalk_session_webhooks.json"
+    webhook_store.write_text(json.dumps({
+        "dingtalk:sw:sender_001_aaaaaaaa": {
+            "webhook": f"http://127.0.0.1:{server.server_address[1]}/dingtalk-webhook",
+            "conversation_type": "group",
+            "sender_staff_id": "staff_001",
+        }
+    }), encoding="utf-8")
+    webhook_count_before_mismatch = captured.get("dingtalk_webhook_count", 0)
+    qwenpaw_body_before_mismatch = captured.get("qwenpaw_body")
+    dingtalk_mention_mismatch = payload({
+        "action": "send",
+        "replyRoute": {
+            "channel": "dingtalk",
+            "targetUser": "sender_001",
+            "targetSession": "aaaaaaaa",
+            "mentionSender": True,
+            "senderStaffId": "staff_wrong",
+        },
+        "text": "Project C is ready.",
+        "agentId": "default",
+    })
+    if dingtalk_mention_mismatch.get("ok"):
+        raise AssertionError(f"dingtalk mention mismatch should fail: {dingtalk_mention_mismatch!r}")
+    if "does not match recorded sender" not in dingtalk_mention_mismatch.get("error", ""):
+        raise AssertionError(f"dingtalk mention mismatch warning missing: {dingtalk_mention_mismatch!r}")
+    if dingtalk_mention_mismatch.get("delivery", {}).get("failed") != "dingtalk_sender_mention_required":
+        raise AssertionError(f"dingtalk mention mismatch delivery mismatch: {dingtalk_mention_mismatch!r}")
+    if captured.get("dingtalk_webhook_count", 0) != webhook_count_before_mismatch:
+        raise AssertionError(f"dingtalk mention mismatch should not call webhook: {captured!r}")
+    if captured.get("qwenpaw_body") != qwenpaw_body_before_mismatch:
+        raise AssertionError(f"dingtalk mention mismatch must not fall back to qwenpaw API: {captured!r}")
+
+    dingtalk_mention_sent = payload({
+        "action": "send",
+        "replyRoute": {
+            "channel": "dingtalk",
+            "targetUser": "sender_001",
+            "targetSession": "aaaaaaaa",
+        },
+        "mentionSender": True,
+        "text": "Project A is ready.",
+        "agentId": "default",
+    })
+    server.shutdown()
+    if not dingtalk_mention_sent.get("ok"):
+        raise AssertionError(f"dingtalk mention send failed: {dingtalk_mention_sent!r}")
+    if dingtalk_mention_sent.get("senderMentioned") is not True:
+        raise AssertionError(f"dingtalk mention marker missing: {dingtalk_mention_sent!r}")
+    if dingtalk_mention_sent.get("mentionedSender") != "staff_001":
+        raise AssertionError(f"dingtalk mentioned sender mismatch: {dingtalk_mention_sent!r}")
+    if captured.get("dingtalk_webhook_path") != "/dingtalk-webhook":
+        raise AssertionError(f"dingtalk webhook path mismatch: {captured!r}")
+    webhook_body = captured.get("dingtalk_webhook_body", {})
+    if webhook_body.get("at", {}).get("atUserIds") != ["staff_001"]:
+        raise AssertionError(f"dingtalk webhook at payload mismatch: {webhook_body!r}")
+    webhook_text = webhook_body.get("markdown", {}).get("text") or webhook_body.get("text", {}).get("content") or ""
+    if "@staff_001" not in webhook_text or "Project A is ready." not in webhook_text:
+        raise AssertionError(f"dingtalk webhook text mismatch: {webhook_body!r}")
+    dingtalk_session = json.loads(dingtalk_session_path.read_text(encoding="utf-8"))
+    dingtalk_msg, _dingtalk_marks = dingtalk_session["agent"]["memory"]["content"][-1]
+    if dingtalk_msg.get("metadata") != {
+        "channel": "dingtalk",
+        "message_id": "",
+        "source": "message_tool_outbound",
+        "user_id": "sender_001",
+        "session_id": "aaaaaaaa",
+        "sender_mentioned": True,
+        "mentioned_sender": "staff_001",
+    }:
+        raise AssertionError(f"dingtalk mention session metadata mismatch: {dingtalk_msg!r}")
+
+    os.environ["AGENTTEAMS_AGENT_ROLE"] = "worker"
     worker_tools = [tool["name"] for tool in list_tools()]
     if "message" in worker_tools:
         raise AssertionError(f"worker should not see message tool: {worker_tools!r}")
@@ -343,6 +718,7 @@ Dir.mktmpdir("teamharness-message-") do |_dir|
         "messageId": sent["messageId"],
         "sendPath": captured["path"],
         "qwenpawSendPath": captured["qwenpaw_path"],
+        "triggerStatus": trigger["status"],
     }, ensure_ascii=False))
   PY
 

--- a/plugins/tests/teamharness/mcp/tools/test-projectflow.rb
+++ b/plugins/tests/teamharness/mcp/tools/test-projectflow.rb
@@ -27,10 +27,15 @@ Dir.mktmpdir("teamharness-projectflow-") do |dir|
   (bin_dir / "mc").chmod(0o755)
 
   python_test = <<~PY
+    import http.server
     import json
     import os
     import pathlib
+    import socketserver
     import sys
+    import threading
+    import time
+    import urllib.parse
 
     sys.path.insert(0, str(pathlib.Path("#{mcp_dir}")))
     import server
@@ -38,8 +43,19 @@ Dir.mktmpdir("teamharness-projectflow-") do |dir|
 
     server.time.strftime = lambda fmt: "20260605-112233"
 
+    workspace = pathlib.Path("#{workspace}")
+    real_shared = pathlib.Path("#{root}") / "real-shared"
+    workspace.mkdir(parents=True, exist_ok=True)
+    real_shared.mkdir(parents=True, exist_ok=True)
+    (workspace / "shared").symlink_to(
+        os.path.relpath(real_shared, workspace),
+        target_is_directory=True,
+    )
+    os.environ["AGENTTEAMS_SHARED_DIR"] = str(real_shared)
+    os.environ["TEAMHARNESS_SHARED_DIR"] = str(real_shared)
+
     common = {
-        "workspaceDir": "#{workspace}",
+        "workspaceDir": str(workspace),
         "storage": {
             "sharedPrefix": "mock/shared",
             "globalSharedPrefix": "mock/global-shared",
@@ -52,11 +68,74 @@ Dir.mktmpdir("teamharness-projectflow-") do |dir|
     )
     os.environ["TEAMHARNESS_RUNTIME_CONFIG"] = str(runtime_config)
 
-    def payload(args):
+    matrix = {"uploads": [], "events": []}
+
+    class MatrixHandler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, format, *args):
+            return
+
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length)
+            parsed = urllib.parse.urlparse(self.path)
+            if parsed.path != "/_matrix/media/v3/upload":
+                self.send_response(404)
+                self.end_headers()
+                return
+            query = urllib.parse.parse_qs(parsed.query)
+            filename = query.get("filename", ["artifact"])[0]
+            matrix["uploads"].append({
+                "filename": filename,
+                "body": body.decode("utf-8", errors="replace"),
+                "auth": self.headers.get("Authorization"),
+                "content_type": self.headers.get("Content-Type"),
+            })
+            payload = {"content_uri": f"mxc://example.test/{len(matrix['uploads'])}-{filename}"}
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(payload).encode("utf-8"))
+
+        def do_PUT(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length)
+            parsed = urllib.parse.urlparse(self.path)
+            if "/send/m.room.message/" not in parsed.path:
+                self.send_response(404)
+                self.end_headers()
+                return
+            matrix["events"].append({
+                "path": parsed.path,
+                "auth": self.headers.get("Authorization"),
+                "content": json.loads(body.decode("utf-8") or "{}"),
+            })
+            payload = {"event_id": f"$project-file-event-{len(matrix['events'])}"}
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(payload).encode("utf-8"))
+
+    class MatrixServer(socketserver.ThreadingTCPServer):
+        allow_reuse_address = True
+        daemon_threads = True
+
+    matrix_server = MatrixServer(("127.0.0.1", 0), MatrixHandler)
+    matrix_thread = threading.Thread(target=matrix_server.serve_forever, daemon=True)
+    matrix_thread.start()
+    matrix_port = matrix_server.server_address[1]
+    os.environ["AGENTTEAMS_MATRIX_URL"] = f"http://127.0.0.1:{matrix_port}"
+    os.environ["AGENTTEAMS_WORKER_MATRIX_TOKEN"] = "test-token"
+    context_file = pathlib.Path("#{root}") / "matrix-context.json"
+    os.environ["TEAMHARNESS_MATRIX_CONTEXT_FILE"] = str(context_file)
+
+    def tool_payload(name, args):
         merged = dict(common)
         merged.update(args)
-        result = call_tool("projectflow", merged)
+        result = call_tool(name, merged)
         return json.loads(result["content"][0]["text"])
+
+    def payload(args):
+        return tool_payload("projectflow", args)
 
     generated = payload({
         "action": "create_project",
@@ -101,6 +180,241 @@ Dir.mktmpdir("teamharness-projectflow-") do |dir|
     }
     if created["project"].get("reply_route") != expected_reply_route:
         raise AssertionError(f"reply route mismatch: {created!r}")
+    if created["project"].get("source_room_id") != "aaaaaaaa":
+        raise AssertionError(f"source room id should come from reply route target session: {created!r}")
+
+    matrix_dm_created = payload({
+        "action": "create_project",
+        "payload": {
+            "projectId": "matrix-dm-project",
+            "title": "Matrix DM Project",
+            "source": "matrix",
+            "requester": "@admin:example.test",
+            "replyRoute": {
+                "channel": "matrix",
+                "targetUser": "@admin:example.test",
+                "targetSession": "!dm-room:example.test",
+            },
+        },
+    })
+    if not matrix_dm_created.get("ok"):
+        raise AssertionError(f"matrix DM create_project failed: {matrix_dm_created!r}")
+    expected_matrix_dm_route = {
+        "channel": "matrix",
+        "target_user": "@admin:example.test",
+        "target_session": "!dm-room:example.test",
+    }
+    if matrix_dm_created["project"].get("reply_route") != expected_matrix_dm_route:
+        raise AssertionError(f"matrix DM reply route mismatch: {matrix_dm_created!r}")
+    if matrix_dm_created["project"].get("source_room_id") != "!dm-room:example.test":
+        raise AssertionError(f"matrix DM source room id should come from reply route target session: {matrix_dm_created!r}")
+    resolved_matrix_dm = payload({
+        "action": "resolve_project",
+        "payload": {"projectId": "matrix-dm-project"},
+    })
+    if resolved_matrix_dm.get("replyRoute") != expected_matrix_dm_route:
+        raise AssertionError(f"resolve_project lost matrix DM reply route: {resolved_matrix_dm!r}")
+    if resolved_matrix_dm.get("sourceRoomId") != "!dm-room:example.test":
+        raise AssertionError(f"resolve_project lost matrix DM sourceRoomId: {resolved_matrix_dm!r}")
+
+    matrix_plan = payload({
+        "action": "plan_dag",
+        "payload": {
+            "projectId": "matrix-dm-project",
+            "tasks": [{
+                "taskId": "matrix-dm-project-01",
+                "title": "Write project report",
+                "assignedTo": "@worker-a:example.test",
+                "dependsOn": [],
+            }],
+        },
+    })
+    if not matrix_plan.get("ok"):
+        raise AssertionError(f"matrix project plan_dag failed: {matrix_plan!r}")
+    project_result_path = pathlib.Path("#{workspace}") / "shared/projects/matrix-dm-project/result.md"
+    project_result_path.parent.mkdir(parents=True, exist_ok=True)
+    project_result_path.write_text("# Matrix DM Project Result\\n\\nReady for requester.\\n", encoding="utf-8")
+    matrix_accepted = payload({
+        "action": "accept_task_result",
+        "payload": {
+            "projectId": "matrix-dm-project",
+            "taskId": "matrix-dm-project-01",
+            "resultStatus": "SUCCESS",
+            "summary": "Project report accepted.",
+            "parentEventId": "$project-parent",
+            "publishArtifacts": True,
+        },
+    })
+    if not matrix_accepted.get("ok"):
+        raise AssertionError(f"matrix accept_task_result failed: {matrix_accepted!r}")
+    matrix_artifacts = matrix_accepted.get("publishedArtifacts") or []
+    if len(matrix_artifacts) != 1 or matrix_artifacts[0].get("status") != "published":
+        raise AssertionError(f"project result was not published: {matrix_accepted!r}")
+    project_artifact = matrix_artifacts[0]
+    if project_artifact.get("filename") != "matrix-dm-project-project-result.md":
+        raise AssertionError(f"project artifact filename mismatch: {project_artifact!r}")
+    if project_artifact.get("sourcePath") != "shared/projects/matrix-dm-project/result.md":
+        raise AssertionError(f"project artifact source mismatch: {project_artifact!r}")
+    if not project_artifact.get("mxcUri") or not project_artifact.get("eventId"):
+        raise AssertionError(f"project artifact missing Matrix references: {project_artifact!r}")
+    if project_artifact.get("parentEventId") != "$project-parent":
+        raise AssertionError(f"project artifact missing parent event reference: {project_artifact!r}")
+    if not matrix["uploads"] or matrix["uploads"][-1].get("filename") != "matrix-dm-project-project-result.md":
+        raise AssertionError(f"project result upload missing: {matrix['uploads']!r}")
+    project_file_event = matrix["events"][-1]["content"]
+    if project_file_event.get("msgtype") != "m.file" or project_file_event.get("body") != "matrix-dm-project-project-result.md":
+        raise AssertionError(f"project result event mismatch: {project_file_event!r}")
+    if project_file_event.get("m.relates_to") != {"rel_type": "com.agentteams.attachment", "event_id": "$project-parent"}:
+        raise AssertionError(f"project result event missing attachment relation: {project_file_event!r}")
+    if not project_file_event.get("url") or not (project_file_event.get("info") or {}).get("size"):
+        raise AssertionError(f"project result event missing file metadata: {project_file_event!r}")
+
+    context_project = payload({
+        "action": "create_project",
+        "payload": {
+            "projectId": "matrix-context-project",
+            "title": "Matrix Context Project",
+            "source": "matrix",
+            "requester": "@admin:example.test",
+            "replyRoute": {
+                "channel": "matrix",
+                "targetUser": "@admin:example.test",
+                "targetSession": "!dm-room:example.test",
+            },
+        },
+    })
+    if not context_project.get("ok"):
+        raise AssertionError(f"context create_project failed: {context_project!r}")
+    context_plan = payload({
+        "action": "plan_dag",
+        "payload": {
+            "projectId": "matrix-context-project",
+            "tasks": [{
+                "taskId": "matrix-context-project-01",
+                "title": "Write context project report",
+                "assignedTo": "@worker-a:example.test",
+                "dependsOn": [],
+            }],
+        },
+    })
+    if not context_plan.get("ok"):
+        raise AssertionError(f"context plan_dag failed: {context_plan!r}")
+    context_result_path = pathlib.Path("#{workspace}") / "shared/projects/matrix-context-project/result.md"
+    context_result_path.parent.mkdir(parents=True, exist_ok=True)
+    context_result_path.write_text("# Matrix Context Project Result\\n\\nReady.\\n", encoding="utf-8")
+    context_file.write_text(json.dumps({
+        "rooms": {
+            "!dm-room:example.test": {
+                "attachmentParentEventId": "$context-project-parent",
+                "updatedAt": time.time(),
+            }
+        }
+    }), encoding="utf-8")
+    context_accepted = payload({
+        "action": "accept_task_result",
+        "payload": {
+            "projectId": "matrix-context-project",
+            "taskId": "matrix-context-project-01",
+            "resultStatus": "SUCCESS",
+            "summary": "Project report accepted using Matrix context parent.",
+            "publishArtifacts": True,
+        },
+    })
+    if not context_accepted.get("ok"):
+        raise AssertionError(f"context accept_task_result failed: {context_accepted!r}")
+    context_artifacts = context_accepted.get("publishedArtifacts") or []
+    if len(context_artifacts) != 1 or context_artifacts[0].get("status") != "published":
+        raise AssertionError(f"context project result was not published: {context_accepted!r}")
+    if context_artifacts[0].get("parentEventId") != "$context-project-parent":
+        raise AssertionError(f"context project result did not infer parent event: {context_accepted!r}")
+    context_project_file_event = matrix["events"][-1]["content"]
+    if context_project_file_event.get("m.relates_to") != {"rel_type": "com.agentteams.attachment", "event_id": "$context-project-parent"}:
+        raise AssertionError(f"context project result event missing attachment relation: {context_project_file_event!r}")
+
+    deferred_project = payload({
+        "action": "create_project",
+        "payload": {
+            "projectId": "deferred-report-project",
+            "title": "Deferred Report Project",
+            "source": "matrix",
+            "requester": "@admin:example.test",
+            "replyRoute": {
+                "channel": "matrix",
+                "targetUser": "@admin:example.test",
+                "targetSession": "!dm-room:example.test",
+            },
+        },
+    })
+    if not deferred_project.get("ok"):
+        raise AssertionError(f"deferred create_project failed: {deferred_project!r}")
+    deferred_plan = payload({
+        "action": "plan_dag",
+        "payload": {
+            "projectId": "deferred-report-project",
+            "tasks": [{
+                "taskId": "deferred-report-project-01",
+                "title": "Write deferred report",
+                "assignedTo": "@worker-a:example.test",
+                "dependsOn": [],
+            }],
+        },
+    })
+    if not deferred_plan.get("ok"):
+        raise AssertionError(f"deferred plan_dag failed: {deferred_plan!r}")
+    deferred_result_path = pathlib.Path("#{workspace}") / "shared/projects/deferred-report-project/result.md"
+    deferred_result_path.parent.mkdir(parents=True, exist_ok=True)
+    deferred_result_path.write_text("# Deferred Project Result\\n\\nPublish after report.\\n", encoding="utf-8")
+    uploads_before_deferred_accept = len(matrix["uploads"])
+    deferred_accepted = payload({
+        "action": "accept_task_result",
+        "payload": {
+            "projectId": "deferred-report-project",
+            "taskId": "deferred-report-project-01",
+            "resultStatus": "SUCCESS",
+            "summary": "Project report accepted but artifact publish is deferred.",
+        },
+    })
+    if not deferred_accepted.get("ok"):
+        raise AssertionError(f"deferred accept_task_result failed: {deferred_accepted!r}")
+    if deferred_accepted.get("publishedArtifacts") != []:
+        raise AssertionError(f"deferred accept should not publish artifacts: {deferred_accepted!r}")
+    if len(matrix["uploads"]) != uploads_before_deferred_accept:
+        raise AssertionError(f"deferred accept uploaded project artifact unexpectedly: {matrix['uploads']!r}")
+
+    uploads_before_complete = len(matrix["uploads"])
+    matrix_completed = payload({
+        "action": "complete_project",
+        "payload": {"projectId": "matrix-dm-project"},
+    })
+    if not matrix_completed.get("ok"):
+        raise AssertionError(f"matrix complete_project failed: {matrix_completed!r}")
+    if matrix_completed.get("publishedArtifacts"):
+        raise AssertionError(f"complete_project should not publish project artifacts by default: {matrix_completed!r}")
+    if len(matrix["uploads"]) != uploads_before_complete:
+        raise AssertionError(f"complete_project uploaded project artifact unexpectedly: {matrix['uploads']!r}")
+
+    report = tool_payload("message", {
+        "action": "send",
+        "replyRoute": expected_matrix_dm_route,
+        "text": "Matrix DM Project is complete.",
+    })
+    if not report.get("ok") or not report.get("messageId"):
+        raise AssertionError(f"requester report send failed: {report!r}")
+    report_artifact = tool_payload("artifact", {
+        "action": "publish_file",
+        "path": "shared/projects/matrix-dm-project/result.md",
+        "filename": "matrix-dm-project-project-result.md",
+        "replyRoute": expected_matrix_dm_route,
+        "parentEventId": report["messageId"],
+    })
+    if not report_artifact.get("ok"):
+        raise AssertionError(f"report artifact publish failed: {report_artifact!r}")
+    artifact_payload = report_artifact.get("artifact") or {}
+    if artifact_payload.get("parentEventId") != report["messageId"]:
+        raise AssertionError(f"report artifact parent should be report message id: {report_artifact!r}")
+    report_file_event = matrix["events"][-1]["content"]
+    if report_file_event.get("m.relates_to") != {"rel_type": "com.agentteams.attachment", "event_id": report["messageId"]}:
+        raise AssertionError(f"report artifact Matrix relation mismatch: {report_file_event!r}")
 
     duplicate_explicit = payload({
         "action": "create_project",
@@ -151,6 +465,10 @@ Dir.mktmpdir("teamharness-projectflow-") do |dir|
     quick_meta = json.loads(quick_meta_path.read_text(encoding="utf-8"))
     if quick_meta.get("room_id") != "!team:example.test" or quick_meta.get("project_id") != quick_project["project_id"]:
         raise AssertionError(f"quick task meta mismatch: {quick_meta!r}")
+    if quick_meta.get("task_title") != "Write Readiness Note":
+        raise AssertionError(f"quick task meta missing console task_title: {quick_meta!r}")
+    if quick_meta.get("assigned_to") != "@worker-a:example.test" or not quick_meta.get("assigned_at"):
+        raise AssertionError(f"quick task meta missing console assignment fields: {quick_meta!r}")
 
     external_quick = payload({
         "action": "create_quick_project",
@@ -180,6 +498,14 @@ Dir.mktmpdir("teamharness-projectflow-") do |dir|
     })
     if not external_quick_ok.get("ok") or external_quick_ok["task"].get("room_id") != "room:!task-room:example.test":
         raise AssertionError(f"external quick project with dedicated room failed: {external_quick_ok!r}")
+    resolved_external_quick = payload({
+        "action": "resolve_project",
+        "payload": {"taskId": external_quick_ok["task"]["task_id"]},
+    })
+    if resolved_external_quick.get("replyRoute") != external_quick_ok["project"].get("reply_route"):
+        raise AssertionError(f"resolve_project lost external quick reply route: {resolved_external_quick!r}")
+    if resolved_external_quick.get("sourceRoomId") != "cccccccc":
+        raise AssertionError(f"resolve_project lost external quick sourceRoomId: {resolved_external_quick!r}")
 
     resolved_quick = payload({
         "action": "resolve_project",
@@ -225,6 +551,26 @@ Dir.mktmpdir("teamharness-projectflow-") do |dir|
     if created_from_requester["project"].get("reply_route") != expected_legacy_route:
         raise AssertionError(f"legacy requester reply route mismatch: {created_from_requester!r}")
 
+    created_from_matrix_requester = payload({
+        "action": "create_project",
+        "payload": {
+            "projectId": "legacy-matrix-requester",
+            "title": "Legacy Matrix Requester",
+            "source": "matrix",
+            "requester": "matrix:!legacy-dm:example.test",
+        },
+    })
+    if not created_from_matrix_requester.get("ok"):
+        raise AssertionError(f"create_project with matrix requester failed: {created_from_matrix_requester!r}")
+    expected_legacy_matrix_route = {
+        "channel": "matrix",
+        "target_session": "!legacy-dm:example.test",
+    }
+    if created_from_matrix_requester["project"].get("reply_route") != expected_legacy_matrix_route:
+        raise AssertionError(f"legacy matrix requester reply route mismatch: {created_from_matrix_requester!r}")
+    if created_from_matrix_requester["project"].get("source_room_id") != "!legacy-dm:example.test":
+        raise AssertionError(f"legacy matrix requester sourceRoomId mismatch: {created_from_matrix_requester!r}")
+
     planned = payload({
         "action": "plan_dag",
         "payload": {
@@ -250,6 +596,51 @@ Dir.mktmpdir("teamharness-projectflow-") do |dir|
     ready = [task["task_id"] for task in planned.get("readyNodes", [])]
     if ready != ["t-001"]:
         raise AssertionError(f"unexpected ready nodes: {planned!r}")
+
+    no_room_created = payload({
+        "action": "create_project",
+        "payload": {
+            "projectId": "no-room-project",
+            "title": "No Room Project",
+            "replyRoute": {
+                "channel": "dingtalk",
+                "targetUser": "sender_009",
+                "targetSession": "dddddddd",
+            },
+        },
+    })
+    if not no_room_created.get("ok"):
+        raise AssertionError(f"no-room create_project failed: {no_room_created!r}")
+    no_room_planned = payload({
+        "action": "plan_dag",
+        "payload": {
+            "projectId": "no-room-project",
+            "tasks": [{
+                "taskId": "no-room-project-01",
+                "title": "No room task",
+                "assignedTo": "@worker-a:example.test",
+                "dependsOn": [],
+            }],
+        },
+    })
+    if not no_room_planned.get("ok"):
+        raise AssertionError(f"no-room plan_dag failed: {no_room_planned!r}")
+    no_room_result_path = pathlib.Path("#{workspace}") / "shared/projects/no-room-project/result.md"
+    no_room_result_path.write_text("# Daily Plan Result\\n\\nNo Matrix route.\\n", encoding="utf-8")
+    no_room_accepted = payload({
+        "action": "accept_task_result",
+        "payload": {
+            "projectId": "no-room-project",
+            "taskId": "no-room-project-01",
+            "resultStatus": "SUCCESS",
+            "summary": "No Matrix room should skip artifact publish.",
+        },
+    })
+    if not no_room_accepted.get("ok"):
+        raise AssertionError(f"no-room accept_task_result failed: {no_room_accepted!r}")
+    skipped_artifacts = no_room_accepted.get("publishedArtifacts") or []
+    if skipped_artifacts:
+        raise AssertionError(f"accept_task_result should not publish project artifacts by default: {no_room_accepted!r}")
 
     checked = payload({
         "action": "ready_nodes",
@@ -428,11 +819,15 @@ Dir.mktmpdir("teamharness-projectflow-") do |dir|
     if "Plan Type: `loop`" not in loop_plan_text or "Fix until tests pass" not in loop_plan_text:
         raise AssertionError(f"loop plan text missing details: {loop_plan_text!r}")
 
+    matrix_server.shutdown()
+    matrix_server.server_close()
+
     print(json.dumps({
         "ok": True,
         "project": created["project"]["project_id"],
         "ready": ready,
         "loopReady": loop_ready,
+        "publishedProjectArtifact": project_artifact["filename"],
         "planPath": str(plan_path),
     }, ensure_ascii=False))
   PY

--- a/plugins/tests/teamharness/mcp/tools/test-protocol.rb
+++ b/plugins/tests/teamharness/mcp/tools/test-protocol.rb
@@ -47,15 +47,16 @@ fail!("tools/list response id mismatch: #{tools_response.inspect}") unless tools
 
 tools = tools_response.dig("result", "tools") || []
 tool_names = tools.map { |tool| tool["name"] }
-expected = %w[health message roomflow filesync projectflow taskflow]
+expected = %w[health message roomflow filesync artifact projectflow taskflow]
 fail!("unexpected tools: #{tool_names.inspect}") unless tool_names == expected
 
 tool_by_name = tools.to_h { |tool| [tool["name"], tool] }
 expected_keywords = {
   "health" => ["MCP server", "not runtime worker health"],
-  "message" => ["cross-room", "cross-channel", "cross-session", "current room/session"],
+  "message" => ["cross-room", "cross-channel", "cross-session", "current room/session", "PROJECT_REQUESTED", "self-trigger", "requester/source"],
   "roomflow" => ["task rooms", "execution-channel", "not requester reply channels"],
-  "filesync" => ["shared/projects", "shared/tasks", "not periodic workspace sync"],
+  "filesync" => ["shared/", "global-shared", "not periodic workspace sync"],
+  "artifact" => ["workspace file", "Matrix room", "m.file"],
   "projectflow" => ["Project Work", "DAG", "Loop", "ordinary direct replies"],
   "taskflow" => ["leader delegates", "worker", "ordinary conversation"]
 }
@@ -71,6 +72,21 @@ expected_keywords.each do |name, keywords|
   fail!("missing object input schema for #{name}: #{tool.inspect}") unless schema.is_a?(Hash) && schema["type"] == "object"
   fail!("missing schema properties for #{name}: #{schema.inspect}") unless schema["properties"].is_a?(Hash)
 end
+
+message_schema = tool_by_name.fetch("message").fetch("inputSchema")
+message_properties = message_schema.fetch("properties")
+fail!("message schema must expose sender for trigger routing") unless message_properties.key?("sender")
+fail!("message schema must expose agentId for same-agent routing") unless message_properties.key?("agentId")
+fail!("message schema must expose top-level type alias") unless message_properties.key?("type")
+sender_schema = JSON.generate(message_properties.fetch("sender"))
+agent_id_schema = JSON.generate(message_properties.fetch("agentId"))
+fail!("message schema sender.agent must require a full Matrix user id") unless sender_schema.include?("Matrix user id") && sender_schema.include?("@leader:matrix.local")
+fail!("message schema agentId must require a full Matrix user id") unless agent_id_schema.include?("Matrix user id") && agent_id_schema.include?("@leader:matrix.local")
+fail!("message schema must reject role/workspace trigger identities") unless sender_schema.include?("role name") && sender_schema.include?("default") && agent_id_schema.include?("role names") && agent_id_schema.include?("default")
+target_schema = JSON.generate(message_properties.fetch("target"))
+fail!("message schema target must use Matrix room string payloads") unless target_schema.include?("room:!room:domain") && target_schema.include?("string")
+fail!("message schema message must support typed trigger payloads") unless JSON.generate(message_properties.fetch("message")).include?("PROJECT_REQUESTED")
+fail!("message schema must document PROJECT_REQUESTED") unless JSON.generate(message_schema).include?("PROJECT_REQUESTED")
 
 puts JSON.pretty_generate(
   "ok" => true,

--- a/plugins/tests/teamharness/mcp/tools/test-roomflow.rb
+++ b/plugins/tests/teamharness/mcp/tools/test-roomflow.rb
@@ -30,10 +30,30 @@ Dir.mktmpdir("teamharness-roomflow-") do |dir|
     runtime_config = pathlib.Path("#{dir}") / "runtime.yaml"
     runtime_config.write_text(json.dumps({
         "team": {
+            "name": "demo-team",
             "admin": {
                 "name": "admin",
                 "matrixUserId": "@runtime-admin:example.test",
             },
+            "members": [
+                {
+                    "name": "leader",
+                    "runtimeName": "leader-runtime",
+                    "role": "team_leader",
+                    "matrixUserId": "@leader-runtime:example.test",
+                },
+                {
+                    "name": "worker",
+                    "runtimeName": "worker-runtime",
+                    "role": "worker",
+                    "matrixUserId": "@worker:example.test",
+                },
+                {
+                    "name": "human-coord",
+                    "role": "coordinator",
+                    "matrixUserId": "@human:example.test",
+                },
+            ],
         },
     }), encoding="utf-8")
     runtime_config_without_admin = pathlib.Path("#{dir}") / "runtime-without-admin.yaml"
@@ -42,7 +62,7 @@ Dir.mktmpdir("teamharness-roomflow-") do |dir|
         "team": {"leaderDmRoomId": "!leader-dm:example.test"},
     }), encoding="utf-8")
 
-    captured = {"posts": [], "gets": []}
+    captured = {"posts": [], "gets": [], "puts": []}
 
     class Handler(http.server.BaseHTTPRequestHandler):
         def do_POST(self):
@@ -58,6 +78,27 @@ Dir.mktmpdir("teamharness-roomflow-") do |dir|
                 payload = json.dumps({"room_id": "!created:example.test"}).encode("utf-8")
             elif self.path == "/_matrix/client/v3/rooms/%21created%3Aexample.test/leave":
                 payload = b"{}"
+            else:
+                self.send_response(404)
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def do_PUT(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            raw = self.rfile.read(length).decode("utf-8")
+            body = json.loads(raw or "{}")
+            captured["puts"].append({
+                "path": self.path,
+                "auth": self.headers.get("Authorization"),
+                "body": body,
+            })
+            if self.path == "/_matrix/client/v3/rooms/%21created%3Aexample.test/state/room.meta/":
+                payload = json.dumps({"event_id": "$room-meta"}).encode("utf-8")
             else:
                 self.send_response(404)
                 self.end_headers()
@@ -85,6 +126,12 @@ Dir.mktmpdir("teamharness-roomflow-") do |dir|
                 ]}).encode("utf-8")
             elif self.path == "/_matrix/client/v3/joined_rooms":
                 payload = json.dumps({"joined_rooms": ["!created:example.test"]}).encode("utf-8")
+            elif self.path == "/_matrix/client/v3/rooms/%21created%3Aexample.test/state/m.room.name":
+                payload = json.dumps({"name": "TASK：Project-Top5-Script"}).encode("utf-8")
+            elif self.path == "/_matrix/client/v3/rooms/%21created%3Aexample.test/state/m.room.topic":
+                payload = json.dumps({"topic": "Task room for top5-script"}).encode("utf-8")
+            elif self.path == "/_matrix/client/v3/user/%40leader%3Aexample.test/rooms/%21created%3Aexample.test/tags":
+                payload = json.dumps({"tags": {"teamharness.project_task": {"order": 0.5}}}).encode("utf-8")
             else:
                 self.send_response(404)
                 self.end_headers()
@@ -109,7 +156,7 @@ Dir.mktmpdir("teamharness-roomflow-") do |dir|
     dry = payload({
         "action": "create_task_room",
         "taskId": "demo-project-001",
-        "name": "Task: demo",
+        "name": "demo",
         "source": "matrix",
         "invite": ["@worker:example.test"],
         "admin": "@admin:example.test",
@@ -117,6 +164,8 @@ Dir.mktmpdir("teamharness-roomflow-") do |dir|
     })
     if not dry.get("ok") or not dry.get("dryRun"):
         raise AssertionError(f"dry create failed: {dry!r}")
+    if dry.get("name") != "TASK：demo-project-001" or dry["content"].get("name") != "TASK：demo-project-001":
+        raise AssertionError(f"dry room name was not normalized: {dry!r}")
     if dry.get("invite") != ["@worker:example.test", "@admin:example.test"]:
         raise AssertionError(f"invite list mismatch: {dry!r}")
     if dry["content"].get("power_level_content_override", {}).get("users", {}).get("@admin:example.test") != 100:
@@ -146,16 +195,17 @@ Dir.mktmpdir("teamharness-roomflow-") do |dir|
     if invalid.get("ok") is not False or "safe id" not in invalid.get("error", ""):
         raise AssertionError(f"unsafe task id was not rejected: {invalid!r}")
 
-    os.environ["HICLAW_MATRIX_URL"] = f"http://127.0.0.1:{server.server_address[1]}"
-    os.environ["HICLAW_WORKER_MATRIX_TOKEN"] = "test-token"
-    os.environ["HICLAW_MATRIX_USER_ID"] = "@leader:example.test"
+    os.environ["AGENTTEAMS_MATRIX_URL"] = f"http://127.0.0.1:{server.server_address[1]}"
+    os.environ["AGENTTEAMS_WORKER_MATRIX_TOKEN"] = "test-token"
+    os.environ["AGENTTEAMS_MATRIX_USER_ID"] = "@leader:example.test"
+    os.environ["TEAMHARNESS_RUNTIME_CONFIG"] = str(runtime_config)
 
     created = payload({
         "action": "create_task_room",
         "taskId": "demo-project-001",
         "name": "Task: demo",
         "source": "matrix",
-        "invite": "@worker:example.test",
+        "invite": ["@worker:example.test", "@human:example.test"],
     })
     if not created.get("ok") or created.get("roomId") != "!created:example.test":
         raise AssertionError(f"create failed: {created!r}")
@@ -164,10 +214,24 @@ Dir.mktmpdir("teamharness-roomflow-") do |dir|
     create_call = captured["posts"][0]
     if create_call.get("auth") != "Bearer test-token":
         raise AssertionError(f"auth mismatch: {captured!r}")
-    if create_call["body"].get("name") != "Task: demo":
+    if create_call["body"].get("name") != "TASK：demo-project-001":
         raise AssertionError(f"room name mismatch: {captured!r}")
-    if create_call["body"].get("invite") != ["@worker:example.test"]:
+    if create_call["body"].get("invite") != ["@worker:example.test", "@human:example.test", "@runtime-admin:example.test"]:
         raise AssertionError(f"real invite mismatch: {captured!r}")
+    room_meta_calls = [put for put in captured["puts"] if put["path"] == "/_matrix/client/v3/rooms/%21created%3Aexample.test/state/room.meta/"]
+    if len(room_meta_calls) != 1:
+        raise AssertionError(f"room.meta should be written after room creation: {captured!r}")
+    room_meta = room_meta_calls[-1]["body"]
+    if room_meta.get("roomKind") != "task_room" or room_meta.get("teamName") != "demo-team":
+        raise AssertionError(f"room meta base mismatch: {room_meta!r}")
+    if room_meta.get("teamAdmin") != {"userId": "@runtime-admin:example.test", "name": "admin"}:
+        raise AssertionError(f"room meta admin mismatch: {room_meta!r}")
+    if room_meta.get("leaderWorker") != {"userId": "@leader-runtime:example.test", "workerName": "leader"}:
+        raise AssertionError(f"room meta leader mismatch: {room_meta!r}")
+    if room_meta.get("workerMembers") != [{"userId": "@worker:example.test", "workerName": "worker"}]:
+        raise AssertionError(f"room meta worker members mismatch: {room_meta!r}")
+    if room_meta.get("humanMembers") != [{"userId": "@human:example.test", "name": "human-coord"}]:
+        raise AssertionError(f"room meta human members mismatch: {room_meta!r}")
 
     listed = payload({"action": "list_rooms"})
     if not listed.get("ok") or listed.get("rooms") != ["!created:example.test"]:
@@ -175,39 +239,49 @@ Dir.mktmpdir("teamharness-roomflow-") do |dir|
     if captured["gets"][0].get("auth") != "Bearer test-token":
         raise AssertionError(f"list auth mismatch: {captured!r}")
 
-    missing_source_room = payload({
-        "action": "create_task_room",
-        "taskId": "demo-project-004",
-        "name": "Task: missing external source room",
-        "source": "dingtalk",
-        "invite": ["@worker:example.test"],
-        "workspaceDir": "#{dir}",
-        "dryRun": True,
+    described = payload({
+        "action": "describe_room",
+        "sessionId": "matrix:!created:example.test",
     })
-    if missing_source_room.get("ok") is not False or "sourceRoomId is required" not in missing_source_room.get("error", ""):
-        raise AssertionError(f"missing sourceRoomId was not rejected: {missing_source_room!r}")
+    if not described.get("ok") or described.get("roomId") != "!created:example.test":
+        raise AssertionError(f"describe_room failed: {described!r}")
+    if described.get("sessionId") != "matrix:!created:example.test":
+        raise AssertionError(f"describe_room session mismatch: {described!r}")
+    if described.get("name") != "TASK：Project-Top5-Script" or described.get("topic") != "Task room for top5-script":
+        raise AssertionError(f"describe_room Matrix state mismatch: {described!r}")
+    if "teamharness.project_task" not in described.get("tags", {}):
+        raise AssertionError(f"describe_room tags mismatch: {described!r}")
 
+    project_created_posts = len([post for post in captured["posts"] if post["path"] == "/_matrix/client/v3/createRoom"])
     external_created = payload({
         "action": "create_task_room",
-        "taskId": "demo-project-005",
+        "projectId": "demo-project-005",
         "name": "Task: external source room",
         "source": "dingtalk",
         "sourceRoomId": "ding-room-001",
+        "sender": "sender_default_001",
         "invite": ["@worker:example.test"],
         "admin": "@admin:example.test",
         "workspaceDir": "#{dir}",
     })
     if not external_created.get("ok") or external_created.get("roomId") != "!created:example.test":
         raise AssertionError(f"external create failed: {external_created!r}")
-    if external_created.get("sourceRoomKey") != "dingtalk:ding-room-001":
-        raise AssertionError(f"source room key mismatch: {external_created!r}")
+    if external_created.get("projectRoomKey") != "project:demo-project-005":
+        raise AssertionError(f"project room key mismatch: {external_created!r}")
+    if "roomBindingScope" in external_created:
+        raise AssertionError(f"deprecated roomBindingScope leaked into project-scoped roomflow result: {external_created!r}")
+    if external_created.get("sourceRoomId") != "ding-room-001" or external_created.get("sender") != "sender_default_001":
+        raise AssertionError(f"external metadata mismatch: {external_created!r}")
     create_posts = len([post for post in captured["posts"] if post["path"] == "/_matrix/client/v3/createRoom"])
+    if create_posts != project_created_posts + 1:
+        raise AssertionError(f"external project create count mismatch: {captured!r}")
     external_reused = payload({
         "action": "create_task_room",
-        "taskId": "demo-project-006",
-        "name": "Task: external source room again",
+        "projectId": "demo-project-005",
+        "name": "Task: same project external source room again",
         "source": "dingtalk",
         "sourceRoomId": "ding-room-001",
+        "sender": "sender_default_001",
         "invite": ["@worker:example.test"],
         "admin": "@admin:example.test",
         "workspaceDir": "#{dir}",
@@ -216,11 +290,29 @@ Dir.mktmpdir("teamharness-roomflow-") do |dir|
         raise AssertionError(f"external room was not reused: {external_reused!r}")
     create_posts_after_reuse = len([post for post in captured["posts"] if post["path"] == "/_matrix/client/v3/createRoom"])
     if create_posts_after_reuse != create_posts:
-        raise AssertionError(f"external reuse created a new room: {captured!r}")
+        raise AssertionError(f"same project reuse created a new room: {captured!r}")
+    if len([put for put in captured["puts"] if put["path"] == "/_matrix/client/v3/rooms/%21created%3Aexample.test/state/room.meta/"]) < 3:
+        raise AssertionError(f"room.meta should be refreshed when reusing a room: {captured!r}")
+    external_same_sender_new_project = payload({
+        "action": "create_task_room",
+        "projectId": "demo-project-006",
+        "name": "Task: same source sender different project",
+        "source": "dingtalk",
+        "sourceRoomId": "ding-room-001",
+        "sender": "sender_default_001",
+        "invite": ["@worker:example.test"],
+        "admin": "@admin:example.test",
+        "workspaceDir": "#{dir}",
+    })
+    if not external_same_sender_new_project.get("ok") or external_same_sender_new_project.get("reused"):
+        raise AssertionError(f"same source sender but different project should create a separate task room: {external_same_sender_new_project!r}")
+    same_sender_new_project_posts = len([post for post in captured["posts"] if post["path"] == "/_matrix/client/v3/createRoom"])
+    if same_sender_new_project_posts != create_posts_after_reuse + 1:
+        raise AssertionError(f"different project did not create a new room: {captured!r}")
 
     os.environ["TEAMHARNESS_RUNTIME_CONFIG"] = str(runtime_config_without_admin)
-    saved_matrix_user_id = os.environ.pop("HICLAW_MATRIX_USER_ID", None)
-    saved_worker_name = os.environ.pop("HICLAW_WORKER_NAME", None)
+    saved_matrix_user_id = os.environ.pop("AGENTTEAMS_MATRIX_USER_ID", None)
+    saved_worker_name = os.environ.pop("AGENTTEAMS_WORKER_NAME", None)
     dry_leader_dm_admin = payload({
         "action": "create_task_room",
         "taskId": "demo-project-003",
@@ -230,9 +322,9 @@ Dir.mktmpdir("teamharness-roomflow-") do |dir|
         "dryRun": True,
     })
     if saved_matrix_user_id is not None:
-        os.environ["HICLAW_MATRIX_USER_ID"] = saved_matrix_user_id
+        os.environ["AGENTTEAMS_MATRIX_USER_ID"] = saved_matrix_user_id
     if saved_worker_name is not None:
-        os.environ["HICLAW_WORKER_NAME"] = saved_worker_name
+        os.environ["AGENTTEAMS_WORKER_NAME"] = saved_worker_name
     if dry_leader_dm_admin.get("invite") != ["@worker:example.test", "@team-admin:example.test"]:
         raise AssertionError(f"leader DM admin was not auto-invited: {dry_leader_dm_admin!r}")
     if dry_leader_dm_admin["content"].get("power_level_content_override", {}).get("users", {}).get("@leader:example.test") != 100:

--- a/plugins/tests/teamharness/mcp/tools/test-taskflow.rb
+++ b/plugins/tests/teamharness/mcp/tools/test-taskflow.rb
@@ -22,11 +22,14 @@ Dir.mktmpdir("teamharness-taskflow-") do |dir|
   log_path = root / "mc.log"
   remote_task.mkpath
   (remote_task / "meta.json").write(JSON.pretty_generate(
-    "task_id" => "remote-001",
-    "project_id" => project_id = "remote-project",
-    "room_id" => "room:!team:example.test",
+    "taskId" => "remote-001",
+    "projectId" => project_id = "remote-project",
+    "roomId" => "room:!team:example.test",
     "status" => "assigned",
-    "spec_path" => "shared/tasks/remote-001/spec.md"
+    "specPath" => "shared/tasks/remote-001/spec.md",
+    "taskTitle" => "Remote task",
+    "assignedTo" => "@worker-remote:example.test",
+    "createdAt" => "2026-06-26T07:00:00Z"
   ))
   (remote_task / "spec.md").write("Remote task spec\n")
   bin_dir.mkpath
@@ -42,16 +45,32 @@ Dir.mktmpdir("teamharness-taskflow-") do |dir|
 
   python_test = <<~PY
     import builtins
+    import http.server
     import json
     import os
     import pathlib
+    import socketserver
     import sys
+    import threading
+    import time
+    import urllib.parse
 
     sys.path.insert(0, str(pathlib.Path("#{mcp_dir}")))
     from server import call_tool
 
+    workspace = pathlib.Path("#{workspace}")
+    real_shared = pathlib.Path("#{root}") / "real-shared"
+    workspace.mkdir(parents=True, exist_ok=True)
+    real_shared.mkdir(parents=True, exist_ok=True)
+    (workspace / "shared").symlink_to(
+        os.path.relpath(real_shared, workspace),
+        target_is_directory=True,
+    )
+    os.environ["AGENTTEAMS_SHARED_DIR"] = str(real_shared)
+    os.environ["TEAMHARNESS_SHARED_DIR"] = str(real_shared)
+
     common = {
-        "workspaceDir": "#{workspace}",
+        "workspaceDir": str(workspace),
         "storage": {
             "sharedPrefix": "mock/shared",
             "globalSharedPrefix": "mock/global-shared",
@@ -63,6 +82,66 @@ Dir.mktmpdir("teamharness-taskflow-") do |dir|
         encoding="utf-8",
     )
     os.environ["TEAMHARNESS_RUNTIME_CONFIG"] = str(runtime_config)
+
+    matrix = {"uploads": [], "events": []}
+
+    class MatrixHandler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, format, *args):
+            return
+
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length)
+            parsed = urllib.parse.urlparse(self.path)
+            if parsed.path != "/_matrix/media/v3/upload":
+                self.send_response(404)
+                self.end_headers()
+                return
+            query = urllib.parse.parse_qs(parsed.query)
+            filename = query.get("filename", ["artifact"])[0]
+            matrix["uploads"].append({
+                "filename": filename,
+                "body": body.decode("utf-8", errors="replace"),
+                "auth": self.headers.get("Authorization"),
+                "content_type": self.headers.get("Content-Type"),
+            })
+            payload = {"content_uri": f"mxc://example.test/{len(matrix['uploads'])}-{filename}"}
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(payload).encode("utf-8"))
+
+        def do_PUT(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length)
+            parsed = urllib.parse.urlparse(self.path)
+            if "/send/m.room.message/" not in parsed.path:
+                self.send_response(404)
+                self.end_headers()
+                return
+            matrix["events"].append({
+                "path": parsed.path,
+                "auth": self.headers.get("Authorization"),
+                "content": json.loads(body.decode("utf-8") or "{}"),
+            })
+            payload = {"event_id": f"$file-event-{len(matrix['events'])}"}
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(payload).encode("utf-8"))
+
+    class MatrixServer(socketserver.ThreadingTCPServer):
+        allow_reuse_address = True
+        daemon_threads = True
+
+    matrix_server = MatrixServer(("127.0.0.1", 0), MatrixHandler)
+    matrix_thread = threading.Thread(target=matrix_server.serve_forever, daemon=True)
+    matrix_thread.start()
+    matrix_port = matrix_server.server_address[1]
+    os.environ["AGENTTEAMS_MATRIX_URL"] = f"http://127.0.0.1:{matrix_port}"
+    os.environ["AGENTTEAMS_WORKER_MATRIX_TOKEN"] = "test-token"
+    context_file = pathlib.Path("#{root}") / "matrix-context.json"
+    os.environ["TEAMHARNESS_MATRIX_CONTEXT_FILE"] = str(context_file)
 
     def payload(name, args):
         merged = dict(common)
@@ -112,6 +191,14 @@ Dir.mktmpdir("teamharness-taskflow-") do |dir|
         raise AssertionError(f"delegate_task failed: {delegated!r}")
     if delegated.get("synced") is not True:
         raise AssertionError(f"delegate_task did not sync task dir: {delegated!r}")
+    delegated_meta = json.loads((pathlib.Path("#{workspace}") / f"shared/tasks/{task_id}/meta.json").read_text(encoding="utf-8"))
+    if delegated_meta.get("task_title") != "Collect input":
+        raise AssertionError(f"delegate_task did not write console task_title: {delegated_meta!r}")
+    if delegated_meta.get("assigned_to") != "@worker-a:example.test":
+        raise AssertionError(f"delegate_task did not write console assigned_to: {delegated_meta!r}")
+    assigned_at = delegated_meta.get("assigned_at")
+    if not assigned_at:
+        raise AssertionError(f"delegate_task did not write console assigned_at: {delegated_meta!r}")
 
     external_project_id = "external-dingtalk-project"
     external_task_id = "external-dingtalk-project-01"
@@ -173,6 +260,30 @@ Dir.mktmpdir("teamharness-taskflow-") do |dir|
     })
     if not delegated_external.get("ok") or delegated_external["task"].get("room_id") != "room:!task-room:example.test":
         raise AssertionError(f"external requester dedicated room delegation failed: {delegated_external!r}")
+    retried_external = payload("taskflow", {
+        "role": "leader",
+        "action": "delegate_task",
+        "payload": {
+            "projectId": external_project_id,
+            "taskId": external_task_id,
+            "roomId": "room:!task-room:example.test",
+            "spec": "Retry in the same dedicated task room.",
+        },
+    })
+    if not retried_external.get("ok"):
+        raise AssertionError(f"same-room external redelegation should be idempotent: {retried_external!r}")
+    blocked_other_assignment_room = payload("taskflow", {
+        "role": "leader",
+        "action": "delegate_task",
+        "payload": {
+            "projectId": external_project_id,
+            "taskId": external_task_id,
+            "roomId": "room:!other-task-room:example.test",
+            "spec": "This should not move the task to another assignment room.",
+        },
+    })
+    if blocked_other_assignment_room.get("ok") or "already delegated to assignment room" not in blocked_other_assignment_room.get("error", ""):
+        raise AssertionError(f"external task should not be delegated to another assignment room: {blocked_other_assignment_room!r}")
 
     acked = payload("taskflow", {
         "role": "worker",
@@ -181,6 +292,36 @@ Dir.mktmpdir("teamharness-taskflow-") do |dir|
     })
     if not acked.get("ok") or acked["task"]["status"] != "in_progress":
         raise AssertionError(f"ack_task failed: {acked!r}")
+    if acked["task"].get("assigned_at") != assigned_at:
+        raise AssertionError(f"ack_task should preserve assigned_at: {acked!r}")
+
+    analysis_path = pathlib.Path("#{workspace}") / "shared/tasks/t-001/workspace/analysis.md"
+    analysis_path.parent.mkdir(parents=True, exist_ok=True)
+    analysis_path.write_text("analysis artifact\\n", encoding="utf-8")
+    detailed_result_path = pathlib.Path("#{workspace}") / "shared/tasks/t-001/result.md"
+    detailed_result_path.write_text(
+        "# Detailed Result Body\\n\\n"
+        "This detailed task result must survive submit_task.\\n\\n"
+        "- preserved worker bullet\\n",
+        encoding="utf-8",
+    )
+
+    invalid_project_deliverable = payload("taskflow", {
+        "role": "worker",
+        "action": "submit_task",
+        "payload": {
+            "taskId": task_id,
+            "status": "SUCCESS",
+            "summary": "Project paths are not task deliverables.",
+            "deliverables": [
+                "shared/projects/project-001/result.md",
+            ],
+        },
+    })
+    if invalid_project_deliverable.get("ok"):
+        raise AssertionError(f"submit_task should reject project-level deliverables: {invalid_project_deliverable!r}")
+    if "shared/tasks/t-001" not in str(invalid_project_deliverable.get("error", "")):
+        raise AssertionError(f"project deliverable error should name task boundary: {invalid_project_deliverable!r}")
 
     submitted = payload("taskflow", {
         "role": "worker",
@@ -189,13 +330,169 @@ Dir.mktmpdir("teamharness-taskflow-") do |dir|
             "taskId": task_id,
             "status": "SUCCESS",
             "summary": "Input collected.",
-            "deliverables": ["shared/tasks/t-001/result.md"],
+            "parentEventId": "$task-parent",
+            "deliverables": [
+                "shared/tasks/t-001/result.md",
+                "shared/tasks/t-001/workspace/analysis.md",
+            ],
         },
     })
     if not submitted.get("ok") or submitted["task"]["status"] != "submitted":
         raise AssertionError(f"submit_task failed: {submitted!r}")
     if submitted.get("synced") is not True:
         raise AssertionError(f"submit_task did not sync result: {submitted!r}")
+    if submitted["task"].get("assigned_at") != assigned_at:
+        raise AssertionError(f"submit_task should preserve assigned_at: {submitted!r}")
+    submitted_result_text = detailed_result_path.read_text(encoding="utf-8")
+    expected_result_text = (
+        "# Detailed Result Body\\n\\n"
+        "This detailed task result must survive submit_task.\\n\\n"
+        "- preserved worker bullet\\n"
+    )
+    if submitted_result_text != expected_result_text:
+        raise AssertionError(f"submit_task should not rewrite agent-owned result.md: {submitted_result_text!r}")
+    published = submitted.get("publishedArtifacts") or []
+    published_by_source = {item.get("sourcePath"): item for item in published}
+    for source, filename in {
+        "shared/tasks/t-001/result.md": "t-001-result.md",
+        "shared/tasks/t-001/workspace/analysis.md": "t-001-analysis.md",
+    }.items():
+        artifact = published_by_source.get(source)
+        if not artifact or artifact.get("status") != "published":
+            raise AssertionError(f"artifact was not published: {source} -> {published!r}")
+        if artifact.get("filename") != filename:
+            raise AssertionError(f"artifact filename mismatch: {artifact!r}")
+        if not artifact.get("mxcUri") or not artifact.get("eventId"):
+            raise AssertionError(f"artifact missing Matrix references: {artifact!r}")
+        if artifact.get("parentEventId") != "$task-parent":
+            raise AssertionError(f"artifact missing parent event reference: {artifact!r}")
+    file_events = [event["content"] for event in matrix["events"]]
+    if [event.get("body") for event in file_events[:2]] != ["t-001-result.md", "t-001-analysis.md"]:
+        raise AssertionError(f"m.file event bodies mismatch: {file_events!r}")
+    for event in file_events[:2]:
+        if event.get("msgtype") != "m.file" or not event.get("url"):
+            raise AssertionError(f"Matrix event is not a file event: {event!r}")
+        if event.get("m.relates_to") != {"rel_type": "com.agentteams.attachment", "event_id": "$task-parent"}:
+            raise AssertionError(f"Matrix file event missing attachment relation: {event!r}")
+        info = event.get("info") or {}
+        if not info.get("size") or not info.get("mimetype"):
+            raise AssertionError(f"Matrix file event missing info: {event!r}")
+    if not all(upload.get("auth") == "Bearer test-token" for upload in matrix["uploads"][:2]):
+        raise AssertionError(f"Matrix upload auth mismatch: {matrix['uploads']!r}")
+
+    context_project_id = "context-parent-project"
+    context_task_id = "context-parent-task"
+    payload("projectflow", {
+        "action": "create_project",
+        "payload": {
+            "projectId": context_project_id,
+            "title": "Context Parent Project",
+            "replyRoute": {
+                "channel": "matrix",
+                "targetUser": "@admin:example.test",
+                "targetSession": "!team:example.test",
+            },
+        },
+    })
+    payload("projectflow", {
+        "action": "plan_dag",
+        "payload": {
+            "projectId": context_project_id,
+            "tasks": [{
+                "taskId": context_task_id,
+                "title": "Submit with context parent",
+                "assignedTo": "@worker-a:example.test",
+                "dependsOn": [],
+            }],
+        },
+    })
+    payload("taskflow", {
+        "role": "leader",
+        "action": "delegate_task",
+        "payload": {
+            "projectId": context_project_id,
+            "taskId": context_task_id,
+            "roomId": "room:!team:example.test",
+            "spec": "Submit without an explicit parentEventId.",
+        },
+    })
+    payload("taskflow", {
+        "role": "worker",
+        "action": "ack_task",
+        "payload": {"taskId": context_task_id},
+    })
+    context_result_path = pathlib.Path("#{workspace}") / "shared/tasks/context-parent-task/result.md"
+    context_result_path.write_text("context result body\\n", encoding="utf-8")
+    context_file.write_text(json.dumps({
+        "rooms": {
+            "!team:example.test": {
+                "attachmentParentEventId": "$context-task-parent",
+                "updatedAt": time.time(),
+            }
+        }
+    }), encoding="utf-8")
+    context_submitted = payload("taskflow", {
+        "role": "worker",
+        "action": "submit_task",
+        "payload": {
+            "taskId": context_task_id,
+            "status": "SUCCESS",
+            "summary": "Submitted using Matrix context parent.",
+            "deliverables": [],
+        },
+    })
+    context_published = context_submitted.get("publishedArtifacts") or []
+    if len(context_published) != 1 or context_published[0].get("status") != "published":
+        raise AssertionError(f"context submit_task should publish result artifact: {context_submitted!r}")
+    if context_published[0].get("parentEventId") != "$context-task-parent":
+        raise AssertionError(f"context submit_task did not infer parent event: {context_submitted!r}")
+    context_event = matrix["events"][-1]["content"]
+    if context_event.get("m.relates_to") != {"rel_type": "com.agentteams.attachment", "event_id": "$context-task-parent"}:
+        raise AssertionError(f"context submit_task file event missing attachment relation: {context_event!r}")
+
+    secret_task_id = "secret-artifact-01"
+    payload("taskflow", {
+        "role": "leader",
+        "action": "delegate_task",
+        "payload": {
+            "projectId": project_id,
+            "taskId": secret_task_id,
+            "roomId": "room:!team:example.test",
+            "spec": "Submit a result with one sensitive deliverable.",
+        },
+    })
+    payload("taskflow", {
+        "role": "worker",
+        "action": "ack_task",
+        "payload": {"taskId": secret_task_id},
+    })
+    secret_path = pathlib.Path("#{workspace}") / "shared/tasks/secret-artifact-01/workspace/token-report.md"
+    secret_path.parent.mkdir(parents=True, exist_ok=True)
+    secret_path.write_text("token=abcdefghijklmnopqrstuvwxyz1234567890\\n", encoding="utf-8")
+    secret_submitted = payload("taskflow", {
+        "role": "worker",
+        "action": "submit_task",
+        "payload": {
+            "taskId": secret_task_id,
+            "status": "SUCCESS",
+            "summary": "Sensitive deliverable should be rejected for publish.",
+            "deliverables": ["shared/tasks/secret-artifact-01/workspace/token-report.md"],
+        },
+    })
+    if not secret_submitted.get("ok") or secret_submitted["task"]["status"] != "submitted":
+        raise AssertionError(f"sensitive submit should still succeed: {secret_submitted!r}")
+    secret_artifacts = {
+        item.get("sourcePath"): item for item in (secret_submitted.get("publishedArtifacts") or [])
+    }
+    secret_artifact = secret_artifacts.get("shared/tasks/secret-artifact-01/workspace/token-report.md")
+    if not secret_artifact or secret_artifact.get("status") != "failed":
+        raise AssertionError(f"sensitive deliverable publish should fail explicitly: {secret_submitted!r}")
+    if "sensitive" not in str(secret_artifact.get("error", "")).lower():
+        raise AssertionError(f"sensitive publish error should be clear and sanitized: {secret_artifact!r}")
+    if any(upload.get("filename") == "secret-artifact-01-token-report.md" for upload in matrix["uploads"]):
+        raise AssertionError(f"sensitive deliverable should not be uploaded: {matrix['uploads']!r}")
+    if any("abcdefghijklmnopqrstuvwxyz1234567890" in upload.get("body", "") for upload in matrix["uploads"]):
+        raise AssertionError("sensitive value leaked into Matrix upload")
 
     checked = payload("taskflow", {
         "role": "leader",
@@ -206,6 +503,12 @@ Dir.mktmpdir("teamharness-taskflow-") do |dir|
         raise AssertionError(f"check_task failed: {checked!r}")
     if checked.get("result", {}).get("summary") != "Input collected.":
         raise AssertionError(f"check_task did not return result summary: {checked!r}")
+    expected_deliverables = [
+        "shared/tasks/t-001/result.md",
+        "shared/tasks/t-001/workspace/analysis.md",
+    ]
+    if checked.get("result", {}).get("deliverables") != expected_deliverables:
+        raise AssertionError(f"check_task deliverables should ignore result body bullets: {checked!r}")
 
     accepted = payload("projectflow", {
         "action": "accept_task_result",
@@ -224,6 +527,9 @@ Dir.mktmpdir("teamharness-taskflow-") do |dir|
     requester_report = accepted["project"].get("requester_report", {})
     if requester_report.get("pending") is not True or requester_report.get("task_id") != task_id:
         raise AssertionError(f"accept_task_result did not mark requester report pending: {accepted!r}")
+    accepted_notification = accepted.get("notificationNeeded", {})
+    if accepted_notification.get("replyRoute", {}).get("target_session") != "!team:example.test":
+        raise AssertionError(f"accepted result should trigger requester report notification: {accepted!r}")
     marked_report = payload("projectflow", {
         "action": "mark_requester_report_sent",
         "payload": {"projectId": project_id},
@@ -232,6 +538,315 @@ Dir.mktmpdir("teamharness-taskflow-") do |dir|
         raise AssertionError(f"mark_requester_report_sent failed: {marked_report!r}")
     if marked_report["project"].get("requester_report", {}).get("pending") is not False:
         raise AssertionError(f"mark_requester_report_sent did not clear pending flag: {marked_report!r}")
+
+    cancellation_project_id = "superseded-project"
+    old_task_id = "superseded-project-old"
+    replacement_task_id = "superseded-project-new"
+    payload("projectflow", {
+        "action": "create_project",
+        "payload": {
+            "projectId": cancellation_project_id,
+            "title": "Superseded Project",
+        },
+    })
+    payload("projectflow", {
+        "action": "plan_dag",
+        "payload": {
+            "projectId": cancellation_project_id,
+            "tasks": [{
+                "taskId": old_task_id,
+                "title": "Old active task",
+                "assignedTo": "@worker-a:example.test",
+                "dependsOn": [],
+            }],
+        },
+    })
+    payload("taskflow", {
+        "role": "leader",
+        "action": "delegate_task",
+        "payload": {
+            "projectId": cancellation_project_id,
+            "taskId": old_task_id,
+            "roomId": "room:!team:example.test",
+            "spec": "This task will be superseded.",
+        },
+    })
+    payload("taskflow", {
+        "role": "worker",
+        "action": "ack_task",
+        "payload": {"taskId": old_task_id},
+    })
+    missing_reason_cancel = payload("taskflow", {
+        "role": "leader",
+        "action": "cancel_task",
+        "payload": {"taskId": old_task_id},
+    })
+    if missing_reason_cancel.get("ok") or "reason is required" not in missing_reason_cancel.get("error", ""):
+        raise AssertionError(f"missing cancel reason should be rejected: {missing_reason_cancel!r}")
+    blank_reason_cancel = payload("taskflow", {
+        "role": "leader",
+        "action": "cancel_task",
+        "payload": {"taskId": old_task_id, "reason": "  "},
+    })
+    if blank_reason_cancel.get("ok") or "reason is required" not in blank_reason_cancel.get("error", ""):
+        raise AssertionError(f"blank cancel reason should be rejected: {blank_reason_cancel!r}")
+    cancelled = payload("taskflow", {
+        "role": "leader",
+        "action": "cancel_task",
+        "payload": {
+            "taskId": old_task_id,
+            "reason": "superseded",
+            "replacementTaskId": replacement_task_id,
+        },
+    })
+    if not cancelled.get("ok") or cancelled["task"].get("status") != "cancelled":
+        raise AssertionError(f"cancel_task failed: {cancelled!r}")
+    if cancelled.get("synced") is not True:
+        raise AssertionError(f"cancel_task did not sync task state: {cancelled!r}")
+    if cancelled["task"].get("cancel_reason") != "superseded":
+        raise AssertionError(f"cancel_task did not record reason: {cancelled!r}")
+    if cancelled["task"].get("replacement_task_id") != replacement_task_id:
+        raise AssertionError(f"cancel_task did not record replacement: {cancelled!r}")
+    cancelled_nodes = {task["task_id"]: task for task in cancelled["project"].get("tasks", [])}
+    if cancelled_nodes.get(old_task_id, {}).get("status") != "cancelled":
+        raise AssertionError(f"cancel_task did not update project node: {cancelled!r}")
+    old_spec_path = pathlib.Path("#{workspace}") / f"shared/tasks/{old_task_id}/spec.md"
+    if not old_spec_path.exists():
+        raise AssertionError("cancel_task should not delete historical task files")
+    old_spec = old_spec_path.read_text(encoding="utf-8")
+    late_delegate = payload("taskflow", {
+        "role": "leader",
+        "action": "delegate_task",
+        "payload": {
+            "projectId": cancellation_project_id,
+            "taskId": old_task_id,
+            "roomId": "room:!team:example.test",
+            "spec": "Late delegate should not overwrite a cancelled task.",
+        },
+    })
+    if late_delegate.get("ok") or "terminal task: cancelled" not in late_delegate.get("error", ""):
+        raise AssertionError(f"cancelled task should reject late delegate_task: {late_delegate!r}")
+    if old_spec_path.read_text(encoding="utf-8") != old_spec:
+        raise AssertionError("late delegate_task should not overwrite spec.md for a cancelled task")
+    late_ack = payload("taskflow", {
+        "role": "worker",
+        "action": "ack_task",
+        "payload": {"taskId": old_task_id},
+    })
+    if late_ack.get("ok") or "terminal task: cancelled" not in late_ack.get("error", ""):
+        raise AssertionError(f"cancelled task should reject late ack_task: {late_ack!r}")
+    late_submit = payload("taskflow", {
+        "role": "worker",
+        "action": "submit_task",
+        "payload": {"taskId": old_task_id, "summary": "late result", "deliverables": []},
+    })
+    if late_submit.get("ok") or "terminal task: cancelled" not in late_submit.get("error", ""):
+        raise AssertionError(f"cancelled task should reject late submit_task: {late_submit!r}")
+    old_meta_path = pathlib.Path("#{workspace}") / f"shared/tasks/{old_task_id}/meta.json"
+    old_meta = json.loads(old_meta_path.read_text(encoding="utf-8"))
+    if old_meta.get("status") != "cancelled":
+        raise AssertionError(f"late worker action revived cancelled task meta: {old_meta!r}")
+    if old_meta.get("cancel_reason") != "superseded":
+        raise AssertionError(f"late task action lost cancel reason: {old_meta!r}")
+    old_result_path = pathlib.Path("#{workspace}") / f"shared/tasks/{old_task_id}/result.md"
+    if old_result_path.exists():
+        raise AssertionError("late submit_task should not write result.md for a cancelled task")
+    cancelled_project_meta = json.loads((pathlib.Path("#{workspace}") / f"shared/projects/{cancellation_project_id}/meta.json").read_text(encoding="utf-8"))
+    cancelled_project_nodes = {task["task_id"]: task for task in cancelled_project_meta.get("tasks", [])}
+    if cancelled_project_nodes.get(old_task_id, {}).get("status") != "cancelled":
+        raise AssertionError(f"late worker action revived cancelled project node: {cancelled_project_meta!r}")
+
+    dag_loop_project_id = "dag-loop-reuse-project"
+    dag_loop_task_id = "dag-loop-shared-task"
+    payload("projectflow", {
+        "action": "create_project",
+        "payload": {"projectId": dag_loop_project_id, "title": "DAG Loop Reuse Project"},
+    })
+    payload("projectflow", {
+        "action": "plan_dag",
+        "payload": {
+            "projectId": dag_loop_project_id,
+            "tasks": [{
+                "taskId": dag_loop_task_id,
+                "title": "Top-level stale task",
+                "assignedTo": "@worker-a:example.test",
+                "dependsOn": [],
+            }],
+        },
+    })
+    payload("projectflow", {
+        "action": "plan_loop",
+        "payload": {
+            "projectId": dag_loop_project_id,
+            "goal": "Repeat until done",
+            "stopCondition": "Done",
+            "iterationTemplate": "One iteration",
+            "maxIterations": 2,
+            "tasks": [{
+                "taskId": dag_loop_task_id,
+                "title": "Active loop task",
+                "assignedTo": "@worker-a:example.test",
+                "dependsOn": [],
+            }],
+        },
+    })
+    dag_loop_meta_path = pathlib.Path("#{workspace}") / f"shared/projects/{dag_loop_project_id}/meta.json"
+    dag_loop_project = json.loads(dag_loop_meta_path.read_text(encoding="utf-8"))
+    dag_loop_project["loop"]["tasks"][0]["status"] = "cancelled"
+    dag_loop_meta_path.write_text(json.dumps(dag_loop_project, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+    dag_loop_task_meta_path = pathlib.Path("#{workspace}") / f"shared/tasks/{dag_loop_task_id}/meta.json"
+    if dag_loop_task_meta_path.exists():
+        raise AssertionError("DAG-to-loop guard setup should not create task meta")
+    dag_loop_delegate = payload("taskflow", {
+        "role": "leader",
+        "action": "delegate_task",
+        "payload": {
+            "projectId": dag_loop_project_id,
+            "taskId": dag_loop_task_id,
+            "roomId": "room:!team:example.test",
+            "spec": "Late delegate should not revive the loop task.",
+        },
+    })
+    if dag_loop_delegate.get("ok") or "terminal task: cancelled" not in dag_loop_delegate.get("error", ""):
+        raise AssertionError(f"DAG-to-loop terminal task should reject delegate_task: {dag_loop_delegate!r}")
+    dag_loop_after = json.loads(dag_loop_meta_path.read_text(encoding="utf-8"))
+    dag_loop_top_nodes = {task["task_id"]: task for task in dag_loop_after.get("tasks", [])}
+    dag_loop_loop_nodes = {task["task_id"]: task for task in dag_loop_after.get("loop", {}).get("tasks", [])}
+    if dag_loop_top_nodes.get(dag_loop_task_id, {}).get("status") != "planned":
+        raise AssertionError(f"failed delegate_task rewrote stale DAG node: {dag_loop_after!r}")
+    if dag_loop_loop_nodes.get(dag_loop_task_id, {}).get("status") != "cancelled":
+        raise AssertionError(f"failed delegate_task revived cancelled loop node: {dag_loop_after!r}")
+    if (pathlib.Path("#{workspace}") / f"shared/tasks/{dag_loop_task_id}/spec.md").exists():
+        raise AssertionError("failed DAG-to-loop delegate_task should not write spec.md")
+
+    worker_cancel = payload("taskflow", {
+        "role": "worker",
+        "action": "cancel_task",
+        "payload": {"taskId": old_task_id, "reason": "manual_replan"},
+    })
+    if worker_cancel.get("ok") or "leader role" not in worker_cancel.get("error", ""):
+        raise AssertionError(f"worker role should not cancel tasks: {worker_cancel!r}")
+
+    missing_cancel = payload("taskflow", {
+        "role": "leader",
+        "action": "cancel_task",
+        "payload": {"taskId": "missing-task", "reason": "manual_replan"},
+    })
+    if missing_cancel.get("ok") or "task not found" not in missing_cancel.get("error", ""):
+        raise AssertionError(f"missing task should return explicit error: {missing_cancel!r}")
+
+    completed_cancel = payload("taskflow", {
+        "role": "leader",
+        "action": "cancel_task",
+        "payload": {"taskId": task_id, "reason": "manual_replan"},
+    })
+    if completed_cancel.get("ok") or "cannot cancel terminal task" not in completed_cancel.get("error", ""):
+        raise AssertionError(f"completed task should not be silently cancelled: {completed_cancel!r}")
+
+    terminal_project_id = "terminal-cancel-project"
+    terminal_tasks = [
+        ("terminal-revision", "Revision terminal"),
+        ("terminal-blocked", "Blocked terminal"),
+        ("terminal-cancelled", "Cancelled terminal"),
+    ]
+    payload("projectflow", {
+        "action": "create_project",
+        "payload": {"projectId": terminal_project_id, "title": "Terminal Cancel Project"},
+    })
+    payload("projectflow", {
+        "action": "plan_dag",
+        "payload": {
+            "projectId": terminal_project_id,
+            "tasks": [
+                {
+                    "taskId": task_id,
+                    "title": title,
+                    "assignedTo": "@worker-a:example.test",
+                    "dependsOn": [],
+                }
+                for task_id, title in terminal_tasks
+            ],
+        },
+    })
+    for terminal_task_id, _title in terminal_tasks:
+        payload("taskflow", {
+            "role": "leader",
+            "action": "delegate_task",
+            "payload": {
+                "projectId": terminal_project_id,
+                "taskId": terminal_task_id,
+                "roomId": "room:!team:example.test",
+                "spec": f"Prepare {terminal_task_id}.",
+            },
+        })
+    payload("projectflow", {
+        "action": "accept_task_result",
+        "payload": {
+            "projectId": terminal_project_id,
+            "taskId": "terminal-revision",
+            "accepted": False,
+            "resultStatus": "SUCCESS",
+            "summary": "Needs revision.",
+        },
+    })
+    payload("projectflow", {
+        "action": "accept_task_result",
+        "payload": {
+            "projectId": terminal_project_id,
+            "taskId": "terminal-blocked",
+            "resultStatus": "BLOCKED",
+            "summary": "Blocked.",
+        },
+    })
+    payload("taskflow", {
+        "role": "leader",
+        "action": "cancel_task",
+        "payload": {"taskId": "terminal-cancelled", "reason": "manual_replan"},
+    })
+    for terminal_task_id in ["terminal-revision", "terminal-blocked", "terminal-cancelled"]:
+        terminal_cancel = payload("taskflow", {
+            "role": "leader",
+            "action": "cancel_task",
+            "payload": {"taskId": terminal_task_id, "reason": "manual_replan"},
+        })
+        if terminal_cancel.get("ok") or "cannot cancel terminal task" not in terminal_cancel.get("error", ""):
+            raise AssertionError(f"terminal task should not be silently cancelled: {terminal_task_id} {terminal_cancel!r}")
+
+    replanned = payload("projectflow", {
+        "action": "plan_dag",
+        "payload": {
+            "projectId": cancellation_project_id,
+            "tasks": [{
+                "taskId": replacement_task_id,
+                "title": "Replacement task",
+                "assignedTo": "@worker-a:example.test",
+                "dependsOn": [],
+            }],
+        },
+    })
+    if not replanned.get("ok"):
+        raise AssertionError(f"replan after cancel_task failed: {replanned!r}")
+    replanned_task_ids = {task["task_id"] for task in replanned["project"].get("tasks", [])}
+    if old_task_id in replanned_task_ids or replacement_task_id not in replanned_task_ids:
+        raise AssertionError(f"replan did not replace old task node: {replanned!r}")
+    old_resolved = payload("projectflow", {
+        "action": "resolve_project",
+        "payload": {"taskId": old_task_id},
+    })
+    if old_resolved.get("task", {}).get("status") != "cancelled":
+        raise AssertionError(f"old task meta should remain cancelled after replan: {old_resolved!r}")
+    delegated_replacement = payload("taskflow", {
+        "role": "leader",
+        "action": "delegate_task",
+        "payload": {
+            "projectId": cancellation_project_id,
+            "taskId": replacement_task_id,
+            "roomId": "room:!team:example.test",
+            "spec": "Replacement task can now proceed.",
+        },
+    })
+    if not delegated_replacement.get("ok") or delegated_replacement["task"].get("status") != "assigned":
+        raise AssertionError(f"replacement task delegation failed: {delegated_replacement!r}")
 
     revision_project_id = "revision-project"
     revision_task_id = "revision-task-01"
@@ -278,6 +893,9 @@ Dir.mktmpdir("teamharness-taskflow-") do |dir|
         raise AssertionError(f"accepted=false did not mark node revision: {rejected!r}")
     if rejected["project"].get("requester_report", {}).get("pending") is True:
         raise AssertionError(f"accepted=false should not create requester report: {rejected!r}")
+    rejected_notification = rejected.get("notificationNeeded", {})
+    if rejected_notification.get("replyRoute"):
+        raise AssertionError(f"accepted=false should not trigger requester report notification: {rejected!r}")
 
     result_path_for_validation = pathlib.Path("#{workspace}") / "shared/tasks/t-001/result.md"
     original_result = result_path_for_validation.read_text(encoding="utf-8")
@@ -287,10 +905,10 @@ Dir.mktmpdir("teamharness-taskflow-") do |dir|
         "action": "check_task",
         "payload": {"taskId": task_id},
     })
-    if not invalid_checked.get("ok") or invalid_checked.get("effective"):
-        raise AssertionError(f"invalid result should be ineffective: {invalid_checked!r}")
-    if "missing result status" not in invalid_checked.get("validationErrors", []):
-        raise AssertionError(f"invalid result should include validation error: {invalid_checked!r}")
+    if not invalid_checked.get("ok") or not invalid_checked.get("effective"):
+        raise AssertionError(f"result body should not override task meta validation: {invalid_checked!r}")
+    if invalid_checked.get("validationErrors"):
+        raise AssertionError(f"result body should not create validation errors: {invalid_checked!r}")
     result_path_for_validation.write_text(original_result, encoding="utf-8")
 
     forbidden_delegate = payload("taskflow", {
@@ -319,7 +937,7 @@ Dir.mktmpdir("teamharness-taskflow-") do |dir|
     if forbidden_submit.get("ok") or "worker or remote-member role" not in forbidden_submit.get("error", ""):
         raise AssertionError(f"leader role should not submit: {forbidden_submit!r}")
 
-    os.environ["HICLAW_WORKER_ROLE"] = "worker"
+    os.environ["AGENTTEAMS_WORKER_ROLE"] = "worker"
     remote_ack = payload("taskflow", {
         "action": "ack_task",
         "task_id": "remote-001",
@@ -328,6 +946,15 @@ Dir.mktmpdir("teamharness-taskflow-") do |dir|
         raise AssertionError(f"ack_task did not infer role and pull remote task: {remote_ack!r}")
     if not (pathlib.Path("#{workspace}") / "shared/tasks/remote-001/spec.md").exists():
         raise AssertionError("ack_task did not pull remote task spec")
+    remote_meta = json.loads((pathlib.Path("#{workspace}") / "shared/tasks/remote-001/meta.json").read_text(encoding="utf-8"))
+    if remote_meta.get("task_title") != "Remote task":
+        raise AssertionError(f"camelCase taskTitle should be converted to task_title: {remote_meta!r}")
+    if remote_meta.get("assigned_to") != "@worker-remote:example.test":
+        raise AssertionError(f"camelCase assignedTo should be converted to assigned_to: {remote_meta!r}")
+    if remote_meta.get("assigned_at") != "2026-06-26T07:00:00Z":
+        raise AssertionError(f"camelCase createdAt should be converted to assigned_at: {remote_meta!r}")
+    if "taskId" in remote_meta or "taskTitle" in remote_meta or "assignedTo" in remote_meta:
+        raise AssertionError(f"camelCase task keys should not be persisted: {remote_meta!r}")
 
     workspace = pathlib.Path("#{workspace}")
     spec_path = workspace / "shared/tasks/t-001/spec.md"
@@ -338,11 +965,20 @@ Dir.mktmpdir("teamharness-taskflow-") do |dir|
         raise AssertionError("task files missing")
     if legacy_state_path.exists():
         raise AssertionError(f"task.json should not be written: {legacy_state_path}")
+    final_meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    if final_meta.get("task_title") != "Collect input" or final_meta.get("assigned_to") != "@worker-a:example.test":
+        raise AssertionError(f"final task meta missing console fields: {final_meta!r}")
+    if final_meta.get("assigned_at") != assigned_at:
+        raise AssertionError(f"final task meta should preserve assigned_at: {final_meta!r}")
+
+    matrix_server.shutdown()
+    matrix_server.server_close()
 
     print(json.dumps({
         "ok": True,
       "task": submitted["task"]["task_id"],
       "status": submitted["task"]["status"],
+      "publishedArtifacts": [item["filename"] for item in published if item.get("status") == "published"],
       "remoteAck": remote_ack["task"]["task_id"],
       "specPath": str(spec_path),
       "resultPath": str(result_path),

--- a/plugins/tests/teamharness/test-contracts.rb
+++ b/plugins/tests/teamharness/test-contracts.rb
@@ -26,6 +26,10 @@ def read(path)
   path.read(encoding: "utf-8")
 end
 
+def normalized(text)
+  text.gsub(/\s+/, " ")
+end
+
 def skill_frontmatter(path)
   text = read(path)
   match = text.match(/\A---\n(.*?)\n---\n/m)
@@ -73,31 +77,55 @@ assert(manager_prompts == expected_manager_prompts, "unexpected manager prompts:
 
 team_prompt = read(plugin_root / prompts.fetch("team"))
 assert(team_prompt.include?("stable collaboration"), "team prompt must define stable collaboration rules")
-assert(team_prompt.include?("not a status database"), "team prompt must reject live status storage")
 assert(team_prompt.include?("Request Modes"), "team prompt must define request modes")
 assert(team_prompt.include?("Direct Reply"), "team prompt must allow ordinary direct replies")
 assert(!team_prompt.include?("Lightweight Action"), "team prompt must not keep the old lightweight action mode")
 assert(team_prompt.include?("Quick Task"), "team prompt must define quick task mode")
 assert(team_prompt.include?("Project Work"), "team prompt must reserve project/task flow for project work")
-assert(team_prompt.include?("Standard Flow Index"), "team prompt must provide a standard flow index")
-assert(team_prompt.include?("| Role | Purpose | Skill | Skill step |"), "team prompt flow index must be role-based")
-assert(team_prompt.include?("Quick Task Flow"), "team prompt must define quick task flow")
-assert(team_prompt.include?("Project Work Flow"), "team prompt must define project work flow")
-assert(team_prompt.include?("restore project state"), "team prompt must restore project state before creating or planning work")
-assert(team_prompt.include?("Create Quick Project"), "team prompt quick task flow must index project-management quick project steps")
-assert(team_prompt.include?("assignment room"), "team prompt must include assignment-room handoff")
-assert(team_prompt.include?("Acknowledge") && team_prompt.include?("Completion Message"), "team prompt must index Worker execution steps")
-assert(team_prompt.include?("project requester source and reply route"), "team prompt must route requester reports through project state")
+assert(team_prompt.include?("Request Modes And Standard Flow"), "team prompt must merge request modes and standard flow")
+assert(!team_prompt.include?("Project Wake-Up Recovery"), "team prompt must not keep project wake-up as a standalone chapter")
+assert(normalized(team_prompt).include?("resolve project context"), "team prompt must resolve project context before result handling")
+assert(team_prompt.include?("create_quick_project"), "team prompt quick task flow must index project-management quick project steps")
+assert(team_prompt.include?("task request message"), "team prompt must route task-room handoff as a task request message")
+assert(team_prompt.include?("roomflow create_task_room"), "team prompt must create task rooms through roomflow")
+assert(!team_prompt.include?("Load `teamharness-team-coordination` if the boundary is unclear"), "team prompt quick task flow must not re-run mode selection")
+assert(normalized(team_prompt).include?("Do not call `delegate_task` for Quick Task"), "team prompt quick task flow must not delegate after create_quick_project")
+assert(team_prompt.include?("create_project") && team_prompt.include?("plan_dag") && team_prompt.include?("plan_loop"), "team prompt project work flow must route planning to project-management")
+assert(team_prompt.include?("Rooms and Channels"), "team prompt must define rooms and channels")
+assert(team_prompt.include?("Source channel / requester room"), "team prompt must define source/requester channels")
+assert(team_prompt.include?("DingTalk") && team_prompt.include?("DM or Team room"), "team prompt must describe requester/source intake channels")
+assert(team_prompt.include?("Task room: a Matrix room"), "team prompt must define Matrix task rooms")
+assert(team_prompt.include?("TASK：<projectId>"), "team prompt must define the project-id task-room name marker")
+assert(team_prompt.include?("roomflow describe_room"), "team prompt must use roomflow describe_room for Matrix room identity")
+assert(team_prompt.include?("name") && team_prompt.include?("topic") && team_prompt.include?("tags"), "team prompt must classify Matrix rooms from Matrix state")
+assert(team_prompt.include?("Project/Task marker"), "team prompt must define task rooms by Project/Task markers")
+assert(normalized(team_prompt).include?("teamharness-communication` to send the task request message"), "team prompt must route requester/source project handoff to communication skill")
+assert(team_prompt.include?("teamharness-roomflow"), "team prompt must route room classification and creation to roomflow skill")
+assert(team_prompt.include?("DingTalk") && team_prompt.include?("external channel"), "team prompt must use one requester/source model across source channels")
+assert(team_prompt.include?("Stop in the source session") && team_prompt.include?("delegate_task"), "team prompt must forbid source-session project/task execution")
+assert(team_prompt.include?("check_task") && team_prompt.include?("accept_task_result"), "team prompt must route submitted results through check and acceptance skills")
+assert(team_prompt.include?("task result path") && team_prompt.include?("resolve project"), "team prompt must resolve project state for result events")
+assert(team_prompt.include?("replyRoute"), "team prompt must route requester reports through project state")
 assert(!team_prompt.include?("Event Resume Flow"), "team prompt must not expose a standalone event resume flow")
 assert(!team_prompt.include?("check_active_tasks"), "team prompt must not mention cancelled hook recovery checks")
 assert(team_prompt.include?("DAG") && team_prompt.include?("Loop"), "team prompt must retain DAG and Loop project modes")
 assert(team_prompt.include?("shared/tasks/{task-id}/"), "team prompt must define task workspace paths")
 assert(team_prompt.include?("non-overridable"), "team prompt must make credential safety non-overridable")
 assert(team_prompt.include?("authorization headers"), "team prompt must forbid credential disclosure")
-assert(team_prompt.include?("Runtime Agent Boundary"), "team prompt must define runtime-agent boundary")
-assert(team_prompt.include?("TeamHarness roster is the authority"), "team prompt must make TeamHarness roster authoritative")
-assert(team_prompt.include?("chat_with_agent"), "team prompt must mention runtime-native agent tools")
-assert(team_prompt.include?("is a team Worker"), "team prompt must reject runtime-native agents as Workers")
+assert(team_prompt.include?("Team Worker Coordination"), "team prompt must define TeamHarness Worker coordination")
+assert(team_prompt.include?("Workers in the team roster"), "team prompt must make TeamHarness Worker roster authoritative")
+assert(team_prompt.include?("chat_with_agent"), "team prompt must mention internal agent tools")
+assert(team_prompt.include?("Do not use internal agent tools"), "team prompt must forbid internal agent tools for Worker coordination")
+assert(team_prompt.include?("Matrix Mentions"), "team prompt must define Matrix mention rules")
+assert(team_prompt.include?("m.mentions") && team_prompt.include?("full member Matrix user id"), "team prompt must require resolvable Matrix mentions")
+assert(team_prompt.include?("wrong") && team_prompt.include?("@name"), "team prompt must reject wrong Matrix @ names")
+assert(team_prompt.include?("Direct Reply And NO_REPLY"), "team prompt must define direct reply and NO_REPLY rules")
+assert(team_prompt.include?("Long Matrix Messages"), "team prompt must limit long Matrix messages")
+assert(team_prompt.include?("Artifacts And Documents"), "team prompt must define artifact publication")
+assert(team_prompt.include?("artifact publish_file"), "team prompt must use artifact publish_file for artifacts")
+assert(team_prompt.include?("only for Matrix rooms") && team_prompt.include?("non-Matrix requester channels"), "team prompt must not imply artifact publish_file works for external requester channels")
+assert(team_prompt.include?("Leader Cross-Room Communication"), "team prompt must define leader cross-room communication")
+assert(team_prompt.include?("teamharness-communication") && team_prompt.include?("message-tool payloads"), "team prompt must route detailed cross-room messaging to communication skill")
 
 worker_prompt = read(plugin_root / agent_prompts.fetch("worker"))
 assert(worker_prompt.include?("NO_REPLY") && worker_prompt.include?("ping-pong"), "worker prompt must suppress ping-pong")
@@ -105,7 +133,7 @@ assert(worker_prompt.include?("Direct Checks"), "worker prompt must define direc
 assert(worker_prompt.include?("Do not use taskflow"), "worker prompt must avoid taskflow for direct checks")
 remote_prompt = read(plugin_root / agent_prompts.fetch("remoteMember"))
 assert(
-  remote_prompt.include?("not") && remote_prompt.include?("HiClaw-managed Worker"),
+  remote_prompt.include?("not") && remote_prompt.include?("AgentTeams-managed Worker"),
   "remote prompt must define remote worker boundary"
 )
 assert(remote_prompt.include?("current room/session"), "remote prompt must avoid message tool for current-session reports")
@@ -114,6 +142,7 @@ leader_prompt = read(plugin_root / agent_prompts.fetch("leader"))
 assert(leader_prompt.include?("Do not treat a worker completion message as automatic project acceptance"), "leader prompt must require acceptance")
 assert(leader_prompt.include?("Request Intake"), "leader prompt must define request intake")
 assert(leader_prompt.include?("Do not create a project"), "leader prompt must avoid project state for direct replies")
+assert(leader_prompt.include?("PROJECT_REQUESTED") && leader_prompt.include?("requester/source session"), "leader prompt must route source project work through task-room self-trigger")
 manager_prompt = read(plugin_root / manager_prompts.fetch("agents"))
 assert(manager_prompt.include?("control-plane"), "manager prompt must state the control-plane boundary")
 
@@ -125,9 +154,9 @@ expected_skills = {
     "find-skills" => %w[leader worker manager remote-member]
   },
   "team" => {
-    "organization" => %w[leader worker manager remote-member],
     "communication" => %w[leader worker manager remote-member],
     "file-sharing" => %w[leader worker manager remote-member],
+    "roomflow" => %w[leader],
     "team-coordination" => %w[leader],
     "project-management" => %w[leader],
     "task-delegation" => %w[leader],
@@ -153,17 +182,39 @@ end
 
 team_skill_dir = plugin_root / "skills/team"
 communication_skill = read(team_skill_dir / "communication/SKILL.md")
+roomflow_skill = read(team_skill_dir / "roomflow/SKILL.md")
 coordination_skill = read(team_skill_dir / "team-coordination/SKILL.md")
 project_skill = read(team_skill_dir / "project-management/SKILL.md")
 delegation_skill = read(team_skill_dir / "task-delegation/SKILL.md")
 execution_skill = read(team_skill_dir / "task-execution/SKILL.md")
+project_skill_text = normalized(project_skill)
+delegation_skill_text = normalized(delegation_skill)
 assert(communication_skill.include?("ordinary direct replies"), "communication skill must cover ordinary direct replies")
 assert(communication_skill.include?("lightweight one-off"), "communication skill must cover lightweight one-off routing")
 assert(communication_skill.include?("current room/session"), "communication skill must avoid message tool for current-session replies")
 assert(communication_skill.include?("cross-session"), "communication skill must cover cross-session message routing")
+assert(communication_skill.include?("mentionSender"), "communication skill must document DingTalk sender mentions for requester reports")
+assert(communication_skill.include?("Task room") && !communication_skill.include?("Team Room"), "communication skill must use task-room terminology")
+assert(communication_skill.include?("Task Room Request Message"), "communication skill must define task-room request message shape")
+assert(communication_skill.include?("PROJECT_REQUESTED: <short task or project title>"), "communication skill must give PROJECT_REQUESTED task-room request example")
+assert(communication_skill.include?('"target": "room:!task-room:matrix.local"'), "communication skill PROJECT_REQUESTED example must use string Matrix room target")
+assert(communication_skill.include?("@prod-observe-oncall-bot:at-cn-rpg4um9o601"), "communication skill PROJECT_REQUESTED example must use a full Matrix user id")
+assert(!communication_skill.include?('"agent": "leader"') && !communication_skill.include?('"agentId": "leader"'), "communication skill PROJECT_REQUESTED example must not use role names as trigger identity")
+assert(communication_skill.include?("Do not use role names") && communication_skill.include?("default"), "communication skill must reject role/workspace names for trigger identity")
+assert(communication_skill.include?("Requester Report Message"), "communication skill must define requester report delivery")
+assert(communication_skill.include?("teamharness-project-management") && communication_skill.include?("<project-management requester report markdown>"), "communication skill must defer requester report content to project-management")
+assert(communication_skill.include?("Do not use Matrix mention syntax") && communication_skill.include?("descriptive owners"), "communication skill must prevent requester-report display mentions")
+assert(normalized(communication_skill).include?("do not describe workspace files as chat attachments") && communication_skill.include?("platform object-storage view"), "communication skill must describe external-channel artifact paths without fake file attachments")
+assert(communication_skill.include?("return to `teamharness-project-management`") && communication_skill.include?("mark_requester_report_sent"), "communication skill must leave requester report state updates to project-management")
+assert(communication_skill.include?("replyRoute") && communication_skill.include?("targetSession"), "communication skill must show requester report delivery payload")
+assert(communication_skill.include?("Quick Task or Project Work handoff"), "communication skill self-trigger must cover Quick Task and Project Work")
+assert(roomflow_skill.include?("roomflow describe_room"), "roomflow skill must document room description")
+assert(roomflow_skill.include?("roomflow create_task_room"), "roomflow skill must document task-room creation")
+assert(roomflow_skill.include?("TASK：<projectId>"), "roomflow skill must document project-id task-room name normalization")
+assert(normalized(roomflow_skill).include?("Different projects from the same DingTalk group or same person still get different task rooms"), "roomflow skill must document project-scoped task-room reuse")
 assert(coordination_skill.include?("Choose Loop"), "coordination skill must retain Loop mode")
 assert(coordination_skill.include?("Do not pre-expand repeated Loop rounds"), "coordination skill must avoid flattening Loop into a large DAG")
-assert(project_skill.include?("Project Work"), "project skill must be scoped to Project Work")
+assert(project_skill.include?("Quick Task") && project_skill.include?("Project Work"), "project skill must cover Quick Task and Project Work")
 assert(project_skill.include?("ordinary direct replies"), "project skill must exclude ordinary direct replies")
 assert(project_skill.include?("meta.json"), "project skill must use CoPaw meta.json state")
 assert(project_skill.include?("resolve_project"), "project skill must document project context resume")
@@ -174,14 +225,33 @@ assert(project_skill.include?("mark_requester_report_sent"), "project skill must
 assert(project_skill.include?("plan_loop"), "project skill must document Loop planning")
 assert(project_skill.include?("ready_loop_nodes"), "project skill must document Loop ready-node resolution")
 assert(project_skill.include?("record_loop_iteration"), "project skill must document Loop iteration recording")
+assert(project_skill.include?("`teamharness-roomflow` owns task-room creation"), "project skill must leave room setup details to roomflow")
+assert(!project_skill.include?("roomBindingScope: \"sender\""), "project skill must not duplicate roomflow sender binding details")
+assert(project_skill.include?("DingTalk group, Matrix DM, or other source room") && project_skill.include?("sourceRoomId") && project_skill.include?("replyRoute"), "project skill must persist requester/source routes")
+assert(project_skill.include?("PROJECT_REQUESTED") && project_skill_text.include?("do not call `create_project` in the requester/source session"), "project skill must move source project creation into the task room")
+assert(project_skill.include?("Do not call this in the requester/source session"), "project skill quick task creation must run in the task room")
 assert(project_skill.include?("Project Status Reports"), "project skill must include requester status report template")
+assert(project_skill.include?("owner or executor cells are descriptive text") && project_skill.include?("Do not prefix them with `@`"), "project report template must avoid display-only Matrix mentions")
 assert(project_skill.include?("After the project state changes"), "project skill must require requester visibility after accepted state changes")
-assert(project_skill.include?("Team Room coordination") && project_skill.include?("do not count as the requester report"), "project skill must not count team-room coordination as requester reporting")
+assert(project_skill.include?("publishArtifacts: true") && project_skill.include?("parentEventId"), "project skill must document explicit project artifact publish after requester report")
+assert(project_skill.include?("non-Matrix channel") && project_skill.include?("do not claim that a file was attached") && project_skill.include?("platform object-storage view"), "project requester report template must avoid fake external-channel file attachment claims")
+assert(project_skill.include?("Task room coordination") && project_skill.include?("do not count as the requester report"), "project skill must not count task-room coordination as requester reporting")
 assert(!project_skill.include?("Loop planning, pause/resume/complete"), "project skill must not mark Loop planning as future")
 assert(delegation_skill.include?("ready project node"), "delegation skill must be scoped to ready project nodes")
 assert(delegation_skill.include?("ordinary conversation"), "delegation skill must not turn ordinary conversation into tasks")
+assert(delegation_skill.include?("For Quick Task") && delegation_skill.include?("do not call\n`delegate_task` again"), "delegation skill must keep Quick Task assignment message separate from delegate_task")
+assert(delegation_skill.include?("normal current-session reply") && delegation_skill.include?("Do not use the `message` tool"), "delegation skill must keep same-room assignment out of message tool")
+assert(delegation_skill.include?("`teamharness-roomflow` owns task-room creation"), "delegation skill must leave room setup details to roomflow")
+assert(!delegation_skill.include?("roomBindingScope: \"sender\""), "delegation skill must not duplicate roomflow sender binding details")
+assert(delegation_skill_text.include?("Do not fall back to the requester/source session"), "delegation skill must keep Project Work assignment inside the task room")
 assert(communication_skill.include?("matrix:!roomid:domain"), "communication skill must support legacy Matrix requester routing")
+assert(communication_skill.include?("Matrix DM requester reports") && communication_skill.include?("targetSession"), "communication skill must document Matrix DM reply routes")
 assert(communication_skill.include?("requester report") && communication_skill.include?("mandatory"), "communication skill must require requester reports after accepted state changes")
+assert(communication_skill.include?("PROJECT_REQUESTED Self Trigger") && communication_skill.include?("matrix_self_trigger"), "communication skill must document PROJECT_REQUESTED trigger result")
+assert(communication_skill.include?("same-agent Quick Task or Project Work handoff"), "communication skill must own PROJECT_REQUESTED handoff details")
+assert(leader_prompt.include?("same runtime\nMatrix account") && leader_prompt.include?("current Matrix user id"), "leader prompt must describe self-trigger identity as the runtime Matrix account")
+assert(leader_prompt.include?("role names such as `leader`") && leader_prompt.include?("workspace names such as\n`default`"), "leader prompt must reject role/workspace names for self-trigger identity")
+assert(normalized(communication_skill).include?("recorded requester route is exactly"), "communication skill must own requester route exclusion rules")
 assert(execution_skill.include?("Do not use this skill or taskflow"), "execution skill must exclude direct checks")
 assert(execution_skill.include?("meta.json"), "execution skill must use CoPaw meta.json state")
 
@@ -189,18 +259,19 @@ server = manifest.fetch("mcp").fetch("servers").fetch(0)
 assert(server.fetch("id") == "teamharness", "MCP server id must be teamharness")
 assert(server.fetch("transport") == "stdio", "TeamHarness MCP must use stdio")
 assert(
-  server.fetch("tools") == %w[health message roomflow filesync projectflow taskflow],
+  server.fetch("tools") == %w[health message roomflow filesync artifact projectflow taskflow],
   "unexpected MCP tools: #{server.fetch("tools").inspect}"
 )
 
 assert(!manifest.key?("hooks"), "TeamHarness v0.1 must not define runtime-neutral top-level hooks")
 
 adapters = manifest.fetch("adapters").to_h { |adapter| [adapter.fetch("id"), adapter.fetch("path")] }
-assert(adapters == { "qwenpaw" => "adapters/qwenpaw", "claude-code" => "adapters/claude-code" }, "unexpected adapters: #{adapters.inspect}")
+assert(adapters == { "qwenpaw" => "adapters/qwenpaw" }, "unexpected adapters: #{adapters.inspect}")
 
 plugin_files = Dir.glob((plugin_root / "**/*").to_s, File::FNM_DOTMATCH)
   .map { |path| Pathname.new(path) }
   .select(&:file?)
+  .reject { |path| path.to_s.start_with?((plugin_root / "remote").to_s + "/") }
   .reject { |path| path.extname == ".pyc" }
 
 combined = plugin_files.map { |path| read(path) }.join("\n")

--- a/plugins/tests/teamharness/test_trace.py
+++ b/plugins/tests/teamharness/test_trace.py
@@ -2,13 +2,13 @@
 """Tests for AgentTeams Task-Trace correlation (SpanProcessor approach).
 
 Test layers:
-  1. find_active_task        - filesystem scanning + room/worker filtering
-  2. AgentTeamsTaskSpanProcessor - span attribute injection + current meta state
-  3. register integration    - TracerProvider registration
-  4. QwenPaw adapter wiring  - install_task_trace_processor()
-  5. End-to-end scenario     - ack -> tool calls -> submit lifecycle
-  6. Session isolation       - multi-room concurrent task scenarios
-  7. Debug logging control   - AGENTTEAMS_TASK_TRACE_DEBUG toggle
+  1. find_active_task        — filesystem scanning + room/worker filtering
+  2. AgentTeamsTaskSpanProcessor — span attribute injection + current meta state
+  3. register integration    — TracerProvider registration
+  4. QwenPaw adapter wiring  — install_task_trace_processor()
+  5. End-to-end scenario     — ack → tool calls → submit lifecycle
+  6. Session isolation       — multi-room concurrent task scenarios
+  7. Debug logging control   — AGENTTEAMS_TASK_TRACE_DEBUG toggle
 """
 
 from __future__ import annotations
@@ -341,7 +341,7 @@ class TestAgentTeamsTaskSpanProcessor:
         processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
         span = _entry_span()
 
-        # No room set -> span stashed but not tagged
+        # No room set → span stashed but not tagged
         processor.on_start(span)
         span.set_attribute.assert_not_called()
 
@@ -800,7 +800,7 @@ class TestAdapterInstallTaskTraceProcessor:
 
 
 class TestEndToEndLifecycle:
-    """Simulates ack -> work -> submit and verifies span attributes at each stage."""
+    """Simulates ack → work → submit and verifies span attributes at each stage."""
 
     def test_full_lifecycle(self, workspace: Path) -> None:
         mod = _load_trace_module()
@@ -899,14 +899,14 @@ class TestSessionIsolation:
         })
         processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
 
-        # Turn in room A -> should tag with task-room-a
+        # Turn in room A → should tag with task-room-a
         token_a = mod.set_current_room("!room-A:m.org")
         span_a = _entry_span()
         processor.on_start(span_a)
         span_a.set_attribute.assert_any_call("agentteams.task.id", "task-room-a")
         mod.reset_current_room(token_a)
 
-        # Turn in room B -> should tag with task-room-b
+        # Turn in room B → should tag with task-room-b
         token_b = mod.set_current_room("!room-B:m.org")
         span_b = _entry_span()
         processor.on_start(span_b)
@@ -1015,9 +1015,9 @@ class TestDeferredEntrySpanTagging:
 
     Real-world flow:
       1. Instrumentation creates ``enter_ai_application_system`` span
-         -> on_start fires, room is NOT set yet -> span is stashed
+         → on_start fires, room is NOT set yet → span is stashed
       2. QwenPawAgent.__call__ wrapper sets room context
-      3. Wrapper calls tag_pending_entry_span() -> stashed span gets tagged
+      3. Wrapper calls tag_pending_entry_span() → stashed span gets tagged
     """
 
     def test_on_start_stashes_entry_span_when_room_not_set(self, workspace: Path) -> None:
@@ -1029,7 +1029,7 @@ class TestDeferredEntrySpanTagging:
         processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
         span = _entry_span()
 
-        # Room NOT set - span should be stashed, not tagged
+        # Room NOT set — span should be stashed, not tagged
         processor.on_start(span)
         span.set_attribute.assert_not_called()
         assert mod.get_pending_entry_span() is span
@@ -1043,7 +1043,7 @@ class TestDeferredEntrySpanTagging:
         processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
         span = _entry_span()
 
-        # on_start without room -> stash
+        # on_start without room → stash
         processor.on_start(span)
         assert mod.get_pending_entry_span() is span
 
@@ -1071,7 +1071,7 @@ class TestDeferredEntrySpanTagging:
         processor = mod.AgentTeamsTaskSpanProcessor(workspace, cache_ttl=0)
         entry = _entry_span()
 
-        # on_start without room -> stash
+        # on_start without room → stash
         processor.on_start(entry)
 
         # Set room, then call tag_current_entry_span (the wrapper's path)

--- a/plugins/tests/teamharness/test_trace_integration.py
+++ b/plugins/tests/teamharness/test_trace_integration.py
@@ -4,7 +4,7 @@
 Uses a real OTel SDK (TracerProvider + InMemorySpanExporter) together with
 the TeamHarness MCP server to verify that ``agentteams.task.id`` and
 ``agentteams.project.id`` appear on exported spans at every stage of the task
-lifecycle:  delegate -> ack -> tool calls -> submit -> post-submit.
+lifecycle:  delegate → ack → tool calls → submit → post-submit.
 
 Prerequisites:
     pip install opentelemetry-api opentelemetry-sdk
@@ -23,7 +23,7 @@ from typing import Any
 import pytest
 
 # ---------------------------------------------------------------------------
-# OTel SDK imports - skip entire module when SDK is absent
+# OTel SDK imports — skip entire module when SDK is absent
 # ---------------------------------------------------------------------------
 otel_sdk = pytest.importorskip("opentelemetry.sdk")
 
@@ -66,7 +66,7 @@ def otel_env(tmp_path: Path):
     install the AgentTeamsTaskSpanProcessor on it.
 
     Uses the provider directly (via provider.get_tracer) instead of the
-    global set_tracer_provider - avoids the "already set" warning and keeps
+    global set_tracer_provider — avoids the "already set" warning and keeps
     tests isolated.
     """
     workspace = tmp_path / "workspaces" / "default"
@@ -134,7 +134,7 @@ def mcp_server(otel_env):
 
     server = _load_module("teamharness_mcp_server_integ", SERVER_MODULE_PATH)
 
-    # Stub out MinIO sync operations - we only care about local meta.json changes
+    # Stub out MinIO sync operations — we only care about local meta.json changes
     server._sync_task = lambda *a, **kw: True
     server._pull_task = lambda *a, **kw: True
 
@@ -302,7 +302,7 @@ class TestAckTask:
         # Simulate: Agent's Entry span starts
         with _room(otel_env.trace_mod, "!room:m.org"):
             with otel_env.tracer.start_as_current_span("enter_ai_application_system"):
-                # Agent calls ack_task via MCP - this changes meta.json to in_progress
+                # Agent calls ack_task via MCP — this changes meta.json to in_progress
                 with otel_env.tracer.start_as_current_span("mcp-tool-call"):
                     payload = _mcp_call(mcp_server, "taskflow", {
                         "workspaceDir": str(ws),
@@ -348,7 +348,7 @@ class TestDuringWork:
                         pass
 
         all_spans = otel_env.exporter.get_finished_spans()
-        assert len(all_spans) == 9  # 3 turns x (entry + llm + tool)
+        assert len(all_spans) == 9  # 3 turns × (entry + llm + tool)
 
         tagged = _spans_with_task(otel_env.exporter, "active-task")
         assert len(tagged) == 3
@@ -403,7 +403,7 @@ class TestSubmitTask:
         # --- Submit turn ---
         with _room(otel_env.trace_mod, "!room:m.org"):
             with otel_env.tracer.start_as_current_span("enter_ai_application_system"):
-                # Entry span is created BEFORE submit - task is still in_progress
+                # Entry span is created BEFORE submit — task is still in_progress
                 with otel_env.tracer.start_as_current_span("mcp-submit"):
                     submit_result = _mcp_call(mcp_server, "taskflow", {
                         "workspaceDir": str(ws),
@@ -439,7 +439,7 @@ class TestSubmitTask:
 
 
 class TestFullLifecycle:
-    """End-to-end: delegate -> ack -> work -> submit -> idle."""
+    """End-to-end: delegate → ack → work → submit → idle."""
 
     def test_delegate_ack_work_submit_idle(self, otel_env, mcp_server) -> None:
         ws = otel_env.workspace
@@ -467,9 +467,8 @@ class TestFullLifecycle:
                 },
             })
             assert delegate_result["ok"] is True
-            assert delegate_result["task"]["assigned_to"] == "worker-a"
 
-        # At this point task status is "assigned" - no spans should be tagged
+        # At this point task status is "assigned" — no spans should be tagged
         delegate_spans = otel_env.exporter.get_finished_spans()
         for span in delegate_spans:
             assert "agentteams.task.id" not in (span.attributes or {})
@@ -567,7 +566,7 @@ class TestRegisterViaRealProvider:
 
             tracer = provider.get_tracer("test")
 
-            # No task yet - span should be clean
+            # No task yet — span should be clean
             with tracer.start_as_current_span("no-task"):
                 pass
             spans = exporter.get_finished_spans()
@@ -576,7 +575,7 @@ class TestRegisterViaRealProvider:
 
             exporter.clear()
 
-            # Write active task - next span should be tagged
+            # Write active task — next span should be tagged
             _write_task(workspace, "reg-task", {
                 "task_id": "reg-task",
                 "project_id": "reg-proj",

--- a/tests/test-21-team-project-dag.sh
+++ b/tests/test-21-team-project-dag.sh
@@ -294,6 +294,8 @@ TEAM_ROOM_ENC=$(echo "${TEAM_ROOM}" | sed 's/!/%21/g')
 LEADER_DM_ENC=$(echo "${LEADER_DM}" | sed 's/!/%21/g')
 
 LEADER_RESPONDED=false
+TEAM_COORDINATED=false
+RUNTIME_ERROR=false
 for i in $(seq 1 20); do
     sleep 30
     log_info "Polling rooms... (${i}/20, elapsed: $((i*30))s)"
@@ -310,11 +312,13 @@ for i in $(seq 1 20); do
     if echo "${TEAM_MSGS}" | grep -q "@${TEST_LEADER}:"; then
         log_info "Leader is active in Team Room"
         LEADER_RESPONDED=true
+        TEAM_COORDINATED=true
     fi
 
     # Check if any worker has responded in Team Room
     if echo "${TEAM_MSGS}" | grep -qi "${TEST_W1}\|${TEST_W2}"; then
         log_info "Workers are responding in Team Room"
+        TEAM_COORDINATED=true
         break
     fi
 
@@ -330,13 +334,18 @@ for i in $(seq 1 20); do
     if [ -n "${DM_MSGS}" ]; then
         log_info "Leader responded in Leader DM"
         LEADER_RESPONDED=true
+        if echo "${DM_MSGS}" | grep -qi "Error:\\|No active model configured"; then
+            RUNTIME_ERROR=true
+        fi
     fi
 done
 
-if [ "${LEADER_RESPONDED}" = "true" ]; then
+if [ "${RUNTIME_ERROR}" = "true" ]; then
+    log_fail "Leader returned a runtime error"
+elif [ "${LEADER_RESPONDED}" = "true" ] && [ "${TEAM_COORDINATED}" = "true" ]; then
     log_pass "Leader received and processed task from Admin via Leader DM"
 else
-    log_fail "Leader did not respond within timeout"
+    log_fail "Leader did not coordinate the task in Team Room within timeout"
 fi
 
 # Final snapshot of all rooms

--- a/tests/test-26-qwenpaw-teamharness-plugin-mode.sh
+++ b/tests/test-26-qwenpaw-teamharness-plugin-mode.sh
@@ -1,0 +1,1349 @@
+#!/bin/bash
+# test-26-qwenpaw-teamharness-plugin-mode.sh - Case 26: QwenPaw TeamHarness plugin-mode team work
+#
+# Verifies the real Team path:
+#   controller -> qwenpaw leader/worker -> qwenpaw plugin install teamharness
+#   -> TeamHarness MCP -> Matrix delegation -> shared task result.
+#
+# This is intentionally not just a plugin smoke test. The final pass condition
+# is a real QwenPaw Team completing one delegated TeamHarness task.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/test-helpers.sh"
+source "${SCRIPT_DIR}/lib/matrix-client.sh"
+source "${SCRIPT_DIR}/lib/minio-client.sh"
+
+test_setup "26-qwenpaw-teamharness-plugin-mode"
+minio_setup
+
+TEST_TEAM="test26-qwenpaw-team-$$"
+TEST_LEADER="${TEST_TEAM}-leader"
+TEST_WORKER="${TEST_TEAM}-worker"
+TEST_MODEL="${HICLAW_E2E_MODEL:-${HICLAW_DEFAULT_MODEL:-qwen3.7-max}}"
+PROJECT_ID="test26-project-$$"
+TASK_ID="test26-task-$$"
+TEST_RUN_ID="$$_$(date +%s)"
+MARKER="TEST26_TEAMHARNESS_PLUGIN_MODE_${TEST_RUN_ID}"
+BOOTSTRAP_LEADER_MARKER="TEST26_QWENPAW_BOOTSTRAP_LEADER_${TEST_RUN_ID}"
+BOOTSTRAP_WORKER_MARKER="TEST26_QWENPAW_BOOTSTRAP_WORKER_${TEST_RUN_ID}"
+LEADER_PACKAGE_V1_MARKER="TEST26_LEADER_PACKAGE_V1_${TEST_RUN_ID}"
+WORKER_PACKAGE_V1_MARKER="TEST26_WORKER_PACKAGE_V1_${TEST_RUN_ID}"
+LEADER_PACKAGE_V2_MARKER="TEST26_LEADER_PACKAGE_V2_${TEST_RUN_ID}"
+WORKER_PACKAGE_V2_MARKER="TEST26_WORKER_PACKAGE_V2_${TEST_RUN_ID}"
+DONE_LINE="TEST26_TEAMHARNESS_DONE ${TASK_ID} ${MARKER}"
+LEADER_CONTAINER="hiclaw-worker-${TEST_LEADER}"
+WORKER_CONTAINER="hiclaw-worker-${TEST_WORKER}"
+K8S_NAMESPACE="${HICLAW_E2E_NAMESPACE:-default}"
+LEADER_PACKAGE_V1_OBJECT="hiclaw-config/packages/${TEST_LEADER}-v1.tar.gz"
+WORKER_PACKAGE_V1_OBJECT="hiclaw-config/packages/${TEST_WORKER}-v1.tar.gz"
+LEADER_PACKAGE_V2_OBJECT="hiclaw-config/packages/${TEST_LEADER}-v2.tar.gz"
+WORKER_PACKAGE_V2_OBJECT="hiclaw-config/packages/${TEST_WORKER}-v2.tar.gz"
+LEADER_PACKAGE_V1_URI="oss://${LEADER_PACKAGE_V1_OBJECT}"
+WORKER_PACKAGE_V1_URI="oss://${WORKER_PACKAGE_V1_OBJECT}"
+LEADER_PACKAGE_V2_URI="oss://${LEADER_PACKAGE_V2_OBJECT}"
+WORKER_PACKAGE_V2_URI="oss://${WORKER_PACKAGE_V2_OBJECT}"
+TEST_MCP_NAME="docs"
+TEST_MCP_URL="https://gateway.example.com/mcp/docs"
+TEST_MCP_TRANSPORT="http"
+TEST_PACKAGE_MCP_NAME="package-docs"
+TEST_PACKAGE_MCP_URL="https://package.example.com/mcp"
+QWENPAW_WORKER_IMAGE=""
+CONTROLLER_NAME=""
+ADMIN_TOKEN=""
+TEAM_ROOM=""
+LEADER_DM=""
+LEADER_MXID=""
+WORKER_MXID=""
+LEADER_CONTAINER_ID_BEFORE_UPDATE=""
+WORKER_CONTAINER_ID_BEFORE_UPDATE=""
+LEADER_CONTAINER_STARTED_BEFORE_UPDATE=""
+WORKER_CONTAINER_STARTED_BEFORE_UPDATE=""
+
+_cleanup() {
+    if [ "${TESTS_FAILED}" -gt 0 ]; then
+        log_info "Tests failed - preserving test26 resources for debugging"
+        log_info "  Team: ${TEST_TEAM}"
+        log_info "  Leader container: ${LEADER_CONTAINER}"
+        log_info "  Worker container: ${WORKER_CONTAINER}"
+        [ -n "${TEAM_ROOM}" ] && log_info "  Team Room: ${TEAM_ROOM}"
+        [ -n "${LEADER_DM}" ] && log_info "  Leader DM: ${LEADER_DM}"
+        return
+    fi
+
+    log_info "Cleaning up test26 resources"
+    _k8s_delete "teams" "${TEST_TEAM}" >/dev/null 2>&1 || true
+    _k8s_delete "workers" "${TEST_LEADER}" >/dev/null 2>&1 || true
+    _k8s_delete "workers" "${TEST_WORKER}" >/dev/null 2>&1 || true
+    sleep 5
+    docker rm -f "${LEADER_CONTAINER}" "${WORKER_CONTAINER}" 2>/dev/null || true
+    exec_in_manager mc rm -r --force "hiclaw-test/hiclaw-storage/teams/${TEST_TEAM}/" 2>/dev/null || true
+    exec_in_manager mc rm -r --force "hiclaw-test/hiclaw-storage/agents/${TEST_LEADER}/" 2>/dev/null || true
+    exec_in_manager mc rm -r --force "hiclaw-test/hiclaw-storage/agents/${TEST_WORKER}/" 2>/dev/null || true
+    exec_in_manager mc rm -r --force "hiclaw-test/hiclaw-storage/agents/${TEST_LEADER}/runtime/" 2>/dev/null || true
+    exec_in_manager mc rm -r --force "hiclaw-test/hiclaw-storage/agents/${TEST_WORKER}/runtime/" 2>/dev/null || true
+    exec_in_manager mc rm -r --force "hiclaw-test/hiclaw-storage/shared/projects/${PROJECT_ID}/" 2>/dev/null || true
+    exec_in_manager mc rm -r --force "hiclaw-test/hiclaw-storage/shared/tasks/${TASK_ID}/" 2>/dev/null || true
+    for object in \
+        "${LEADER_PACKAGE_V1_OBJECT}" \
+        "${WORKER_PACKAGE_V1_OBJECT}" \
+        "${LEADER_PACKAGE_V2_OBJECT}" \
+        "${WORKER_PACKAGE_V2_OBJECT}"; do
+        exec_in_manager mc rm --force "hiclaw-test/hiclaw-storage/${object}" 2>/dev/null || true
+    done
+}
+trap _cleanup EXIT
+
+_controller_env() {
+    local key="$1"
+    docker exec "${TEST_CONTROLLER_CONTAINER:-hiclaw-controller}" printenv "${key}" 2>/dev/null || true
+}
+
+_container_env() {
+    local container="$1"
+    docker exec "${container}" sh -c "tr '\\0' '\\n' < /proc/1/environ" 2>/dev/null || true
+}
+
+_env_value() {
+    local env_text="$1"
+    local key="$2"
+    printf '%s\n' "${env_text}" | grep "^${key}=" | head -1 | cut -d= -f2-
+}
+
+_controller_labels_json() {
+    if [ -n "${CONTROLLER_NAME}" ]; then
+        jq -nc --arg controller "${CONTROLLER_NAME}" '{"hiclaw.io/controller":$controller}'
+    else
+        printf '{}\n'
+    fi
+}
+
+_k8s_api() {
+    local method="$1"
+    local content_type="$2"
+    local path="$3"
+
+    if [ "${method}" = "GET" ] || [ "${method}" = "DELETE" ]; then
+        docker exec "${TEST_CONTROLLER_CONTAINER:-hiclaw-controller}" sh -c '
+            token="$(cut -d, -f1 /data/hiclaw-controller/pki/token.csv)"
+            curl -ksS -X "$1" \
+                -H "Authorization: Bearer ${token}" \
+                "https://127.0.0.1:6443$2"
+        ' sh "${method}" "${path}"
+        return $?
+    fi
+
+    docker exec -i "${TEST_CONTROLLER_CONTAINER:-hiclaw-controller}" sh -c '
+        token="$(cut -d, -f1 /data/hiclaw-controller/pki/token.csv)"
+        curl -ksS -X "$1" \
+            -H "Authorization: Bearer ${token}" \
+            -H "Content-Type: $2" \
+            --data-binary @- \
+            "https://127.0.0.1:6443$3"
+    ' sh "${method}" "${content_type}" "${path}"
+}
+
+_k8s_resource_path() {
+    local plural="$1"
+    local name="${2:-}"
+    local path="/apis/hiclaw.io/v1beta1/namespaces/${K8S_NAMESPACE}/${plural}"
+    if [ -n "${name}" ]; then
+        path="${path}/${name}"
+    fi
+    printf '%s\n' "${path}"
+}
+
+_k8s_get() {
+    local plural="$1"
+    local name="$2"
+    _k8s_api GET "" "$(_k8s_resource_path "${plural}" "${name}")"
+}
+
+_k8s_delete() {
+    local plural="$1"
+    local name="$2"
+    _k8s_api DELETE "" "$(_k8s_resource_path "${plural}" "${name}")"
+}
+
+_k8s_create() {
+    local plural="$1"
+    local body="$2"
+    printf '%s' "${body}" | _k8s_api POST "application/json" "$(_k8s_resource_path "${plural}")"
+}
+
+_k8s_patch_merge() {
+    local plural="$1"
+    local name="$2"
+    local body="$3"
+    printf '%s' "${body}" | _k8s_api PATCH "application/merge-patch+json" "$(_k8s_resource_path "${plural}" "${name}")"
+}
+
+_wait_k8s_jq() {
+    local plural="$1"
+    local name="$2"
+    local filter="$3"
+    local timeout="${4:-180}"
+    local elapsed=0
+    local body=""
+    while [ "${elapsed}" -lt "${timeout}" ]; do
+        body="$(_k8s_get "${plural}" "${name}" 2>/dev/null || echo "{}")"
+        if printf '%s\n' "${body}" | jq -e "${filter}" >/dev/null 2>&1; then
+            printf '%s\n' "${body}"
+            return 0
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+    printf '%s\n' "${body}"
+    return 1
+}
+
+_container_has_cmdline() {
+    local container="$1"
+    local pattern="$2"
+    docker exec "${container}" sh -c '
+        for f in /proc/[0-9]*/cmdline; do
+            tr "\0" " " < "$f"
+            echo
+        done | grep -q "$1"
+    ' sh "${pattern}" >/dev/null 2>&1
+}
+
+_agent_api() {
+    local container="$1"
+    local method="$2"
+    local path="$3"
+    docker exec "${container}" sh -c '
+        port="${HICLAW_CONSOLE_PORT:-8088}"
+        curl -sf -X "'"${method}"'" "http://127.0.0.1:${port}'"${path}"'"
+    ' 2>/dev/null
+}
+
+_wait_agent_api_ok() {
+    local container="$1"
+    local method="$2"
+    local path="$3"
+    local filter="$4"
+    local timeout="${5:-180}"
+    local elapsed=0
+    while [ "${elapsed}" -lt "${timeout}" ]; do
+        local body
+        body=$(_agent_api "${container}" "${method}" "${path}" 2>/dev/null || true)
+        if [ -n "${body}" ] && echo "${body}" | jq -e "${filter}" >/dev/null 2>&1; then
+            printf '%s\n' "${body}"
+            return 0
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+    return 1
+}
+
+_wait_container_file() {
+    local container="$1"
+    local path="$2"
+    local timeout="${3:-120}"
+    local elapsed=0
+    while [ "${elapsed}" -lt "${timeout}" ]; do
+        if docker exec "${container}" test -f "${path}" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+    return 1
+}
+
+_yaml_to_json() {
+    ruby -ryaml -rjson -e 'puts JSON.generate(YAML.load(STDIN.read) || {})'
+}
+
+_qwenpaw_mcp_call() {
+    local container="$1"
+    local tool="$2"
+    local args_json="$3"
+    local output
+    output=$(docker exec -i \
+        -e TEST_MCP_TOOL="${tool}" \
+        -e TEST_MCP_ARGS="${args_json}" \
+        "${container}" \
+        /opt/venv/qwenpaw/bin/python - <<'PY'
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+for item in Path("/proc/1/environ").read_bytes().split(b"\0"):
+    if item and b"=" in item:
+        key, value = item.split(b"=", 1)
+        os.environ.setdefault(key.decode(), value.decode())
+
+workspace = Path(os.environ["QWENPAW_WORKING_DIR"]) / "workspaces" / "default"
+agent_config = json.loads((workspace / "agent.json").read_text(encoding="utf-8"))
+client = agent_config["mcp"]["clients"]["teamharness"]
+
+env = dict(os.environ)
+env.update({str(k): str(v) for k, v in (client.get("env") or {}).items()})
+request = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+        "name": os.environ["TEST_MCP_TOOL"],
+        "arguments": json.loads(os.environ["TEST_MCP_ARGS"]),
+    },
+}
+proc = subprocess.run(
+    [client["command"], *client.get("args", [])],
+    input=json.dumps(request) + "\n",
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    cwd=client.get("cwd") or None,
+    env=env,
+)
+if proc.returncode != 0:
+    print(proc.stderr, file=sys.stderr)
+    print(proc.stdout, file=sys.stderr)
+    raise SystemExit(proc.returncode)
+lines = [line for line in proc.stdout.splitlines() if line.strip()]
+if not lines:
+    print("empty MCP response", file=sys.stderr)
+    raise SystemExit(1)
+response = json.loads(lines[-1])
+if response.get("error"):
+    print(json.dumps(response, ensure_ascii=False), file=sys.stderr)
+    raise SystemExit(1)
+print(response["result"]["content"][0]["text"])
+PY
+    ) || {
+        printf '%s\n' "${output}" >&2
+        return 1
+    }
+    printf '%s\n' "${output}" | python3 -c '
+import json
+import sys
+
+for line in sys.stdin:
+    text = line.strip()
+    if not text.startswith("{"):
+        continue
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        continue
+    if isinstance(parsed, dict) and ("ok" in parsed or "tool" in parsed or "error" in parsed):
+        print(json.dumps(parsed, ensure_ascii=False))
+        raise SystemExit(0)
+print("no JSON MCP payload found", file=sys.stderr)
+raise SystemExit(1)
+'
+}
+
+_leader_mcp_call() {
+    _qwenpaw_mcp_call "${LEADER_CONTAINER}" "$@"
+}
+
+_worker_mcp_call() {
+    _qwenpaw_mcp_call "${WORKER_CONTAINER}" "$@"
+}
+
+_wait_leader_shared_stat() {
+    local path="$1"
+    local timeout="${2:-120}"
+    local elapsed=0
+    local stat_args
+    stat_args=$(jq -nc --arg path "${path}" '{action:"stat", path:$path}')
+    while [ "${elapsed}" -lt "${timeout}" ]; do
+        local result
+        result=$(_leader_mcp_call filesync "${stat_args}" 2>/dev/null || echo "{}")
+        if echo "${result}" | jq -e '.ok == true and .exists == true' >/dev/null 2>&1; then
+            printf '%s\n' "${result}"
+            return 0
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+    return 1
+}
+
+_wait_runtime_package_ref() {
+    local member="$1"
+    local expected="$2"
+    local timeout="${3:-180}"
+    local elapsed=0
+    local yaml=""
+    local json="{}"
+    while [ "${elapsed}" -lt "${timeout}" ]; do
+        yaml="$(minio_read_file "agents/${member}/runtime/runtime.yaml" 2>/dev/null || true)"
+        json="$(printf '%s' "${yaml}" | _yaml_to_json 2>/dev/null || echo "{}")"
+        if printf '%s\n' "${json}" | jq -e --arg package "${expected}" '.desired.agentPackage.ref == $package' >/dev/null 2>&1; then
+            printf '%s\n' "${yaml}"
+            return 0
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+    printf '%s\n' "${yaml}"
+    return 1
+}
+
+_wait_workspace_marker() {
+    local container="$1"
+    local path="$2"
+    local expected="$3"
+    local timeout="${4:-180}"
+    local elapsed=0
+    while [ "${elapsed}" -lt "${timeout}" ]; do
+        if docker exec "${container}" sh -c "grep -Fq '$expected' '$path'" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+    return 1
+}
+
+_assert_runtime_yaml_has_no_secret_values() {
+    local yaml="$1"
+    local container="$2"
+    local env_text
+    env_text="$(_container_env "${container}")"
+    for key in HICLAW_WORKER_MATRIX_TOKEN HICLAW_WORKER_GATEWAY_KEY HICLAW_FS_SECRET_KEY; do
+        local value
+        value="$(_env_value "${env_text}" "${key}")"
+        if [ -n "${value}" ] && [ "${#value}" -ge 4 ] && printf '%s' "${yaml}" | grep -Fq "${value}"; then
+            log_fail "runtime.yaml leaks secret value from ${key}"
+        else
+            log_pass "runtime.yaml does not leak ${key} value"
+        fi
+    done
+    if printf '%s\n' "${yaml}" | grep -Eq '^[[:space:]]*(accessKey|fsAccessKey|storageAccessKey):[[:space:]]*'; then
+        log_fail "runtime.yaml writes storage access key value instead of env reference"
+    else
+        log_pass "runtime.yaml references storage access key by env name only"
+    fi
+}
+
+_dump_debug_snapshot() {
+    log_info "Debug snapshot for test26"
+    for container in "${LEADER_CONTAINER}" "${WORKER_CONTAINER}"; do
+        if docker ps -a --format '{{.Names}}' | grep -q "^${container}$"; then
+            log_info "Logs tail: ${container}"
+            docker logs --tail 120 "${container}" 2>&1 || true
+            log_info "TeamHarness status: ${container}"
+            _agent_api "${container}" GET /api/teamharness/status || true
+        fi
+    done
+    if [ -n "${ADMIN_TOKEN}" ] && [ -n "${TEAM_ROOM}" ]; then
+        log_info "Recent Team Room messages:"
+        matrix_read_messages "${ADMIN_TOKEN}" "${TEAM_ROOM}" 30 2>/dev/null | \
+            jq -r '.chunk[] | select(.type == "m.room.message") | "\(.sender): \(.content.body // "")"' || true
+    fi
+    exec_in_manager mc ls --recursive "hiclaw-test/hiclaw-storage/shared/projects/${PROJECT_ID}/" 2>/dev/null || true
+    exec_in_manager mc ls --recursive "hiclaw-test/hiclaw-storage/shared/tasks/${TASK_ID}/" 2>/dev/null || true
+}
+
+_create_test_agentspec_package() {
+    local role="$1"
+    local version="$2"
+    local marker="$3"
+    local object="$4"
+    local bootstrap_marker="${BOOTSTRAP_WORKER_MARKER}"
+    if [ "${role}" = "leader" ]; then
+        bootstrap_marker="${BOOTSTRAP_LEADER_MARKER}"
+    fi
+
+    exec_in_manager bash -c "set -eu
+        work='/tmp/hiclaw-test26-package-${TEST_TEAM}-${role}-${version}'
+        archive='/tmp/${TEST_TEAM}-${role}-${version}-agentspec.tar.gz'
+        rm -rf \"\${work}\" \"\${archive}\"
+        mkdir -p \"\${work}/config/config\" \"\${work}/config/bootstrap\" \"\${work}/config/materials\" \"\${work}/skills/test26-package-skill\"
+        cat >\"\${work}/manifest.json\" <<'EOF'
+{\"name\":\"test26-${role}-agentspec\",\"version\":\"${version}\"}
+EOF
+        cat >\"\${work}/mcp.json\" <<'EOF'
+{\"mcpServers\":{\"package-docs\":{\"url\":\"https://package.example.com/mcp\",\"transport\":\"http\",\"description\":\"test26 package MCP\"}}}
+EOF
+        cat >\"\${work}/config/AGENTS.md\" <<'EOF'
+# TEST26 AgentSpec Package
+
+This AGENTS.md came from the QwenPaw AgentSpec package.
+Role: ${role}
+Version: ${version}
+Marker: ${marker}
+EOF
+        cat >\"\${work}/config/SOUL.md\" <<'EOF'
+# TEST26 AgentSpec Package Soul
+
+This SOUL.md came from the QwenPaw AgentSpec package.
+Role: ${role}
+Version: ${version}
+Marker: ${marker}
+EOF
+        cat >\"\${work}/config/config/credagent.json\" <<'EOF'
+{\"output_sanitize\":[]}
+EOF
+        cat >\"\${work}/config/config/settings.yaml\" <<'EOF'
+test26: true
+role: ${role}
+version: ${version}
+EOF
+        cat >\"\${work}/config/hot-update-marker.txt\" <<'EOF'
+${marker}
+EOF
+        cat >\"\${work}/config/BOOTSTRAP.md\" <<'EOF'
+# TEST26 AgentSpec Package Bootstrap
+
+This BOOTSTRAP.md came from the QwenPaw AgentSpec package root.
+
+This bootstrap is non-interactive. Do not ask the user to confirm identity.
+Complete these steps immediately before handling the user's request:
+
+1. Run the packaged hello script:
+   sh bootstrap/test26-hello.sh
+
+2. Reply with exactly this marker:
+
+${bootstrap_marker}
+EOF
+        cat >\"\${work}/config/bootstrap/test26-seed.md\" <<'EOF'
+# TEST26 AgentSpec Config Bootstrap
+
+This config/bootstrap file came from the QwenPaw AgentSpec package.
+EOF
+        cat >\"\${work}/config/bootstrap/test26-hello.sh\" <<'EOF'
+#!/bin/sh
+set -eu
+
+marker='${bootstrap_marker}'
+role=\"\${HICLAW_WORKER_ROLE:-\${HICLAW_AGENT_ROLE:-unknown}}\"
+
+mkdir -p bootstrap
+printf '%s\n' \"\${marker}\" > bootstrap/test26-hello-result.txt
+printf '%s\n' \"\${role}\" > bootstrap/test26-hello-role.txt
+EOF
+        chmod +x \"\${work}/config/bootstrap/test26-hello.sh\"
+        cat >\"\${work}/config/materials/test26-note.md\" <<'EOF'
+# TEST26 AgentSpec Custom Material
+
+This custom material came from the QwenPaw AgentSpec package root.
+EOF
+        cat >\"\${work}/skills/test26-package-skill/SKILL.md\" <<'EOF'
+---
+name: test26-package-skill
+description: Marks that the AgentSpec package skill was installed into the QwenPaw workspace.
+---
+
+# TEST26 Package Skill
+
+This skill came from the QwenPaw AgentSpec package.
+EOF
+        tar -czf \"\${archive}\" -C \"\${work}\" .
+        mc cp \"\${archive}\" 'hiclaw-test/hiclaw-storage/${object}' >/dev/null
+    "
+}
+
+_create_qwenpaw_worker_cr() {
+    local name="$1"
+    local package_uri="$2"
+    local soul="$3"
+    local labels
+    local body
+    labels="$(_controller_labels_json)"
+    body=$(jq -nc \
+        --arg name "${name}" \
+        --arg namespace "${K8S_NAMESPACE}" \
+        --arg model "${TEST_MODEL}" \
+        --arg package "${package_uri}" \
+        --arg mcp_name "${TEST_MCP_NAME}" \
+        --arg mcp_url "${TEST_MCP_URL}" \
+        --arg mcp_transport "${TEST_MCP_TRANSPORT}" \
+        --arg soul "${soul}" \
+        --argjson labels "${labels}" \
+        '{
+            apiVersion:"hiclaw.io/v1beta1",
+            kind:"Worker",
+            metadata:{name:$name, namespace:$namespace, labels:$labels},
+            spec:{
+                runtime:"qwenpaw",
+                model:$model,
+                package:$package,
+                mcpServers:[{name:$mcp_name, url:$mcp_url, transport:$mcp_transport}],
+                soul:$soul
+            }
+        }')
+    _k8s_create "workers" "${body}"
+}
+
+_create_decoupled_team_cr() {
+    local labels
+    local body
+    labels="$(_controller_labels_json)"
+    body=$(jq -nc \
+        --arg name "${TEST_TEAM}" \
+        --arg namespace "${K8S_NAMESPACE}" \
+        --arg leader "${TEST_LEADER}" \
+        --arg worker "${TEST_WORKER}" \
+        --argjson labels "${labels}" \
+        '{
+            apiVersion:"hiclaw.io/v1beta1",
+            kind:"Team",
+            metadata:{name:$name, namespace:$namespace, labels:$labels},
+            spec:{
+                teamName:$name,
+                workerMembers:[
+                    {name:$leader, role:"team_leader"},
+                    {name:$worker, role:"worker"}
+                ]
+            }
+        }')
+    _k8s_create "teams" "${body}"
+}
+
+_patch_worker_package_ref() {
+    local name="$1"
+    local package_uri="$2"
+    local body
+    body=$(jq -nc --arg package "${package_uri}" '{spec:{package:$package}}')
+    _k8s_patch_merge "workers" "${name}" "${body}"
+}
+
+# ============================================================
+# Section 1: Image baseline
+# ============================================================
+log_section "QwenPaw Image Plugin Package Baseline"
+
+QWENPAW_WORKER_IMAGE="$(_controller_env HICLAW_QWENPAW_WORKER_IMAGE)"
+QWENPAW_WORKER_IMAGE="${HICLAW_E2E_QWENPAW_WORKER_IMAGE:-${QWENPAW_WORKER_IMAGE:-hiclaw/qwenpaw-worker:latest}}"
+CONTROLLER_NAME="$(_controller_env HICLAW_CONTROLLER_NAME)"
+
+if docker image inspect "${QWENPAW_WORKER_IMAGE}" >/dev/null 2>&1; then
+    log_pass "QwenPaw worker image exists: ${QWENPAW_WORKER_IMAGE}"
+else
+    log_fail "QwenPaw worker image missing: ${QWENPAW_WORKER_IMAGE} (run make build-qwenpaw-worker)"
+    test_teardown "26-qwenpaw-teamharness-plugin-mode"; test_summary; exit $?
+fi
+
+if docker run --rm --entrypoint qwenpaw-worker "${QWENPAW_WORKER_IMAGE}" --help >/dev/null 2>&1; then
+    log_pass "qwenpaw-worker --help works in image"
+else
+    log_fail "qwenpaw-worker --help failed in image"
+fi
+
+if docker run --rm --entrypoint qwenpaw "${QWENPAW_WORKER_IMAGE}" --help >/dev/null 2>&1; then
+    log_pass "qwenpaw --help works in image"
+else
+    log_fail "qwenpaw --help failed in image"
+fi
+
+IMAGE_PACKAGE_CHECK=$(docker run --rm -i --entrypoint /opt/venv/qwenpaw/bin/python "${QWENPAW_WORKER_IMAGE}" - <<'PY' 2>&1
+from pathlib import Path
+import zipfile
+
+zip_path = Path("/opt/hiclaw/plugins/teamharness-qwenpaw.zip")
+assert zip_path.is_file(), zip_path
+with zipfile.ZipFile(zip_path) as archive:
+    names = set(archive.namelist())
+    assert any(name.endswith("/plugin.json") for name in names)
+    assert any(name.endswith("/plugin.py") for name in names)
+    assert any(name.endswith("/teamharness/plugin.yaml") for name in names)
+    assert any(name.endswith("/teamharness/prompts/team/TEAMS.md") for name in names)
+    assert any(name.endswith("/teamharness/mcp/server.py") for name in names)
+    assert not any("agentteam" in name for name in names)
+print("ok")
+PY
+)
+IMAGE_PACKAGE_CHECK=$(printf '%s\n' "${IMAGE_PACKAGE_CHECK}" | tail -n 1)
+assert_eq "ok" "${IMAGE_PACKAGE_CHECK}" "Image carries opaque TeamHarness QwenPaw plugin zip"
+
+# ============================================================
+# Section 2: Create real QwenPaw Team
+# ============================================================
+log_section "Create QwenPaw Team"
+
+if _create_test_agentspec_package "leader" "v1" "${LEADER_PACKAGE_V1_MARKER}" "${LEADER_PACKAGE_V1_OBJECT}" && \
+   _create_test_agentspec_package "worker" "v1" "${WORKER_PACKAGE_V1_MARKER}" "${WORKER_PACKAGE_V1_OBJECT}" && \
+   _create_test_agentspec_package "leader" "v2" "${LEADER_PACKAGE_V2_MARKER}" "${LEADER_PACKAGE_V2_OBJECT}" && \
+   _create_test_agentspec_package "worker" "v2" "${WORKER_PACKAGE_V2_MARKER}" "${WORKER_PACKAGE_V2_OBJECT}"; then
+    log_pass "Leader and worker AgentSpec package versions uploaded to MinIO"
+else
+    log_fail "Failed to upload test AgentSpec packages to MinIO"
+fi
+
+LEADER_SOUL=$(cat <<EOF
+# ${TEST_LEADER}
+
+You are the leader for ${TEST_TEAM}. Use TeamHarness tools for project
+planning, task delegation, shared files, and team-room messages. Delegate
+worker tasks instead of completing them yourself.
+EOF
+)
+WORKER_SOUL=$(cat <<EOF
+# ${TEST_WORKER}
+
+You are a QwenPaw worker for ${TEST_TEAM}. When assigned a TeamHarness
+task, acknowledge it, use the shared task spec, write requested
+deliverables, submit the task, and reply in the Team Room.
+EOF
+)
+
+CREATE_LEADER_OUTPUT=$(_create_qwenpaw_worker_cr "${TEST_LEADER}" "${LEADER_PACKAGE_V1_URI}" "${LEADER_SOUL}" 2>&1 || true)
+if echo "${CREATE_LEADER_OUTPUT}" | jq -e --arg name "${TEST_LEADER}" '.metadata.name == $name' >/dev/null 2>&1; then
+    log_pass "Leader Worker CR created through Kubernetes API"
+else
+    log_fail "Leader Worker CR create failed: ${CREATE_LEADER_OUTPUT}"
+fi
+
+CREATE_WORKER_OUTPUT=$(_create_qwenpaw_worker_cr "${TEST_WORKER}" "${WORKER_PACKAGE_V1_URI}" "${WORKER_SOUL}" 2>&1 || true)
+if echo "${CREATE_WORKER_OUTPUT}" | jq -e --arg name "${TEST_WORKER}" '.metadata.name == $name' >/dev/null 2>&1; then
+    log_pass "Worker Worker CR created through Kubernetes API"
+else
+    log_fail "Worker Worker CR create failed: ${CREATE_WORKER_OUTPUT}"
+fi
+
+CREATE_TEAM_OUTPUT=$(_create_decoupled_team_cr 2>&1 || true)
+if echo "${CREATE_TEAM_OUTPUT}" | jq -e --arg name "${TEST_TEAM}" '.metadata.name == $name and (.spec.workerMembers | length == 2)' >/dev/null 2>&1; then
+    log_pass "Decoupled Team CR created through Kubernetes API"
+else
+    log_fail "Decoupled Team CR create failed: ${CREATE_TEAM_OUTPUT}"
+fi
+
+TEAM_JSON=$(_wait_k8s_jq "teams" "${TEST_TEAM}" '.status.phase == "Active"' 300 2>/dev/null || echo "{}")
+if echo "${TEAM_JSON}" | jq -e '.status.phase == "Active"' >/dev/null 2>&1; then
+    log_pass "Team is Active"
+else
+    log_fail "Team did not become Active"
+fi
+
+TEAM_ROOM=$(echo "${TEAM_JSON}" | jq -r '.status.teamRoomID // empty')
+LEADER_DM=$(echo "${TEAM_JSON}" | jq -r '.status.leaderDMRoomID // empty')
+assert_not_empty "${TEAM_ROOM}" "Team Room ID available"
+assert_not_empty "${LEADER_DM}" "Leader DM Room ID available"
+
+for member in "${TEST_LEADER}" "${TEST_WORKER}"; do
+    MEMBER_JSON=$(_wait_k8s_jq "workers" "${member}" '.status.roomID and .status.matrixUserID' 240 2>/dev/null || echo "{}")
+    if echo "${MEMBER_JSON}" | jq -e '.status.roomID and .status.matrixUserID' >/dev/null 2>&1; then
+        log_pass "Member ${member} provisioned"
+    else
+        log_fail "Member ${member} not provisioned"
+    fi
+    MEMBER_JSON=$(_wait_k8s_jq "workers" "${member}" '.status.phase == "Running"' 240 2>/dev/null || echo "{}")
+    if echo "${MEMBER_JSON}" | jq -e '.status.phase == "Running"' >/dev/null 2>&1; then
+        log_pass "Member ${member} is Running"
+    else
+        log_fail "Member ${member} did not reach Running"
+    fi
+    if wait_for_worker_container "${member}" 240; then
+        log_pass "Container for ${member} is running"
+    else
+        log_fail "Container for ${member} did not start"
+    fi
+done
+
+LEADER_JSON=$(_k8s_get "workers" "${TEST_LEADER}" 2>/dev/null || echo "{}")
+WORKER_JSON=$(_k8s_get "workers" "${TEST_WORKER}" 2>/dev/null || echo "{}")
+LEADER_MXID=$(echo "${LEADER_JSON}" | jq -r '.status.matrixUserID // empty')
+WORKER_MXID=$(echo "${WORKER_JSON}" | jq -r '.status.matrixUserID // empty')
+assert_eq "qwenpaw" "$(echo "${LEADER_JSON}" | jq -r '.spec.runtime // empty')" "Leader runtime is qwenpaw"
+assert_eq "qwenpaw" "$(echo "${WORKER_JSON}" | jq -r '.spec.runtime // empty')" "Worker runtime is qwenpaw"
+assert_not_empty "${LEADER_MXID}" "Leader Matrix ID available"
+assert_not_empty "${WORKER_MXID}" "Worker Matrix ID available"
+
+assert_eq "${QWENPAW_WORKER_IMAGE}" "$(docker inspect --format '{{.Config.Image}}' "${LEADER_CONTAINER}" 2>/dev/null || echo "")" "Leader uses QwenPaw image"
+assert_eq "${QWENPAW_WORKER_IMAGE}" "$(docker inspect --format '{{.Config.Image}}' "${WORKER_CONTAINER}" 2>/dev/null || echo "")" "Worker uses QwenPaw image"
+
+if _container_has_cmdline "${LEADER_CONTAINER}" "qwenpaw app --host"; then
+    log_pass "Leader qwenpaw app process is running"
+else
+    log_fail "Leader qwenpaw app process is not running"
+fi
+if _container_has_cmdline "${WORKER_CONTAINER}" "qwenpaw app --host"; then
+    log_pass "Worker qwenpaw app process is running"
+else
+    log_fail "Worker qwenpaw app process is not running"
+fi
+
+# ============================================================
+# Section 3: Controller runtime.yaml projection
+# ============================================================
+log_section "Runtime Config Projection"
+
+if minio_wait_for_file "agents/${TEST_LEADER}/runtime/runtime.yaml" 120; then
+    log_pass "Leader runtime.yaml written"
+else
+    log_fail "Leader runtime.yaml missing"
+fi
+if minio_wait_for_file "agents/${TEST_WORKER}/runtime/runtime.yaml" 120; then
+    log_pass "Worker runtime.yaml written"
+else
+    log_fail "Worker runtime.yaml missing"
+fi
+
+LEADER_RUNTIME_YAML=$(minio_read_file "agents/${TEST_LEADER}/runtime/runtime.yaml")
+WORKER_RUNTIME_YAML=$(minio_read_file "agents/${TEST_WORKER}/runtime/runtime.yaml")
+LEADER_RUNTIME_JSON=$(printf '%s' "${LEADER_RUNTIME_YAML}" | _yaml_to_json 2>/dev/null || echo "{}")
+WORKER_RUNTIME_JSON=$(printf '%s' "${WORKER_RUNTIME_YAML}" | _yaml_to_json 2>/dev/null || echo "{}")
+
+if echo "${LEADER_RUNTIME_JSON}" | jq -e --arg member "${TEST_LEADER}" \
+    '.member.runtimeName == $member and .member.runtime == "qwenpaw"' >/dev/null 2>&1; then
+    log_pass "Leader runtime.yaml contains QwenPaw worker facts"
+else
+    log_fail "Leader runtime.yaml missing QwenPaw worker facts"
+fi
+
+if echo "${WORKER_RUNTIME_JSON}" | jq -e --arg member "${TEST_WORKER}" \
+    '.member.runtimeName == $member and .member.runtime == "qwenpaw"' >/dev/null 2>&1; then
+    log_pass "Worker runtime.yaml contains QwenPaw worker facts"
+else
+    log_fail "Worker runtime.yaml missing QwenPaw worker facts"
+fi
+
+if echo "${LEADER_RUNTIME_JSON}" | jq -e '.desired.model.model and .credentials.matrixTokenEnv and .credentials.gatewayKeyEnv and .credentials.storageSecretKeyEnv' >/dev/null 2>&1 && \
+   echo "${WORKER_RUNTIME_JSON}" | jq -e '.desired.model.model and .credentials.matrixTokenEnv and .credentials.gatewayKeyEnv and .credentials.storageSecretKeyEnv' >/dev/null 2>&1; then
+    log_pass "runtime.yaml contains desired model and credential env names"
+else
+    log_fail "runtime.yaml missing desired model or credential env names"
+fi
+
+if echo "${LEADER_RUNTIME_JSON}" | jq -e --arg name "${TEST_MCP_NAME}" --arg url "${TEST_MCP_URL}" --arg transport "${TEST_MCP_TRANSPORT}" '.desired.mcpServers[] | select(.name == $name and .url == $url and .transport == $transport)' >/dev/null 2>&1 && \
+   echo "${WORKER_RUNTIME_JSON}" | jq -e --arg name "${TEST_MCP_NAME}" --arg url "${TEST_MCP_URL}" --arg transport "${TEST_MCP_TRANSPORT}" '.desired.mcpServers[] | select(.name == $name and .url == $url and .transport == $transport)' >/dev/null 2>&1; then
+    log_pass "runtime.yaml projects controller MCP servers"
+else
+    log_fail "runtime.yaml missing controller MCP servers"
+fi
+
+if echo "${LEADER_RUNTIME_JSON}" | jq -e --arg package "${LEADER_PACKAGE_V1_URI}" '.desired.agentPackage.ref == $package' >/dev/null 2>&1 && \
+   echo "${WORKER_RUNTIME_JSON}" | jq -e --arg package "${WORKER_PACKAGE_V1_URI}" '.desired.agentPackage.ref == $package' >/dev/null 2>&1; then
+    log_pass "runtime.yaml projects role-specific AgentSpec package refs"
+else
+    log_fail "runtime.yaml missing role-specific AgentSpec package refs"
+fi
+
+if echo "${LEADER_RUNTIME_JSON}" | jq -e --arg leader "${TEST_LEADER}" --arg worker "${TEST_WORKER}" --arg workerMxid "${WORKER_MXID}" \
+    '.team.members[] | select(.runtimeName == $leader and .role == "team_leader")' >/dev/null 2>&1 && \
+   echo "${LEADER_RUNTIME_JSON}" | jq -e --arg worker "${TEST_WORKER}" --arg workerMxid "${WORKER_MXID}" \
+    '.team.members[] | select(.runtimeName == $worker and .role == "worker" and .matrixUserId == $workerMxid)' >/dev/null 2>&1 && \
+   echo "${WORKER_RUNTIME_JSON}" | jq -e --arg leader "${TEST_LEADER}" --arg worker "${TEST_WORKER}" \
+    '([.team.members[].runtimeName] | index($leader) and index($worker))' >/dev/null 2>&1; then
+    log_pass "runtime.yaml projects TeamHarness roster facts"
+else
+    log_fail "runtime.yaml missing TeamHarness roster facts"
+fi
+
+_assert_runtime_yaml_has_no_secret_values "${LEADER_RUNTIME_YAML}${WORKER_RUNTIME_YAML}" "${WORKER_CONTAINER}"
+
+LEADER_ENV="$(_container_env "${LEADER_CONTAINER}")"
+WORKER_ENV="$(_container_env "${WORKER_CONTAINER}")"
+assert_eq "standalone" "$(_env_value "${LEADER_ENV}" HICLAW_WORKER_ROLE)" "Decoupled leader Worker daemon role remains standalone"
+assert_eq "standalone" "$(_env_value "${WORKER_ENV}" HICLAW_WORKER_ROLE)" "Decoupled worker daemon role remains standalone"
+
+# ============================================================
+# Section 4: QwenPaw plugin-mode install and TeamHarness assets
+# ============================================================
+log_section "QwenPaw Plugin Mode"
+
+for container in "${LEADER_CONTAINER}" "${WORKER_CONTAINER}"; do
+    if _wait_agent_api_ok "${container}" GET /api/teamharness/health '.ok == true and .plugin == "teamharness" and .adapter == "qwenpaw"' 240 >/dev/null; then
+        log_pass "${container} TeamHarness health endpoint is healthy"
+    else
+        log_fail "${container} TeamHarness health endpoint did not become healthy"
+    fi
+    if _wait_agent_api_ok "${container}" POST /api/teamharness/sync '.ok == true' 120 >/dev/null; then
+        log_pass "${container} TeamHarness sync endpoint succeeded"
+    else
+        log_fail "${container} TeamHarness sync endpoint failed"
+    fi
+    if _agent_api "${container}" GET /api/agentteam/health >/dev/null 2>&1; then
+        log_fail "${container} legacy /api/agentteam/health should not be required"
+    else
+        log_pass "${container} legacy /api/agentteam/health is absent"
+    fi
+done
+
+WORKER_HOME="/root/hiclaw-fs/agents/${TEST_WORKER}"
+WORKER_QWENPAW_DIR="${WORKER_HOME}/.qwenpaw"
+WORKER_DEFAULT_WS="${WORKER_QWENPAW_DIR}/workspaces/default"
+LEADER_HOME="/root/hiclaw-fs/agents/${TEST_LEADER}"
+LEADER_QWENPAW_DIR="${LEADER_HOME}/.qwenpaw"
+LEADER_DEFAULT_WS="${LEADER_QWENPAW_DIR}/workspaces/default"
+
+for container in "${LEADER_CONTAINER}" "${WORKER_CONTAINER}"; do
+    if [ "${container}" = "${LEADER_CONTAINER}" ]; then
+        home="${LEADER_HOME}"
+        qwenpaw_dir="${LEADER_QWENPAW_DIR}"
+        workspace="${LEADER_DEFAULT_WS}"
+        role="team_leader"
+        package_v1_marker="${LEADER_PACKAGE_V1_MARKER}"
+    else
+        home="${WORKER_HOME}"
+        qwenpaw_dir="${WORKER_QWENPAW_DIR}"
+        workspace="${WORKER_DEFAULT_WS}"
+        role="worker"
+        package_v1_marker="${WORKER_PACKAGE_V1_MARKER}"
+    fi
+
+    for artifact in \
+        "${qwenpaw_dir}/plugins/teamharness/plugin.json" \
+        "${qwenpaw_dir}/plugins/teamharness/plugin.py" \
+        "${qwenpaw_dir}/plugins/teamharness/teamharness/plugin.yaml" \
+        "${qwenpaw_dir}/plugins/teamharness/teamharness/prompts/team/TEAMS.md" \
+        "${qwenpaw_dir}/plugins/teamharness/teamharness/mcp/server.py"; do
+        if docker exec "${container}" test -f "${artifact}" >/dev/null 2>&1; then
+            log_pass "${container} has TeamHarness artifact: ${artifact}"
+        else
+            log_fail "${container} missing TeamHarness artifact: ${artifact}"
+        fi
+    done
+
+    if docker exec "${container}" test ! -e "${qwenpaw_dir}/plugins/agentteam" >/dev/null 2>&1 && \
+       docker exec "${container}" test ! -e "${home}/.agentteams" >/dev/null 2>&1; then
+        log_pass "${container} does not use legacy agentteam plugin state"
+    else
+        log_fail "${container} contains legacy agentteam plugin state"
+    fi
+
+    if docker exec "${container}" test -f "${workspace}/TEAMS.md" >/dev/null 2>&1; then
+        log_pass "${container} workspace TeamHarness prompt exists"
+    else
+        log_fail "${container} workspace TeamHarness prompt missing"
+    fi
+
+    if docker exec "${container}" sh -c "grep -q 'member.role: ${role}' '${workspace}/TEAMS.md' && grep -q '${TEST_TEAM}' '${workspace}/TEAMS.md'" >/dev/null 2>&1; then
+        log_pass "${container} TEAMS.md contains ${role} team context"
+    else
+        log_fail "${container} TEAMS.md missing ${role} team context"
+    fi
+
+    if docker exec "${container}" sh -c "grep -Fq '<!-- BEGIN HICLAW RUNTIME TEAM CONTEXT -->' '${workspace}/TEAMS.md' && grep -Fq 'runtimeName: ${TEST_LEADER}' '${workspace}/TEAMS.md' && grep -Fq 'runtimeName: ${TEST_WORKER}' '${workspace}/TEAMS.md' && grep -Fq 'matrixUserId: ${WORKER_MXID}' '${workspace}/TEAMS.md' && test ! -e '${qwenpaw_dir}/teamharness/team-context.json'" >/dev/null 2>&1; then
+        log_pass "${container} TEAMS.md contains runtime roster facts without intermediate cache"
+    else
+        log_fail "${container} TEAMS.md missing runtime roster facts or created intermediate cache"
+    fi
+
+    if docker exec "${container}" sh -c "jq -e '.system_prompt_files | index(\"TEAMS.md\")' '${workspace}/agent.json'" >/dev/null 2>&1; then
+        log_pass "${container} agent prompt files include TEAMS.md"
+    else
+        log_fail "${container} agent prompt files missing TEAMS.md"
+    fi
+
+    if docker exec "${container}" sh -c "jq -e '.mcp.clients.teamharness.enabled == true and .mcp.clients.teamharness.command and (.mcp.clients.teamharness.args | length > 0)' '${workspace}/agent.json'" >/dev/null 2>&1; then
+        log_pass "${container} agent config includes TeamHarness MCP client"
+    else
+        log_fail "${container} agent config missing TeamHarness MCP client"
+    fi
+
+    if docker exec "${container}" sh -c "jq -e --arg name '${TEST_PACKAGE_MCP_NAME}' --arg url '${TEST_PACKAGE_MCP_URL}' '.mcp.clients[\$name].url == \$url and (.mcp.clients[\$name].enabled != false)' '${workspace}/agent.json' && test ! -f '${workspace}/mcp.json'" >/dev/null 2>&1; then
+        log_pass "${container} agent config embeds AgentSpec package MCP"
+    else
+        log_fail "${container} agent config missing AgentSpec package MCP"
+    fi
+
+    if docker exec "${container}" sh -c "grep -q 'TEST26 AgentSpec Package' '${workspace}/AGENTS.md' && grep -q 'TEST26 AgentSpec Package Soul' '${workspace}/SOUL.md'" >/dev/null 2>&1; then
+        log_pass "${container} workspace includes AgentSpec package prompts"
+    else
+        log_fail "${container} workspace missing AgentSpec package prompts"
+    fi
+
+    if docker exec "${container}" sh -c "grep -q 'TEST26 AgentSpec Package Bootstrap' '${workspace}/BOOTSTRAP.md'" >/dev/null 2>&1; then
+        log_pass "${container} workspace includes AgentSpec package bootstrap"
+    else
+        log_fail "${container} workspace missing AgentSpec package bootstrap"
+    fi
+
+    if docker exec "${container}" sh -c "grep -q 'TEST26 AgentSpec Config Bootstrap' '${workspace}/bootstrap/test26-seed.md' && grep -q 'test26-hello-result.txt' '${workspace}/bootstrap/test26-hello.sh' && grep -q 'TEST26 AgentSpec Custom Material' '${workspace}/materials/test26-note.md' && test -f '${workspace}/config/credagent.json' && test -f '${workspace}/config/settings.yaml'" >/dev/null 2>&1; then
+        log_pass "${container} workspace includes AgentSpec package custom materials"
+    else
+        log_fail "${container} workspace missing AgentSpec package custom materials"
+    fi
+
+    if docker exec "${container}" sh -c "grep -Fq '${package_v1_marker}' '${workspace}/hot-update-marker.txt'" >/dev/null 2>&1; then
+        log_pass "${container} workspace includes role-specific v1 package marker"
+    else
+        log_fail "${container} workspace missing role-specific v1 package marker"
+    fi
+
+    if docker exec "${container}" sh -c "test -f '${workspace}/skills/test26-package-skill/SKILL.md' && jq -e '.skills[\"test26-package-skill\"].enabled == true' '${workspace}/skill.json'" >/dev/null 2>&1; then
+        log_pass "${container} workspace enables AgentSpec package skill"
+    else
+        log_fail "${container} workspace missing enabled AgentSpec package skill"
+    fi
+done
+
+_workspace_skill_check() {
+    local container="$1"
+    local workspace="$2"
+    local required="$3"
+    local forbidden="$4"
+    docker exec -i \
+        -e TEST_WORKSPACE="${workspace}" \
+        -e TEST_REQUIRED="${required}" \
+        -e TEST_FORBIDDEN="${forbidden}" \
+        "${container}" \
+        /opt/venv/qwenpaw/bin/python - <<'PY' 2>/dev/null | tail -n 1
+import json
+import os
+from pathlib import Path
+
+workspace = Path(os.environ["TEST_WORKSPACE"])
+required = [item for item in os.environ["TEST_REQUIRED"].split(",") if item]
+forbidden = [item for item in os.environ["TEST_FORBIDDEN"].split(",") if item]
+manifest = json.loads((workspace / "skill.json").read_text(encoding="utf-8"))
+skills = manifest.get("skills") or {}
+missing = [name for name in required if not (workspace / "skills" / name / "SKILL.md").is_file()]
+disabled = [name for name in required if not skills.get(name, {}).get("enabled")]
+unexpected = [name for name in forbidden if (workspace / "skills" / name).exists() or name in skills]
+problems = []
+if missing:
+    problems.append("missing:" + ",".join(missing))
+if disabled:
+    problems.append("disabled:" + ",".join(disabled))
+if unexpected:
+    problems.append("unexpected:" + ",".join(unexpected))
+print("ok" if not problems else ";".join(problems))
+PY
+}
+
+_workspace_runtime_projection_check() {
+    local container="$1"
+    local workspace="$2"
+    docker exec -i \
+        -e TEST_WORKSPACE="${workspace}" \
+        -e TEST_MODEL="${TEST_MODEL}" \
+        -e TEST_MCP_NAME="${TEST_MCP_NAME}" \
+        -e TEST_MCP_URL="${TEST_MCP_URL}" \
+        -e TEST_MCP_TRANSPORT="${TEST_MCP_TRANSPORT}" \
+        "${container}" \
+        /opt/venv/qwenpaw/bin/python - <<'PY' 2>/dev/null | tail -n 1
+import json
+import os
+from pathlib import Path
+
+workspace = Path(os.environ["TEST_WORKSPACE"])
+model = os.environ["TEST_MODEL"]
+mcp_name = os.environ["TEST_MCP_NAME"]
+mcp_url = os.environ["TEST_MCP_URL"]
+mcp_transport = os.environ["TEST_MCP_TRANSPORT"]
+
+problems = []
+agent = json.loads((workspace / "agent.json").read_text(encoding="utf-8"))
+active = agent.get("active_model") or {}
+if active.get("provider_id") != "hiclaw-gateway" or active.get("model") != model:
+    problems.append("active_model")
+
+for rel in ["mcporter-servers.json", "config/mcporter.json"]:
+    path = workspace / rel
+    if not path.is_file():
+        problems.append(f"missing:{rel}")
+        continue
+    data = json.loads(path.read_text(encoding="utf-8"))
+    server = (data.get("mcpServers") or {}).get(mcp_name) or {}
+    if server.get("url") != mcp_url or server.get("transport") != mcp_transport:
+        problems.append(f"mcp:{rel}")
+    authorization = (server.get("headers") or {}).get("Authorization", "")
+    if not authorization.startswith("Bearer "):
+        problems.append(f"auth:{rel}")
+
+print("ok" if not problems else ";".join(problems))
+PY
+}
+
+LEADER_RUNTIME_PROJECTION_CHECK=$(_workspace_runtime_projection_check "${LEADER_CONTAINER}" "${LEADER_DEFAULT_WS}")
+assert_eq "ok" "${LEADER_RUNTIME_PROJECTION_CHECK}" "Leader applies controller model and MCP config"
+
+WORKER_RUNTIME_PROJECTION_CHECK=$(_workspace_runtime_projection_check "${WORKER_CONTAINER}" "${WORKER_DEFAULT_WS}")
+assert_eq "ok" "${WORKER_RUNTIME_PROJECTION_CHECK}" "Worker applies controller model and MCP config"
+
+LEADER_SKILL_CHECK=$(_workspace_skill_check \
+    "${LEADER_CONTAINER}" \
+    "${LEADER_DEFAULT_WS}" \
+    "teamharness-communication,teamharness-file-sharing,teamharness-team-coordination,teamharness-project-management,teamharness-task-delegation" \
+    "teamharness-task-execution")
+assert_eq "ok" "${LEADER_SKILL_CHECK}" "Leader workspace enables TeamHarness role skills"
+
+WORKER_SKILL_CHECK=$(_workspace_skill_check \
+    "${WORKER_CONTAINER}" \
+    "${WORKER_DEFAULT_WS}" \
+    "teamharness-communication,teamharness-file-sharing,teamharness-mcporter,teamharness-task-execution" \
+    "teamharness-task-delegation")
+assert_eq "ok" "${WORKER_SKILL_CHECK}" "Worker workspace enables TeamHarness role skills"
+
+MCP_HEALTH=$(_worker_mcp_call health '{}' 2>/dev/null || echo "{}")
+if echo "${MCP_HEALTH}" | jq -e '.ok == true' >/dev/null 2>&1; then
+    log_pass "Worker TeamHarness MCP health tool ok"
+else
+    log_fail "Worker TeamHarness MCP health tool failed"
+fi
+
+MCP_LIST=$(_worker_mcp_call filesync "$(jq -nc '{action:"list", path:"shared/"}')" 2>/dev/null || echo "{}")
+if echo "${MCP_LIST}" | jq -e '.ok == true' >/dev/null 2>&1; then
+    log_pass "Worker TeamHarness filesync can list shared/"
+else
+    log_fail "Worker TeamHarness filesync failed to list shared/"
+fi
+
+# ============================================================
+# Section 5: AgentSpec hot update through Worker CR package refs
+# ============================================================
+log_section "QwenPaw AgentSpec Hot Update"
+
+LEADER_CONTAINER_ID_BEFORE_UPDATE=$(docker inspect --format '{{.Id}}' "${LEADER_CONTAINER}" 2>/dev/null || echo "")
+WORKER_CONTAINER_ID_BEFORE_UPDATE=$(docker inspect --format '{{.Id}}' "${WORKER_CONTAINER}" 2>/dev/null || echo "")
+LEADER_CONTAINER_STARTED_BEFORE_UPDATE=$(docker inspect --format '{{.State.StartedAt}}' "${LEADER_CONTAINER}" 2>/dev/null || echo "")
+WORKER_CONTAINER_STARTED_BEFORE_UPDATE=$(docker inspect --format '{{.State.StartedAt}}' "${WORKER_CONTAINER}" 2>/dev/null || echo "")
+assert_not_empty "${LEADER_CONTAINER_ID_BEFORE_UPDATE}" "Captured leader container identity before hot update"
+assert_not_empty "${WORKER_CONTAINER_ID_BEFORE_UPDATE}" "Captured worker container identity before hot update"
+
+PATCH_LEADER_OUTPUT=$(_patch_worker_package_ref "${TEST_LEADER}" "${LEADER_PACKAGE_V2_URI}" 2>&1 || true)
+if echo "${PATCH_LEADER_OUTPUT}" | jq -e --arg package "${LEADER_PACKAGE_V2_URI}" '.spec.package == $package' >/dev/null 2>&1; then
+    log_pass "Leader Worker CR package patched to v2"
+else
+    log_fail "Leader Worker CR package patch failed: ${PATCH_LEADER_OUTPUT}"
+fi
+
+PATCH_WORKER_OUTPUT=$(_patch_worker_package_ref "${TEST_WORKER}" "${WORKER_PACKAGE_V2_URI}" 2>&1 || true)
+if echo "${PATCH_WORKER_OUTPUT}" | jq -e --arg package "${WORKER_PACKAGE_V2_URI}" '.spec.package == $package' >/dev/null 2>&1; then
+    log_pass "Worker Worker CR package patched to v2"
+else
+    log_fail "Worker Worker CR package patch failed: ${PATCH_WORKER_OUTPUT}"
+fi
+
+LEADER_RUNTIME_YAML=$(_wait_runtime_package_ref "${TEST_LEADER}" "${LEADER_PACKAGE_V2_URI}" 240 || true)
+if printf '%s' "${LEADER_RUNTIME_YAML}" | _yaml_to_json 2>/dev/null | jq -e --arg package "${LEADER_PACKAGE_V2_URI}" '.desired.agentPackage.ref == $package' >/dev/null 2>&1; then
+    log_pass "Leader runtime.yaml projected v2 package ref"
+else
+    log_fail "Leader runtime.yaml did not project v2 package ref"
+fi
+
+WORKER_RUNTIME_YAML=$(_wait_runtime_package_ref "${TEST_WORKER}" "${WORKER_PACKAGE_V2_URI}" 240 || true)
+if printf '%s' "${WORKER_RUNTIME_YAML}" | _yaml_to_json 2>/dev/null | jq -e --arg package "${WORKER_PACKAGE_V2_URI}" '.desired.agentPackage.ref == $package' >/dev/null 2>&1; then
+    log_pass "Worker runtime.yaml projected v2 package ref"
+else
+    log_fail "Worker runtime.yaml did not project v2 package ref"
+fi
+
+LEADER_RUNTIME_JSON=$(printf '%s' "${LEADER_RUNTIME_YAML}" | _yaml_to_json 2>/dev/null || echo "{}")
+WORKER_RUNTIME_JSON=$(printf '%s' "${WORKER_RUNTIME_YAML}" | _yaml_to_json 2>/dev/null || echo "{}")
+if echo "${LEADER_RUNTIME_JSON}" | jq -e --arg leader "${TEST_LEADER}" --arg worker "${TEST_WORKER}" --arg workerMxid "${WORKER_MXID}" \
+    '.member.role == "team_leader" and (.team.members[] | select(.runtimeName == $leader and .role == "team_leader"))' >/dev/null 2>&1 && \
+   echo "${LEADER_RUNTIME_JSON}" | jq -e --arg worker "${TEST_WORKER}" --arg workerMxid "${WORKER_MXID}" \
+    '.team.members[] | select(.runtimeName == $worker and .role == "worker" and .matrixUserId == $workerMxid)' >/dev/null 2>&1 && \
+   echo "${WORKER_RUNTIME_JSON}" | jq -e --arg leader "${TEST_LEADER}" --arg worker "${TEST_WORKER}" \
+    '.member.role == "worker" and ([.team.members[].runtimeName] | index($leader) and index($worker))' >/dev/null 2>&1; then
+    log_pass "runtime.yaml preserves TeamHarness roster facts after hot update"
+else
+    log_fail "runtime.yaml lost TeamHarness roster facts after hot update"
+fi
+
+if _wait_workspace_marker "${LEADER_CONTAINER}" "${LEADER_DEFAULT_WS}/hot-update-marker.txt" "${LEADER_PACKAGE_V2_MARKER}" 300; then
+    log_pass "Leader QwenPaw worker applied v2 AgentSpec package"
+else
+    log_fail "Leader QwenPaw worker did not apply v2 AgentSpec package"
+fi
+
+if _wait_workspace_marker "${WORKER_CONTAINER}" "${WORKER_DEFAULT_WS}/hot-update-marker.txt" "${WORKER_PACKAGE_V2_MARKER}" 300; then
+    log_pass "Worker QwenPaw worker applied v2 AgentSpec package"
+else
+    log_fail "Worker QwenPaw worker did not apply v2 AgentSpec package"
+fi
+
+if docker exec "${LEADER_CONTAINER}" sh -c "grep -Fq 'member.role: team_leader' '${LEADER_DEFAULT_WS}/TEAMS.md' && grep -Fq 'runtimeName: ${TEST_LEADER}' '${LEADER_DEFAULT_WS}/TEAMS.md' && grep -Fq 'runtimeName: ${TEST_WORKER}' '${LEADER_DEFAULT_WS}/TEAMS.md' && grep -Fq 'matrixUserId: ${WORKER_MXID}' '${LEADER_DEFAULT_WS}/TEAMS.md'" >/dev/null 2>&1 && \
+   docker exec "${WORKER_CONTAINER}" sh -c "grep -Fq 'member.role: worker' '${WORKER_DEFAULT_WS}/TEAMS.md' && grep -Fq 'runtimeName: ${TEST_LEADER}' '${WORKER_DEFAULT_WS}/TEAMS.md' && grep -Fq 'runtimeName: ${TEST_WORKER}' '${WORKER_DEFAULT_WS}/TEAMS.md'" >/dev/null 2>&1; then
+    log_pass "TEAMS.md preserves runtime roster facts after hot update"
+else
+    log_fail "TEAMS.md lost runtime roster facts after hot update"
+fi
+
+assert_eq "${LEADER_CONTAINER_ID_BEFORE_UPDATE}" "$(docker inspect --format '{{.Id}}' "${LEADER_CONTAINER}" 2>/dev/null || echo "")" "Leader container was not recreated by package update"
+assert_eq "${WORKER_CONTAINER_ID_BEFORE_UPDATE}" "$(docker inspect --format '{{.Id}}' "${WORKER_CONTAINER}" 2>/dev/null || echo "")" "Worker container was not recreated by package update"
+assert_eq "${LEADER_CONTAINER_STARTED_BEFORE_UPDATE}" "$(docker inspect --format '{{.State.StartedAt}}' "${LEADER_CONTAINER}" 2>/dev/null || echo "")" "Leader container start time unchanged after package update"
+assert_eq "${WORKER_CONTAINER_STARTED_BEFORE_UPDATE}" "$(docker inspect --format '{{.State.StartedAt}}' "${WORKER_CONTAINER}" 2>/dev/null || echo "")" "Worker container start time unchanged after package update"
+
+# ============================================================
+# Section 6: Real Team work through Matrix and TeamHarness
+# ============================================================
+log_section "Real Team Work Through QwenPaw + TeamHarness"
+
+if ! require_llm_key; then
+    log_fail "test26 requires a real LLM key because the pass condition is real Team work"
+    _dump_debug_snapshot
+    test_teardown "26-qwenpaw-teamharness-plugin-mode"
+    test_summary
+    exit $?
+fi
+
+ADMIN_TOKEN=$(matrix_login "${TEST_ADMIN_USER}" "${TEST_ADMIN_PASSWORD}" 2>/dev/null | jq -r '.access_token // empty')
+assert_not_empty "${ADMIN_TOKEN}" "Admin Matrix login succeeded"
+
+if matrix_wait_for_user_joined "${ADMIN_TOKEN}" "${LEADER_DM}" "${LEADER_MXID}" 240; then
+    log_pass "QwenPaw leader joined Leader DM"
+else
+    log_fail "QwenPaw leader did not join Leader DM"
+fi
+if matrix_wait_for_user_joined "${ADMIN_TOKEN}" "${TEAM_ROOM}" "${LEADER_MXID}" 240; then
+    log_pass "QwenPaw leader joined Team Room"
+else
+    log_fail "QwenPaw leader did not join Team Room"
+fi
+if matrix_wait_for_user_joined "${ADMIN_TOKEN}" "${TEAM_ROOM}" "${WORKER_MXID}" 240; then
+    log_pass "QwenPaw worker joined Team Room"
+else
+    log_fail "QwenPaw worker did not join Team Room"
+fi
+
+log_section "QwenPaw Native Bootstrap"
+
+LEADER_BOOTSTRAP_PROMPT="Please run your package bootstrap now. Follow BOOTSTRAP.md exactly: run the packaged hello script, then reply with the requested marker. Do not ask me to confirm identity."
+if matrix_send_message "${ADMIN_TOKEN}" "${LEADER_DM}" "${LEADER_BOOTSTRAP_PROMPT}" >/dev/null 2>&1; then
+    log_pass "Admin sent package bootstrap request to QwenPaw leader"
+else
+    log_fail "Admin failed to send package bootstrap request to QwenPaw leader"
+fi
+
+LEADER_BOOTSTRAP_REPLY=$(matrix_wait_for_message_containing \
+    "${ADMIN_TOKEN}" "${LEADER_DM}" "${LEADER_MXID}" "${BOOTSTRAP_LEADER_MARKER}" 360 2>/dev/null || true)
+if echo "${LEADER_BOOTSTRAP_REPLY}" | grep -Fq "${BOOTSTRAP_LEADER_MARKER}"; then
+    log_pass "QwenPaw leader completed package bootstrap instructions"
+else
+    log_fail "QwenPaw leader did not complete package bootstrap instructions"
+fi
+
+if _wait_container_file "${LEADER_CONTAINER}" "${LEADER_DEFAULT_WS}/.bootstrap_completed" 120; then
+    log_pass "QwenPaw leader wrote bootstrap completion flag"
+else
+    log_fail "QwenPaw leader did not write bootstrap completion flag"
+fi
+
+if docker exec "${LEADER_CONTAINER}" sh -c "grep -Fq '${BOOTSTRAP_LEADER_MARKER}' '${LEADER_DEFAULT_WS}/bootstrap/test26-hello-result.txt'" >/dev/null 2>&1; then
+    log_pass "QwenPaw leader hello script wrote expected marker"
+else
+    log_fail "QwenPaw leader hello script did not write expected marker"
+fi
+
+WORKER_BOOTSTRAP_PROMPT="Please run your package bootstrap now. Follow BOOTSTRAP.md exactly: run the packaged hello script, then reply with the requested marker. Do not ask me to confirm identity."
+if matrix_send_mention_message "${ADMIN_TOKEN}" "${TEAM_ROOM}" "${WORKER_MXID}" "${WORKER_BOOTSTRAP_PROMPT}" >/dev/null 2>&1; then
+    log_pass "Admin sent package bootstrap mention to QwenPaw worker"
+else
+    log_fail "Admin failed to send package bootstrap mention to QwenPaw worker"
+fi
+
+WORKER_BOOTSTRAP_REPLY=$(matrix_wait_for_message_containing \
+    "${ADMIN_TOKEN}" "${TEAM_ROOM}" "${WORKER_MXID}" "${BOOTSTRAP_WORKER_MARKER}" 360 2>/dev/null || true)
+if echo "${WORKER_BOOTSTRAP_REPLY}" | grep -Fq "${BOOTSTRAP_WORKER_MARKER}"; then
+    log_pass "QwenPaw worker completed package bootstrap instructions"
+else
+    log_fail "QwenPaw worker did not complete package bootstrap instructions"
+fi
+
+if _wait_container_file "${WORKER_CONTAINER}" "${WORKER_DEFAULT_WS}/.bootstrap_completed" 120; then
+    log_pass "QwenPaw worker wrote bootstrap completion flag"
+else
+    log_fail "QwenPaw worker did not write bootstrap completion flag"
+fi
+
+if docker exec "${WORKER_CONTAINER}" sh -c "grep -Fq '${BOOTSTRAP_WORKER_MARKER}' '${WORKER_DEFAULT_WS}/bootstrap/test26-hello-result.txt'" >/dev/null 2>&1; then
+    log_pass "QwenPaw worker hello script wrote expected marker"
+else
+    log_fail "QwenPaw worker hello script did not write expected marker"
+fi
+
+TASK_PROMPT=$(cat <<EOF
+Please complete this TeamHarness plugin-mode E2E request by coordinating with
+the worker. Do not complete the worker task yourself.
+
+Project id: ${PROJECT_ID}
+Task id: ${TASK_ID}
+Completion marker: ${MARKER}
+
+Required leader steps:
+1. Use projectflow create_project for projectId ${PROJECT_ID}.
+2. Use projectflow plan_dag with exactly one task whose taskId is ${TASK_ID}
+   and whose assignedTo is the worker runtimeName from your TeamHarness
+   roster facts. Do not invent a different task id.
+3. Use taskflow delegate_task for projectId ${PROJECT_ID}, taskId ${TASK_ID},
+   using the Team Room from your TeamHarness roster facts, and the task spec
+   below. This must create
+   shared/tasks/${TASK_ID}/spec.md.
+4. Use the TeamHarness message tool to assign the task in the Team Room. The
+   assignment must visibly mention the worker Matrix user from your TeamHarness
+   roster facts, include ${TASK_ID}, include shared/tasks/${TASK_ID}/spec.md,
+   and tell the assignee to call taskflow ack_task before reading the spec.
+
+Task spec to delegate:
+# Task: Write TeamHarness plugin-mode readiness note
+
+First call taskflow ack_task for task ${TASK_ID}. Use the returned spec as the
+execution contract.
+
+Create shared/tasks/${TASK_ID}/workspace/readiness-note.txt with this exact
+line:
+${MARKER}
+
+Then call taskflow submit_task with status SUCCESS, a summary containing
+${MARKER}, and deliverable shared/tasks/${TASK_ID}/workspace/readiness-note.txt.
+
+After submit_task succeeds, reply in the Team Room with exactly this completion
+line and one short summary sentence:
+${DONE_LINE}
+
+Mention the leader Matrix user from your TeamHarness roster facts in the
+completion message.
+EOF
+)
+
+if matrix_send_message "${ADMIN_TOKEN}" "${LEADER_DM}" "${TASK_PROMPT}" >/dev/null 2>&1; then
+    log_pass "Admin sent real TeamHarness task to QwenPaw leader"
+else
+    log_fail "Admin failed to send task to QwenPaw leader"
+fi
+
+LEADER_ASSIGNMENT=$(matrix_wait_for_message_containing \
+    "${ADMIN_TOKEN}" "${TEAM_ROOM}" "${LEADER_MXID}" "${TASK_ID}" 480 2>/dev/null || true)
+if echo "${LEADER_ASSIGNMENT}" | grep -q "${TASK_ID}" && echo "${LEADER_ASSIGNMENT}" | grep -q "${WORKER_MXID}"; then
+    log_pass "Leader assigned TeamHarness task to worker in Team Room"
+else
+    log_fail "Leader did not assign TeamHarness task to worker in Team Room"
+fi
+
+SPEC_STAT=$(_wait_leader_shared_stat "shared/tasks/${TASK_ID}/spec.md" 180 || echo "{}")
+if echo "${SPEC_STAT}" | jq -e '.ok == true and .exists == true' >/dev/null 2>&1; then
+    log_pass "Task spec exists in shared storage after leader delegation"
+else
+    log_fail "Task spec missing after leader delegation"
+fi
+
+WORKER_REPLY=$(matrix_wait_for_message_containing \
+    "${ADMIN_TOKEN}" "${TEAM_ROOM}" "${WORKER_MXID}" "${MARKER}" 720 2>/dev/null || true)
+if echo "${WORKER_REPLY}" | grep -q "${DONE_LINE}"; then
+    log_pass "Worker completed delegated TeamHarness task in Team Room"
+else
+    log_fail "Worker did not complete delegated TeamHarness task"
+fi
+
+RESULT_STAT=$(_wait_leader_shared_stat "shared/tasks/${TASK_ID}/result.md" 180 || echo "{}")
+if echo "${RESULT_STAT}" | jq -e '.ok == true and .exists == true' >/dev/null 2>&1; then
+    log_pass "Task result exists in shared storage"
+else
+    log_fail "Task result missing in shared storage"
+fi
+
+DELIVERABLE_STAT=$(_wait_leader_shared_stat "shared/tasks/${TASK_ID}/workspace/readiness-note.txt" 180 || echo "{}")
+if echo "${DELIVERABLE_STAT}" | jq -e '.ok == true and .exists == true' >/dev/null 2>&1; then
+    log_pass "Task deliverable exists in shared storage"
+else
+    log_fail "Task deliverable missing in shared storage"
+fi
+
+CHECK_ARGS=$(jq -nc --arg task "${TASK_ID}" '{action:"check_task", payload:{taskId:$task}}')
+TASK_CHECK=$(_leader_mcp_call taskflow "${CHECK_ARGS}" 2>/dev/null || echo "{}")
+if echo "${TASK_CHECK}" | jq -e --arg marker "${MARKER}" \
+    '.ok == true and .effective == true and (.result.summary | contains($marker))' >/dev/null 2>&1; then
+    log_pass "Leader verified submitted worker result through taskflow"
+else
+    log_fail "Leader could not verify submitted worker result through taskflow"
+fi
+
+_dump_debug_snapshot
+
+test_teardown "26-qwenpaw-teamharness-plugin-mode"
+test_summary


### PR DESCRIPTION
## Summary
- Add TeamHarness QwenPaw adapter support for runtime team context, MCP client wiring, task trace packaging, and role skills.
- Expand TeamHarness MCP with message, roomflow, artifact, projectflow, and taskflow behavior needed for workerflow handoff.
- Add focused adapter/package/MCP contract tests and a QwenPaw TeamHarness e2e script.

## Scope
This PR excludes SchedulerX skills, credential/JWT bootstrap helpers, edge/local worker runtime, and broad naming/Helm/controller changes.

## Validation
- git diff --check HEAD
- bash -n tests/test-21-team-project-dag.sh
- bash -n tests/test-26-qwenpaw-teamharness-plugin-mode.sh
- ruby plugins/tests/teamharness/test-contracts.rb
- ruby plugins/tests/teamharness/mcp/test-server.rb
- uv run --with pytest --with pyyaml pytest plugins/tests/teamharness/adapters/qwenpaw/test_adapter.py plugins/tests/teamharness/adapters/qwenpaw/test_package.py plugins/tests/teamharness/test_trace.py plugins/tests/teamharness/test_trace_integration.py
- ruby plugins/tests/teamharness/mcp/tools/test-message.rb
- ruby plugins/tests/teamharness/mcp/tools/test-projectflow.rb
- ruby plugins/tests/teamharness/mcp/tools/test-taskflow.rb
- ruby plugins/tests/teamharness/mcp/tools/test-filesync.rb
- ruby plugins/tests/teamharness/mcp/tools/test-artifact.rb
- ruby plugins/tests/teamharness/mcp/tools/test-protocol.rb
- ruby plugins/tests/teamharness/mcp/tools/test-roomflow.rb