### PR TITLE
fix(test): target Manager agent for MCP checks

### DIFF
--- a/tests/test-12-github-mcp-tools.sh
+++ b/tests/test-12-github-mcp-tools.sh
@@ -22,8 +22,8 @@ fi
 TEST_OWNER="${TEST_GITHUB_OWNER:-higress-group}"
 TEST_REPO="${TEST_GITHUB_REPO:-hiclaw}"
 
-# Manager container name
-MANAGER_CONTAINER="${TEST_CONTROLLER_CONTAINER:-hiclaw-manager}"
+# Manager Agent container name
+MANAGER_CONTAINER="${TEST_AGENT_CONTAINER:-${TEST_CONTROLLER_CONTAINER:-agentteams-manager}}"
 
 # Helper function to call mcporter inside Manager container
 mcporter_call() {


### PR DESCRIPTION
## Summary

In the embedded architecture, `TEST_CONTROLLER_CONTAINER` names the infrastructure/controller container while `TEST_AGENT_CONTAINER` names the Manager Agent container. Test 12 still used the controller variable for all `mcporter` commands, so the GitHub MCP checks ran in a container without the Manager workspace or MCP configuration.

Prefer `TEST_AGENT_CONTAINER`, retain the controller fallback for legacy all-in-one deployments, and use the current Manager name as the final fallback.

## Verification

- recording Docker stub before the fix: all 18 `mcporter` calls targeted `agentteams-controller`
- recording Docker stub after the fix: all 18 calls target `agentteams-manager`
- `bash -n tests/test-12-github-mcp-tools.sh`
- `git diff --check`