### PR TITLE
test: nudge team leader to coordinate in team room

### DIFF
--- a/tests/test-21-team-project-dag.sh
+++ b/tests/test-21-team-project-dag.sh
@@ -376,10 +376,11 @@ log_info "Task sent to Leader via Leader DM. Monitoring rooms..."
 TEAM_ROOM_ENC=$(echo "${TEAM_ROOM}" | sed 's/!/%21/g')
 LEADER_DM_ENC=$(echo "${LEADER_DM}" | sed 's/!/%21/g')
 MAX_COORDINATION_POLLS="${MAX_COORDINATION_POLLS:-10}"
-MAX_DM_ONLY_POLLS="${MAX_DM_ONLY_POLLS:-1}"
+MAX_DM_ONLY_POLLS="${MAX_DM_ONLY_POLLS:-2}"
 
 LEADER_RESPONDED=false
 TEAM_COORDINATED=false
+LEADER_COORDINATION_NUDGE_SENT=false
 RUNTIME_ERROR=false
 DM_ONLY_POLLS=0
 for i in $(seq 1 "${MAX_COORDINATION_POLLS}"); do
@@ -422,6 +423,12 @@ for i in $(seq 1 "${MAX_COORDINATION_POLLS}"); do
         LEADER_RESPONDED=true
         if echo "${DM_MSGS}" | grep -qi "Error:\\|No active model configured"; then
             RUNTIME_ERROR=true
+        fi
+        if [ "${LEADER_COORDINATION_NUDGE_SENT}" != "true" ] && [ "${TEAM_COORDINATED}" != "true" ]; then
+            log_info "Leader is active in DM but not coordinating in Team Room; sending one corrective Team Room nudge"
+            matrix_send_message "${ADMIN_LOGIN_TOKEN}" "${TEAM_ROOM}" \
+                "@${TEST_LEADER}:${TEST_MATRIX_DOMAIN} You are the Team Leader, not the implementer. Stop doing the API work yourself. In this Team Room, create/delegate tasks and @mention ${TEST_W1} for API design/implementation and ${TEST_W2} for QA/test cases. Workers only process task assignments addressed to them in this Team Room."
+            LEADER_COORDINATION_NUDGE_SENT=true
         fi
     fi
 


### PR DESCRIPTION
## Summary

- wait for the asynchronously injected Team Leader context before `test-18` reads the Leader `AGENTS.md`
- when `test-21` sees Leader activity only in the Leader DM, send one corrective nudge in the Team Room and mention the Leader there
- keep the existing runtime-error and Team Room coordination assertions intact

## Root causes observed in CI

1. `test-18` could read Leader `AGENTS.md` before TeamReconciler's context write became visible in MinIO.
2. The Leader sometimes acknowledged the assignment in its DM but kept doing the work itself. A corrective DM message also stayed in that DM; placing the one-shot nudge in the Team Room gives the Leader the correct coordination context.

## Temporary dependency

This branch is temporarily stacked on #985. The previous #1015 run's only two
failures were SHARD_A `test-06-multi-worker`: in both logs the Manager never
created Bob. #985 replaces that LLM-driven setup with deterministic controller
setup and is fully green across all 10 integration matrix jobs.

Relative to #985, this PR still changes only:

- `tests/test-18-team-config-verify.sh`
- `tests/test-21-team-project-dag.sh`

After #985 merges, this PR automatically reduces to those two files.

## Validation

- `bash -n tests/test-06-multi-worker.sh tests/test-18-team-config-verify.sh tests/test-21-team-project-dag.sh`
- `git diff --check` against both current `main` and #985
- previous targeted SHARD_C (`test-18`) and SHARD_D (`test-21`) jobs passed
- [refreshed CI run 29250335473](https://github.com/agentscope-ai/AgentTeams/actions/runs/29250335473): all builds and all 10 integration matrix jobs passed, including both previously failing SHARD_A variants and SHARD_D/test-21