### PR TITLE
docs: clarify OpenAI-compatible provider setup

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -77,7 +77,7 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; $wc=New-Object Net.WebClient; 
 
 第三步：选择安装模式，快速开始请选择阿里云百炼快速安装。您也可以选择其他模型服务，手动配置。
 
-第四步：选择大模型服务商。选择百炼，您也可以接入其他支持 OpenAPI 协议的模型服务，目前 Anthropic 协议还未支持，排期中。
+第四步：选择大模型服务商。快速开始会默认使用阿里云百炼；如果使用 DeepSeek、OpenAI、Qwen 国际站、自部署模型等服务，请选择手动配置里的 **OpenAI 兼容 API**，并填写对应的 Base URL、API Key 和模型 ID。Base URL 通常需要包含 `/v1`，例如 `https://api.deepseek.com/v1`。
 
 第五步：选择模型接口。百炼 Coding Plan 和百炼通用接口有所不同，这里我们选择 Coding Plan 接口。[购买Coding Plan](https://bailian.console.aliyun.com/cn-beijing/?source_channel=4qjGAvs1Pl&tab=coding-plan#/efm/index)
 
@@ -86,7 +86,7 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; $wc=New-Object Net.WebClient; 
 第七步：开始测试 API 联通性，若测试成功，效果如下。
 ![测试](https://img.alicdn.com/imgextra/i4/O1CN0148wFGG1lYeWKd3Uat_!!6000000004831-2-tps-1752-600.png)
 
-若测试不成功，您需要检查模粘贴的型 API Key是否完整或无空格，若再次尝试仍无法通过，建议像模型服务厂商提交服务工单。
+若测试不成功，您需要检查粘贴的模型 API Key 是否完整或无空格、Base URL 是否包含服务商要求的路径（常见为 `/v1`）、模型 ID 是否正确。再次尝试仍无法通过时，建议向对应模型服务厂商提交服务工单。
 
 第八步：选择网络访问模式。这里我们选择仅本机使用，若允许外部访问，例如和同事建立 Matrix roon，则选择允许外部访问。选择后，按回车键即可，确定端口号、网关主机端口、Higress 控制台主机端口、Maxtrix 域名、Element Web 直接访问的主机端口、文件系统域名等，均采用默认值，无须手动配置。
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ This guide walks you through installing HiClaw, creating your first Agent team, 
 ## Prerequisites
 
 - Docker installed and running
-- An LLM API key (e.g., Qwen, OpenAI)
+- An LLM API key. Alibaba Bailian/Qwen is the quick-start default, but any OpenAI-compatible provider can be used by choosing manual setup and entering its Base URL (usually ending in `/v1`), API key, and model id.
 - (Optional) A GitHub Personal Access Token for GitHub collaboration features
 
 ---
@@ -24,6 +24,7 @@ bash <(curl -sSL https://higress.ai/hiclaw/install.sh)
 
 Follow the interactive prompts to configure:
 - LLM Provider and API Key
+- For DeepSeek, OpenAI-compatible local models, or other non-default providers, choose manual setup and enter the provider Base URL with `/v1` when required.
 - Admin username and password
 - Domain names (press Enter to accept defaults)
 - GitHub PAT (optional)

--- a/docs/zh-cn/quickstart.md
+++ b/docs/zh-cn/quickstart.md
@@ -5,7 +5,7 @@
 ## 前置条件
 
 - 已安装并运行 Docker
-- 一个 LLM API Key（如阿里云百炼 Qwen、OpenAI 等）
+- 一个 LLM API Key。快速开始默认使用阿里云百炼/Qwen；如果使用 DeepSeek、自部署模型或其他 OpenAI 兼容服务，请在安装时选择手动配置，并填写对应 Base URL（通常以 `/v1` 结尾）、API Key 和模型 ID。
 - （可选）GitHub 个人访问令牌（PAT），用于 GitHub 协作功能
 
 ---
@@ -22,6 +22,7 @@ bash <(curl -sSL https://higress.ai/hiclaw/install.sh)
 
 按照交互提示配置：
 - LLM 提供商和 API Key
+- DeepSeek、自部署模型或其他非默认服务商请选择手动配置；服务商要求 `/v1` 时，Base URL 需要包含该路径。
 - 管理员用户名和密码
 - 域名（直接回车使用默认值）
 - GitHub PAT（可选）


### PR DESCRIPTION
## Summary

- Clarify in the Chinese README that quick start defaults to Bailian, but manual setup supports OpenAI-compatible providers such as DeepSeek, OpenAI, Qwen Cloud, and self-hosted models.
- Fix the misleading "OpenAPI" wording to "OpenAI-compatible API".
- Add the same quick-start prerequisite/setup hint in English and Chinese quickstart docs.

## Why

Fixes #929. Users reading the quick-start flow can mistake Bailian for the only supported provider. This makes the supported OpenAI-compatible path visible before installation.

## Validation

- `git diff --check`

Docs-only change.
