### PR TITLE
fix(controller): skip manager reconciler when disabled

### DIFF
--- a/hiclaw-controller/internal/app/app.go
+++ b/hiclaw-controller/internal/app/app.go
@@ -647,30 +647,34 @@ func (a *App) initReconcilers(_ context.Context) error {
 		return fmt.Errorf("setup HumanReconciler: %w", err)
 	}
 
-	mgrReconciler := &controller.ManagerReconciler{
-		Client:           a.mgr.GetClient(),
-		Provisioner:      a.provisioner,
-		Deployer:         a.deployer,
-		Backend:          a.registry,
-		EnvBuilder:       a.envBuilder,
-		ResourcePrefix:   resourcePrefix,
-		ManagerResources: a.cfg.ManagerResources(),
-		DefaultRuntime:   a.cfg.ManagerRuntime,
-		ControllerName:   a.cfg.ControllerName,
-		UserLanguage:     a.cfg.UserLanguage,
-		UserTimezone:     a.cfg.UserTimezone,
-		GatewayClient:    a.gateway,
-	}
-	if a.cfg.KubeMode == "embedded" {
-		mgrReconciler.EmbeddedConfig = &controller.ManagerEmbeddedConfig{
-			WorkspaceDir:       a.cfg.ManagerWorkspaceDir,
-			HostShareDir:       a.cfg.HostShareDir,
-			ExtraEnv:           a.cfg.ManagerAgentEnv(),
-			ManagerConsolePort: a.cfg.ManagerConsolePort,
+	if a.cfg.ManagerEnabled {
+		mgrReconciler := &controller.ManagerReconciler{
+			Client:           a.mgr.GetClient(),
+			Provisioner:      a.provisioner,
+			Deployer:         a.deployer,
+			Backend:          a.registry,
+			EnvBuilder:       a.envBuilder,
+			ResourcePrefix:   resourcePrefix,
+			ManagerResources: a.cfg.ManagerResources(),
+			DefaultRuntime:   a.cfg.ManagerRuntime,
+			ControllerName:   a.cfg.ControllerName,
+			UserLanguage:     a.cfg.UserLanguage,
+			UserTimezone:     a.cfg.UserTimezone,
+			GatewayClient:    a.gateway,
 		}
-	}
-	if err := mgrReconciler.SetupWithManager(a.mgr); err != nil {
-		return fmt.Errorf("setup ManagerReconciler: %w", err)
+		if a.cfg.KubeMode == "embedded" {
+			mgrReconciler.EmbeddedConfig = &controller.ManagerEmbeddedConfig{
+				WorkspaceDir:       a.cfg.ManagerWorkspaceDir,
+				HostShareDir:       a.cfg.HostShareDir,
+				ExtraEnv:           a.cfg.ManagerAgentEnv(),
+				ManagerConsolePort: a.cfg.ManagerConsolePort,
+			}
+		}
+		if err := mgrReconciler.SetupWithManager(a.mgr); err != nil {
+			return fmt.Errorf("setup ManagerReconciler: %w", err)
+		}
+	} else {
+		ctrl.Log.WithName("app").Info("skipping ManagerReconciler because Manager provisioning is disabled")
 	}
 
 	if err := a.mgr.Add(&agentteamsmetrics.CRCountCollector{


### PR DESCRIPTION
## Summary
- skip ManagerReconciler registration when Manager provisioning is disabled
- keep the existing CR count collector manager-skip behavior unchanged
- avoid requiring Manager CR dependencies in Worker-only OSS deployments

## Scope
This is a narrow controller startup fix for AGENTTEAMS_MANAGER_ENABLED/HICLAW_MANAGER_ENABLED=false deployments. It does not change CRDs, API groups, Helm defaults, worker deployment modes, Matrix AppService envs, image names, TeamHarness, QwenPaw, Remote/Sandbox workers, SchedulerX, or Alibaba credential/provider internals.

## Validation
- git diff --check
- go test ./internal/app ./internal/metrics