### PR TITLE
fix(openhuman): restore AgentTeams runtime contract

### DIFF
--- a/agentteams-controller/internal/backend/docker.go
+++ b/agentteams-controller/internal/backend/docker.go
@@ -159,7 +159,9 @@ func (d *DockerBackend) Create(ctx context.Context, req CreateRequest) (*WorkerR
 
 	// Infer WorkingDir from HOME env if not set
 	if req.WorkingDir == "" {
-		if home, ok := req.Env["HOME"]; ok {
+		if req.Runtime == RuntimeOpenHuman {
+			req.WorkingDir = "/home/openhuman/.openhuman"
+		} else if home, ok := req.Env["HOME"]; ok {
 			req.WorkingDir = home
 		}
 	}

--- a/agentteams-controller/internal/backend/docker_test.go
+++ b/agentteams-controller/internal/backend/docker_test.go
@@ -382,11 +382,11 @@ func TestDockerCreatePullsImage(t *testing.T) {
 }
 
 // captureCreateImagesServer is a minimal Docker mock that records the Image
-// field of every POST /containers/create request. Other endpoints return the
-// minimum responses required to make DockerBackend.Create succeed.
+// and WorkingDir fields of every POST /containers/create request.
 type capturedCreateBodies struct {
-	srv    *httptest.Server
-	images []string
+	srv         *httptest.Server
+	images      []string
+	workingDirs []string
 }
 
 func (c *capturedCreateBodies) lastImage() string {
@@ -394,6 +394,13 @@ func (c *capturedCreateBodies) lastImage() string {
 		return ""
 	}
 	return c.images[len(c.images)-1]
+}
+
+func (c *capturedCreateBodies) lastWorkingDir() string {
+	if len(c.workingDirs) == 0 {
+		return ""
+	}
+	return c.workingDirs[len(c.workingDirs)-1]
 }
 
 func captureCreateImagesServer(t *testing.T) *capturedCreateBodies {
@@ -409,6 +416,11 @@ func captureCreateImagesServer(t *testing.T) *capturedCreateBodies {
 		json.NewDecoder(r.Body).Decode(&body)
 		if img, ok := body["Image"].(string); ok {
 			captured.images = append(captured.images, img)
+		}
+		if workingDir, ok := body["WorkingDir"].(string); ok {
+			captured.workingDirs = append(captured.workingDirs, workingDir)
+		} else {
+			captured.workingDirs = append(captured.workingDirs, "")
 		}
 		w.WriteHeader(http.StatusCreated)
 		json.NewEncoder(w).Encode(map[string]string{"Id": "sha256-test"})
@@ -603,11 +615,13 @@ func TestDockerCreateResolvesImageFromRuntime(t *testing.T) {
 	}{
 		{"explicit_copaw_uses_copaw_image", RuntimeCopaw, "", "agentteams/copaw-worker:latest"},
 		{"explicit_hermes_uses_hermes_image", RuntimeHermes, "", "agentteams/hermes-worker:latest"},
+		{"explicit_openhuman_uses_openhuman_image", RuntimeOpenHuman, "", "agentteams/openhuman-worker:latest"},
 		{"explicit_qwenpaw_uses_qwenpaw_image", RuntimeQwenPaw, "", "agentteams/qwenpaw-worker:latest"},
 		{"explicit_openclaw_uses_worker_image", RuntimeOpenClaw, "", "agentteams/worker-agent:latest"},
 		{"empty_runtime_with_no_fallback_uses_worker_image", "", "", "agentteams/worker-agent:latest"},
 		{"empty_runtime_with_copaw_fallback_uses_copaw_image", "", RuntimeCopaw, "agentteams/copaw-worker:latest"},
 		{"empty_runtime_with_hermes_fallback_uses_hermes_image", "", RuntimeHermes, "agentteams/hermes-worker:latest"},
+		{"empty_runtime_with_openhuman_fallback_uses_openhuman_image", "", RuntimeOpenHuman, "agentteams/openhuman-worker:latest"},
 		{"empty_runtime_with_qwenpaw_fallback_uses_qwenpaw_image", "", RuntimeQwenPaw, "agentteams/qwenpaw-worker:latest"},
 		{"explicit_runtime_overrides_fallback", RuntimeOpenClaw, RuntimeHermes, "agentteams/worker-agent:latest"},
 	}
@@ -618,11 +632,12 @@ func TestDockerCreateResolvesImageFromRuntime(t *testing.T) {
 
 			b := &DockerBackend{
 				config: DockerConfig{
-					WorkerImage:        "agentteams/worker-agent:latest",
-					CopawWorkerImage:   "agentteams/copaw-worker:latest",
-					HermesWorkerImage:  "agentteams/hermes-worker:latest",
-					QwenPawWorkerImage: "agentteams/qwenpaw-worker:latest",
-					DefaultNetwork:     "agentteams-net",
+					WorkerImage:          "agentteams/worker-agent:latest",
+					CopawWorkerImage:     "agentteams/copaw-worker:latest",
+					HermesWorkerImage:    "agentteams/hermes-worker:latest",
+					OpenHumanWorkerImage: "agentteams/openhuman-worker:latest",
+					QwenPawWorkerImage:   "agentteams/qwenpaw-worker:latest",
+					DefaultNetwork:       "agentteams-net",
 				},
 				containerPrefix: "agentteams-worker-",
 				client: &http.Client{
@@ -640,6 +655,54 @@ func TestDockerCreateResolvesImageFromRuntime(t *testing.T) {
 			}
 			if got := capturedImages.lastImage(); got != tc.wantImage {
 				t.Fatalf("create body Image = %q, want %q", got, tc.wantImage)
+			}
+		})
+	}
+}
+
+func TestDockerCreateRuntimeWorkingDir(t *testing.T) {
+	const home = "/root/agentteams-fs/agents/x"
+	cases := []struct {
+		name           string
+		runtime        string
+		explicit       string
+		wantWorkingDir string
+	}{
+		{"openclaw_uses_home", RuntimeOpenClaw, "", home},
+		{"copaw_uses_home", RuntimeCopaw, "", home},
+		{"hermes_uses_home", RuntimeHermes, "", home},
+		{"openhuman_uses_dedicated_workspace", RuntimeOpenHuman, "", "/home/openhuman/.openhuman"},
+		{"explicit_working_dir_wins", RuntimeOpenHuman, "/custom/workspace", "/custom/workspace"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			captured := captureCreateImagesServer(t)
+			defer captured.srv.Close()
+			b := &DockerBackend{
+				config: DockerConfig{
+					WorkerImage:          "agentteams/worker-agent:latest",
+					CopawWorkerImage:     "agentteams/copaw-worker:latest",
+					HermesWorkerImage:    "agentteams/hermes-worker:latest",
+					OpenHumanWorkerImage: "agentteams/openhuman-worker:latest",
+					DefaultNetwork:       "agentteams-net",
+				},
+				containerPrefix: "agentteams-worker-",
+				client: &http.Client{
+					Transport: &testTransport{serverURL: captured.srv.URL},
+				},
+			}
+
+			_, err := b.Create(context.Background(), CreateRequest{
+				Name:       "x",
+				Runtime:    tc.runtime,
+				WorkingDir: tc.explicit,
+				Env:        map[string]string{"HOME": home},
+			})
+			if err != nil {
+				t.Fatalf("Create failed: %v", err)
+			}
+			if got := captured.lastWorkingDir(); got != tc.wantWorkingDir {
+				t.Fatalf("create body WorkingDir = %q, want %q", got, tc.wantWorkingDir)
 			}
 		})
 	}

--- a/agentteams-controller/internal/backend/interface_test.go
+++ b/agentteams-controller/internal/backend/interface_test.go
@@ -13,10 +13,12 @@ func TestResolveRuntime(t *testing.T) {
 		{"explicit_over_empty_fallback", RuntimeOpenClaw, "", RuntimeOpenClaw},
 		{"empty_uses_fallback_hermes", "", RuntimeHermes, RuntimeHermes},
 		{"empty_uses_fallback_copaw", "", RuntimeCopaw, RuntimeCopaw},
+		{"empty_uses_fallback_openhuman", "", RuntimeOpenHuman, RuntimeOpenHuman},
 		{"empty_uses_fallback_qwenpaw", "", RuntimeQwenPaw, RuntimeQwenPaw},
 		{"empty_and_no_fallback_uses_openclaw", "", "", RuntimeOpenClaw},
 		{"explicit_openclaw_preserved", RuntimeOpenClaw, RuntimeHermes, RuntimeOpenClaw},
 		{"explicit_hermes_preserved", RuntimeHermes, RuntimeCopaw, RuntimeHermes},
+		{"explicit_openhuman_preserved", RuntimeOpenHuman, RuntimeCopaw, RuntimeOpenHuman},
 		{"explicit_qwenpaw_preserved", RuntimeQwenPaw, RuntimeCopaw, RuntimeQwenPaw},
 	}
 	for _, tc := range cases {
@@ -38,6 +40,7 @@ func TestValidRuntime(t *testing.T) {
 		{RuntimeOpenClaw, true},
 		{RuntimeCopaw, true},
 		{RuntimeHermes, true},
+		{RuntimeOpenHuman, true},
 		{RuntimeQwenPaw, true},
 		{"unknown", false},
 	}

--- a/agentteams-controller/internal/backend/kubernetes.go
+++ b/agentteams-controller/internal/backend/kubernetes.go
@@ -280,6 +280,8 @@ func (k *K8sBackend) Create(ctx context.Context, req CreateRequest) (*WorkerResu
 				req.Env = map[string]string{}
 			}
 			req.Env["HOME"] = req.WorkingDir
+		case req.Runtime == RuntimeOpenHuman:
+			req.WorkingDir = "/home/openhuman/.openhuman"
 		default:
 			// Both openclaw and hermes use the same workspace layout:
 			// HOME == WorkingDir == /root/agentteams-fs/agents/<name> (== MinIO
@@ -744,6 +746,8 @@ func defaultRuntime(runtime string) string {
 		return RuntimeCopaw
 	case RuntimeHermes:
 		return RuntimeHermes
+	case RuntimeOpenHuman:
+		return RuntimeOpenHuman
 	case RuntimeQwenPaw:
 		return RuntimeQwenPaw
 	default:

--- a/agentteams-controller/internal/backend/kubernetes_test.go
+++ b/agentteams-controller/internal/backend/kubernetes_test.go
@@ -618,8 +618,8 @@ func TestK8sWithPrefixStop(t *testing.T) {
 
 // TestK8sCreateRuntimeWorkingDir verifies WorkingDir / HOME defaulting per
 // runtime. The hermes runtime now shares the openclaw layout: WorkingDir ==
-// HOME == /root/agentteams-fs/agents/<name> (== MinIO mirror root). Only copaw
-// now shares the same layout.
+// HOME == /root/agentteams-fs/agents/<name> (== MinIO mirror root). OpenHuman
+// keeps the dedicated workspace baked into its image.
 func TestK8sCreateRuntimeWorkingDir(t *testing.T) {
 	cases := []struct {
 		name           string
@@ -630,18 +630,20 @@ func TestK8sCreateRuntimeWorkingDir(t *testing.T) {
 		{"openclaw", RuntimeOpenClaw, "/root/agentteams-fs/agents/x", "/root/agentteams-fs/agents/x"},
 		{"hermes", RuntimeHermes, "/root/agentteams-fs/agents/x", "/root/agentteams-fs/agents/x"},
 		{"copaw", RuntimeCopaw, "/root/agentteams-fs/agents/x", "/root/agentteams-fs/agents/x"},
+		{"openhuman", RuntimeOpenHuman, "/home/openhuman/.openhuman", ""},
 		{"empty_default", "", "/root/agentteams-fs/agents/x", "/root/agentteams-fs/agents/x"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			client := newFakeK8sCoreClient()
 			b := NewK8sBackendWithClient(client, K8sConfig{
-				Namespace:         "agentteams",
-				WorkerImage:       "agentteams/worker-agent:latest",
-				CopawWorkerImage:  "agentteams/copaw-worker:latest",
-				HermesWorkerImage: "agentteams/hermes-worker:latest",
-				WorkerCPU:         "1000m",
-				WorkerMemory:      "2Gi",
+				Namespace:            "agentteams",
+				WorkerImage:          "agentteams/worker-agent:latest",
+				CopawWorkerImage:     "agentteams/copaw-worker:latest",
+				HermesWorkerImage:    "agentteams/hermes-worker:latest",
+				OpenHumanWorkerImage: "agentteams/openhuman-worker:latest",
+				WorkerCPU:            "1000m",
+				WorkerMemory:         "2Gi",
 			}, "agentteams-worker-", nil)
 
 			if _, err := b.Create(context.Background(), CreateRequest{
@@ -685,11 +687,13 @@ func TestK8sCreateResolvesImageFromRuntime(t *testing.T) {
 	}{
 		{"explicit_copaw", RuntimeCopaw, "", "agentteams/copaw-worker:latest", RuntimeCopaw},
 		{"explicit_hermes", RuntimeHermes, "", "agentteams/hermes-worker:latest", RuntimeHermes},
+		{"explicit_openhuman", RuntimeOpenHuman, "", "agentteams/openhuman-worker:latest", RuntimeOpenHuman},
 		{"explicit_qwenpaw", RuntimeQwenPaw, "", "agentteams/qwenpaw-worker:latest", RuntimeQwenPaw},
 		{"explicit_openclaw", RuntimeOpenClaw, "", "agentteams/worker-agent:latest", RuntimeOpenClaw},
 		{"empty_no_fallback", "", "", "agentteams/worker-agent:latest", RuntimeOpenClaw},
 		{"empty_with_copaw_fallback", "", RuntimeCopaw, "agentteams/copaw-worker:latest", RuntimeCopaw},
 		{"empty_with_hermes_fallback", "", RuntimeHermes, "agentteams/hermes-worker:latest", RuntimeHermes},
+		{"empty_with_openhuman_fallback", "", RuntimeOpenHuman, "agentteams/openhuman-worker:latest", RuntimeOpenHuman},
 		{"empty_with_qwenpaw_fallback", "", RuntimeQwenPaw, "agentteams/qwenpaw-worker:latest", RuntimeQwenPaw},
 		{"explicit_overrides_fallback", RuntimeOpenClaw, RuntimeHermes, "agentteams/worker-agent:latest", RuntimeOpenClaw},
 	}
@@ -697,13 +701,14 @@ func TestK8sCreateResolvesImageFromRuntime(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			client := newFakeK8sCoreClient()
 			b := NewK8sBackendWithClient(client, K8sConfig{
-				Namespace:          "agentteams",
-				WorkerImage:        "agentteams/worker-agent:latest",
-				CopawWorkerImage:   "agentteams/copaw-worker:latest",
-				HermesWorkerImage:  "agentteams/hermes-worker:latest",
-				QwenPawWorkerImage: "agentteams/qwenpaw-worker:latest",
-				WorkerCPU:          "1000m",
-				WorkerMemory:       "2Gi",
+				Namespace:            "agentteams",
+				WorkerImage:          "agentteams/worker-agent:latest",
+				CopawWorkerImage:     "agentteams/copaw-worker:latest",
+				HermesWorkerImage:    "agentteams/hermes-worker:latest",
+				OpenHumanWorkerImage: "agentteams/openhuman-worker:latest",
+				QwenPawWorkerImage:   "agentteams/qwenpaw-worker:latest",
+				WorkerCPU:            "1000m",
+				WorkerMemory:         "2Gi",
 			}, "agentteams-worker-", nil)
 
 			if _, err := b.Create(context.Background(), CreateRequest{

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -34,6 +34,7 @@ Record release-facing changes here before the next release.
 - **Install script model env passthrough**: Pass custom model override env vars to the Controller container so that `AGENTTEAMS_MODEL_VISION` and related settings actually reach the config generator.
 - **Bridge model capability propagation**: Propagate model `input` modalities from openclaw.json through `_write_providers_json()` so QwenPaw's `ModelInfo` receives `supports_image`/`supports_video`/`supports_multimodal` flags instead of relying on fail-open defaults.
 - **Manager diagnostic loops**: Manager prompts and Worker lifecycle guidance stop repeated no-op troubleshooting commands and treat a missing Worker in `agt get workers` as the deletion boundary instead of looping on Matrix room probes. ([#975](https://github.com/agentscope-ai/AgentTeams/pull/975))
+- **OpenHuman runtime contract**: Preserve the runtime's dedicated workspace across Docker and Kubernetes backends, resolve Matrix identity from AgentTeams env, and support inline or projected controller auth tokens. ([#1031](https://github.com/agentscope-ai/AgentTeams/pull/1031))
 
 ---
 
@@ -51,6 +52,7 @@ Record release-facing changes here before the next release.
 - **CoPaw Team 任务分配交接**：由 `taskflow(delegate_task)` 返回必须执行的 Team Room `message` 动作，根据 Team roster 规范化 Worker 别名，每分钟刷新 Controller 管理的运行时上下文，并将非 Team Room 中的任务分配回复重定向到 Team Room。([#1120](https://github.com/agentscope-ai/AgentTeams/pull/1120))
 - **Worker 端口暴露 CLI**：将 `--expose` 参数编码为数值端口，并在创建、更新或应用请求到达 Controller 前拒绝无效或越界输入。
 - **Manager 诊断循环**：Manager 提示和 Worker 生命周期指引会停止重复执行无效果的排障命令，并以 `agt get workers` 不再列出目标 Worker 作为删除完成边界，避免继续循环探测 Matrix Room。([#975](https://github.com/agentscope-ai/AgentTeams/pull/975))
+- **OpenHuman 运行时契约**：Docker 与 Kubernetes 后端保留其专用 workspace，从 AgentTeams 环境变量解析 Matrix 身份，并兼容内联或投影的 Controller 认证 Token。([#1031](https://github.com/agentscope-ai/AgentTeams/pull/1031))
 
 ---
 

--- a/openhuman/scripts/openhuman-worker-entrypoint.sh
+++ b/openhuman/scripts/openhuman-worker-entrypoint.sh
@@ -35,7 +35,9 @@
 set -e
 
 # Source shared environment bootstrap (provides ensure_mc_credentials in cloud mode)
-source /opt/agentteams/scripts/lib/agentteams-env.sh 2>/dev/null || true
+if [ -f /opt/agentteams/scripts/lib/agentteams-env.sh ]; then
+    source /opt/agentteams/scripts/lib/agentteams-env.sh
+fi
 
 WORKER_NAME="${AGENTTEAMS_WORKER_NAME:?AGENTTEAMS_WORKER_NAME is required}"
 WORKER_CR_NAME="${AGENTTEAMS_WORKER_CR_NAME:-${WORKER_NAME}}"
@@ -182,6 +184,9 @@ BRIDGE_HOMESERVER="${BRIDGE_HOMESERVER:-${AGENTTEAMS_MATRIX_URL:-${MATRIX_HOMESE
 BRIDGE_ACCESS_TOKEN="${BRIDGE_ACCESS_TOKEN:-${AGENTTEAMS_WORKER_MATRIX_TOKEN:-${MATRIX_ACCESS_TOKEN:-}}}"
 BRIDGE_ROOM_ID="${BRIDGE_ROOM_ID:-${AGENTTEAMS_WORKER_ROOM_ID:-${MATRIX_HOME_ROOM_ID:-}}}"
 BRIDGE_USER_ID="${BRIDGE_USER_ID:-${AGENTTEAMS_MATRIX_USER_ID:-${MATRIX_USER_ID:-}}}"
+if [ -z "${BRIDGE_USER_ID}" ] && [ -n "${AGENTTEAMS_MATRIX_DOMAIN:-}" ]; then
+    BRIDGE_USER_ID="@${WORKER_NAME}:${AGENTTEAMS_MATRIX_DOMAIN}"
+fi
 
 # LLM fallback: AGENTTEAMS_AI_GATEWAY_URL is the base host (no /v1 suffix);
 # AGENTTEAMS_WORKER_GATEWAY_KEY is the Higress consumer key for this worker.
@@ -338,10 +343,14 @@ CORE_PID=$!
 
     # Report ready to controller
     if [ -n "${AGENTTEAMS_CONTROLLER_URL:-}" ]; then
+        AUTH_TOKEN="${AGENTTEAMS_AUTH_TOKEN:-}"
+        if [ -z "${AUTH_TOKEN}" ] && [ -n "${AGENTTEAMS_AUTH_TOKEN_FILE:-}" ]; then
+            AUTH_TOKEN=$(cat "${AGENTTEAMS_AUTH_TOKEN_FILE}" 2>/dev/null || true)
+        fi
         agt worker report-ready --name "${WORKER_CR_NAME}" 2>/dev/null || \
             curl -sf -X POST "${AGENTTEAMS_CONTROLLER_URL}/api/v1/workers/${WORKER_CR_NAME}/ready" \
                 -H "Content-Type: application/json" \
-                -H "Authorization: Bearer $(cat ${AGENTTEAMS_AUTH_TOKEN_FILE:-/var/run/secrets/agentteams/token} 2>/dev/null)" 2>/dev/null || \
+                -H "Authorization: Bearer ${AUTH_TOKEN}" 2>/dev/null || \
             log "WARNING: Failed to report ready to controller"
     fi
 ) &

--- a/openhuman/tests/test-entrypoint-agentteams-env.sh
+++ b/openhuman/tests/test-entrypoint-agentteams-env.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+ENTRYPOINT="${REPO_ROOT}/openhuman/scripts/openhuman-worker-entrypoint.sh"
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+
+MOCK_BIN="${TMP_ROOT}/bin"
+LOG_DIR="${TMP_ROOT}/logs"
+WORKSPACE="${TMP_ROOT}/workspace"
+mkdir -p "${MOCK_BIN}" "${LOG_DIR}" "${WORKSPACE}"
+printf '# Agent instructions\n' >"${WORKSPACE}/AGENTS.md"
+printf '# Worker identity\n' >"${WORKSPACE}/SOUL.md"
+
+cat >"${MOCK_BIN}/mc" <<'MOCK'
+#!/bin/sh
+printf '%s\n' "$*" >>"${TEST_LOG_DIR}/mc.log"
+MOCK
+
+cat >"${MOCK_BIN}/openhuman-core" <<'MOCK'
+#!/bin/sh
+printf '%s\n' "$*" >>"${TEST_LOG_DIR}/openhuman-core.log"
+MOCK
+
+for command_name in curl agt sleep; do
+    cat >"${MOCK_BIN}/${command_name}" <<'MOCK'
+#!/bin/sh
+exit 1
+MOCK
+done
+chmod +x "${MOCK_BIN}"/*
+
+if ! env -i \
+    PATH="${MOCK_BIN}:${PATH}" \
+    HOME="${TMP_ROOT}/home" \
+    TEST_LOG_DIR="${LOG_DIR}" \
+    OPENHUMAN_WORKSPACE="${WORKSPACE}" \
+    AGENTTEAMS_WORKER_NAME="worker-a" \
+    AGENTTEAMS_WORKER_CR_NAME="worker-cr-a" \
+    AGENTTEAMS_RUNTIME="docker" \
+    AGENTTEAMS_FS_ENDPOINT="http://minio:9000" \
+    AGENTTEAMS_FS_ACCESS_KEY="worker-a" \
+    AGENTTEAMS_FS_SECRET_KEY="minio-secret" \
+    AGENTTEAMS_FS_BUCKET="agentteams-storage" \
+    AGENTTEAMS_STORAGE_ALIAS="agentteams" \
+    AGENTTEAMS_STORAGE_PREFIX="agentteams/agentteams-storage" \
+    AGENTTEAMS_MATRIX_URL="http://matrix:8080" \
+    AGENTTEAMS_MATRIX_DOMAIN="matrix.example" \
+    AGENTTEAMS_WORKER_MATRIX_TOKEN="matrix-token" \
+    AGENTTEAMS_WORKER_ROOM_ID="!worker-room:matrix.example" \
+    AGENTTEAMS_AI_GATEWAY_URL="http://gateway:8080" \
+    AGENTTEAMS_WORKER_GATEWAY_KEY="gateway-key" \
+    AGENTTEAMS_DEFAULT_MODEL="qwen-test" \
+    bash "${ENTRYPOINT}" >"${LOG_DIR}/entrypoint.log" 2>&1; then
+    cat "${LOG_DIR}/entrypoint.log" >&2
+    exit 1
+fi
+
+grep -Fq 'alias set agentteams http://minio:9000 worker-a minio-secret' "${LOG_DIR}/mc.log"
+grep -Fq 'mirror agentteams/agentteams-storage/agents/worker-a/' "${LOG_DIR}/mc.log"
+grep -Fq 'config update_model_settings --inference_url http://gateway:8080/v1 --api_key gateway-key --default_model qwen-test' \
+    "${LOG_DIR}/openhuman-core.log"
+grep -Fq 'homeserver = "http://matrix:8080"' "${WORKSPACE}/config.toml"
+grep -Fq 'access_token = "matrix-token"' "${WORKSPACE}/config.toml"
+grep -Fq 'room_id = "!worker-room:matrix.example"' "${WORKSPACE}/config.toml"
+grep -Fq 'user_id = "@worker-a:matrix.example"' "${WORKSPACE}/config.toml"
+grep -Fq 'models.providers["agentteams-gateway"]' "${ENTRYPOINT}"
+
+echo "OpenHuman AgentTeams entrypoint contract: PASS"


### PR DESCRIPTION
## Summary

- make the OpenHuman entrypoint consume the terminal `AGENTTEAMS_*` worker, storage, Matrix, gateway, and controller contract
- read the renamed `agentteams-gateway` provider from generated `openclaw.json`
- restore OpenHuman's dedicated Docker/Kubernetes working directory and Kubernetes runtime label
- point Helm at the published `agentteams-openhuman-worker` image

## Root cause

The backend normalization in #998 removed the existing OpenHuman working-directory and runtime-label cases while adding QwenPaw. The subsequent AgentTeams hard rename updated the controller contract but did not update the OpenHuman entrypoint or its Helm image default. A current controller therefore injects `AGENTTEAMS_WORKER_NAME`, while the entrypoint exits immediately requiring `HICLAW_WORKER_NAME`; it also looks for the retired storage alias and gateway provider.

## Impact

OpenHuman workers can start from current Docker and Kubernetes controller requests, pull their workspace from the AgentTeams storage prefix, build Matrix/LLM configuration from current fields, and report readiness with current controller auth settings. Other worker runtimes are unchanged.

## Validation

- `go test ./...` in `hiclaw-controller/` with Go 1.25.0
- `bash openhuman/tests/test-entrypoint-agentteams-env.sh`
- `bash -n openhuman/scripts/openhuman-worker-entrypoint.sh openhuman/tests/test-entrypoint-agentteams-env.sh`
- Helm 3.14.0 dependency build, lint, and template dry run using the repository workflow values
- `git diff --check`
