### PR TITLE
test: honor AgentTeams worker runtime env

### DIFF
--- a/tests/test-02-create-worker.sh
+++ b/tests/test-02-create-worker.sh
@@ -54,7 +54,7 @@ wait_for_session_stable 5 60
 
 # Snapshot metrics baseline before sending message (to calculate delta later)
 METRICS_BASELINE=$(snapshot_baseline)
-TEST_WORKER_RUNTIME="${HICLAW_DEFAULT_WORKER_RUNTIME:-openclaw}"
+TEST_WORKER_RUNTIME="${AGENTTEAMS_DEFAULT_WORKER_RUNTIME:-${HICLAW_DEFAULT_WORKER_RUNTIME:-openclaw}}"
 
 # Send create worker request.
 #

--- a/tests/test-06-multi-worker.sh
+++ b/tests/test-06-multi-worker.sh
@@ -48,7 +48,7 @@ fi
 # Alice is running from previous tests; bob will be created below (offset=0 is correct for new workers)
 wait_for_worker_container "alice" 60
 METRICS_BASELINE=$(snapshot_baseline "alice" "bob")
-TEST_WORKER_RUNTIME="${HICLAW_DEFAULT_WORKER_RUNTIME:-openclaw}"
+TEST_WORKER_RUNTIME="${AGENTTEAMS_DEFAULT_WORKER_RUNTIME:-${HICLAW_DEFAULT_WORKER_RUNTIME:-openclaw}}"
 # worker-management/SKILL.md tells Manager to ask admin for FOUR inputs
 # (name / runtime / SOUL / skills) before running `hiclaw create worker`
 # and not to invent defaults. A vague prompt that only names the worker is

--- a/tests/test-15-import-worker-zip.sh
+++ b/tests/test-15-import-worker-zip.sh
@@ -79,7 +79,7 @@ WORK_DIR="/tmp/agentteams-test-${TEST_WORKER}"
 # defaults to openclaw on the controller side (defaultRuntime("") returns
 # RuntimeOpenClaw), which makes the "copaw shard" run a hidden openclaw
 # worker -- defeating the point of the matrix expansion.
-TEST_WORKER_RUNTIME="${HICLAW_DEFAULT_WORKER_RUNTIME:-openclaw}"
+TEST_WORKER_RUNTIME="${AGENTTEAMS_DEFAULT_WORKER_RUNTIME:-${HICLAW_DEFAULT_WORKER_RUNTIME:-openclaw}}"
 
 exec_in_manager bash -c "
     mkdir -p ${WORK_DIR}/package/config ${WORK_DIR}/package/skills/test-skill


### PR DESCRIPTION
## Summary

- Make tests 02, 06, and 15 prefer `AGENTTEAMS_DEFAULT_WORKER_RUNTIME`.
- Preserve the legacy variable as a fallback for direct local test invocations.
- Keep `openclaw` as the final default.

## Root cause

The integration matrix now exports `AGENTTEAMS_DEFAULT_WORKER_RUNTIME`, but these three worker-creating tests still read only `HICLAW_DEFAULT_WORKER_RUNTIME`. Copaw and Hermes matrix jobs therefore explicitly created OpenClaw workers, so their reported runtime coverage did not match the configured matrix dimension.

## Verification

- `bash -n` passes for all three scripts.
- Shell assertions cover new-variable precedence, legacy fallback, and the default value in every file.
- `git diff --check`

This is test-only and does not change runtime behavior.