### PR TITLE
Add MiniMax-M3 vision model metadata

### DIFF
--- a/hiclaw-controller/internal/agentconfig/generator.go
+++ b/hiclaw-controller/internal/agentconfig/generator.go
@@ -395,6 +395,7 @@ func defaultModelSpec(modelName string) ModelSpec {
 		"MiniMax-M2.7":           {200000, 128000, false, true},
 		"MiniMax-M2.7-highspeed": {200000, 128000, false, true},
 		"MiniMax-M2.5":           {200000, 128000, false, true},
+		"MiniMax-M3":             {1000000, 128000, true, true},
 	}
 
 	p, found := presets[modelName]
@@ -455,7 +456,7 @@ func (g *Generator) allModelSpecs(selectedModel string) []ModelSpec {
 		"qwen3.6-plus", "qwen3.5-plus",
 		"deepseek-chat", "deepseek-reasoner",
 		"kimi-k2.5", "glm-5",
-		"MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5",
+		"MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M3",
 	}
 
 	specs := make([]ModelSpec, 0, len(allModels)+1)
@@ -479,7 +480,7 @@ func (g *Generator) allModelAliases(selectedModel string) map[string]interface{}
 		"qwen3.6-plus", "qwen3.5-plus",
 		"deepseek-chat", "deepseek-reasoner",
 		"kimi-k2.5", "glm-5",
-		"MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5",
+		"MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M3",
 	}
 
 	aliases := make(map[string]interface{})

--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -675,7 +675,7 @@ $script:KnownModels = @(
     "gpt-5.4", "gpt-5.3-codex", "gpt-5-mini", "gpt-5-nano",
     "claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5",
     "qwen3.6-plus", "qwen3.5-plus", "deepseek-chat", "deepseek-reasoner",
-    "kimi-k2.5", "glm-5", "MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5"
+    "kimi-k2.5", "glm-5", "MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M3"
 )
 
 function Test-KnownModel {

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -1116,7 +1116,7 @@ resolve_embedded_image() {
 # ============================================================
 # Known models list — used to detect custom models during install
 # ============================================================
-KNOWN_MODELS="gpt-5.4 gpt-5.3-codex gpt-5-mini gpt-5-nano claude-opus-4-6 claude-sonnet-4-6 claude-haiku-4-5 qwen3.6-plus qwen3.5-plus deepseek-chat deepseek-reasoner kimi-k2.5 glm-5 MiniMax-M2.7 MiniMax-M2.7-highspeed MiniMax-M2.5"
+KNOWN_MODELS="gpt-5.4 gpt-5.3-codex gpt-5-mini gpt-5-nano claude-opus-4-6 claude-sonnet-4-6 claude-haiku-4-5 qwen3.6-plus qwen3.5-plus deepseek-chat deepseek-reasoner kimi-k2.5 glm-5 MiniMax-M2.7 MiniMax-M2.7-highspeed MiniMax-M2.5 MiniMax-M3"
 
 is_known_model() {
     local model="$1"

--- a/manager/agent/skills/model-switch/scripts/update-manager-model.sh
+++ b/manager/agent/skills/model-switch/scripts/update-manager-model.sh
@@ -99,6 +99,8 @@ case "${MODEL_NAME}" in
         CTX=200000; MAX=64000 ;;
     deepseek-chat|deepseek-reasoner|kimi-k2.5)
         CTX=256000; MAX=128000 ;;
+    MiniMax-M3)
+        CTX=1000000; MAX=128000 ;;
     glm-5|MiniMax-M2.7|MiniMax-M2.7-highspeed|MiniMax-M2.5)
         CTX=200000; MAX=128000 ;;
     *)
@@ -112,7 +114,7 @@ fi
 
 # Resolve input modalities: only vision-capable models get "image"
 case "${MODEL_NAME}" in
-    gpt-5.4|gpt-5.3-codex|gpt-5-mini|gpt-5-nano|claude-opus-4-6|claude-sonnet-4-6|claude-haiku-4-5|qwen3.6-plus|qwen3.5-plus|kimi-k2.5)
+    gpt-5.4|gpt-5.3-codex|gpt-5-mini|gpt-5-nano|claude-opus-4-6|claude-sonnet-4-6|claude-haiku-4-5|qwen3.6-plus|qwen3.5-plus|kimi-k2.5|MiniMax-M3)
         INPUT='["text", "image"]' ;;
     *)
         INPUT='["text"]' ;;

