### PR TITLE
docs(k8s): add remote access ingress guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,11 +234,71 @@ For all configurable values (gateway/storage providers, image tags, resources, p
 
 **Access**
 
+For a temporary local admin session, forward the Higress Gateway:
+
 ```bash
 kubectl port-forward -n hiclaw-system svc/higress-gateway 18080:80
 ```
 
-Then open http://localhost:18080 in your browser and log in to Element Web. For an actual cluster, configure an Ingress / LoadBalancer / DNS record pointing at `svc/higress-gateway` and set `gateway.publicURL` accordingly.
+Then open http://localhost:18080 and log in to Element Web. The port-forward
+ends when the command exits and is not suitable for shared access.
+
+For company or Internet access, expose only `svc/higress-gateway` through an
+HTTPS Ingress or LoadBalancer. `gateway.publicURL` is written into the Element
+Web configuration as its Matrix homeserver URL, so it must exactly match the
+public origin that users open (for example, `https://agentteams.example.com`).
+
+1. Point the public DNS name at your Ingress controller or load balancer.
+2. Provision a TLS certificate Secret in `hiclaw-system`.
+3. Set the same origin on the Helm release:
+
+```bash
+helm upgrade hiclaw higress.io/hiclaw \
+  -n hiclaw-system --reuse-values \
+  --set gateway.publicURL=https://agentteams.example.com
+```
+
+4. Route that host to the Higress Gateway. This generic example assumes an
+   NGINX IngressClass and an existing `agentteams-tls` Secret; replace both to
+   match your cluster:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: agentteams
+  namespace: hiclaw-system
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - agentteams.example.com
+      secretName: agentteams-tls
+  rules:
+    - host: agentteams.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: higress-gateway
+                port:
+                  number: 80
+```
+
+Verify both the web entry point and Matrix routing after DNS and TLS are ready:
+
+```bash
+curl -fsSI https://agentteams.example.com/
+curl -fsS https://agentteams.example.com/_matrix/client/versions
+```
+
+Keep the controller API, Tuwunel, MinIO, and the Higress Console private unless
+you apply separate authentication and network policy. Use HTTPS for shared
+access because Matrix login credentials and access tokens pass through this
+endpoint. A `LoadBalancer` Service can replace the Ingress, but the DNS, TLS,
+and `gateway.publicURL` requirements remain the same.
 
 **Upgrade**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -243,11 +243,69 @@ helm install hiclaw higress.io/hiclaw \
 
 **访问**
 
+临时从本机管理集群时，可以转发 Higress Gateway：
+
 ```bash
 kubectl port-forward -n hiclaw-system svc/higress-gateway 18080:80
 ```
 
-然后在浏览器中打开 http://localhost:18080 登录 Element Web。生产集群中请通过 Ingress / LoadBalancer / DNS 指向 `svc/higress-gateway`，并相应地修改 `gateway.publicURL`。
+然后在浏览器中打开 http://localhost:18080 登录 Element Web。命令退出后转发即停止，
+因此该方式不适合多人共享。
+
+公司内网或公网访问时，只需通过 HTTPS Ingress 或 LoadBalancer 暴露
+`svc/higress-gateway`。`gateway.publicURL` 会写入 Element Web 配置，作为 Matrix
+Homeserver 地址，因此必须与用户实际打开的公网 Origin 完全一致，例如
+`https://agentteams.example.com`。
+
+1. 将公网域名解析到 Ingress Controller 或负载均衡器。
+2. 在 `hiclaw-system` 命名空间中准备 TLS 证书 Secret。
+3. 在 Helm Release 中设置相同的公网地址：
+
+```bash
+helm upgrade hiclaw higress.io/hiclaw \
+  -n hiclaw-system --reuse-values \
+  --set gateway.publicURL=https://agentteams.example.com
+```
+
+4. 将该域名路由到 Higress Gateway。以下通用示例假设使用 NGINX
+   IngressClass，并已存在 `agentteams-tls` Secret；请按集群实际情况替换：
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: agentteams
+  namespace: hiclaw-system
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - agentteams.example.com
+      secretName: agentteams-tls
+  rules:
+    - host: agentteams.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: higress-gateway
+                port:
+                  number: 80
+```
+
+DNS 与 TLS 生效后，分别验证 Web 入口和 Matrix 路由：
+
+```bash
+curl -fsSI https://agentteams.example.com/
+curl -fsS https://agentteams.example.com/_matrix/client/versions
+```
+
+Controller API、Tuwunel、MinIO 和 Higress Console 应保持集群内访问；如确需暴露，
+请另行配置身份认证和网络策略。多人共享时必须使用 HTTPS，因为 Matrix 登录凭据和
+Access Token 都会经过该入口。也可以用 `LoadBalancer` Service 代替 Ingress，但 DNS、
+TLS 和 `gateway.publicURL` 的要求不变。
 
 **升级**
 


### PR DESCRIPTION
## Summary

- Separate temporary `kubectl port-forward` access from shared company/Internet access.
- Document how `gateway.publicURL`, public DNS, and TLS must use the same origin.
- Add a concrete Kubernetes Ingress example routing the public host to `svc/higress-gateway`.
- Add web and Matrix endpoint verification commands.
- Clarify that the controller API, Tuwunel, MinIO, and Higress Console should remain private.
- Keep the English and Chinese README guidance aligned.

## Validation

- Parsed both embedded Ingress examples with PyYAML.
- Verified command/hostname parity between `README.md` and `README.zh-CN.md`.
- `git diff --check`

Docs-only change; no runtime behavior is modified.

Closes #1025