### PR TITLE
fix(test): update import mock Manager name

### DIFF
--- a/tests/test-16-import-worker-package-default.sh
+++ b/tests/test-16-import-worker-package-default.sh
@@ -29,7 +29,7 @@ case "$1" in
         exit 0
         ;;
     ps)
-        echo "hiclaw-manager"
+        echo "agentteams-manager"
         exit 0
         ;;
     cp)
@@ -37,7 +37,7 @@ case "$1" in
         ;;
     exec)
         shift
-        if [ "${1:-}" = "hiclaw-manager" ]; then
+        if [ "${1:-}" = "agentteams-manager" ]; then
             shift
         fi
         case "${1:-}" in


### PR DESCRIPTION
## Summary

The hard rename updated `hiclaw-import.sh` to discover and execute `agentteams-manager`, but its unit-style Docker mock still returned and stripped `hiclaw-manager`. As a result, the test no longer reached the mocked `hiclaw` command and failed 5 of 6 assertions. Align the mock with the production container name.

## Verification

- `bash tests/test-16-import-worker-package-default.sh` (6/6 passed; previously 1/6)
- `bash -n tests/test-16-import-worker-package-default.sh install/hiclaw-import.sh`
- `git diff --check`