### PR TITLE
chore(rename): use AgentTeams image names

### DIFF
--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -94,14 +94,14 @@ jobs:
       - name: Summary
         env:
           BASE_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/openclaw-base
-          MANAGER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-manager
-          MANAGER_COPAW_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-manager-copaw
-          WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-worker
-          COPAW_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-copaw-worker
-          HERMES_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-hermes-worker
-          QWENPAW_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-qwenpaw-worker
-          CONTROLLER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-controller
-          EMBEDDED_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-embedded
+          MANAGER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-manager
+          MANAGER_COPAW_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-manager-copaw
+          WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-worker
+          COPAW_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-copaw-worker
+          HERMES_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-hermes-worker
+          QWENPAW_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-qwenpaw-worker
+          CONTROLLER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-controller
+          EMBEDDED_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-embedded
         run: |
           STABLE_TAG="${{ steps.meta.outputs.base_stable_tag }}"
           echo "### RC Build Summary" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,14 +138,14 @@ jobs:
           VERSION: ${{ steps.meta.outputs.version }}
           TARGETS: ${{ steps.meta.outputs.targets }}
           OPENCLAW_BASE_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/openclaw-base
-          MANAGER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-manager
-          MANAGER_COPAW_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-manager-copaw
-          WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-worker
-          COPAW_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-copaw-worker
-          HERMES_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-hermes-worker
-          QWENPAW_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-qwenpaw-worker
-          CONTROLLER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-controller
-          EMBEDDED_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/hiclaw-embedded
+          MANAGER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-manager
+          MANAGER_COPAW_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-manager-copaw
+          WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-worker
+          COPAW_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-copaw-worker
+          HERMES_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-hermes-worker
+          QWENPAW_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-qwenpaw-worker
+          CONTROLLER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-controller
+          EMBEDDED_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-embedded
         run: |
           echo "### Build Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,16 +86,16 @@ jobs:
 
           \`\`\`bash
           # Embedded all-in-one (infra + controller; pulled by the installer)
-          docker pull ${REGISTRY}/${REPO}/hiclaw-embedded:${VERSION}
+          docker pull ${REGISTRY}/${REPO}/agentteams-embedded:${VERSION}
 
           # Manager (lightweight; spawned by the embedded controller)
-          docker pull ${REGISTRY}/${REPO}/hiclaw-manager:${VERSION}
+          docker pull ${REGISTRY}/${REPO}/agentteams-manager:${VERSION}
 
           # Worker
-          docker pull ${REGISTRY}/${REPO}/hiclaw-worker:${VERSION}
+          docker pull ${REGISTRY}/${REPO}/agentteams-worker:${VERSION}
 
-          # Controller (used standalone in k8s; bundled inside hiclaw-embedded for docker installs)
-          docker pull ${REGISTRY}/${REPO}/hiclaw-controller:${VERSION}
+          # Controller (used standalone in k8s; bundled inside agentteams-embedded for docker installs)
+          docker pull ${REGISTRY}/${REPO}/agentteams-controller:${VERSION}
           \`\`\`
 
           ---

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -108,7 +108,7 @@ jobs:
             echo "openclaw_base=true" >> $GITHUB_OUTPUT
           fi
 
-  # Step 1a: Build the shared base image (hiclaw-controller)
+  # Step 1a: Build the shared base image (agentteams-controller)
   build-base:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -133,13 +133,13 @@ jobs:
 
       - name: Save image
         run: |
-          docker save hiclaw/hiclaw-controller:latest | gzip > /tmp/hiclaw-controller.tar.gz
+          docker save agentteams/agentteams-controller:latest | gzip > /tmp/agentteams-controller.tar.gz
 
       - name: Upload image
         uses: actions/upload-artifact@v4
         with:
           name: image-controller
-          path: /tmp/hiclaw-controller.tar.gz
+          path: /tmp/agentteams-controller.tar.gz
           retention-days: 1
 
   # Step 1b: Build openclaw-base from this PR's source, but only when
@@ -226,7 +226,7 @@ jobs:
           path: /tmp
 
       - name: Load controller image
-        run: gunzip -c /tmp/hiclaw-controller.tar.gz | docker load
+        run: gunzip -c /tmp/agentteams-controller.tar.gz | docker load
 
       - name: Download local openclaw-base image
         if: |
@@ -269,8 +269,9 @@ jobs:
           # each per-target tar only contains its own deltas.
           docker save \
             $(docker images --format '{{.Repository}}:{{.Tag}}' \
-              | grep -E '^hiclaw/' \
+              | grep -E '^(agentteams|hiclaw)/' \
               | grep -v '<none>' \
+              | grep -v 'agentteams-controller' \
               | grep -v 'hiclaw-controller' \
               | grep -v 'openclaw-base') \
             | gzip > /tmp/hiclaw-${{ matrix.target }}.tar.gz
@@ -653,12 +654,12 @@ jobs:
           # from GitHub-hosted runners (frequently times out on `docker pull`).
           # Published images are auto-mirrored from cn-hangzhou to us-west-1.
           REGISTRY=higress-registry.us-west-1.cr.aliyuncs.com/higress
-          docker pull ${REGISTRY}/hiclaw-manager:${VERSION}
-          docker pull ${REGISTRY}/hiclaw-worker:${VERSION}
-          docker pull ${REGISTRY}/hiclaw-controller:${VERSION}
-          docker tag ${REGISTRY}/hiclaw-manager:${VERSION} hiclaw/manager-agent:${VERSION}
-          docker tag ${REGISTRY}/hiclaw-worker:${VERSION} hiclaw/worker-agent:${VERSION}
-          docker tag ${REGISTRY}/hiclaw-controller:${VERSION} hiclaw/hiclaw-controller:${VERSION}
+          docker pull ${REGISTRY}/agentteams-manager:${VERSION}
+          docker pull ${REGISTRY}/agentteams-worker:${VERSION}
+          docker pull ${REGISTRY}/agentteams-controller:${VERSION}
+          docker tag ${REGISTRY}/agentteams-manager:${VERSION} agentteams/manager:${VERSION}
+          docker tag ${REGISTRY}/agentteams-worker:${VERSION} agentteams/worker-agent:${VERSION}
+          docker tag ${REGISTRY}/agentteams-controller:${VERSION} agentteams/agentteams-controller:${VERSION}
 
       - name: Install HiClaw
         env:
@@ -670,9 +671,9 @@ jobs:
           HICLAW_MOUNT_SOCKET=1 \
           HICLAW_MATRIX_E2EE=0 \
           HICLAW_LLM_PROVIDER=qwen \
-          HICLAW_INSTALL_MANAGER_IMAGE=hiclaw/manager-agent:${VERSION} \
-          HICLAW_INSTALL_WORKER_IMAGE=hiclaw/worker-agent:${VERSION} \
-          HICLAW_INSTALL_CONTROLLER_IMAGE=hiclaw/hiclaw-controller:${VERSION} \
+          HICLAW_INSTALL_MANAGER_IMAGE=agentteams/manager:${VERSION} \
+          HICLAW_INSTALL_WORKER_IMAGE=agentteams/worker-agent:${VERSION} \
+          HICLAW_INSTALL_CONTROLLER_IMAGE=agentteams/agentteams-controller:${VERSION} \
           bash ./install/hiclaw-install.sh manager
 
       - name: Wait for Manager to be ready

--- a/Makefile
+++ b/Makefile
@@ -24,16 +24,16 @@ VERSION        ?= latest
 REGISTRY       ?= higress-registry.cn-hangzhou.cr.aliyuncs.com
 REPO           ?= higress
 
-MANAGER_IMAGE        ?= $(REGISTRY)/$(REPO)/hiclaw-manager
-MANAGER_COPAW_IMAGE  ?= $(REGISTRY)/$(REPO)/hiclaw-manager-copaw
-WORKER_IMAGE         ?= $(REGISTRY)/$(REPO)/hiclaw-worker
-COPAW_WORKER_IMAGE   ?= $(REGISTRY)/$(REPO)/hiclaw-copaw-worker
-HERMES_WORKER_IMAGE  ?= $(REGISTRY)/$(REPO)/hiclaw-hermes-worker
-QWENPAW_WORKER_IMAGE ?= $(REGISTRY)/$(REPO)/hiclaw-qwenpaw-worker
+MANAGER_IMAGE        ?= $(REGISTRY)/$(REPO)/agentteams-manager
+MANAGER_COPAW_IMAGE  ?= $(REGISTRY)/$(REPO)/agentteams-manager-copaw
+WORKER_IMAGE         ?= $(REGISTRY)/$(REPO)/agentteams-worker
+COPAW_WORKER_IMAGE   ?= $(REGISTRY)/$(REPO)/agentteams-copaw-worker
+HERMES_WORKER_IMAGE  ?= $(REGISTRY)/$(REPO)/agentteams-hermes-worker
+QWENPAW_WORKER_IMAGE ?= $(REGISTRY)/$(REPO)/agentteams-qwenpaw-worker
 OPENHUMAN_WORKER_IMAGE ?= $(REGISTRY)/$(REPO)/hiclaw-openhuman-worker
 OPENCLAW_BASE_IMAGE  ?= $(REGISTRY)/$(REPO)/openclaw-base
-CONTROLLER_IMAGE     ?= $(REGISTRY)/$(REPO)/hiclaw-controller
-EMBEDDED_IMAGE       ?= $(REGISTRY)/$(REPO)/hiclaw-embedded
+CONTROLLER_IMAGE     ?= $(REGISTRY)/$(REPO)/agentteams-controller
+EMBEDDED_IMAGE       ?= $(REGISTRY)/$(REPO)/agentteams-embedded
 
 MANAGER_TAG        ?= $(MANAGER_IMAGE):$(VERSION)
 MANAGER_COPAW_TAG  ?= $(MANAGER_COPAW_IMAGE):$(VERSION)
@@ -47,16 +47,16 @@ CONTROLLER_TAG     ?= $(CONTROLLER_IMAGE):$(VERSION)
 EMBEDDED_TAG       ?= $(EMBEDDED_IMAGE):$(VERSION)
 
 # Local image names (no registry prefix, used by tests and install script)
-LOCAL_MANAGER        = hiclaw/hiclaw-manager:$(VERSION)
-LOCAL_MANAGER_COPAW  = hiclaw/hiclaw-manager-copaw:$(VERSION)
-LOCAL_WORKER         = hiclaw/worker-agent:$(VERSION)
-LOCAL_COPAW_WORKER   = hiclaw/copaw-worker:$(VERSION)
-LOCAL_HERMES_WORKER  = hiclaw/hermes-worker:$(VERSION)
-LOCAL_QWENPAW_WORKER = hiclaw/qwenpaw-worker:$(VERSION)
+LOCAL_MANAGER        = agentteams/manager:$(VERSION)
+LOCAL_MANAGER_COPAW  = agentteams/manager-copaw:$(VERSION)
+LOCAL_WORKER         = agentteams/worker-agent:$(VERSION)
+LOCAL_COPAW_WORKER   = agentteams/copaw-worker:$(VERSION)
+LOCAL_HERMES_WORKER  = agentteams/hermes-worker:$(VERSION)
+LOCAL_QWENPAW_WORKER = agentteams/qwenpaw-worker:$(VERSION)
 LOCAL_OPENHUMAN_WORKER = hiclaw/openhuman-worker:$(VERSION)
 LOCAL_OPENCLAW_BASE  = hiclaw/openclaw-base:$(VERSION)
-LOCAL_CONTROLLER     = hiclaw/hiclaw-controller:$(VERSION)
-LOCAL_EMBEDDED       = hiclaw/hiclaw-embedded:$(VERSION)
+LOCAL_CONTROLLER     = agentteams/agentteams-controller:$(VERSION)
+LOCAL_EMBEDDED       = agentteams/agentteams-embedded:$(VERSION)
 
 # Higress base image registry (regional mirrors auto-synced from cn-hangzhou primary)
 #   China (default): higress-registry.cn-hangzhou.cr.aliyuncs.com
@@ -153,7 +153,7 @@ build-hiclaw-controller: ## Build hiclaw-controller image (prerequisite for Mana
 build-manager: build-hiclaw-controller ## Build Manager image (OpenClaw runtime)
 	@echo "==> Building Manager image: $(LOCAL_MANAGER) (registry: $(HIGRESS_REGISTRY))"
 	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(BUILTIN_VERSION_ARG) $(OPENCLAW_BASE_BUILD_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
-		--build-arg HICLAW_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER) \
+		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER) \
 		-f manager/Dockerfile \
 		-t $(LOCAL_MANAGER) \
 		.
@@ -161,7 +161,7 @@ build-manager: build-hiclaw-controller ## Build Manager image (OpenClaw runtime)
 build-manager-copaw: build-hiclaw-controller ## Build Manager CoPaw image (Python runtime)
 	@echo "==> Building Manager CoPaw image: $(LOCAL_MANAGER_COPAW) (registry: $(HIGRESS_REGISTRY))"
 	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(BUILTIN_VERSION_ARG) $(DOCKER_BUILD_ARGS) \
-		--build-arg HICLAW_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER) \
+		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER) \
 		-f manager/Dockerfile.copaw \
 		-t $(LOCAL_MANAGER_COPAW) \
 		.
@@ -169,7 +169,7 @@ build-manager-copaw: build-hiclaw-controller ## Build Manager CoPaw image (Pytho
 build-embedded: build-hiclaw-controller ## Build embedded all-in-one controller image (infra + controller, no agent)
 	@echo "==> Building embedded image: $(LOCAL_EMBEDDED) (registry: $(HIGRESS_REGISTRY))"
 	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(DOCKER_BUILD_ARGS) \
-		--build-arg HICLAW_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER) \
+		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER) \
 		-f hiclaw-controller/Dockerfile.embedded \
 		-t $(LOCAL_EMBEDDED) \
 		.
@@ -313,7 +313,7 @@ ifeq ($(IS_PODMAN),1)
 	$(foreach plat,$(subst $(comma), ,$(MULTIARCH_PLATFORMS)), \
 		echo "  -> Building hiclaw-embedded for $(plat)..." && \
 		podman build --platform $(plat) \
-			--build-arg HICLAW_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
+			--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
 			$(REGISTRY_ARG) $(DOCKER_BUILD_ARGS) \
 			--manifest $(EMBEDDED_TAG) \
 			-f hiclaw-controller/Dockerfile.embedded . && ) true
@@ -325,7 +325,7 @@ else
 	docker buildx build \
 		--builder $(BUILDX_BUILDER) \
 		--platform $(MULTIARCH_PLATFORMS) \
-		--build-arg HICLAW_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
+		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
 		$(REGISTRY_ARG) $(DOCKER_BUILD_ARGS) \
 		-t $(EMBEDDED_TAG) \
 		$(if $(PUSH_LATEST),-t $(EMBEDDED_IMAGE):latest) \
@@ -341,7 +341,7 @@ ifeq ($(IS_PODMAN),1)
 		echo "  -> Building Manager for $(plat)..." && \
 		podman build --platform $(plat) \
 			$(REGISTRY_ARG) $(BUILTIN_VERSION_ARG) $(OPENCLAW_BASE_PUSH_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
-			--build-arg HICLAW_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
+			--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
 			-f manager/Dockerfile \
 			--manifest $(MANAGER_TAG) \
 			. && ) true
@@ -354,7 +354,7 @@ else
 		--builder $(BUILDX_BUILDER) \
 		--platform $(MULTIARCH_PLATFORMS) \
 		$(REGISTRY_ARG) $(BUILTIN_VERSION_ARG) $(OPENCLAW_BASE_PUSH_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
-		--build-arg HICLAW_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
+		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
 		-f manager/Dockerfile \
 		-t $(MANAGER_TAG) \
 		$(if $(PUSH_LATEST),-t $(MANAGER_IMAGE):latest) \
@@ -370,7 +370,7 @@ ifeq ($(IS_PODMAN),1)
 		echo "  -> Building Manager CoPaw for $(plat)..." && \
 		podman build --platform $(plat) \
 			$(REGISTRY_ARG) $(BUILTIN_VERSION_ARG) $(DOCKER_BUILD_ARGS) \
-			--build-arg HICLAW_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
+			--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
 			-f manager/Dockerfile.copaw \
 			--manifest $(MANAGER_COPAW_TAG) \
 			. && ) true
@@ -383,7 +383,7 @@ else
 		--builder $(BUILDX_BUILDER) \
 		--platform $(MULTIARCH_PLATFORMS) \
 		$(REGISTRY_ARG) $(BUILTIN_VERSION_ARG) $(DOCKER_BUILD_ARGS) \
-		--build-arg HICLAW_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
+		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
 		-f manager/Dockerfile.copaw \
 		-t $(MANAGER_COPAW_TAG) \
 		$(if $(PUSH_LATEST),-t $(MANAGER_COPAW_IMAGE):latest) \
@@ -400,7 +400,7 @@ ifeq ($(IS_PODMAN),1)
 		echo "  -> Building Worker for $(plat)..." && \
 		podman build --platform $(plat) \
 			$(REGISTRY_ARG) $(OPENCLAW_BASE_PUSH_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
-			--build-arg HICLAW_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
+			--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
 			--manifest $(WORKER_TAG) \
 			./worker/ && ) true
 	podman manifest push --all $(WORKER_TAG) docker://$(WORKER_TAG)
@@ -412,7 +412,7 @@ else
 		--builder $(BUILDX_BUILDER) \
 		--platform $(MULTIARCH_PLATFORMS) \
 		$(REGISTRY_ARG) $(OPENCLAW_BASE_PUSH_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
-		--build-arg HICLAW_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
+		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
 		-t $(WORKER_TAG) \
 		$(if $(PUSH_LATEST),-t $(WORKER_IMAGE):latest) \
 		--push \
@@ -427,7 +427,7 @@ ifeq ($(IS_PODMAN),1)
 		echo "  -> Building CoPaw Worker for $(plat)..." && \
 		podman build --platform $(plat) \
 			$(REGISTRY_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
-			--build-arg HICLAW_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
+			--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
 			--manifest $(COPAW_WORKER_TAG) \
 			./copaw/ && ) true
 	podman manifest push --all $(COPAW_WORKER_TAG) docker://$(COPAW_WORKER_TAG)
@@ -439,7 +439,7 @@ else
 		--builder $(BUILDX_BUILDER) \
 		--platform $(MULTIARCH_PLATFORMS) \
 		$(REGISTRY_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
-		--build-arg HICLAW_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
+		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
 		-t $(COPAW_WORKER_TAG) \
 		$(if $(PUSH_LATEST),-t $(COPAW_WORKER_IMAGE):latest) \
 		--push \
@@ -454,7 +454,7 @@ ifeq ($(IS_PODMAN),1)
 		echo "  -> Building Hermes Worker for $(plat)..." && \
 		podman build --platform $(plat) \
 			$(REGISTRY_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
-			--build-arg HICLAW_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
+			--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
 			--manifest $(HERMES_WORKER_TAG) \
 			./hermes/ && ) true
 	podman manifest push --all $(HERMES_WORKER_TAG) docker://$(HERMES_WORKER_TAG)
@@ -466,7 +466,7 @@ else
 		--builder $(BUILDX_BUILDER) \
 		--platform $(MULTIARCH_PLATFORMS) \
 		$(REGISTRY_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
-		--build-arg HICLAW_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
+		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(CONTROLLER_TAG) \
 		-t $(HERMES_WORKER_TAG) \
 		$(if $(PUSH_LATEST),-t $(HERMES_WORKER_IMAGE):latest) \
 		--push \

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,14 @@ LOCAL_OPENHUMAN_WORKER = hiclaw/openhuman-worker:$(VERSION)
 LOCAL_OPENCLAW_BASE  = hiclaw/openclaw-base:$(VERSION)
 LOCAL_CONTROLLER     = agentteams/agentteams-controller:$(VERSION)
 LOCAL_CONTROLLER_LEGACY = hiclaw/hiclaw-controller:$(VERSION)
+LOCAL_CONTROLLER_BUILD_IMAGE ?= $(shell \
+	if docker image inspect $(LOCAL_CONTROLLER) >/dev/null 2>&1; then \
+		printf '%s' '$(LOCAL_CONTROLLER)'; \
+	elif docker image inspect $(LOCAL_CONTROLLER_LEGACY) >/dev/null 2>&1; then \
+		printf '%s' '$(LOCAL_CONTROLLER_LEGACY)'; \
+	else \
+		printf '%s' '$(LOCAL_CONTROLLER)'; \
+	fi)
 LOCAL_EMBEDDED       = agentteams/agentteams-embedded:$(VERSION)
 
 # Higress base image registry (regional mirrors auto-synced from cn-hangzhou primary)
@@ -155,7 +163,7 @@ build-hiclaw-controller: ## Build hiclaw-controller image (prerequisite for Mana
 build-manager: build-hiclaw-controller ## Build Manager image (OpenClaw runtime)
 	@echo "==> Building Manager image: $(LOCAL_MANAGER) (registry: $(HIGRESS_REGISTRY))"
 	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(BUILTIN_VERSION_ARG) $(OPENCLAW_BASE_BUILD_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
-		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER) \
+		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER_BUILD_IMAGE) \
 		-f manager/Dockerfile \
 		-t $(LOCAL_MANAGER) \
 		.
@@ -163,7 +171,7 @@ build-manager: build-hiclaw-controller ## Build Manager image (OpenClaw runtime)
 build-manager-copaw: build-hiclaw-controller ## Build Manager CoPaw image (Python runtime)
 	@echo "==> Building Manager CoPaw image: $(LOCAL_MANAGER_COPAW) (registry: $(HIGRESS_REGISTRY))"
 	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(BUILTIN_VERSION_ARG) $(DOCKER_BUILD_ARGS) \
-		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER) \
+		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER_BUILD_IMAGE) \
 		-f manager/Dockerfile.copaw \
 		-t $(LOCAL_MANAGER_COPAW) \
 		.
@@ -171,7 +179,7 @@ build-manager-copaw: build-hiclaw-controller ## Build Manager CoPaw image (Pytho
 build-embedded: build-hiclaw-controller ## Build embedded all-in-one controller image (infra + controller, no agent)
 	@echo "==> Building embedded image: $(LOCAL_EMBEDDED) (registry: $(HIGRESS_REGISTRY))"
 	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(DOCKER_BUILD_ARGS) \
-		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER) \
+		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER_BUILD_IMAGE) \
 		-f hiclaw-controller/Dockerfile.embedded \
 		-t $(LOCAL_EMBEDDED) \
 		.
@@ -179,18 +187,21 @@ build-embedded: build-hiclaw-controller ## Build embedded all-in-one controller 
 build-worker: ## Build Worker image
 	@echo "==> Building Worker image: $(LOCAL_WORKER) (registry: $(HIGRESS_REGISTRY))"
 	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(OPENCLAW_BASE_BUILD_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
+		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER_BUILD_IMAGE) \
 		-t $(LOCAL_WORKER) \
 		./worker/
 
 build-copaw-worker: ## Build CoPaw Worker image
 	@echo "==> Building CoPaw Worker image: $(LOCAL_COPAW_WORKER) (registry: $(HIGRESS_REGISTRY))"
 	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
+		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER_BUILD_IMAGE) \
 		-t $(LOCAL_COPAW_WORKER) \
 		./copaw/
 
 build-hermes-worker: ## Build Hermes Worker image
 	@echo "==> Building Hermes Worker image: $(LOCAL_HERMES_WORKER) (registry: $(HIGRESS_REGISTRY))"
 	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
+		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER_BUILD_IMAGE) \
 		-t $(LOCAL_HERMES_WORKER) \
 		./hermes/
 

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,12 @@ LOCAL_WORKER         = agentteams/worker-agent:$(VERSION)
 LOCAL_COPAW_WORKER   = agentteams/copaw-worker:$(VERSION)
 LOCAL_HERMES_WORKER  = agentteams/hermes-worker:$(VERSION)
 LOCAL_QWENPAW_WORKER = agentteams/qwenpaw-worker:$(VERSION)
+LOCAL_MANAGER_LEGACY        = hiclaw/hiclaw-manager:$(VERSION)
+LOCAL_MANAGER_COPAW_LEGACY  = hiclaw/hiclaw-manager-copaw:$(VERSION)
+LOCAL_WORKER_LEGACY         = hiclaw/worker-agent:$(VERSION)
+LOCAL_COPAW_WORKER_LEGACY   = hiclaw/copaw-worker:$(VERSION)
+LOCAL_HERMES_WORKER_LEGACY  = hiclaw/hermes-worker:$(VERSION)
+LOCAL_QWENPAW_WORKER_LEGACY = hiclaw/qwenpaw-worker:$(VERSION)
 LOCAL_OPENHUMAN_WORKER = hiclaw/openhuman-worker:$(VERSION)
 LOCAL_OPENCLAW_BASE  = hiclaw/openclaw-base:$(VERSION)
 LOCAL_CONTROLLER     = agentteams/agentteams-controller:$(VERSION)
@@ -66,6 +72,7 @@ LOCAL_CONTROLLER_BUILD_IMAGE ?= $(shell \
 		printf '%s' '$(LOCAL_CONTROLLER)'; \
 	fi)
 LOCAL_EMBEDDED       = agentteams/agentteams-embedded:$(VERSION)
+LOCAL_EMBEDDED_LEGACY = hiclaw/hiclaw-embedded:$(VERSION)
 
 # Higress base image registry (regional mirrors auto-synced from cn-hangzhou primary)
 #   China (default): higress-registry.cn-hangzhou.cr.aliyuncs.com
@@ -166,6 +173,7 @@ build-manager: build-hiclaw-controller ## Build Manager image (OpenClaw runtime)
 		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER_BUILD_IMAGE) \
 		-f manager/Dockerfile \
 		-t $(LOCAL_MANAGER) \
+		-t $(LOCAL_MANAGER_LEGACY) \
 		.
 
 build-manager-copaw: build-hiclaw-controller ## Build Manager CoPaw image (Python runtime)
@@ -174,6 +182,7 @@ build-manager-copaw: build-hiclaw-controller ## Build Manager CoPaw image (Pytho
 		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER_BUILD_IMAGE) \
 		-f manager/Dockerfile.copaw \
 		-t $(LOCAL_MANAGER_COPAW) \
+		-t $(LOCAL_MANAGER_COPAW_LEGACY) \
 		.
 
 build-embedded: build-hiclaw-controller ## Build embedded all-in-one controller image (infra + controller, no agent)
@@ -182,6 +191,7 @@ build-embedded: build-hiclaw-controller ## Build embedded all-in-one controller 
 		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER_BUILD_IMAGE) \
 		-f hiclaw-controller/Dockerfile.embedded \
 		-t $(LOCAL_EMBEDDED) \
+		-t $(LOCAL_EMBEDDED_LEGACY) \
 		.
 
 build-worker: ## Build Worker image
@@ -189,6 +199,7 @@ build-worker: ## Build Worker image
 	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(OPENCLAW_BASE_BUILD_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
 		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER_BUILD_IMAGE) \
 		-t $(LOCAL_WORKER) \
+		-t $(LOCAL_WORKER_LEGACY) \
 		./worker/
 
 build-copaw-worker: ## Build CoPaw Worker image
@@ -196,6 +207,7 @@ build-copaw-worker: ## Build CoPaw Worker image
 	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
 		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER_BUILD_IMAGE) \
 		-t $(LOCAL_COPAW_WORKER) \
+		-t $(LOCAL_COPAW_WORKER_LEGACY) \
 		./copaw/
 
 build-hermes-worker: ## Build Hermes Worker image
@@ -203,6 +215,7 @@ build-hermes-worker: ## Build Hermes Worker image
 	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
 		--build-arg AGENTTEAMS_CONTROLLER_IMAGE=$(LOCAL_CONTROLLER_BUILD_IMAGE) \
 		-t $(LOCAL_HERMES_WORKER) \
+		-t $(LOCAL_HERMES_WORKER_LEGACY) \
 		./hermes/
 
 build-openhuman-worker: ## Build OpenHuman Worker image (Rust + native Matrix)
@@ -218,6 +231,7 @@ build-qwenpaw-worker: ## Build QwenPaw Worker image
 	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(SHARED_LIB_CTX) $(DOCKER_BUILD_ARGS) \
 		-f qwenpaw/Dockerfile \
 		-t $(LOCAL_QWENPAW_WORKER) \
+		-t $(LOCAL_QWENPAW_WORKER_LEGACY) \
 		.
 
 # ---------- Tag ----------

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ LOCAL_QWENPAW_WORKER = agentteams/qwenpaw-worker:$(VERSION)
 LOCAL_OPENHUMAN_WORKER = hiclaw/openhuman-worker:$(VERSION)
 LOCAL_OPENCLAW_BASE  = hiclaw/openclaw-base:$(VERSION)
 LOCAL_CONTROLLER     = agentteams/agentteams-controller:$(VERSION)
+LOCAL_CONTROLLER_LEGACY = hiclaw/hiclaw-controller:$(VERSION)
 LOCAL_EMBEDDED       = agentteams/agentteams-embedded:$(VERSION)
 
 # Higress base image registry (regional mirrors auto-synced from cn-hangzhou primary)
@@ -147,6 +148,7 @@ build-hiclaw-controller: ## Build hiclaw-controller image (prerequisite for Mana
 	@rm -rf ./hiclaw-controller/agent && cp -r ./manager/agent ./hiclaw-controller/agent
 	docker build $(PLATFORM_FLAG) $(REGISTRY_ARG) $(DOCKER_BUILD_ARGS) \
 		-t $(LOCAL_CONTROLLER) \
+		-t $(LOCAL_CONTROLLER_LEGACY) \
 		./hiclaw-controller/
 	@rm -rf ./hiclaw-controller/agent
 

--- a/copaw/Dockerfile
+++ b/copaw/Dockerfile
@@ -18,13 +18,13 @@
 # ============================================================
 
 ARG HIGRESS_REGISTRY=higress-registry.cn-hangzhou.cr.aliyuncs.com
-ARG HICLAW_CONTROLLER_IMAGE=hiclaw/hiclaw-controller:latest
+ARG AGENTTEAMS_CONTROLLER_IMAGE=agentteams/agentteams-controller:latest
 
 # ============ Stage 1: mc (MinIO Client) ============
 FROM ${HIGRESS_REGISTRY}/higress/mc:20260216 AS mc
 
 # ============ Stage 2: hiclaw CLI (from controller image) ============
-FROM ${HICLAW_CONTROLLER_IMAGE} AS hiclaw-controller
+FROM ${AGENTTEAMS_CONTROLLER_IMAGE} AS hiclaw-controller
 
 # ============ Final Image ============
 FROM ${HIGRESS_REGISTRY}/higress/python:3.11-slim

--- a/copaw/src/copaw_worker/bridge.py
+++ b/copaw/src/copaw_worker/bridge.py
@@ -189,6 +189,39 @@ def _resolve_vision_enabled(cfg: dict[str, Any]) -> bool:
     return "image" in input_types
 
 
+def _resolve_matrix_user_id(
+    matrix_raw: dict[str, Any],
+    *,
+    profile: str = "worker",
+) -> str:
+    """Resolve the Matrix MXID that CoPaw tools use for proactive sends."""
+    explicit = matrix_raw.get("userId") or matrix_raw.get("user_id")
+    if explicit:
+        return str(explicit)
+
+    env_user_id = (
+        os.environ.get("AGENTTEAMS_MATRIX_USER_ID")
+        or os.environ.get("HICLAW_MATRIX_USER_ID")
+        or os.environ.get("COPAW_MATRIX_USER_ID")
+    )
+    if env_user_id:
+        return env_user_id
+
+    matrix_domain = (
+        os.environ.get("AGENTTEAMS_MATRIX_DOMAIN")
+        or os.environ.get("HICLAW_MATRIX_DOMAIN")
+    )
+    localpart = (
+        os.environ.get("AGENTTEAMS_WORKER_NAME")
+        or os.environ.get("HICLAW_WORKER_NAME")
+        or ("manager" if profile == "manager" else "")
+    )
+    if matrix_domain and localpart:
+        return f"@{localpart}:{matrix_domain}"
+
+    return ""
+
+
 # ---------------------------------------------------------------------------
 # config.json
 # ---------------------------------------------------------------------------
@@ -203,6 +236,7 @@ def _write_config_json(
         matrix_raw.get("homeserver", ""), in_container
     )
     access_token = matrix_raw.get("accessToken", "")
+    user_id = _resolve_matrix_user_id(matrix_raw)
 
     # DM allowlist
     dm_cfg = matrix_raw.get("dm", {})
@@ -239,6 +273,8 @@ def _write_config_json(
     }
     if history_limit is not None:
         matrix_channel_cfg["history_limit"] = int(history_limit)
+    if user_id:
+        matrix_channel_cfg["user_id"] = user_id
 
     config_path = working_dir / "config.json"
     # Merge with existing config to avoid clobbering other settings
@@ -332,6 +368,7 @@ def _write_agent_json(
     matrix_raw = cfg.get("channels", {}).get("matrix", {})
     homeserver = _port_remap(matrix_raw.get("homeserver", ""), in_container)
     access_token = matrix_raw.get("accessToken", "")
+    user_id = _resolve_matrix_user_id(matrix_raw, profile=profile)
 
     dm_cfg = matrix_raw.get("dm", {})
     dm_allow_from: list[str] = dm_cfg.get("allowFrom", [])
@@ -344,6 +381,8 @@ def _write_agent_json(
         matrix_ch["homeserver"] = homeserver
     if access_token:
         matrix_ch["access_token"] = access_token
+    if user_id:
+        matrix_ch["user_id"] = user_id
     matrix_ch["allow_from"] = dm_allow_from
     matrix_ch["group_allow_from"] = group_allow_from
     matrix_ch["groups"] = groups

--- a/copaw/src/copaw_worker/hooks/tools/taskflow.py
+++ b/copaw/src/copaw_worker/hooks/tools/taskflow.py
@@ -64,6 +64,84 @@ def _store() -> FileSystemTaskStore:
     return FileSystemTaskStore(_workspace_dir())
 
 
+def _runtime_root() -> Path:
+    configured = os.getenv("COPAW_WORKING_DIR")
+    if configured:
+        return Path(configured).expanduser().resolve().parent
+
+    workspace = _workspace_dir().resolve()
+    if workspace.name == "default" and workspace.parent.name == "workspaces":
+        copaw_dir = workspace.parent.parent
+        if copaw_dir.name == ".copaw":
+            return copaw_dir.parent
+    return workspace
+
+
+def _strip_yaml_string(value: str) -> str:
+    text = value.strip()
+    if not text or text in {"null", "~"}:
+        return ""
+    if "#" in text:
+        text = text.split("#", 1)[0].strip()
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in {"'", '"'}:
+        return text[1:-1]
+    return text
+
+
+def _runtime_config_field(section: str, key: str) -> str:
+    path = _runtime_root() / "runtime" / "runtime.yaml"
+    if not path.exists():
+        return ""
+
+    in_section = False
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return ""
+    for raw_line in lines:
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        if not raw_line.startswith((" ", "\t")):
+            in_section = raw_line.strip() == f"{section}:"
+            continue
+        if not in_section:
+            continue
+        stripped = raw_line.strip()
+        if ":" not in stripped:
+            continue
+        field, value = stripped.split(":", 1)
+        if field.strip() == key:
+            return _strip_yaml_string(value)
+    return ""
+
+
+def _normalize_room_id(room_id: str) -> str:
+    text = (room_id or "").strip()
+    if text.startswith("room:"):
+        text = text[len("room:") :].strip()
+    return text
+
+
+def _room_target(room_id: str) -> str:
+    text = (room_id or "").strip()
+    if text.startswith("room:"):
+        return text
+    return f"room:{text}"
+
+
+def _require_team_leader_assignment_room(room_id: str) -> None:
+    role = _runtime_config_field("member", "role")
+    team_room_id = _runtime_config_field("team", "teamRoomId")
+    if role != "team_leader" or not team_room_id:
+        return
+
+    if _normalize_room_id(room_id) != _normalize_room_id(team_room_id):
+        raise TaskflowError(
+            "team leader task assignments must use the Team Room "
+            f"{_room_target(team_room_id)}, not {room_id}",
+        )
+
+
 def _current_actor() -> str | None:
     configured = (
         os.getenv("AGENTTEAMS_MATRIX_USER_ID")
@@ -183,6 +261,7 @@ async def taskflow(
             task_id = _required_str(payload_data, "taskId")
             room_id = _required_str(payload_data, "roomId")
             spec = _required_str(payload_data, "spec")
+            _require_team_leader_assignment_room(room_id)
             if dryRun:
                 return _ok(
                     dryRun=True,

--- a/copaw/src/copaw_worker/matrix_channel.py
+++ b/copaw/src/copaw_worker/matrix_channel.py
@@ -13,6 +13,7 @@ import logging
 import mimetypes
 import os
 import re
+import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, AsyncIterator, Callable, Dict, List, Optional
@@ -38,6 +39,10 @@ from nio import (
 from nio.responses import WhoamiResponse
 
 logger = logging.getLogger(__name__)
+
+_MATRIX_USER_ID_RE = re.compile(
+    r"@[a-zA-Z0-9._=+/\-]+:[a-zA-Z0-9.\-]+(?::\d+)?",
+)
 
 # Token refresh tunables
 MAX_TOKEN_REFRESH_RETRIES = 3
@@ -177,6 +182,70 @@ def _normalize_user_id(uid: str) -> str:
     if not uid.startswith("@"):
         uid = "@" + uid
     return uid
+
+
+def _strip_yaml_string(value: str) -> str:
+    text = value.strip()
+    if not text or text in {"null", "~"}:
+        return ""
+    if "#" in text:
+        text = text.split("#", 1)[0].strip()
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in {"'", '"'}:
+        return text[1:-1]
+    return text
+
+
+def _runtime_root() -> Path:
+    configured = os.getenv("COPAW_WORKING_DIR")
+    if configured:
+        return Path(configured).expanduser().resolve().parent
+
+    cwd = Path.cwd().resolve()
+    if cwd.name == "default" and cwd.parent.name == "workspaces":
+        copaw_dir = cwd.parent.parent
+        if copaw_dir.name == ".copaw":
+            return copaw_dir.parent
+    return cwd
+
+
+def _runtime_config_field(section: str, key: str) -> str:
+    path = _runtime_root() / "runtime" / "runtime.yaml"
+    if not path.exists():
+        return ""
+
+    in_section = False
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return ""
+    for raw_line in lines:
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        if not raw_line.startswith((" ", "\t")):
+            in_section = raw_line.strip() == f"{section}:"
+            continue
+        if not in_section:
+            continue
+        stripped = raw_line.strip()
+        if ":" not in stripped:
+            continue
+        field, value = stripped.split(":", 1)
+        if field.strip() == key:
+            return _strip_yaml_string(value)
+    return ""
+
+
+def _extract_matrix_user_ids(text: str) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for match in _MATRIX_USER_ID_RE.finditer(text or ""):
+        mxid = match.group(0)
+        key = mxid.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(mxid)
+    return result
 
 
 class MatrixChannel(BaseChannel):
@@ -1457,7 +1526,11 @@ class MatrixChannel(BaseChannel):
     # ------------------------------------------------------------------
 
     def _apply_mention(
-        self, content: dict[str, Any], user_id: str, room_id: str
+        self,
+        content: dict[str, Any],
+        room_id: str,
+        explicit_user_ids: list[str] | None = None,
+        fallback_user_id: str | None = None,
     ) -> None:
         """Add a full Matrix mention to an outgoing event content dict.
 
@@ -1465,21 +1538,46 @@ class MatrixChannel(BaseChannel):
         ``formatted_body`` with an HTML pill so clients render the
         mention visually.
         """
-        content["m.mentions"] = {"user_ids": [user_id]}
+        targets = list(explicit_user_ids or _extract_matrix_user_ids(content.get("body", "")))
+        if not targets and fallback_user_id:
+            targets.append(fallback_user_id)
 
-        display_name = self._resolve_display_name(user_id, room_id)
-        pill = (
-            f'<a href="https://matrix.to/#/{user_id}">'
-            f"{display_name}</a>"
-        )
+        visible: list[str] = []
+        seen: set[str] = set()
+        for target in targets:
+            if not target:
+                continue
+            key = target.lower()
+            if key in seen or key == (self._user_id or "").lower():
+                continue
+            seen.add(key)
+            visible.append(target)
+        if not visible:
+            return
+
+        content["m.mentions"] = {"user_ids": visible}
 
         body = content.get("body", "")
-        # Reuse already-converted formatted_body (set by send()) or convert now
         html_body = content.get("formatted_body") or _md_to_html(body)
+
+        for target in reversed(visible):
+            display_name = self._resolve_display_name(target, room_id)
+            encoded_target = urllib.parse.quote(target)
+            pill = (
+                f'<a href="https://matrix.to/#/{encoded_target}">'
+                f"{display_name}</a>"
+            )
+            if target not in body:
+                body = f"{target} {body}" if body else target
+            escaped = html.escape(target)
+            if escaped in html_body:
+                html_body = html_body.replace(escaped, pill, 1)
+            else:
+                html_body = f"{pill} {html_body}" if html_body else pill
+
         content["format"] = "org.matrix.custom.html"
-        content["formatted_body"] = f"{pill} {html_body}" if html_body else pill
-        # Prepend plain-text fallback so non-HTML clients also see the mention
-        content["body"] = f"{display_name} {body}" if body else display_name
+        content["formatted_body"] = html_body
+        content["body"] = body
 
     def _resolve_display_name(self, user_id: str, room_id: str) -> str:
         """Best-effort display name for *user_id* in *room_id*."""
@@ -1493,6 +1591,27 @@ class MatrixChannel(BaseChannel):
                 except Exception:
                     pass
         return user_id.split(":")[0].lstrip("@") or user_id
+
+    def _team_assignment_room(self, current_room_id: str, text: str) -> str:
+        role = _runtime_config_field("member", "role")
+        if role != "team_leader":
+            return current_room_id
+
+        team_room_id = _runtime_config_field("team", "teamRoomId")
+        leader_dm_room_id = _runtime_config_field("team", "leaderDmRoomId")
+        team_name = _runtime_config_field("team", "name")
+        if not team_room_id or not leader_dm_room_id:
+            return current_room_id
+        if current_room_id != leader_dm_room_id:
+            return current_room_id
+
+        for mxid in _extract_matrix_user_ids(text):
+            localpart = mxid.removeprefix("@").split(":", 1)[0]
+            if localpart.endswith("-lead"):
+                continue
+            if not team_name or localpart.startswith(f"{team_name}-"):
+                return team_room_id
+        return current_room_id
 
     # ------------------------------------------------------------------
     # Outgoing send — text
@@ -1516,9 +1635,16 @@ class MatrixChannel(BaseChannel):
             "formatted_body": _md_to_html(text),
         }
 
-        sender_id = (meta or {}).get("sender_id") or (meta or {}).get("user_id")
-        if sender_id:
-            self._apply_mention(content, sender_id, room_id)
+        explicit_mentions = _extract_matrix_user_ids(text)
+        rerouted_room_id = self._team_assignment_room(room_id, text)
+        if rerouted_room_id != room_id:
+            logger.info(
+                "MatrixChannel: rerouting team assignment from Leader DM %s to Team Room %s",
+                room_id,
+                rerouted_room_id,
+            )
+            room_id = rerouted_room_id
+        self._apply_mention(content, room_id, explicit_mentions)
 
         try:
             await self._client.room_send(
@@ -1598,7 +1724,7 @@ class MatrixChannel(BaseChannel):
             }
             sender_id = (meta or {}).get("sender_id") or (meta or {}).get("user_id")
             if sender_id:
-                self._apply_mention(event_content, sender_id, room_id)
+                self._apply_mention(event_content, room_id, fallback_user_id=sender_id)
 
             await self._client.room_send(
                 room_id, "m.room.message", event_content,

--- a/copaw/src/copaw_worker/run_copaw_app.py
+++ b/copaw/src/copaw_worker/run_copaw_app.py
@@ -1,0 +1,16 @@
+"""Run the upstream CoPaw app with HiClaw runtime hooks installed."""
+
+from __future__ import annotations
+
+import runpy
+
+from copaw_worker.hooks import install_tool_hooks
+
+
+def main() -> None:
+    install_tool_hooks()
+    runpy.run_module("copaw", run_name="__main__", alter_sys=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/copaw/src/copaw_worker/worker.py
+++ b/copaw/src/copaw_worker/worker.py
@@ -187,6 +187,9 @@ class Worker:
         """Start CoPaw. If console_port is set, run the full FastAPI app via
         uvicorn (gives access to the web console). Otherwise start the runner
         and channel manager directly (lightweight, no HTTP server)."""
+        from copaw_worker.hooks import install_tool_hooks
+
+        install_tool_hooks()
         if self.config.console_port:
             await self._run_copaw_with_console(self.config.console_port)
         else:

--- a/copaw/tests/test_channel_mention.py
+++ b/copaw/tests/test_channel_mention.py
@@ -44,6 +44,43 @@ async def _noop_typing(_room_id, _typing):
     return None
 
 
+def test_team_leader_assignment_in_dm_routes_to_team_room(tmp_path, monkeypatch):
+    working_dir = tmp_path / "leader" / ".copaw"
+    monkeypatch.setenv("COPAW_WORKING_DIR", str(working_dir))
+    runtime_dir = tmp_path / "leader" / "runtime"
+    runtime_dir.mkdir(parents=True)
+    (runtime_dir / "runtime.yaml").write_text(
+        "kind: MemberRuntimeConfig\n"
+        "member:\n"
+        "  role: team_leader\n"
+        "team:\n"
+        "  name: dag-team-1\n"
+        "  teamRoomId: \"!team-room:hs.local\"\n"
+        "  leaderDmRoomId: \"!leader-dm:hs.local\"\n",
+        encoding="utf-8",
+    )
+
+    ch = _make_channel("@dag-team-1-lead:hs.local")
+    client = _FakeClient()
+    ch._client = client
+    ch._send_typing = _noop_typing
+
+    asyncio.run(
+        ch.send(
+            "!leader-dm:hs.local",
+            "@dag-team-1-dev:hs.local Task assigned: implement the API.",
+            {"sender_id": "@admin:hs.local"},
+        ),
+    )
+
+    assert client.sent[0][0] == "!team-room:hs.local"
+    assert client.sent[0][2]["m.mentions"] == {
+        "user_ids": ["@dag-team-1-dev:hs.local"],
+    }
+    assert client.sent[0][2]["body"].startswith("@dag-team-1-dev:hs.local ")
+    assert "admin " not in client.sent[0][2]["body"]
+
+
 def test_apply_mention_explicit_user_ids_prefixes_body_and_adds_anchor():
     ch = _make_channel()
     content = {

--- a/copaw/tests/test_message_tool.py
+++ b/copaw/tests/test_message_tool.py
@@ -311,3 +311,20 @@ def test_install_tool_hooks_registers_message(monkeypatch):
     assert ("message", "override") in names
     assert ("filesync", "override") in names
     assert ("taskflow", "override") in names
+
+
+def test_run_copaw_app_installs_hooks_before_start(monkeypatch):
+    import copaw_worker.run_copaw_app as app
+
+    calls = []
+
+    monkeypatch.setattr(app, "install_tool_hooks", lambda: calls.append("hooks"))
+
+    def fake_run_module(name, *, run_name, alter_sys):
+        calls.append((name, run_name, alter_sys))
+
+    monkeypatch.setattr(app.runpy, "run_module", fake_run_module)
+
+    app.main()
+
+    assert calls == ["hooks", ("copaw", "__main__", True)]

--- a/copaw/tests/test_taskflow_tool.py
+++ b/copaw/tests/test_taskflow_tool.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -32,6 +33,19 @@ def _mock_sync(monkeypatch) -> MagicMock:
     mock = MagicMock()
     monkeypatch.setattr(taskflow_tool, "create_sync", lambda: mock)
     return mock
+
+
+def _write_team_leader_runtime_config(base_dir: Path) -> None:
+    runtime_dir = base_dir / "runtime"
+    runtime_dir.mkdir(parents=True)
+    (runtime_dir / "runtime.yaml").write_text(
+        "kind: MemberRuntimeConfig\n"
+        "member:\n"
+        "  role: team_leader\n"
+        "team:\n"
+        "  teamRoomId: \"!team:domain\"\n"
+        "  leaderDmRoomId: \"!leader-dm:domain\"\n",
+    )
 
 
 @pytest.mark.asyncio
@@ -481,6 +495,99 @@ async def test_delegate_task_requires_room_id(tmp_path, monkeypatch):
 
     assert payload["ok"] is False
     assert payload["error"] == "payload.roomId is required"
+
+
+@pytest.mark.asyncio
+async def test_delegate_task_rejects_team_leader_dm_room(tmp_path, monkeypatch):
+    leader_dir = tmp_path / "leader"
+    working_dir = leader_dir / ".copaw"
+    _write_team_leader_runtime_config(leader_dir)
+    monkeypatch.setenv("COPAW_WORKING_DIR", str(working_dir))
+    _set_actor(monkeypatch, "@leader:domain")
+
+    assert _response_json(
+        await projectflow(
+            action="create_project",
+            payload={"projectId": "tp-team-room", "title": "Team room project"},
+        )
+    )["ok"] is True
+    assert _response_json(
+        await projectflow(
+            action="plan_dag",
+            payload={
+                "projectId": "tp-team-room",
+                "tasks": [
+                    {
+                        "taskId": "tp-team-room-01",
+                        "title": "Team task",
+                        "assignedTo": "@worker:domain",
+                        "dependsOn": [],
+                    }
+                ],
+            },
+        )
+    )["ok"] is True
+
+    response = await taskflow(
+        action="delegate_task",
+        payload={
+            "projectId": "tp-team-room",
+            "taskId": "tp-team-room-01",
+            "roomId": "room:!leader-dm:domain",
+            "spec": "Do work.",
+        },
+    )
+    payload = _response_json(response)
+
+    assert payload["ok"] is False
+    assert "must use the Team Room room:!team:domain" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_delegate_task_accepts_team_leader_team_room(tmp_path, monkeypatch):
+    leader_dir = tmp_path / "leader"
+    working_dir = leader_dir / ".copaw"
+    _write_team_leader_runtime_config(leader_dir)
+    monkeypatch.setenv("COPAW_WORKING_DIR", str(working_dir))
+    _set_actor(monkeypatch, "@leader:domain")
+    _mock_sync(monkeypatch)
+
+    assert _response_json(
+        await projectflow(
+            action="create_project",
+            payload={"projectId": "tp-team-ok", "title": "Team room project"},
+        )
+    )["ok"] is True
+    assert _response_json(
+        await projectflow(
+            action="plan_dag",
+            payload={
+                "projectId": "tp-team-ok",
+                "tasks": [
+                    {
+                        "taskId": "tp-team-ok-01",
+                        "title": "Team task",
+                        "assignedTo": "@worker:domain",
+                        "dependsOn": [],
+                    }
+                ],
+            },
+        )
+    )["ok"] is True
+
+    response = await taskflow(
+        action="delegate_task",
+        payload={
+            "projectId": "tp-team-ok",
+            "taskId": "tp-team-ok-01",
+            "roomId": "room:!team:domain",
+            "spec": "Do work.",
+        },
+    )
+    payload = _response_json(response)
+
+    assert payload["ok"] is True
+    assert payload["task"]["room_id"] == "room:!team:domain"
 
 
 @pytest.mark.asyncio

--- a/copaw/tests/test_worker_health.py
+++ b/copaw/tests/test_worker_health.py
@@ -648,3 +648,25 @@ async def test_worker_marks_copaw_unhealthy_when_app_exits_unexpectedly(tmp_path
     assert copaw["healthiness"] == "unhealthy"
     assert copaw["message"] == "CoPaw app exited unexpectedly"
     assert copaw["details"]["operation"] == "run_copaw"
+
+
+@pytest.mark.anyio
+async def test_worker_installs_hooks_before_copaw_runner(tmp_path, monkeypatch):
+    calls = []
+
+    fake_hooks = types.ModuleType("copaw_worker.hooks")
+    fake_hooks.install_tool_hooks = lambda: calls.append("hooks")
+    monkeypatch.setitem(sys.modules, "copaw_worker.hooks", fake_hooks)
+
+    config = _config(tmp_path)
+    config.console_port = None
+    worker = Worker(config)
+
+    async def fake_headless():
+        calls.append("headless")
+
+    monkeypatch.setattr(worker, "_run_copaw_headless", fake_headless)
+
+    await worker._run_copaw()
+
+    assert calls == ["hooks", "headless"]

--- a/helm/hiclaw/values.yaml
+++ b/helm/hiclaw/values.yaml
@@ -187,7 +187,7 @@ credentialProvider:
 controller:
   replicaCount: 1               # increase for HA with leader election
   image:
-    repository: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/hiclaw-controller
+    repository: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/agentteams-controller
     tag: ""                   # defaults to global.imageTag
     pullPolicy: IfNotPresent
   service:
@@ -251,7 +251,7 @@ manager:
   model: ""                     # LLM model; defaults to credentials.defaultModel
   runtime: "openclaw"           # openclaw | copaw | hermes
   image:
-    repository: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/hiclaw-manager
+    repository: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/agentteams-manager
     tag: ""                     # defaults to global.imageTag
   resources:
     requests:
@@ -296,13 +296,13 @@ cms:
 worker:
   defaultImage:
     openclaw:
-      repository: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/hiclaw-worker
+      repository: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/agentteams-worker
       tag: ""                 # defaults to global.imageTag
     copaw:
-      repository: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/hiclaw-copaw-worker
+      repository: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/agentteams-copaw-worker
       tag: ""                 # defaults to global.imageTag
     hermes:
-      repository: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/hiclaw-hermes-worker
+      repository: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/agentteams-hermes-worker
       tag: ""                 # defaults to global.imageTag
     openhuman:
       repository: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/hiclaw-openhuman-worker

--- a/hermes/Dockerfile
+++ b/hermes/Dockerfile
@@ -10,7 +10,7 @@
 #
 # Build args:
 #   HIGRESS_REGISTRY        - base image registry for mc + python
-#   HICLAW_CONTROLLER_IMAGE - source for the hiclaw CLI binary
+#   AGENTTEAMS_CONTROLLER_IMAGE - source for the hiclaw CLI binary
 #   APT_MIRROR              - Debian mirror (default: empty / official)
 #   PIP_INDEX_URL           - PyPI mirror (default: official PyPI)
 #   NPM_REGISTRY            - npm registry (default: official)
@@ -21,13 +21,13 @@
 # ============================================================
 
 ARG HIGRESS_REGISTRY=higress-registry.cn-hangzhou.cr.aliyuncs.com
-ARG HICLAW_CONTROLLER_IMAGE=hiclaw/hiclaw-controller:latest
+ARG AGENTTEAMS_CONTROLLER_IMAGE=agentteams/agentteams-controller:latest
 
 # ============ Stage 1: mc (MinIO Client) ============
 FROM ${HIGRESS_REGISTRY}/higress/mc:20260216 AS mc
 
 # ============ Stage 2: hiclaw CLI (from controller image) ============
-FROM ${HICLAW_CONTROLLER_IMAGE} AS hiclaw-controller
+FROM ${AGENTTEAMS_CONTROLLER_IMAGE} AS hiclaw-controller
 
 # ============ Final Image ============
 FROM ${HIGRESS_REGISTRY}/higress/python:3.11-slim

--- a/hiclaw-controller/Dockerfile.embedded
+++ b/hiclaw-controller/Dockerfile.embedded
@@ -9,11 +9,11 @@
 #
 # Build args:
 #   HIGRESS_REGISTRY            - base image registry
-#   HICLAW_CONTROLLER_IMAGE     - pre-built controller image for COPY --from
+#   AGENTTEAMS_CONTROLLER_IMAGE     - pre-built controller image for COPY --from
 # ============================================================
 
 ARG HIGRESS_REGISTRY=higress-registry.cn-hangzhou.cr.aliyuncs.com
-ARG HICLAW_CONTROLLER_IMAGE=hiclaw/hiclaw-controller:latest
+ARG AGENTTEAMS_CONTROLLER_IMAGE=agentteams/agentteams-controller:latest
 
 # ============ Stage 1: Tuwunel Matrix Server ============
 FROM ${HIGRESS_REGISTRY}/higress/tuwunel:20260216 AS tuwunel
@@ -28,7 +28,7 @@ FROM ${HIGRESS_REGISTRY}/higress/mc:20260216 AS mc
 FROM ${HIGRESS_REGISTRY}/higress/element-web:20260216 AS element-web
 
 # ============ Stage 5: hiclaw-controller (pre-built image) ============
-FROM ${HICLAW_CONTROLLER_IMAGE} AS hiclaw-controller
+FROM ${AGENTTEAMS_CONTROLLER_IMAGE} AS hiclaw-controller
 
 # ============ Final Image: Based on Higress all-in-one ============
 FROM ${HIGRESS_REGISTRY}/higress/all-in-one:2.2.1

--- a/hiclaw-controller/internal/server/resource_handler.go
+++ b/hiclaw-controller/internal/server/resource_handler.go
@@ -98,6 +98,10 @@ func (h *ResourceHandler) CreateWorker(w http.ResponseWriter, r *http.Request) {
 	if req.ContainerManaged != nil {
 		containerManaged = *req.ContainerManaged
 	}
+	runtime := req.Runtime
+	if runtime == "" {
+		runtime = backend.RuntimeOpenClaw
+	}
 
 	worker := &v1beta1.Worker{
 		ObjectMeta: metav1.ObjectMeta{
@@ -108,7 +112,7 @@ func (h *ResourceHandler) CreateWorker(w http.ResponseWriter, r *http.Request) {
 			Model:            req.Model,
 			ModelProvider:    req.ModelProvider,
 			WorkerName:       req.WorkerName,
-			Runtime:          req.Runtime,
+			Runtime:          runtime,
 			Image:            req.Image,
 			Identity:         req.Identity,
 			Soul:             req.Soul,

--- a/hiclaw-controller/internal/server/resource_handler_test.go
+++ b/hiclaw-controller/internal/server/resource_handler_test.go
@@ -651,6 +651,28 @@ func TestCreateWorkerPersistsRuntimeWorkerName(t *testing.T) {
 	}
 }
 
+func TestCreateWorkerDefaultsRuntime(t *testing.T) {
+	scheme := newServerTestScheme(t)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	handler := NewResourceHandler(k8sClient, "default", nil, "")
+
+	body := []byte(`{"name":"worker-cr"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workers", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.CreateWorker(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusCreated, rec.Code, rec.Body.String())
+	}
+
+	var stored v1beta1.Worker
+	if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "worker-cr", Namespace: "default"}, &stored); err != nil {
+		t.Fatalf("get created worker: %v", err)
+	}
+	if got := stored.Spec.Runtime; got != "openclaw" {
+		t.Fatalf("worker.spec.runtime = %q, want openclaw", got)
+	}
+}
+
 func TestCreateTeam_StampsControllerLabel(t *testing.T) {
 	scheme := newServerTestScheme(t)
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()

--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -2792,13 +2792,13 @@ function Install-Manager {
         docker volume create $config.DATA_DIR | Out-Null
     }
 
-    # Pull images (skip if already exists locally for `hiclaw/`-prefixed local builds).
-    $LocalImagePrefix = "hiclaw/"
+    # Pull images (skip if already exists locally for local build tags).
+    $LocalImagePattern = "^(hiclaw|agentteams)/"
     if ($script:HICLAW_USE_EMBEDDED -eq "1") {
         # Embedded image was already pulled by Resolve-EmbeddedImage unless overridden;
         # for an explicit override we still need to ensure it is present locally.
         if ($env:HICLAW_INSTALL_EMBEDDED_IMAGE) {
-            if ($script:EMBEDDED_IMAGE.StartsWith($LocalImagePrefix)) {
+            if ($script:EMBEDDED_IMAGE -match $LocalImagePattern) {
                 $imgExists = docker image inspect $script:EMBEDDED_IMAGE 2>$null
                 if ($LASTEXITCODE -ne 0) {
                     Write-Log "Pulling embedded image: $($script:EMBEDDED_IMAGE)"
@@ -2811,7 +2811,7 @@ function Install-Manager {
         }
         # Manager image — controller will spawn it inside; pull here so the spawn doesn't
         # have to wait on the network.
-        if ($managerImage.StartsWith($LocalImagePrefix)) {
+        if ($managerImage -match $LocalImagePattern) {
             $imgExists = docker image inspect $managerImage 2>$null
             if ($LASTEXITCODE -eq 0) {
                 Write-Log (Get-Msg "install.image.exists" -f $managerImage)
@@ -2824,7 +2824,7 @@ function Install-Manager {
             & docker pull $managerImage
         }
     } else {
-        if ($managerImage.StartsWith($LocalImagePrefix)) {
+        if ($managerImage -match $LocalImagePattern) {
             $managerImageExists = docker image inspect $managerImage 2>$null
             if ($LASTEXITCODE -eq 0) {
                 Write-Log (Get-Msg "install.image.exists" -f $managerImage)
@@ -2840,7 +2840,7 @@ function Install-Manager {
 
     # Pull all worker runtime images (workers may use any runtime regardless of the default)
     foreach ($workerImg in @($script:WORKER_IMAGE, $script:COPAW_WORKER_IMAGE, $script:HERMES_WORKER_IMAGE)) {
-        if ($workerImg.StartsWith($LocalImagePrefix)) {
+        if ($workerImg -match $LocalImagePattern) {
             $imgExists = docker image inspect $workerImg 2>$null
             if ($LASTEXITCODE -eq 0) {
                 Write-Log (Get-Msg "install.image.worker_exists" -f $workerImg)

--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -751,8 +751,8 @@ function Resolve-EmbeddedImage {
         return
     }
 
-    $versioned = "$($script:HICLAW_REGISTRY)/higress/hiclaw-embedded:$($script:HICLAW_VERSION)"
-    $latestTag = "$($script:HICLAW_REGISTRY)/higress/hiclaw-embedded:latest"
+    $versioned = "$($script:HICLAW_REGISTRY)/higress/agentteams-embedded:$($script:HICLAW_VERSION)"
+    $latestTag = "$($script:HICLAW_REGISTRY)/higress/agentteams-embedded:latest"
 
     if ($script:HICLAW_VERSION -eq "latest") {
         $script:EMBEDDED_IMAGE = $latestTag
@@ -2465,31 +2465,31 @@ function Install-Manager {
     $script:MANAGER_IMAGE = if ($env:HICLAW_INSTALL_MANAGER_IMAGE) {
         $env:HICLAW_INSTALL_MANAGER_IMAGE
     } else {
-        "$($script:HICLAW_REGISTRY)/higress/hiclaw-manager:$($script:HICLAW_VERSION)"
+        "$($script:HICLAW_REGISTRY)/higress/agentteams-manager:$($script:HICLAW_VERSION)"
     }
 
     $script:WORKER_IMAGE = if ($env:HICLAW_INSTALL_WORKER_IMAGE) {
         $env:HICLAW_INSTALL_WORKER_IMAGE
     } else {
-        "$($script:HICLAW_REGISTRY)/higress/hiclaw-worker:$($script:HICLAW_VERSION)"
+        "$($script:HICLAW_REGISTRY)/higress/agentteams-worker:$($script:HICLAW_VERSION)"
     }
 
     $script:COPAW_WORKER_IMAGE = if ($env:HICLAW_INSTALL_COPAW_WORKER_IMAGE) {
         $env:HICLAW_INSTALL_COPAW_WORKER_IMAGE
     } else {
-        "$($script:HICLAW_REGISTRY)/higress/hiclaw-copaw-worker:$($script:HICLAW_VERSION)"
+        "$($script:HICLAW_REGISTRY)/higress/agentteams-copaw-worker:$($script:HICLAW_VERSION)"
     }
 
     $script:HERMES_WORKER_IMAGE = if ($env:HICLAW_INSTALL_HERMES_WORKER_IMAGE) {
         $env:HICLAW_INSTALL_HERMES_WORKER_IMAGE
     } else {
-        "$($script:HICLAW_REGISTRY)/higress/hiclaw-hermes-worker:$($script:HICLAW_VERSION)"
+        "$($script:HICLAW_REGISTRY)/higress/agentteams-hermes-worker:$($script:HICLAW_VERSION)"
     }
 
     $script:MANAGER_COPAW_IMAGE = if ($env:HICLAW_INSTALL_MANAGER_COPAW_IMAGE) {
         $env:HICLAW_INSTALL_MANAGER_COPAW_IMAGE
     } else {
-        "$($script:HICLAW_REGISTRY)/higress/hiclaw-manager-copaw:$($script:HICLAW_VERSION)"
+        "$($script:HICLAW_REGISTRY)/higress/agentteams-manager-copaw:$($script:HICLAW_VERSION)"
     }
 
     # Backward compatibility: accept old env var name from previous versions
@@ -2497,7 +2497,7 @@ function Install-Manager {
     $script:CONTROLLER_IMAGE = if ($controllerImageOverride) {
         $controllerImageOverride
     } else {
-        "$($script:HICLAW_REGISTRY)/higress/hiclaw-controller:$($script:HICLAW_VERSION)"
+        "$($script:HICLAW_REGISTRY)/higress/agentteams-controller:$($script:HICLAW_VERSION)"
     }
 
     # Resolve embedded controller image (sets $script:EMBEDDED_IMAGE and
@@ -3436,7 +3436,7 @@ function Install-Worker {
     $workerImage = if ($env:HICLAW_INSTALL_WORKER_IMAGE) {
         $env:HICLAW_INSTALL_WORKER_IMAGE
     } else {
-        "$registry/higress/hiclaw-worker:$($script:HICLAW_VERSION)"
+        "$registry/higress/agentteams-worker:$($script:HICLAW_VERSION)"
     }
 
     Write-Log (Get-Msg "worker.starting" -f $Name)

--- a/install/hiclaw-install.ps1
+++ b/install/hiclaw-install.ps1
@@ -2794,13 +2794,42 @@ function Install-Manager {
 
     # Pull images (skip if already exists locally for local build tags).
     $LocalImagePattern = "^(hiclaw|agentteams)/"
+    function Resolve-LegacyLocalImage {
+        param([string]$Image)
+        switch -Regex ($Image) {
+            '^agentteams/manager:(.+)$' { return "hiclaw/hiclaw-manager:$($Matches[1])" }
+            '^agentteams/manager-copaw:(.+)$' { return "hiclaw/hiclaw-manager-copaw:$($Matches[1])" }
+            '^agentteams/worker-agent:(.+)$' { return "hiclaw/worker-agent:$($Matches[1])" }
+            '^agentteams/copaw-worker:(.+)$' { return "hiclaw/copaw-worker:$($Matches[1])" }
+            '^agentteams/hermes-worker:(.+)$' { return "hiclaw/hermes-worker:$($Matches[1])" }
+            '^agentteams/qwenpaw-worker:(.+)$' { return "hiclaw/qwenpaw-worker:$($Matches[1])" }
+            '^agentteams/agentteams-embedded:(.+)$' { return "hiclaw/hiclaw-embedded:$($Matches[1])" }
+            '^agentteams/agentteams-controller:(.+)$' { return "hiclaw/hiclaw-controller:$($Matches[1])" }
+            default { return $null }
+        }
+    }
+    function Test-OrTagLocalImage {
+        param([string]$Image)
+        $imgExists = docker image inspect $Image 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            return $true
+        }
+        $legacyImage = Resolve-LegacyLocalImage $Image
+        if ($legacyImage) {
+            $legacyExists = docker image inspect $legacyImage 2>$null
+            if ($LASTEXITCODE -eq 0) {
+                docker tag $legacyImage $Image
+                return $true
+            }
+        }
+        return $false
+    }
     if ($script:HICLAW_USE_EMBEDDED -eq "1") {
         # Embedded image was already pulled by Resolve-EmbeddedImage unless overridden;
         # for an explicit override we still need to ensure it is present locally.
         if ($env:HICLAW_INSTALL_EMBEDDED_IMAGE) {
             if ($script:EMBEDDED_IMAGE -match $LocalImagePattern) {
-                $imgExists = docker image inspect $script:EMBEDDED_IMAGE 2>$null
-                if ($LASTEXITCODE -ne 0) {
+                if (-not (Test-OrTagLocalImage $script:EMBEDDED_IMAGE)) {
                     Write-Log "Pulling embedded image: $($script:EMBEDDED_IMAGE)"
                     & docker pull $script:EMBEDDED_IMAGE
                 }
@@ -2812,8 +2841,7 @@ function Install-Manager {
         # Manager image — controller will spawn it inside; pull here so the spawn doesn't
         # have to wait on the network.
         if ($managerImage -match $LocalImagePattern) {
-            $imgExists = docker image inspect $managerImage 2>$null
-            if ($LASTEXITCODE -eq 0) {
+            if (Test-OrTagLocalImage $managerImage) {
                 Write-Log (Get-Msg "install.image.exists" -f $managerImage)
             } else {
                 Write-Log (Get-Msg "install.image.pulling_manager" -f $managerImage)
@@ -2825,8 +2853,7 @@ function Install-Manager {
         }
     } else {
         if ($managerImage -match $LocalImagePattern) {
-            $managerImageExists = docker image inspect $managerImage 2>$null
-            if ($LASTEXITCODE -eq 0) {
+            if (Test-OrTagLocalImage $managerImage) {
                 Write-Log (Get-Msg "install.image.exists" -f $managerImage)
             } else {
                 Write-Log (Get-Msg "install.image.pulling_manager" -f $managerImage)
@@ -2841,8 +2868,7 @@ function Install-Manager {
     # Pull all worker runtime images (workers may use any runtime regardless of the default)
     foreach ($workerImg in @($script:WORKER_IMAGE, $script:COPAW_WORKER_IMAGE, $script:HERMES_WORKER_IMAGE)) {
         if ($workerImg -match $LocalImagePattern) {
-            $imgExists = docker image inspect $workerImg 2>$null
-            if ($LASTEXITCODE -eq 0) {
+            if (Test-OrTagLocalImage $workerImg) {
                 Write-Log (Get-Msg "install.image.worker_exists" -f $workerImg)
             } else {
                 Write-Log (Get-Msg "install.image.pulling_worker" -f $workerImg)

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -1026,12 +1026,12 @@ HERMES_WORKER_IMAGE="${HICLAW_INSTALL_HERMES_WORKER_IMAGE:-}"
 CONTROLLER_IMAGE="${HICLAW_INSTALL_CONTROLLER_IMAGE:-}"
 
 resolve_image_tags() {
-    MANAGER_IMAGE="${HICLAW_INSTALL_MANAGER_IMAGE:-${HICLAW_REGISTRY}/higress/hiclaw-manager:${HICLAW_VERSION}}"
-    MANAGER_COPAW_IMAGE="${HICLAW_INSTALL_MANAGER_COPAW_IMAGE:-${HICLAW_REGISTRY}/higress/hiclaw-manager-copaw:${HICLAW_VERSION}}"
-    WORKER_IMAGE="${HICLAW_INSTALL_WORKER_IMAGE:-${HICLAW_REGISTRY}/higress/hiclaw-worker:${HICLAW_VERSION}}"
-    COPAW_WORKER_IMAGE="${HICLAW_INSTALL_COPAW_WORKER_IMAGE:-${HICLAW_REGISTRY}/higress/hiclaw-copaw-worker:${HICLAW_VERSION}}"
-    HERMES_WORKER_IMAGE="${HICLAW_INSTALL_HERMES_WORKER_IMAGE:-${HICLAW_REGISTRY}/higress/hiclaw-hermes-worker:${HICLAW_VERSION}}"
-    EMBEDDED_IMAGE="${HICLAW_INSTALL_EMBEDDED_IMAGE:-${HICLAW_REGISTRY}/higress/hiclaw-embedded:${HICLAW_VERSION}}"
+    MANAGER_IMAGE="${HICLAW_INSTALL_MANAGER_IMAGE:-${HICLAW_REGISTRY}/higress/agentteams-manager:${HICLAW_VERSION}}"
+    MANAGER_COPAW_IMAGE="${HICLAW_INSTALL_MANAGER_COPAW_IMAGE:-${HICLAW_REGISTRY}/higress/agentteams-manager-copaw:${HICLAW_VERSION}}"
+    WORKER_IMAGE="${HICLAW_INSTALL_WORKER_IMAGE:-${HICLAW_REGISTRY}/higress/agentteams-worker:${HICLAW_VERSION}}"
+    COPAW_WORKER_IMAGE="${HICLAW_INSTALL_COPAW_WORKER_IMAGE:-${HICLAW_REGISTRY}/higress/agentteams-copaw-worker:${HICLAW_VERSION}}"
+    HERMES_WORKER_IMAGE="${HICLAW_INSTALL_HERMES_WORKER_IMAGE:-${HICLAW_REGISTRY}/higress/agentteams-hermes-worker:${HICLAW_VERSION}}"
+    EMBEDDED_IMAGE="${HICLAW_INSTALL_EMBEDDED_IMAGE:-${HICLAW_REGISTRY}/higress/agentteams-embedded:${HICLAW_VERSION}}"
     # CoPaw Worker introduced in v1.0.4; Hermes Worker introduced in v1.1.0
     if [ -z "${HICLAW_INSTALL_COPAW_WORKER_IMAGE:-}" ] && _ver_lt "${HICLAW_VERSION}" "v1.0.4"; then
         COPAW_WORKER_IMAGE=""
@@ -1058,8 +1058,8 @@ resolve_embedded_image() {
         return 0
     fi
 
-    local _versioned="${HICLAW_REGISTRY}/higress/hiclaw-embedded:${HICLAW_VERSION}"
-    local _latest="${HICLAW_REGISTRY}/higress/hiclaw-embedded:latest"
+    local _versioned="${HICLAW_REGISTRY}/higress/agentteams-embedded:${HICLAW_VERSION}"
+    local _latest="${HICLAW_REGISTRY}/higress/agentteams-embedded:latest"
 
     # Skip probe when HICLAW_VERSION is "latest" — no point trying the same tag twice.
     if [ "${HICLAW_VERSION}" = "latest" ]; then

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -3185,14 +3185,19 @@ EOF
     # (HICLAW_MATRIX_E2EE is already written to ENV_FILE above via --env-file)
 
     # Pull images (manager based on runtime config; all worker runtimes always pulled)
-    LOCAL_IMAGE_PREFIX="hiclaw/"
+    _is_local_image() {
+        case "$1" in
+            hiclaw/*|agentteams/*) return 0 ;;
+            *) return 1 ;;
+        esac
+    }
 
     # Helper: pull or skip a single image
     # Args: $1=image  $2=exists_msg_key  $3=pulling_msg_key
     _pull_image() {
         local _img="$1" _exists_key="$2" _pull_key="$3"
         [ -z "${_img}" ] && return 0
-        if echo "${_img}" | grep -q "^${LOCAL_IMAGE_PREFIX}"; then
+        if _is_local_image "${_img}"; then
             if ${DOCKER_CMD} image inspect "${_img}" >/dev/null 2>&1; then
                 log "$(msg "${_exists_key}" "${_img}")"
                 return 0

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -3205,23 +3205,30 @@ EOF
         esac
     }
 
+    _ensure_local_image_tag() {
+        local _img="$1"
+        [ -z "${_img}" ] && return 1
+        _is_local_image "${_img}" || return 1
+        if ${DOCKER_CMD} image inspect "${_img}" >/dev/null 2>&1; then
+            return 0
+        fi
+        local _legacy_img
+        _legacy_img="$(_legacy_local_image_for "${_img}")"
+        if [ -n "${_legacy_img}" ] && ${DOCKER_CMD} image inspect "${_legacy_img}" >/dev/null 2>&1; then
+            ${DOCKER_CMD} tag "${_legacy_img}" "${_img}"
+            return 0
+        fi
+        return 1
+    }
+
     # Helper: pull or skip a single image
     # Args: $1=image  $2=exists_msg_key  $3=pulling_msg_key
     _pull_image() {
         local _img="$1" _exists_key="$2" _pull_key="$3"
         [ -z "${_img}" ] && return 0
-        if _is_local_image "${_img}"; then
-            if ${DOCKER_CMD} image inspect "${_img}" >/dev/null 2>&1; then
-                log "$(msg "${_exists_key}" "${_img}")"
-                return 0
-            fi
-            local _legacy_img
-            _legacy_img="$(_legacy_local_image_for "${_img}")"
-            if [ -n "${_legacy_img}" ] && ${DOCKER_CMD} image inspect "${_legacy_img}" >/dev/null 2>&1; then
-                ${DOCKER_CMD} tag "${_legacy_img}" "${_img}"
-                log "$(msg "${_exists_key}" "${_img}")"
-                return 0
-            fi
+        if _ensure_local_image_tag "${_img}"; then
+            log "$(msg "${_exists_key}" "${_img}")"
+            return 0
         fi
         log "$(msg "${_pull_key}" "${_img}")"
         local _attempt=1
@@ -3241,6 +3248,9 @@ EOF
 
     # Embedded controller image (resolve versioned tag, fallback to latest)
     resolve_embedded_image
+    if [ "${HICLAW_USE_EMBEDDED}" = "1" ]; then
+        _ensure_local_image_tag "${EMBEDDED_IMAGE}" || true
+    fi
 
     # Manager image is always required (select based on runtime)
     if [ "${HICLAW_MANAGER_RUNTIME}" = "copaw" ]; then

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -3192,6 +3192,19 @@ EOF
         esac
     }
 
+    _legacy_local_image_for() {
+        case "$1" in
+            agentteams/manager:*) printf '%s\n' "hiclaw/hiclaw-manager:${1##*:}" ;;
+            agentteams/manager-copaw:*) printf '%s\n' "hiclaw/hiclaw-manager-copaw:${1##*:}" ;;
+            agentteams/worker-agent:*) printf '%s\n' "hiclaw/worker-agent:${1##*:}" ;;
+            agentteams/copaw-worker:*) printf '%s\n' "hiclaw/copaw-worker:${1##*:}" ;;
+            agentteams/hermes-worker:*) printf '%s\n' "hiclaw/hermes-worker:${1##*:}" ;;
+            agentteams/qwenpaw-worker:*) printf '%s\n' "hiclaw/qwenpaw-worker:${1##*:}" ;;
+            agentteams/agentteams-embedded:*) printf '%s\n' "hiclaw/hiclaw-embedded:${1##*:}" ;;
+            agentteams/agentteams-controller:*) printf '%s\n' "hiclaw/hiclaw-controller:${1##*:}" ;;
+        esac
+    }
+
     # Helper: pull or skip a single image
     # Args: $1=image  $2=exists_msg_key  $3=pulling_msg_key
     _pull_image() {
@@ -3199,6 +3212,13 @@ EOF
         [ -z "${_img}" ] && return 0
         if _is_local_image "${_img}"; then
             if ${DOCKER_CMD} image inspect "${_img}" >/dev/null 2>&1; then
+                log "$(msg "${_exists_key}" "${_img}")"
+                return 0
+            fi
+            local _legacy_img
+            _legacy_img="$(_legacy_local_image_for "${_img}")"
+            if [ -n "${_legacy_img}" ] && ${DOCKER_CMD} image inspect "${_legacy_img}" >/dev/null 2>&1; then
+                ${DOCKER_CMD} tag "${_legacy_img}" "${_img}"
                 log "$(msg "${_exists_key}" "${_img}")"
                 return 0
             fi

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -7,18 +7,18 @@
 # or K8s Pods (incluster). HICLAW_RUNTIME env var selects mode.
 #
 # Build from project root:
-#   docker build -f manager/Dockerfile -t hiclaw/hiclaw-manager:latest .
+#   docker build -f manager/Dockerfile -t agentteams/manager:latest .
 # ============================================================
 
 ARG HIGRESS_REGISTRY=higress-registry.cn-hangzhou.cr.aliyuncs.com
 ARG OPENCLAW_BASE_IMAGE=hiclaw/openclaw-base:20260423-8359cbc
-ARG HICLAW_CONTROLLER_IMAGE=hiclaw/hiclaw-controller:latest
+ARG AGENTTEAMS_CONTROLLER_IMAGE=agentteams/agentteams-controller:latest
 
 # ============ Stage 1: MinIO Client (mc) ============
 FROM ${HIGRESS_REGISTRY}/higress/mc:20260216 AS mc
 
 # ============ Stage 2: hiclaw CLI (from controller image) ============
-FROM ${HICLAW_CONTROLLER_IMAGE} AS hiclaw-controller
+FROM ${AGENTTEAMS_CONTROLLER_IMAGE} AS hiclaw-controller
 
 # ============ Final Image ============
 FROM ${OPENCLAW_BASE_IMAGE}

--- a/manager/Dockerfile.copaw
+++ b/manager/Dockerfile.copaw
@@ -7,24 +7,24 @@
 # or K8s Pods (incluster). HICLAW_RUNTIME env var selects mode.
 #
 # Build from project root:
-#   docker build -f manager/Dockerfile.copaw -t hiclaw/hiclaw-manager-copaw:latest .
+#   docker build -f manager/Dockerfile.copaw -t agentteams/manager-copaw:latest .
 #
 # Build args:
 #   HIGRESS_REGISTRY        - base image registry (default: cn-hangzhou)
-#   HICLAW_CONTROLLER_IMAGE - pre-built controller image for hiclaw CLI
+#   AGENTTEAMS_CONTROLLER_IMAGE - pre-built controller image for hiclaw CLI
 #   COPAW_VERSION           - CoPaw version to install from PyPI (default: 1.0.0)
 #   PIP_INDEX_URL           - PyPI mirror (default: official pypi.org)
 #   APT_MIRROR              - Debian APT mirror (default: empty; set to mirrors.aliyun.com for China)
 # ============================================================
 
 ARG HIGRESS_REGISTRY=higress-registry.cn-hangzhou.cr.aliyuncs.com
-ARG HICLAW_CONTROLLER_IMAGE=hiclaw/hiclaw-controller:latest
+ARG AGENTTEAMS_CONTROLLER_IMAGE=agentteams/agentteams-controller:latest
 
 # ============ Stage 1: MinIO Client (mc) ============
 FROM ${HIGRESS_REGISTRY}/higress/mc:20260216 AS mc
 
 # ============ Stage 2: hiclaw CLI (from controller image) ============
-FROM ${HICLAW_CONTROLLER_IMAGE} AS hiclaw-controller
+FROM ${AGENTTEAMS_CONTROLLER_IMAGE} AS hiclaw-controller
 
 # ============ Final Image: Python 3.11 ============
 FROM ${HIGRESS_REGISTRY}/higress/python:3.11-slim

--- a/manager/agent/copaw-manager-agent/HEARTBEAT.md
+++ b/manager/agent/copaw-manager-agent/HEARTBEAT.md
@@ -185,8 +185,8 @@ For each entry (one JSON object per line):
    PHASE=$(hiclaw get workers -o json | jq -r --arg n "<NAME>" '.[] | select(.name==$n) | .phase // "Unknown"')
    ```
 2. **`Pending`** and queued < 90s ago — leave the entry, drain again next heartbeat.
-3. **`Pending`** and queued > 90s ago — flag the anomaly to admin in DM (Step 7) and remove the entry using the safe rewrite command below.
-4. **`Failed`** — read the worker's `message` field, notify admin in DM with the failure reason, remove the entry using the safe rewrite command below.
+3. **`Pending`** and queued > 90s ago — flag the anomaly to admin in DM (Step 7) and remove the entry using the drain helper below.
+4. **`Failed`** — read the worker's `message` field, notify admin in DM with the failure reason, remove the entry using the drain helper below.
 5. **`Running`** — fetch `roomID` from `hiclaw get workers -o json`, greet the Worker, then notify admin in DM that the Worker is up:
    ```bash
    ROOM_ID=$(hiclaw get workers -o json | jq -r --arg n "<NAME>" '.[] | select(.name==$n) | .roomID // empty')
@@ -195,12 +195,12 @@ For each entry (one JSON object per line):
    # Then notify admin via copaw channels send to the resolved admin DM room:
    #   "<NAME> is now Running and greeted in their Worker room."
    ```
-   Remove the entry from `~/pending-workers.json` after successful greeting + notify using the safe rewrite command below.
+   Remove the entry from `~/pending-workers.json` after successful greeting + notify using the drain helper below.
 
-Never run `rm`, `unlink`, or any delete command for `~/pending-workers.json`; Tool Guard may pause the Admin DM session and block later admin requests. Keep the file, even if it becomes empty. To remove a processed entry, use exactly this safe rewrite pattern:
+Never run `rm`, `unlink`, `mv`, or any inline rewrite command for `~/pending-workers.json`; Tool Guard may pause the Admin DM session and block later admin requests. Keep the file, even if it becomes empty. To remove a processed entry, call the helper:
 
 ```bash
-jq -c 'select(.name != "<NAME>")' ~/pending-workers.json > ~/pending-workers.json.tmp && mv ~/pending-workers.json.tmp ~/pending-workers.json
+bash /opt/hiclaw/agent/skills/worker-management/scripts/drain-pending-worker.sh --worker "<NAME>"
 ```
 
 ---

--- a/manager/agent/copaw-manager-agent/HEARTBEAT.md
+++ b/manager/agent/copaw-manager-agent/HEARTBEAT.md
@@ -185,8 +185,8 @@ For each entry (one JSON object per line):
    PHASE=$(hiclaw get workers -o json | jq -r --arg n "<NAME>" '.[] | select(.name==$n) | .phase // "Unknown"')
    ```
 2. **`Pending`** and queued < 90s ago — leave the entry, drain again next heartbeat.
-3. **`Pending`** and queued > 90s ago — flag the anomaly to admin in DM (Step 7) and remove the entry.
-4. **`Failed`** — read the worker's `message` field, notify admin in DM with the failure reason, remove the entry.
+3. **`Pending`** and queued > 90s ago — flag the anomaly to admin in DM (Step 7) and remove the entry using the safe rewrite command below.
+4. **`Failed`** — read the worker's `message` field, notify admin in DM with the failure reason, remove the entry using the safe rewrite command below.
 5. **`Running`** — fetch `roomID` from `hiclaw get workers -o json`, greet the Worker, then notify admin in DM that the Worker is up:
    ```bash
    ROOM_ID=$(hiclaw get workers -o json | jq -r --arg n "<NAME>" '.[] | select(.name==$n) | .roomID // empty')
@@ -195,9 +195,13 @@ For each entry (one JSON object per line):
    # Then notify admin via copaw channels send to the resolved admin DM room:
    #   "<NAME> is now Running and greeted in their Worker room."
    ```
-   Remove the entry from `~/pending-workers.json` after successful greeting + notify.
+   Remove the entry from `~/pending-workers.json` after successful greeting + notify using the safe rewrite command below.
 
-To remove a processed entry, rewrite the file without that line (e.g. `jq -c 'select(.name != "<NAME>")' ~/pending-workers.json > ~/pending-workers.json.tmp && mv ~/pending-workers.json.tmp ~/pending-workers.json`).
+Never run `rm`, `unlink`, or any delete command for `~/pending-workers.json`; Tool Guard may pause the Admin DM session and block later admin requests. Keep the file, even if it becomes empty. To remove a processed entry, use exactly this safe rewrite pattern:
+
+```bash
+jq -c 'select(.name != "<NAME>")' ~/pending-workers.json > ~/pending-workers.json.tmp && mv ~/pending-workers.json.tmp ~/pending-workers.json
+```
 
 ---
 

--- a/manager/agent/skills/worker-management/SKILL.md
+++ b/manager/agent/skills/worker-management/SKILL.md
@@ -15,11 +15,11 @@ Before running `hiclaw create worker`, ask admin for these four inputs in one tu
    | Runtime      | Language | RAM    | When to pick                                              |
    |--------------|----------|--------|-----------------------------------------------------------|
    | `openclaw`   | Node.js  | ~500MB | General tasks. Also the hard-coded fallback when `HICLAW_DEFAULT_WORKER_RUNTIME` is unset. |
-   | `copaw`      | Python   | ~150MB | Python tasks, **or** admin needs `--remote` (host mode).  |
+   | `copaw`      | Python   | ~150MB | Python tasks or AgentScope-based worker behavior. |
    | `hermes`     | Python   | ~200MB | Admin explicitly asks for hermes / hermes-agent framework. |
    | `openhuman`  | Rust     | ~300MB | Admin explicitly asks for OpenHuman / openhuman framework. Native Matrix support with E2EE. |
 
-   `--remote` mode is **copaw-only** — use it when admin says "local mode" / "run on my machine" (it means "remote from Manager" = LOCAL on admin's machine). If admin doesn't pass `--runtime` to `hiclaw create worker`, the controller falls back to `HICLAW_DEFAULT_WORKER_RUNTIME` chosen at install — so always offer the four options explicitly instead of silently using the fallback.
+   In OSS, `hiclaw create worker` creates a controller-managed Local worker. Do not use or suggest Remote/pip worker flags. Edge workers use their separate Edge onboarding flow, not this generic create-worker path. If admin doesn't pass `--runtime` to `hiclaw create worker`, the controller falls back to `HICLAW_DEFAULT_WORKER_RUNTIME` chosen at install — so always offer the four options explicitly instead of silently using the fallback.
 3. **SOUL (role)** — short description of expertise/style. Offer to draft a default if admin has no preference.
 4. **Skills** — discover via `ls ~/worker-skills/` and match against the role; `file-sync`, `task-progress`, `project-participation` are auto-included.
 
@@ -55,7 +55,7 @@ hiclaw create worker --name <NAME> --no-wait \
 ## Gotchas
 
 - **Worker name must be lowercase and > 3 characters** — Tuwunel stores usernames in lowercase; short names cause registration failures
-- **`--remote` means "remote from Manager"** — which is actually LOCAL from the admin's perspective. Use it when admin says "local mode" / "run on my machine"
+- **Local means controller-managed** — in OSS, `hiclaw create worker` provisions a Local worker through the controller. Do not map "local mode" to Remote/pip worker flags.
 - **`file-sync`, `task-progress`, `project-participation` are default skills** — always included, cannot be removed
 - **Use `hiclaw-find-worker` only for Nacos-backed market imports or Worker discovery during task assignment** — generic Worker creation and lifecycle changes stay in this skill
 - **Peer mentions cause loops if not briefed** — after enabling, explicitly tell Workers to only @mention peers for blocking info, never for acknowledgments
@@ -76,7 +76,6 @@ Read the relevant doc **before** executing. Do not load all of them.
 | Switch a worker's runtime (openclaw ↔ copaw ↔ hermes ↔ openhuman) | (this file, "Switching Runtime" below) | `scripts/update-worker-config.sh --runtime ...` |
 | Open/close QwenPaw console | `references/console.md` | `scripts/enable-worker-console.sh` |
 | Enable direct @mentions between workers | `references/peer-mentions.md` | `scripts/enable-peer-mentions.sh` |
-| Get remote worker install command | `references/lifecycle.md` | `scripts/get-worker-install-cmd.sh` |
 | Reset a worker | `references/create-worker.md` | `hiclaw delete worker` + `hiclaw create worker` |
 | Delete a worker (remove container) | `references/lifecycle.md` | `scripts/lifecycle-worker.sh` |
 
@@ -100,5 +99,4 @@ What happens behind the scenes:
 Constraints:
 
 - `--package-dir` and `--channel-policy` cannot be combined with `--runtime` — apply those separately after the runtime switch settles
-- For **remote-mode** workers (`--remote` at create time), the container lives on the admin's machine and the controller cannot recreate it. Tell the admin to run `lifecycle-worker.sh --action delete --worker <NAME>` followed by `hiclaw create worker --remote --runtime <NEW>` on their machine
 - The wrapper preserves Matrix account/room/credentials/MinIO data but loses container-local ephemeral state — see the runtime gotcha above

--- a/manager/agent/skills/worker-management/references/create-worker.md
+++ b/manager/agent/skills/worker-management/references/create-worker.md
@@ -294,14 +294,14 @@ This reply mentions the Worker name explicitly so the admin (and the integration
 
 In your **next** heartbeat or self-triggered turn, for each entry in `~/pending-workers.json`:
 
-1. `hiclaw get workers -o json` and check the entry's `phase`. If still `Pending` and queued < 90s ago, leave it for a later heartbeat. If `Failed`, notify admin in DM and remove the entry using the safe rewrite command below.
+1. `hiclaw get workers -o json` and check the entry's `phase`. If still `Pending` and queued < 90s ago, leave it for a later heartbeat. If `Failed`, notify admin in DM and remove the entry using the drain helper below.
 2. If `Running`, run `send-worker-greeting.sh --worker <NAME> --room "<ROOM_ID>"` to greet the Worker in their room, then notify admin in DM with: `"<NAME> is now Running and greeted."`
-3. Remove the processed entry from `~/pending-workers.json` using the safe rewrite command below.
+3. Remove the processed entry from `~/pending-workers.json` using the drain helper below.
 
-Never run `rm`, `unlink`, or any delete command for `~/pending-workers.json`; Tool Guard may pause the Admin DM session and block later admin requests. Keep the file, even if it becomes empty. To remove a processed entry, use exactly this safe rewrite pattern:
+Never run `rm`, `unlink`, `mv`, or any inline rewrite command for `~/pending-workers.json`; Tool Guard may pause the Admin DM session and block later admin requests. Keep the file, even if it becomes empty. To remove a processed entry, call the helper:
 
 ```bash
-jq -c 'select(.name != "<NAME>")' ~/pending-workers.json > ~/pending-workers.json.tmp && mv ~/pending-workers.json.tmp ~/pending-workers.json
+bash /opt/hiclaw/agent/skills/worker-management/scripts/drain-pending-worker.sh --worker "<NAME>"
 ```
 
 If you have HEARTBEAT.md, add a one-line bullet there reminding yourself to drain `~/pending-workers.json` at every heartbeat.

--- a/manager/agent/skills/worker-management/references/create-worker.md
+++ b/manager/agent/skills/worker-management/references/create-worker.md
@@ -294,9 +294,15 @@ This reply mentions the Worker name explicitly so the admin (and the integration
 
 In your **next** heartbeat or self-triggered turn, for each entry in `~/pending-workers.json`:
 
-1. `hiclaw get workers -o json` and check the entry's `phase`. If still `Pending` and queued < 90s ago, leave it for a later heartbeat. If `Failed`, notify admin in DM and remove the entry.
+1. `hiclaw get workers -o json` and check the entry's `phase`. If still `Pending` and queued < 90s ago, leave it for a later heartbeat. If `Failed`, notify admin in DM and remove the entry using the safe rewrite command below.
 2. If `Running`, run `send-worker-greeting.sh --worker <NAME> --room "<ROOM_ID>"` to greet the Worker in their room, then notify admin in DM with: `"<NAME> is now Running and greeted."`
-3. Remove the processed entry from `~/pending-workers.json`.
+3. Remove the processed entry from `~/pending-workers.json` using the safe rewrite command below.
+
+Never run `rm`, `unlink`, or any delete command for `~/pending-workers.json`; Tool Guard may pause the Admin DM session and block later admin requests. Keep the file, even if it becomes empty. To remove a processed entry, use exactly this safe rewrite pattern:
+
+```bash
+jq -c 'select(.name != "<NAME>")' ~/pending-workers.json > ~/pending-workers.json.tmp && mv ~/pending-workers.json.tmp ~/pending-workers.json
+```
 
 If you have HEARTBEAT.md, add a one-line bullet there reminding yourself to drain `~/pending-workers.json` at every heartbeat.
 

--- a/manager/agent/skills/worker-management/references/create-worker.md
+++ b/manager/agent/skills/worker-management/references/create-worker.md
@@ -6,11 +6,11 @@ If the admin asks you to import an existing Worker template, search a registry f
 
 | Admin says | Runtime | Flags |
 |------------|---------|-------|
-| "copaw", "Python worker", "pip worker", "host worker" | `copaw` | |
-| "local worker", "local mode", "access my local environment", "run on my machine" | `copaw` | `--remote` |
+| "copaw", "Python worker" | `copaw` | |
+| "local worker", "local mode", "container worker", "docker worker", "access my local environment", or "run on my machine" | default (uses `${HICLAW_DEFAULT_WORKER_RUNTIME}`, normally `openclaw`) | |
 | "hermes", "hermes worker", "hermes-agent" | `hermes` | |
 | "openhuman", "OpenHuman worker", "openhuman framework" | `openhuman` | |
-| "openclaw", "container worker", "docker worker", or none of the above | default (uses `${HICLAW_DEFAULT_WORKER_RUNTIME}`, normally `openclaw`) | |
+| "openclaw", or none of the above | default (uses `${HICLAW_DEFAULT_WORKER_RUNTIME}`, normally `openclaw`) | |
 
 When in doubt, ask: "Should this be a copaw (Python, ~150MB RAM), openclaw (Node.js, ~500MB RAM), hermes (Python, ~200MB RAM), or openhuman (Rust, ~300MB RAM, native Matrix E2EE) worker?"
 
@@ -160,9 +160,8 @@ The controller authorizes the Worker on **existing** MCP servers only. If the ad
 ### Result JSON (`-o json` output)
 
 The JSON response contains the worker status. Key fields:
-- `"status"` — `"ready"` (container running), `"starting"` (health check pending), or `"pending_install"` (no container runtime)
+- `"status"` — `"ready"` (container running) or `"starting"` (health check pending)
 - `"room_id"` — Worker's Matrix room ID
-- `"install_cmd"` — (when status is `pending_install`) Provide this **verbatim in a code block** (do NOT redact `--fs-secret`)
 
 ## Step 2.5: Poll for Ready
 
@@ -207,7 +206,7 @@ Run `echo "${HICLAW_MANAGER_RUNTIME:-openclaw}"` if unsure. Then follow the matc
 
 **OpenClaw / Hermes Manager** — incremental DM messages are supported, so polling-then-reply within a single turn is fine: → use **Path A**.
 
-**QwenPaw Manager** — only the final text reply of a turn reaches admin in DM (see `copaw-manager-agent/AGENTS.md` "Message Sending Rules"). Polling for `phase=Running` blocks the reply for 30-60s+ and tends to compound when admin sends a follow-up message during that window (the runtime queues both, then the model conflates them and replies only to the latest). → use **Path B (fast-reply)**.
+**CoPaw / QwenPaw Manager** — only the final text reply of a turn reaches admin in DM (see `copaw-manager-agent/AGENTS.md` "Message Sending Rules"). Polling for `phase=Running` blocks the reply for 30-60s+ and tends to compound when admin sends a follow-up message during that window (the runtime queues both, then the model conflates them and replies only to the latest). → use **Path B (fast-reply)**.
 
 ---
 
@@ -253,9 +252,9 @@ If the helper exits with code 2 instead of sending, it prints the target room, m
 
 ---
 
-### Path B — QwenPaw Manager (fast-reply, deferred greeting)
+### Path B — CoPaw / QwenPaw Manager (fast-reply, deferred greeting)
 
-**Hard rule for QwenPaw**: your create-worker turn MUST emit its final DM reply within ~60s of receiving the admin's request. Polling for `phase=Running` and greeting the Worker happen in **separate later turns**, not in the same turn as the admin reply.
+**Hard rule for CoPaw / QwenPaw**: your create-worker turn MUST emit its final DM reply within ~60s of receiving the admin's request. Polling for `phase=Running` and greeting the Worker happen in **separate later turns**, not in the same turn as the admin reply.
 
 #### B1. Confirm controller accepted the create request
 

--- a/manager/agent/skills/worker-management/scripts/drain-pending-worker.sh
+++ b/manager/agent/skills/worker-management/scripts/drain-pending-worker.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# drain-pending-worker.sh - Remove one processed Worker from pending-workers.json.
+#
+# Usage:
+#   drain-pending-worker.sh --worker <NAME> [--file <PATH>]
+#
+# Keep this behind a helper so CoPaw Manager heartbeat turns do not emit shell
+# commands containing mv/rm into the admin DM Tool Guard path.
+
+set -euo pipefail
+
+WORKER=""
+FILE="${PENDING_WORKERS_FILE:-${HOME}/pending-workers.json}"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --worker) WORKER="${2:-}"; shift 2 ;;
+        --file) FILE="${2:-}"; shift 2 ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            echo "Usage: drain-pending-worker.sh --worker <NAME> [--file <PATH>]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "${WORKER}" ]; then
+    echo "Usage: drain-pending-worker.sh --worker <NAME> [--file <PATH>]" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "${FILE}")"
+touch "${FILE}"
+
+TMP="${FILE}.tmp.$$"
+trap 'rm -f "${TMP}"' EXIT
+
+if [ -s "${FILE}" ]; then
+    jq -c --arg name "${WORKER}" 'select(.name != $name)' "${FILE}" > "${TMP}"
+else
+    : > "${TMP}"
+fi
+
+cat "${TMP}" > "${FILE}"
+echo "Drained ${WORKER} from ${FILE}"

--- a/manager/agent/team-leader-agent/AGENTS.md
+++ b/manager/agent/team-leader-agent/AGENTS.md
@@ -83,6 +83,8 @@ Project and task state must be changed through the runtime tools described by yo
 
 Do not create, edit, delete, or repair `shared/projects/**` or `shared/tasks/**` with shell commands, heredocs, direct file writes, `rm`, `mkdir`, `cp`, or Python module execution. Do not invoke project/task implementation modules directly. If a tool call fails or state looks inconsistent, report the blocker instead of manually patching the state.
 
+`taskflow(delegate_task)` only creates and publishes task state; it does not notify the Worker. After every successful delegation, you must send a visible Team Room assignment message with `message`, including the assigned Worker's full Matrix ID. Do not say a Worker is working, start polling, or send a requester progress update until that Team Room assignment message has been sent.
+
 Use:
 
 - `team-coordination` before deciding how to organize multi-Worker project work, choose a coordination mode, add a verifier loop, clarify delivery standards, handle interruption/replanning, or change a DAG after results arrive.
@@ -157,6 +159,7 @@ Do not:
 - Create bare tasks outside a Project.
 - Ask Workers to manage or edit project state.
 - Create, repair, or delete Project/Task state through shell commands or direct Python module execution.
+- Treat `taskflow(delegate_task)` as a Worker notification. It is only state/file creation; the Worker is not assigned until you send the Team Room @mention.
 - Send normal task assignments to Worker private rooms instead of the team room.
 - Treat Worker results, blockers, or heartbeat events as casual chat.
 - Send frequent requester updates for polling, waiting, routine checks, or unchanged state.

--- a/manager/agent/team-leader-agent/AGENTS.md
+++ b/manager/agent/team-leader-agent/AGENTS.md
@@ -72,6 +72,17 @@ Before using any tool-backed capability, read the relevant skill in this session
 
 When a CoPaw tool requires your agent id, use `default`.
 
+**Project/tool boundary**
+
+Project and task state must be changed through the runtime tools described by your skills:
+
+- Use `projectflow` for Project metadata, plans, ready nodes, lifecycle, and DAG/Loop state.
+- Use `taskflow` for Worker task delegation and task result checks.
+- Use `filesync` for publishing, pulling, and verifying shared files.
+- Use `message` for cross-room Matrix messages.
+
+Do not create, edit, delete, or repair `shared/projects/**` or `shared/tasks/**` with shell commands, heredocs, direct file writes, `rm`, `mkdir`, `cp`, or Python module execution. Do not invoke project/task implementation modules directly. If a tool call fails or state looks inconsistent, report the blocker instead of manually patching the state.
+
 Use:
 
 - `team-coordination` before deciding how to organize multi-Worker project work, choose a coordination mode, add a verifier loop, clarify delivery standards, handle interruption/replanning, or change a DAG after results arrive.
@@ -145,6 +156,7 @@ Do not:
 - Infer Manager source just because the work is external, multi-step, or project-shaped.
 - Create bare tasks outside a Project.
 - Ask Workers to manage or edit project state.
+- Create, repair, or delete Project/Task state through shell commands or direct Python module execution.
 - Send normal task assignments to Worker private rooms instead of the team room.
 - Treat Worker results, blockers, or heartbeat events as casual chat.
 - Send frequent requester updates for polling, waiting, routine checks, or unchanged state.

--- a/manager/agent/team-leader-agent/AGENTS.md
+++ b/manager/agent/team-leader-agent/AGENTS.md
@@ -81,9 +81,11 @@ Project and task state must be changed through the runtime tools described by yo
 - Use `filesync` for publishing, pulling, and verifying shared files.
 - Use `message` for cross-room Matrix messages.
 
+These are QwenPaw/CoPaw MCP tools exposed in your tool list. They are not shell commands, CLI binaries, Python modules, or HTTP endpoints. Call the tool directly; do not look for a binary, call implementation modules, or construct Matrix API requests yourself.
+
 Do not create, edit, delete, or repair `shared/projects/**` or `shared/tasks/**` with shell commands, heredocs, direct file writes, `rm`, `mkdir`, `cp`, or Python module execution. Do not invoke project/task implementation modules directly. If a tool call fails or state looks inconsistent, report the blocker instead of manually patching the state.
 
-`taskflow(delegate_task)` only creates and publishes task state; it does not notify the Worker. After every successful delegation, you must send a visible Team Room assignment message with `message`, including the assigned Worker's full Matrix ID. Do not say a Worker is working, start polling, or send a requester progress update until that Team Room assignment message has been sent.
+taskflow(delegate_task) only creates and publishes task state; it does not notify the Worker. After every successful delegation, you must send a visible Team Room assignment message with `message`, including the assigned Worker's full Matrix ID. Do not say a Worker is working, start polling, or send a requester progress update until that Team Room assignment message has been sent.
 
 Use:
 

--- a/manager/agent/team-leader-agent/skills/project-management/SKILL.md
+++ b/manager/agent/team-leader-agent/skills/project-management/SKILL.md
@@ -7,6 +7,8 @@ description: Use before any projectflow call or Team Leader workflow involving P
 
 You manage Project files, Project lifecycle, and Project execution plans. Use this skill as the Project state layer. Use `team-coordination` to decide the strategy, and use `task-management` to delegate or check individual Worker tasks.
 
+Project state is tool-owned. Do not create, edit, delete, or repair `shared/projects/**` with shell commands, heredocs, direct file writes, `rm`, `mkdir`, `cp`, or Python module execution. Use `projectflow` actions only. If `projectflow` fails or returns inconsistent state, stop and report the blocker instead of manually patching files.
+
 ## Scope
 
 Use this skill for:

--- a/manager/agent/team-leader-agent/skills/task-management/SKILL.md
+++ b/manager/agent/team-leader-agent/skills/task-management/SKILL.md
@@ -75,6 +75,8 @@ Do not call `check_active_tasks` from heartbeat or routine recovery checks for n
 
 `taskflow` handles file sync internally: `delegate_task` auto-pushes the task directory, `check_task` auto-pulls the task directory. Use `filesync` separately only for project-level files or non-task shared files.
 
+`delegate_task` does not send Matrix messages. A task is not actually assigned to the Worker until you send a visible Team Room message that @mentions the assigned Worker's full Matrix ID. Do not start polling the task, tell the requester that the Worker is working, or wait for results before this Team Room notification has been sent.
+
 ## Task Spec Language
 
 Write task specs in the language selected by `AGENTS.md` Response Language.
@@ -181,7 +183,7 @@ After delegation:
 
 1. `delegate_task` auto-pushes `shared/tasks/{task-id}/`. Do not call `filesync push` for the task directory.
 2. Publish `shared/projects/{project-id}/`, because the plan marker changed.
-3. @mention the assigned Worker in the assignment room.
+3. @mention the assigned Worker in the assignment room. For Team work, this must be the Team Room, not the Leader DM and not the Worker's private room.
 4. Include only the task ID, title, and instruction to start.
 
 Do not prescribe Worker-internal acknowledgement, push, submit, or planning steps.

--- a/manager/agent/team-leader-agent/skills/task-management/SKILL.md
+++ b/manager/agent/team-leader-agent/skills/task-management/SKILL.md
@@ -7,6 +7,8 @@ description: Use before any Leader taskflow call or task-level workflow involvin
 
 You manage individual Worker task delegation and result checks. Use this skill as the task execution layer. Use `team-coordination` for work organization strategy and `project-management` for Project state, DAG, Loop, lifecycle, and ready-node operations.
 
+Task state is tool-owned. Do not create, edit, delete, or repair `shared/tasks/**` with shell commands, heredocs, direct file writes, `rm`, `mkdir`, `cp`, or Python module execution. Use `taskflow` actions only. If `taskflow` fails or returns inconsistent state, stop and report the blocker instead of manually patching files.
+
 ## Scope
 
 Use this skill for:

--- a/manager/agent/team-leader-agent/skills/task-management/SKILL.md
+++ b/manager/agent/team-leader-agent/skills/task-management/SKILL.md
@@ -54,6 +54,8 @@ Use `taskflow` for Leader task actions:
 - `delegate_task`
 - `check_task`
 
+`taskflow` is a QwenPaw/CoPaw MCP tool exposed in your tool list. It is not a shell command, CLI binary, Python module, or HTTP endpoint. Call the tool directly; do not search for a binary or manually edit task files if the tool is unavailable.
+
 Worker runtimes use their own task actions:
 
 - `ack_task`
@@ -75,7 +77,7 @@ Do not call `check_active_tasks` from heartbeat or routine recovery checks for n
 
 `taskflow` handles file sync internally: `delegate_task` auto-pushes the task directory, `check_task` auto-pulls the task directory. Use `filesync` separately only for project-level files or non-task shared files.
 
-`delegate_task` does not send Matrix messages. A task is not actually assigned to the Worker until you send a visible Team Room message that @mentions the assigned Worker's full Matrix ID. Do not start polling the task, tell the requester that the Worker is working, or wait for results before this Team Room notification has been sent.
+delegate_task does not send Matrix messages. A task is not actually assigned to the Worker until you send a visible Team Room message that @mentions the assigned Worker's full Matrix ID. Do not start polling the task, tell the requester that the Worker is working, or wait for results before this Team Room notification has been sent.
 
 ## Task Spec Language
 

--- a/manager/scripts/init/start-copaw-manager.sh
+++ b/manager/scripts/init/start-copaw-manager.sh
@@ -240,4 +240,5 @@ export COPAW_LOG_LEVEL
 export PYTHONPATH="/opt/hiclaw/copaw/src:${PYTHONPATH:-}"
 
 # Use uvicorn to run CoPaw FastAPI app (enables AgentConfigWatcher for hot-reload)
-exec python3 -m copaw app --host 0.0.0.0 --port 18799
+# The wrapper installs HiClaw-owned tools before CoPaw creates any agents.
+exec python3 -m copaw_worker.run_copaw_app app --host 0.0.0.0 --port 18799

--- a/openhuman/Dockerfile
+++ b/openhuman/Dockerfile
@@ -27,7 +27,7 @@
 
 # Top-level build args (must be declared before any FROM that references them).
 ARG HIGRESS_REGISTRY=higress-registry.cn-hangzhou.cr.aliyuncs.com
-ARG HICLAW_CONTROLLER_IMAGE=hiclaw/hiclaw-controller:latest
+ARG AGENTTEAMS_CONTROLLER_IMAGE=agentteams/agentteams-controller:latest
 
 # ==========================================================================
 # Stage 0: mc (MinIO Client) — pulled from internal image instead of dl.min.io
@@ -38,7 +38,7 @@ FROM ${HIGRESS_REGISTRY}/higress/mc:20260216 AS mc
 # ==========================================================================
 # Stage 1: hiclaw CLI (from controller image)
 # ==========================================================================
-FROM ${HICLAW_CONTROLLER_IMAGE} AS hiclaw-controller
+FROM ${AGENTTEAMS_CONTROLLER_IMAGE} AS hiclaw-controller
 
 # ==========================================================================
 # Stage 2: Build the Rust binary with channel-matrix enabled

--- a/tests/lib/test-helpers.sh
+++ b/tests/lib/test-helpers.sh
@@ -203,7 +203,7 @@ wait_for_manager_agent_ready() {
     while [ "${elapsed}" -lt "${timeout}" ]; do
         case "${manager_runtime}" in
             copaw)
-                if docker exec "${agent_container}" pgrep -f "copaw app" >/dev/null 2>&1 && \
+                if docker exec "${agent_container}" pgrep -f "copaw(_worker\\.run_copaw_app)? app" >/dev/null 2>&1 && \
                    docker exec "${agent_container}" curl -sf http://127.0.0.1:18799/ >/dev/null 2>&1; then
                     runtime_ready=true
                     break

--- a/tests/test-01-manager-boot.sh
+++ b/tests/test-01-manager-boot.sh
@@ -118,7 +118,7 @@ case "${MANAGER_RUNTIME}" in
             log_fail "CoPaw agent.json valid"
         fi
 
-        if docker exec "${_AGENT_CTR}" pgrep -f "copaw app" >/dev/null 2>&1; then
+        if docker exec "${_AGENT_CTR}" pgrep -f "copaw(_worker\\.run_copaw_app)? app" >/dev/null 2>&1; then
             log_pass "CoPaw process running"
         else
             log_fail "CoPaw process running"

--- a/tests/test-21-team-project-dag.sh
+++ b/tests/test-21-team-project-dag.sh
@@ -226,10 +226,12 @@ assert_contains "${PROJECT_SKILL}" "Project state is tool-owned" "project-manage
 assert_contains "${PROJECT_SKILL}" "ready_nodes" "project-management documents DAG ready nodes"
 assert_contains "${TASK_SKILL}" "taskflow" "task-management documents taskflow"
 assert_contains "${TASK_SKILL}" "Task state is tool-owned" "task-management forbids manual task state mutation"
+assert_contains "${TASK_SKILL}" "delegate_task does not send Matrix messages" "task-management requires explicit Team Room notification"
 assert_contains "${TASK_SKILL}" "delegate_task" "task-management documents task delegation"
 assert_contains "${COORDINATION_SKILL}" "DAG" "team-coordination documents DAG strategy"
 assert_contains "${COORDINATION_SKILL}" "Loop" "team-coordination documents Loop strategy"
 assert_contains "${LEADER_AGENTS}" "Project/tool boundary" "Leader AGENTS documents tool-owned project/task boundary"
+assert_contains "${LEADER_AGENTS}" "taskflow(delegate_task) only creates and publishes task state" "Leader AGENTS requires Team Room assignment after taskflow"
 
 # ============================================================
 # Section 8: End-to-End LLM Test — Admin delegates via Leader DM

--- a/tests/test-21-team-project-dag.sh
+++ b/tests/test-21-team-project-dag.sh
@@ -219,13 +219,17 @@ LEADER_HOME="/root/hiclaw-fs/agents/${TEST_LEADER}"
 PROJECT_SKILL=$(exec_in_manager mc cat "${STORAGE_PREFIX}/agents/${TEST_LEADER}/skills/project-management/SKILL.md" 2>/dev/null)
 TASK_SKILL=$(exec_in_manager mc cat "${STORAGE_PREFIX}/agents/${TEST_LEADER}/skills/task-management/SKILL.md" 2>/dev/null)
 COORDINATION_SKILL=$(exec_in_manager mc cat "${STORAGE_PREFIX}/agents/${TEST_LEADER}/skills/team-coordination/SKILL.md" 2>/dev/null)
+LEADER_AGENTS=$(exec_in_manager mc cat "${STORAGE_PREFIX}/agents/${TEST_LEADER}/AGENTS.md" 2>/dev/null)
 
 assert_contains "${PROJECT_SKILL}" "projectflow" "project-management documents projectflow"
+assert_contains "${PROJECT_SKILL}" "Project state is tool-owned" "project-management forbids manual project state mutation"
 assert_contains "${PROJECT_SKILL}" "ready_nodes" "project-management documents DAG ready nodes"
 assert_contains "${TASK_SKILL}" "taskflow" "task-management documents taskflow"
+assert_contains "${TASK_SKILL}" "Task state is tool-owned" "task-management forbids manual task state mutation"
 assert_contains "${TASK_SKILL}" "delegate_task" "task-management documents task delegation"
 assert_contains "${COORDINATION_SKILL}" "DAG" "team-coordination documents DAG strategy"
 assert_contains "${COORDINATION_SKILL}" "Loop" "team-coordination documents Loop strategy"
+assert_contains "${LEADER_AGENTS}" "Project/tool boundary" "Leader AGENTS documents tool-owned project/task boundary"
 
 # ============================================================
 # Section 8: End-to-End LLM Test — Admin delegates via Leader DM

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -12,13 +12,13 @@
 
 ARG HIGRESS_REGISTRY=higress-registry.cn-hangzhou.cr.aliyuncs.com
 ARG OPENCLAW_BASE_IMAGE=hiclaw/openclaw-base:20260423-8359cbc
-ARG HICLAW_CONTROLLER_IMAGE=hiclaw/hiclaw-controller:latest
+ARG AGENTTEAMS_CONTROLLER_IMAGE=agentteams/agentteams-controller:latest
 
 # ============ Stage 1: mc (MinIO Client) ============
 FROM ${HIGRESS_REGISTRY}/higress/mc:20260216 AS mc
 
 # ============ Stage 2: hiclaw CLI (from controller image) ============
-FROM ${HICLAW_CONTROLLER_IMAGE} AS hiclaw-controller
+FROM ${AGENTTEAMS_CONTROLLER_IMAGE} AS hiclaw-controller
 
 # ============ Final Image: Based on openclaw-base ============
 # openclaw-base already includes: all-in-one + Node.js 22 + OpenClaw + mcporter + common tools


### PR DESCRIPTION
## Summary
- switch default build, install, Helm, workflow, and release image repositories from `hiclaw-*` to `agentteams-*`
- rename the controller image build arg consumed by runtime Dockerfiles to `AGENTTEAMS_CONTROLLER_IMAGE`
- keep legacy local tags during the transition so base-branch `pull_request_target` workflows can still load artifacts
- make the installers recognize `agentteams/*` local image tags so embedded CI installs use loaded PR images instead of pulling unpublished Docker Hub names
- keep runtime env vars, CRDs, CLI names, container names, and storage/Matrix contracts unchanged for follow-up PRs

## Validation
- `git diff --check`
- `bash -n install/hiclaw-install.sh`
- PowerShell parser check for `install/hiclaw-install.ps1`
- Ruby YAML parse for `.github/workflows/build.yml`, `.github/workflows/build-rc.yml`, `.github/workflows/release.yml`, `.github/workflows/test-integration.yml`
- `make -n build-hiclaw-controller build-manager build-manager-copaw build-worker build-copaw-worker build-hermes-worker build-openhuman-worker build-qwenpaw-worker build-embedded`
- `make -n push-hiclaw-controller push-manager push-manager-copaw push-worker push-copaw-worker push-hermes-worker push-openhuman-worker push-qwenpaw-worker push-embedded`
- `make -n install-embedded SKIP_BUILD=1`

Note: `make helm-template` could not run in this local worktree because `helm` is not installed.