### PR TITLE
fix(ci): fall back to legacy LLM API key secret

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -357,7 +357,7 @@ jobs:
       - name: Run embedded integration tests
         id: tests
         env:
-          AGENTTEAMS_LLM_API_KEY: ${{ secrets.AGENTTEAMS_LLM_API_KEY }}
+          AGENTTEAMS_LLM_API_KEY: ${{ secrets.AGENTTEAMS_LLM_API_KEY || secrets.HICLAW_LLM_API_KEY }}
           AGENTTEAMS_LLM_PROVIDER: qwen
           AGENTTEAMS_DEFAULT_MODEL: ${{ inputs.model || 'qwen3.6-plus' }}
           AGENTTEAMS_MANAGER_RUNTIME: ${{ matrix.manager_runtime }}
@@ -643,7 +643,7 @@ jobs:
 
       - name: Install AgentTeams
         env:
-          AGENTTEAMS_LLM_API_KEY: ${{ secrets.AGENTTEAMS_LLM_API_KEY }}
+          AGENTTEAMS_LLM_API_KEY: ${{ secrets.AGENTTEAMS_LLM_API_KEY || secrets.HICLAW_LLM_API_KEY }}
         run: |
           VERSION=${{ steps.version.outputs.version }}
           AGENTTEAMS_NON_INTERACTIVE=1 \
@@ -676,7 +676,7 @@ jobs:
 
       - name: Run integration tests
         env:
-          AGENTTEAMS_LLM_API_KEY: ${{ secrets.AGENTTEAMS_LLM_API_KEY }}
+          AGENTTEAMS_LLM_API_KEY: ${{ secrets.AGENTTEAMS_LLM_API_KEY || secrets.HICLAW_LLM_API_KEY }}
         run: |
           TEST_GATEWAY_PORT=18080 TEST_CONSOLE_PORT=18001 TEST_MANAGER_CONTAINER=agentteams-manager \
             ./tests/run-all-tests.sh --skip-build --use-existing --test-filter "$NON_GITHUB_TESTS"


### PR DESCRIPTION
## Summary

- Keep the runtime-facing environment variable as `AGENTTEAMS_LLM_API_KEY`.
- Resolve its value from the new Actions secret first, then fall back to `HICLAW_LLM_API_KEY` while repository secrets are migrated.
- Apply the same fallback to PR integration tests and release-baseline install/test jobs.

## Root cause

The AgentTeams contract rename changed the workflow to read only `secrets.AGENTTEAMS_LLM_API_KEY`, but the configured repository secret still uses the legacy name. Run [#1647](https://github.com/agentscope-ai/AgentTeams/actions/runs/29327402001) therefore failed eight integration jobs before any test started with `LLM API Key is required`.

## Verification

- Parsed `.github/workflows/test-integration.yml` with PyYAML.
- Confirmed all three workflow consumers use the fallback expression.
- `git diff --check`

This unblocks current PR CI, including #985, without exposing or renaming any secret.