### PR TITLE
fix(make): target AgentTeams containers in dev utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -799,7 +799,7 @@ verify: ## Run post-install verification against the running Manager container
 
 status: ## Show status of Manager and all Worker containers
 	@echo "==> AgentTeams container status:"
-	@docker ps -a --filter "name=hiclaw-" --format "table {{.Names}}\t{{.Status}}\t{{.Image}}" 2>/dev/null \
+	@docker ps -a --filter "name=agentteams-" --format "table {{.Names}}\t{{.Status}}\t{{.Image}}" 2>/dev/null \
 		|| echo "  (no containers found or Docker not available)"
 
 logs: ## Show recent logs for Manager and all Workers (override with LINES=N, default 50)
@@ -823,7 +823,7 @@ clean: ## Remove local images and test containers
 	@echo "==> Stopping and removing test containers..."
 	-docker stop $(TEST_CONTAINER) 2>/dev/null
 	-docker rm $(TEST_CONTAINER) 2>/dev/null
-	-docker ps -a --filter "name=hiclaw-test-worker-" --format '{{.Names}}' | xargs -r docker rm -f 2>/dev/null
+	-docker ps -a --filter "name=agentteams-test-worker-" --format '{{.Names}}' | xargs -r docker rm -f 2>/dev/null
 	@echo "==> Removing local images..."
 	-docker rmi $(LOCAL_MANAGER) 2>/dev/null
 	-docker rmi $(LOCAL_WORKER) 2>/dev/null


### PR DESCRIPTION
## Summary

- make `make status` list the renamed `agentteams-*` containers
- make `make clean` remove `agentteams-test-worker-*` containers created by the current test harness

## Root cause

The AgentTeams contract rename updated the container names and most Makefile targets, but these two Docker name filters still used the old `hiclaw-*` prefixes. As a result, `make status` omitted current containers and `make clean` left current test workers behind.

## Validation

- ran `make status` against a recording Docker stub and verified the `name=agentteams-` filter plus controller/manager output
- ran `make clean TEST_CONTAINER=agentteams-manager-test` against the stub and verified both current test workers were removed
- ran `make -n status` and `make -n clean TEST_CONTAINER=agentteams-manager-test`
- ran `git diff --check`
