### PR TITLE
docs: add local model timeout diagnostics

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -439,6 +439,30 @@ container itself, not your Mac or host machine. Use a reachable host address,
 for example `http://host.docker.internal:<port>/v1` on Docker Desktop, or the
 host LAN IP on Linux/Podman when `host.docker.internal` is not available.
 
+### Preflight passes but chat still times out
+
+The installer's API connectivity test sends a very small request. A later chat
+can still time out if the real Manager/Worker container cannot reach the same
+URL, Higress routes to a different upstream, or the local model needs longer
+than the runtime timeout.
+
+For self-hosted services such as Xinference, verify from inside the controller
+or Manager container with the exact base URL and API key:
+
+```bash
+docker exec -it agentteams-controller sh
+curl -sS -m 90 "$BASE_URL/chat/completions" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"<MODEL>","messages":[{"role":"user","content":"ping"}]}'
+```
+
+If logs show `MODEL_TIMEOUT` with `timeout limit: 60 seconds`, confirm you are
+using the official current QwenPaw/CoPaw image; older or manually installed
+CoPaw packages may not include AgentTeams' longer timeout patch. If the container
+curl also times out, fix the upstream model service, LAN route, firewall, or
+provider latency before changing AgentTeams configuration.
+
 ### Multiple providers and task-specific models
 
 Configure separate Higress AI routes with prefix or regex model matching rules,

--- a/docs/zh-cn/faq.md
+++ b/docs/zh-cn/faq.md
@@ -424,6 +424,28 @@ Higress 里定义的全部路由。
 Docker Desktop 下的 `http://host.docker.internal:<port>/v1`，或在 Linux/Podman 下使用
 宿主机局域网 IP。
 
+### 预检通过但对话仍然超时
+
+安装脚本的 API 连通性测试只发送很小的请求。后续真实对话仍可能超时，常见原因是
+Manager/Worker 容器实际访问不到同一个地址、Higress 路由到了不同上游，或本地模型响应
+时间超过运行时 timeout。
+
+使用 Xinference 等自部署服务时，先在 controller 或 Manager 容器内用同一个 base URL 和
+API key 验证：
+
+```bash
+docker exec -it agentteams-controller sh
+curl -sS -m 90 "$BASE_URL/chat/completions" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"<MODEL>","messages":[{"role":"user","content":"ping"}]}'
+```
+
+如果日志里出现 `MODEL_TIMEOUT` 且包含 `timeout limit: 60 seconds`，确认使用的是当前官方
+QwenPaw/CoPaw 镜像；旧镜像或手动安装的 CoPaw 包可能没有包含 AgentTeams 的长 timeout 补丁。
+如果容器内 `curl` 也超时，请优先修复上游模型服务、局域网路由、防火墙或供应商延迟问题，
+再调整 AgentTeams 配置。
+
 ### 多供应商和按任务使用不同模型
 
 在 Higress 中配置多条 AI 路由，每条路由使用不同的前缀或正则匹配规则，例如一条匹配


### PR DESCRIPTION
## Summary

- Add FAQ diagnostics for OpenAI-compatible local models that pass install preflight but time out during real chat.
- Include container-side `curl` verification for Xinference-style services.
- Call out `MODEL_TIMEOUT` with a 60 second limit as a signal to verify current official QwenPaw/CoPaw images.
- Add the same guidance to the Chinese FAQ.

## Why

Helps users debug #899, where install-time connectivity passed but runtime model calls from the chat interface timed out against a local Xinference OpenAI-compatible endpoint.

## Validation

- `git diff --check`

Docs-only change; no runtime tests were needed.
