### PR TITLE
fix(test): update MinIO mock for AgentTeams alias

### DIFF
--- a/manager/tests/test-update-builtin-section-minio.sh
+++ b/manager/tests/test-update-builtin-section-minio.sh
@@ -37,10 +37,10 @@ mc() {
     local src="$2"
     local dst="$3"
 
-    # Determine which arg is a "minio path" (contains "hiclaw/") vs local path
+    # Determine which arg is a MinIO path (starts with "agentteams/") vs local path.
     _resolve() {
         local p="$1"
-        if [[ "${p}" == hiclaw/* ]]; then
+        if [[ "${p}" == agentteams/* ]]; then
             echo "${FAKE_MINIO_ROOT}/${p}"
         else
             echo "${p}"


### PR DESCRIPTION
## Summary

- update the MinIO unit-test mock to recognize the `agentteams/` alias
- align the mock implementation with the renamed paths already used by the test cases

## Root cause

The AgentTeams hard rename updated the fake MinIO paths and assertions, but the mock resolver still classified only `hiclaw/*` as remote paths. As a result, `mc cp` treated every `agentteams/*` object path as a local filesystem path and all MinIO merge scenarios failed before exercising the intended behavior.

## Impact

This restores the unit test without changing production behavior. The test now exercises create, update, preservation, repair, idempotency, and multi-worker cases against the current storage alias.

## Validation

- `bash manager/tests/test-update-builtin-section-minio.sh` (20 passed)
- `bash manager/tests/test-update-builtin-section.sh` (40 passed)
- `bash -n manager/tests/test-update-builtin-section-minio.sh manager/scripts/lib/builtin-merge.sh`
- `git diff --check`
