### PR TITLE
fix(test): align QwenPaw test with AgentTeams contracts

### DIFF
--- a/tests/test-26-qwenpaw-teamharness-plugin-mode.sh
+++ b/tests/test-26-qwenpaw-teamharness-plugin-mode.sh
@@ -125,8 +125,8 @@ _k8s_api() {
     local path="$3"
 
     if [ "${method}" = "GET" ] || [ "${method}" = "DELETE" ]; then
-        docker exec "${TEST_CONTROLLER_CONTAINER:-hiclaw-controller}" sh -c '
-            token="$(cut -d, -f1 /data/hiclaw-controller/pki/token.csv)"
+        docker exec "${TEST_CONTROLLER_CONTAINER:-agentteams-controller}" sh -c '
+            token="$(cut -d, -f1 /data/agentteams-controller/pki/token.csv)"
             curl -ksS -X "$1" \
                 -H "Authorization: Bearer ${token}" \
                 "https://127.0.0.1:6443$2"
@@ -134,8 +134,8 @@ _k8s_api() {
         return $?
     fi
 
-    docker exec -i "${TEST_CONTROLLER_CONTAINER:-hiclaw-controller}" sh -c '
-        token="$(cut -d, -f1 /data/hiclaw-controller/pki/token.csv)"
+    docker exec -i "${TEST_CONTROLLER_CONTAINER:-agentteams-controller}" sh -c '
+        token="$(cut -d, -f1 /data/agentteams-controller/pki/token.csv)"
         curl -ksS -X "$1" \
             -H "Authorization: Bearer ${token}" \
             -H "Content-Type: $2" \
@@ -147,7 +147,7 @@ _k8s_api() {
 _k8s_resource_path() {
     local plural="$1"
     local name="${2:-}"
-    local path="/apis/hiclaw.io/v1beta1/namespaces/${K8S_NAMESPACE}/${plural}"
+    local path="/apis/agentteams.io/v1beta1/namespaces/${K8S_NAMESPACE}/${plural}"
     if [ -n "${name}" ]; then
         path="${path}/${name}"
     fi
@@ -564,7 +564,7 @@ _create_qwenpaw_worker_cr() {
         --arg soul "${soul}" \
         --argjson labels "${labels}" \
         '{
-            apiVersion:"hiclaw.io/v1beta1",
+            apiVersion:"agentteams.io/v1beta1",
             kind:"Worker",
             metadata:{name:$name, namespace:$namespace, labels:$labels},
             spec:{
@@ -589,7 +589,7 @@ _create_decoupled_team_cr() {
         --arg worker "${TEST_WORKER}" \
         --argjson labels "${labels}" \
         '{
-            apiVersion:"hiclaw.io/v1beta1",
+            apiVersion:"agentteams.io/v1beta1",
             kind:"Team",
             metadata:{name:$name, namespace:$namespace, labels:$labels},
             spec:{

--- a/tests/test-26-qwenpaw-teamharness-plugin-mode.sh
+++ b/tests/test-26-qwenpaw-teamharness-plugin-mode.sh
@@ -1030,7 +1030,7 @@ mcp_transport = os.environ["TEST_MCP_TRANSPORT"]
 problems = []
 agent = json.loads((workspace / "agent.json").read_text(encoding="utf-8"))
 active = agent.get("active_model") or {}
-if active.get("provider_id") != "hiclaw-gateway" or active.get("model") != model:
+if active.get("provider_id") != "agentteams-gateway" or active.get("model") != model:
     problems.append("active_model")
 
 for rel in ["mcporter-servers.json", "config/mcporter.json"]:


### PR DESCRIPTION
## Summary

Test 26 still targeted several retired HiClaw contracts after the hard rename: the QwenPaw provider ID, embedded controller container and data directory, Kubernetes API path, and Worker/Team `apiVersion` values. Align the integration test with the canonical AgentTeams runtime and API contracts so it can create resources and validate the generated workspace once CI reaches the shard.

This changes only the integration test; production behavior already uses these AgentTeams values.

## Verification

- extracted workspace projection check against an `agentteams-gateway` fixture: `ok`
- exact static contract check for controller, token path, API group, resource declarations, and provider ID
- `bash -n tests/test-26-qwenpaw-teamharness-plugin-mode.sh`
- `go test ./api/v1beta1 ./internal/config ./internal/service` with Go 1.25.0
- `git diff --check`

The previous integration run stopped during `install-embedded` with the base-workflow LLM secret issue tracked in #1026, before any test shard ran.