--- a/manager/agent/skills/worker-management/references/worker-openclaw.json.tmpl
+++ b/manager/agent/skills/worker-management/references/worker-openclaw.json.tmpl
@@ -58,7 +58,8 @@
           { "id": "glm-5",             "name": "glm-5",             "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
           { "id": "MiniMax-M2.7",      "name": "MiniMax-M2.7",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
           { "id": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed", "reasoning": true, "contextWindow": 200000, "maxTokens": 128000, "input": ["text"] },
-          { "id": "MiniMax-M2.5",      "name": "MiniMax-M2.5",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] }
+          { "id": "MiniMax-M2.5",      "name": "MiniMax-M2.5",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
+          { "id": "MiniMax-M3",        "name": "MiniMax-M3",        "reasoning": true,  "contextWindow": 1000000, "maxTokens": 128000, "input": ["text", "image"] }
         ]
       }
     }
@@ -86,7 +87,8 @@
         "hiclaw-gateway/glm-5":             { "alias": "glm-5" },
         "hiclaw-gateway/MiniMax-M2.7":      { "alias": "MiniMax-M2.7" },
         "hiclaw-gateway/MiniMax-M2.7-highspeed": { "alias": "MiniMax-M2.7-highspeed" },
-        "hiclaw-gateway/MiniMax-M2.5":      { "alias": "MiniMax-M2.5" }
+        "hiclaw-gateway/MiniMax-M2.5":      { "alias": "MiniMax-M2.5" },
+        "hiclaw-gateway/MiniMax-M3":        { "alias": "MiniMax-M3" }
       },
       "maxConcurrent": 4,
       "subagents": {

--- a/manager/agent/skills/worker-management/scripts/generate-worker-config.sh
+++ b/manager/agent/skills/worker-management/scripts/generate-worker-config.sh
@@ -47,6 +47,8 @@ case "${MODEL_NAME}" in
         CTX=200000; MAX=64000 ;;
     deepseek-chat|deepseek-reasoner|kimi-k2.5)
         CTX=256000; MAX=128000 ;;
+    MiniMax-M3)
+        CTX=1000000; MAX=128000 ;;
     glm-5|MiniMax-M2.7|MiniMax-M2.7-highspeed|MiniMax-M2.5)
         CTX=200000; MAX=128000 ;;
     *)
@@ -59,7 +61,7 @@ esac
 
 # Resolve input modalities: only vision-capable models get "image"
 case "${MODEL_NAME}" in
-    gpt-5.4|gpt-5.3-codex|gpt-5-mini|gpt-5-nano|claude-opus-4-6|claude-sonnet-4-6|claude-haiku-4-5|qwen3.6-plus|qwen3.5-plus|kimi-k2.5)
+    gpt-5.4|gpt-5.3-codex|gpt-5-mini|gpt-5-nano|claude-opus-4-6|claude-sonnet-4-6|claude-haiku-4-5|qwen3.6-plus|qwen3.5-plus|kimi-k2.5|MiniMax-M3)
         INPUT='["text", "image"]' ;;
     *)
         INPUT='["text"]' ;;

