### PR TITLE
fix(teamharness): align QwenPaw and AgentSpec contracts

### DIFF
--- a/docs/teamharness-boundary-and-contracts.md
+++ b/docs/teamharness-boundary-and-contracts.md
@@ -18,7 +18,7 @@ TeamHarness owns:
   projects, task delegation, and task execution.
 - Explicit MCP tools for team messages, shared files, project flow, task flow,
   and plugin health.
-- A single plugin tarball installed through the HiClaw `agentteams` CLI by
+- A single plugin tarball installed through the AgentTeams `agentteams` CLI by
   default and compatible with LoongSuite `plugin-probe` for local runtimes.
 
 TeamHarness does not own:
@@ -64,7 +64,7 @@ Runtime adapter to TeamHarness:
 TeamHarness plugin package to AgentSpec package:
 
 - The TeamHarness plugin package is runtime infrastructure.
-- `desired.agentPackage` in `runtime.yaml` is a HiClaw AgentSpec package and
+- `desired.agentPackage` in `runtime.yaml` is an AgentTeams AgentSpec package and
   belongs to the worker desired-state apply path.
 - Updating an AgentSpec package must not be modeled as updating the TeamHarness
   plugin package.

--- a/plugins/tests/cli/test_agentteams_plugin_cli.py
+++ b/plugins/tests/cli/test_agentteams_plugin_cli.py
@@ -113,8 +113,8 @@ class AgentTeamsPluginCliTest(unittest.TestCase):
             "$PILOT_DATA/plugins/teamharness",
         )
         self.assertEqual(definition["pluginProbe"]["mountType"], "wrapper")
-        self.assertIn("qwenpaw", definition["detection"]["commands"])
-        self.assertIn("claude", definition["detection"]["commands"])
+        self.assertEqual(definition["detection"]["paths"], ["~/.qwenpaw"])
+        self.assertEqual(definition["detection"]["commands"], ["qwenpaw"])
 
     def test_cli_installs_updates_and_uninstalls_same_tarball(self) -> None:
         package = self.package_teamharness()


### PR DESCRIPTION
## Summary

Two contract surfaces drifted after recent changes:

- #1009 intentionally made TeamHarness QwenPaw-only, but the plugin CLI test still required a Claude command. Assert the exact QwenPaw path and command instead.
- the AgentTeams hard rename updated the Ruby boundary assertion, but the boundary document still described the HiClaw CLI and AgentSpec package. Align those terms with the current product contract.

## Verification

Ran the canonical `plugins/tests/run-integration-tests.sh` entrypoint with Ruby 2.7 and loopback proxy bypassed:

- plugin CLI: 5/5 passed
- TeamHarness manifest and boundary contracts: passed
- QwenPaw adapter: 10/10 passed
- QwenPaw package build: passed
- TeamHarness server, message, filesync, projectflow, and taskflow contract tests: passed
- `git diff --check`