### PR TITLE
fix(copaw): preserve provider input capabilities

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -27,6 +27,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 
 **Bug Fixes**
 
+- **CoPaw multimodal models**: Preserve controller model input modalities when bridging provider configuration so CoPaw does not strip image and video content from capable models.
 - **Legacy Team channel policy**: Legacy Team reconciliation now writes final Matrix channel allow-lists to member runtime config and re-adds the Team Leader to the Manager allow-list so controller integration tests observe durable policy state.
 - **Sandbox worker-deps hardening**: Sandbox-backed Workers now prepare controller-owned worker-deps env/token/data material before claim creation, recycle stale SandboxClaims and bound Sandboxes on runtime-affecting changes, and use bounded ServiceAccount token projection for built-in SandboxClaim mounts.
 - **CLI AgentTeams auth env**: The `hiclaw` CLI now discovers `AGENTTEAMS_CONTROLLER_URL`, `AGENTTEAMS_AUTH_TOKEN`, `AGENTTEAMS_AUTH_TOKEN_FILE`, and `AGENTTEAMS_CLUSTER_ID` while preserving legacy `HICLAW_*` fallbacks, so Manager and Worker containers can use the terminal env names for controller calls.

--- a/copaw/src/copaw_worker/bridge.py
+++ b/copaw/src/copaw_worker/bridge.py
@@ -425,11 +425,29 @@ def _write_providers_json(
         api_key = provider_cfg.get("apiKey", "")
 
         models_raw = provider_cfg.get("models", [])
-        models = [
-            {"id": m["id"], "name": m.get("name", m["id"])}
-            for m in models_raw
-            if m.get("id")
-        ]
+        models = []
+        for model_cfg in models_raw:
+            model_id = model_cfg.get("id")
+            if not model_id:
+                continue
+
+            model = {
+                "id": model_id,
+                "name": model_cfg.get("name", model_id),
+            }
+            input_types = model_cfg.get("input")
+            if isinstance(input_types, list):
+                modalities = {
+                    input_type
+                    for input_type in input_types
+                    if isinstance(input_type, str)
+                }
+                model.update({
+                    "supports_image": "image" in modalities,
+                    "supports_video": "video" in modalities,
+                    "supports_multimodal": bool(modalities - {"text"}),
+                })
+            models.append(model)
 
         custom_providers[provider_id] = {
             "id": provider_id,

--- a/copaw/tests/test_bridge_providers.py
+++ b/copaw/tests/test_bridge_providers.py
@@ -1,0 +1,61 @@
+"""Focused tests for the OpenClaw-to-CoPaw provider bridge."""
+
+import json
+
+from copaw_worker.bridge import _write_providers_json
+
+
+def test_provider_model_input_modalities_are_preserved(tmp_path):
+    """Provider model inputs become CoPaw model capability annotations."""
+    cfg = {
+        "models": {
+            "providers": {
+                "gw": {
+                    "baseUrl": "http://aigw:8080/v1",
+                    "apiKey": "key123",
+                    "models": [
+                        {
+                            "id": "vision-model",
+                            "name": "Vision Model",
+                            "input": ["text", "image"],
+                        },
+                        {"id": "video-model", "input": ["text", "video"]},
+                        {"id": "text-model", "input": ["text"]},
+                        {"id": "unknown-model"},
+                    ],
+                },
+            },
+        },
+        "agents": {
+            "defaults": {"model": {"primary": "gw/vision-model"}},
+        },
+    }
+
+    _write_providers_json(cfg, tmp_path, in_container=False)
+
+    providers = json.loads((tmp_path / "providers.json").read_text())
+    models = providers["custom_providers"]["gw"]["models"]
+    assert models == [
+        {
+            "id": "vision-model",
+            "name": "Vision Model",
+            "supports_image": True,
+            "supports_video": False,
+            "supports_multimodal": True,
+        },
+        {
+            "id": "video-model",
+            "name": "video-model",
+            "supports_image": False,
+            "supports_video": True,
+            "supports_multimodal": True,
+        },
+        {
+            "id": "text-model",
+            "name": "text-model",
+            "supports_image": False,
+            "supports_video": False,
+            "supports_multimodal": False,
+        },
+        {"id": "unknown-model", "name": "unknown-model"},
+    ]


### PR DESCRIPTION
## Summary

- translate existing provider model `input` modalities into CoPaw's
  `supports_image`, `supports_video`, and `supports_multimodal` annotations
- leave capabilities unset when legacy model entries have no `input` field, so
  CoPaw can still probe unknown models
- add a focused regression test for image, video, text-only, and unknown models

## Focused follow-up

#945 bundled this bug with controller fields, peer mentions, and runtime
changes, and was closed in favor of smaller follow-ups. #1002 wires custom
model vision configuration into the controller's existing model `input`
metadata, while #1012 adds metadata for a specific vision model. Both are on
the producer side; the current CoPaw bridge still copies only model `id` and
`name`. This PR fixes only that remaining bridge conversion and does not change
OpenClaw or controller configuration.

Fixes #931.

## Validation

- `PYTHONPATH=copaw/src python -m pytest -q copaw/tests/test_bridge_providers.py`
- generated vision and unknown-model metadata validates against CoPaw 1.0.2
  `ModelInfo` while preserving `None` for unknown capabilities
- `python -m compileall -q copaw/src/copaw_worker/bridge.py copaw/tests/test_bridge_providers.py`
- `git diff --check`