--- a/manager/configs/known-models.json
+++ b/manager/configs/known-models.json
@@ -14,5 +14,6 @@
   { "id": "glm-5",             "name": "glm-5",             "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
   { "id": "MiniMax-M2.7",      "name": "MiniMax-M2.7",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
   { "id": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed", "reasoning": true, "contextWindow": 200000, "maxTokens": 128000, "input": ["text"] },
-  { "id": "MiniMax-M2.5",      "name": "MiniMax-M2.5",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] }
+  { "id": "MiniMax-M2.5",      "name": "MiniMax-M2.5",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
+  { "id": "MiniMax-M3",        "name": "MiniMax-M3",        "reasoning": true,  "contextWindow": 1000000, "maxTokens": 128000, "input": ["text", "image"] }
 ]

--- a/manager/configs/manager-openclaw.json.tmpl
+++ b/manager/configs/manager-openclaw.json.tmpl
@@ -65,7 +65,8 @@
           { "id": "glm-5",             "name": "glm-5",             "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
           { "id": "MiniMax-M2.7",      "name": "MiniMax-M2.7",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
           { "id": "MiniMax-M2.7-highspeed", "name": "MiniMax-M2.7-highspeed", "reasoning": true, "contextWindow": 200000, "maxTokens": 128000, "input": ["text"] },
-          { "id": "MiniMax-M2.5",      "name": "MiniMax-M2.5",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] }
+          { "id": "MiniMax-M2.5",      "name": "MiniMax-M2.5",      "reasoning": true,  "contextWindow": 200000,  "maxTokens": 128000, "input": ["text"] },
+          { "id": "MiniMax-M3",        "name": "MiniMax-M3",        "reasoning": true,  "contextWindow": 1000000, "maxTokens": 128000, "input": ["text", "image"] }
         ]
       }
     }
@@ -93,7 +94,8 @@
         "hiclaw-gateway/glm-5":             { "alias": "glm-5" },
         "hiclaw-gateway/MiniMax-M2.7":      { "alias": "MiniMax-M2.7" },
         "hiclaw-gateway/MiniMax-M2.7-highspeed": { "alias": "MiniMax-M2.7-highspeed" },
-        "hiclaw-gateway/MiniMax-M2.5":      { "alias": "MiniMax-M2.5" }
+        "hiclaw-gateway/MiniMax-M2.5":      { "alias": "MiniMax-M2.5" },
+        "hiclaw-gateway/MiniMax-M3":        { "alias": "MiniMax-M3" }
       },
       "maxConcurrent": 8,
       "subagents": {

--- a/manager/scripts/init/start-manager-agent.sh
+++ b/manager/scripts/init/start-manager-agent.sh
@@ -646,6 +646,8 @@ case "${MODEL_NAME}" in
         export MODEL_CONTEXT_WINDOW=200000 MODEL_MAX_TOKENS=64000 ;;
     deepseek-chat|deepseek-reasoner|kimi-k2.5)
         export MODEL_CONTEXT_WINDOW=256000 MODEL_MAX_TOKENS=128000 ;;
+    MiniMax-M3)
+        export MODEL_CONTEXT_WINDOW=1000000 MODEL_MAX_TOKENS=128000 ;;
     glm-5|MiniMax-M2.7|MiniMax-M2.7-highspeed|MiniMax-M2.5)
         export MODEL_CONTEXT_WINDOW=200000 MODEL_MAX_TOKENS=128000 ;;
     *)
@@ -668,7 +670,7 @@ log "Matrix E2EE: ${MATRIX_E2EE_ENABLED}"
 
 # Resolve input modalities: only vision-capable models get "image"
 case "${MODEL_NAME}" in
-    gpt-5.4|gpt-5.3-codex|gpt-5-mini|gpt-5-nano|claude-opus-4-6|claude-sonnet-4-6|claude-haiku-4-5|qwen3.6-plus|qwen3.5-plus|kimi-k2.5)
+    gpt-5.4|gpt-5.3-codex|gpt-5-mini|gpt-5-nano|claude-opus-4-6|claude-sonnet-4-6|claude-haiku-4-5|qwen3.6-plus|qwen3.5-plus|kimi-k2.5|MiniMax-M3)
         export MODEL_INPUT='["text", "image"]' ;;
     *)
         export MODEL_INPUT='["text"]' ;;


### PR DESCRIPTION
Reason: add target image capability using existing tool/provider pattern

## Summary
- Add MiniMax-M3 as a known model with a 1,000,000 token context window and image input support.
- Update manager/worker model registries, model switching scripts, installers, and controller config generation so MiniMax-M3 is treated as a built-in vision-capable MiniMax model.

## Test plan
- jq empty manager/configs/known-models.json
- bash -n manager/agent/skills/model-switch/scripts/update-manager-model.sh
- bash -n manager/agent/skills/worker-management/scripts/generate-worker-config.sh
- bash -n install/hiclaw-install.sh
- go test ./internal/agentconfig ./api/v1beta1 (from hiclaw-controller)

🤖 Generated with [Claude Code](https://claude.com/claude-code)