### PR TITLE
fix(install): restore mode-specific step routing

### DIFF
--- a/install/agentteams-install.sh
+++ b/install/agentteams-install.sh
@@ -1677,8 +1677,9 @@ should_skip_step() {
             local _env="${AGENTTEAMS_ENV_FILE:-${HOME}/agentteams-manager.env}"
             [ ! -f "${_env}" ] && return 0
             ;;
-        # Keep-All upgrade mode: skip all config steps (step_volume/step_workspace handled separately)
-        step_llm|step_admin|step_network|step_ports|step_domains|step_github|step_skills|step_runtime|step_manager_runtime|step_dashboard|step_e2ee|step_docker_proxy|step_idle|step_hostshare)
+        # Keep-All upgrade mode: skip base config steps. Steps with additional
+        # mode-specific rules are handled by their dedicated cases below.
+        step_llm|step_admin|step_network|step_ports|step_domains|step_github|step_skills|step_runtime|step_dashboard)
             [ "${AGENTTEAMS_UPGRADE}" = "1" ] && [ "${AGENTTEAMS_UPGRADE_KEEP_ALL}" = "1" ] && return 0
             ;;
         step_volume|step_workspace)
@@ -1689,19 +1690,23 @@ should_skip_step() {
         step_e2ee|step_idle)
             [ "${AGENTTEAMS_NON_INTERACTIVE}" = "1" ] && return 0
             [ "${AGENTTEAMS_QUICKSTART}" = "1" ] && [ "${AGENTTEAMS_UPGRADE}" != "1" ] && return 0
+            [ "${AGENTTEAMS_UPGRADE}" = "1" ] && [ "${AGENTTEAMS_UPGRADE_KEEP_ALL}" = "1" ] && return 0
             ;;
         step_docker_proxy)
             [ "${AGENTTEAMS_NON_INTERACTIVE}" = "1" ] && return 0
             [ "${AGENTTEAMS_QUICKSTART}" = "1" ] && [ "${AGENTTEAMS_UPGRADE}" != "1" ] && return 0
             # Embedded mode handles docker access natively — skip this step
             [ "${AGENTTEAMS_USE_EMBEDDED:-}" = "1" ] && return 0
+            [ "${AGENTTEAMS_UPGRADE}" = "1" ] && [ "${AGENTTEAMS_UPGRADE_KEEP_ALL}" = "1" ] && return 0
             ;;
         step_manager_runtime)
             [ "${AGENTTEAMS_NON_INTERACTIVE}" = "1" ] && return 0
+            [ "${AGENTTEAMS_UPGRADE}" = "1" ] && [ "${AGENTTEAMS_UPGRADE_KEEP_ALL}" = "1" ] && return 0
             ;;
         step_hostshare)
             [ "${AGENTTEAMS_NON_INTERACTIVE}" = "1" ] && return 0
             [ "${AGENTTEAMS_QUICKSTART}" = "1" ] && return 0
+            [ "${AGENTTEAMS_UPGRADE}" = "1" ] && [ "${AGENTTEAMS_UPGRADE_KEEP_ALL}" = "1" ] && return 0
             ;;
         step_podman_autostart)
             # Only relevant for Podman with systemd

--- a/install/tests/test-step-routing.sh
+++ b/install/tests/test-step-routing.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INSTALL_SCRIPT="${INSTALL_SCRIPT:-${ROOT_DIR}/install/agentteams-install.sh}"
+HELPER_FILE="$(mktemp "${TMPDIR:-/tmp}/agentteams-step-routing.XXXXXX")"
+trap 'rm -f "${HELPER_FILE}"' EXIT
+
+# Bash 3 may race when sourcing process substitution. Materialize the function
+# first so sourcing is synchronous on every supported platform.
+sed -n '/^should_skip_step() {/,/^}/p' "${INSTALL_SCRIPT}" >"${HELPER_FILE}"
+source "${HELPER_FILE}"
+
+PASS=0
+FAIL=0
+
+pass() { printf 'PASS: %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf 'FAIL: %s\n' "$1" >&2; FAIL=$((FAIL + 1)); }
+
+assert_skipped() {
+    local step="$1" context="$2"
+    if should_skip_step "${step}"; then
+        pass "${context}: ${step} is skipped"
+    else
+        fail "${context}: ${step} should be skipped"
+    fi
+}
+
+assert_runs() {
+    local step="$1" context="$2"
+    if should_skip_step "${step}"; then
+        fail "${context}: ${step} should run"
+    else
+        pass "${context}: ${step} runs"
+    fi
+}
+
+reset_mode() {
+    AGENTTEAMS_NON_INTERACTIVE=0
+    AGENTTEAMS_QUICKSTART=0
+    AGENTTEAMS_UPGRADE=0
+    AGENTTEAMS_UPGRADE_KEEP_ALL=0
+    AGENTTEAMS_USE_EMBEDDED=0
+    AGENTTEAMS_ENV_FILE="${ROOT_DIR}/install/tests/nonexistent.env"
+    DOCKER_CMD=docker
+}
+
+reset_mode
+AGENTTEAMS_QUICKSTART=1
+for step in step_e2ee step_idle step_docker_proxy step_hostshare; do
+    assert_skipped "${step}" "quick start"
+done
+assert_runs step_manager_runtime "quick start"
+
+reset_mode
+AGENTTEAMS_NON_INTERACTIVE=1
+for step in step_manager_runtime step_e2ee step_idle step_docker_proxy step_hostshare; do
+    assert_skipped "${step}" "non-interactive"
+done
+
+reset_mode
+AGENTTEAMS_USE_EMBEDDED=1
+assert_skipped step_docker_proxy "embedded"
+
+reset_mode
+AGENTTEAMS_UPGRADE=1
+AGENTTEAMS_UPGRADE_KEEP_ALL=1
+for step in \
+    step_llm step_admin step_network step_ports step_domains step_github \
+    step_skills step_runtime step_manager_runtime step_dashboard step_e2ee \
+    step_docker_proxy step_idle step_hostshare; do
+    assert_skipped "${step}" "keep-all upgrade"
+done
+
+reset_mode
+for step in step_manager_runtime step_e2ee step_idle step_docker_proxy step_hostshare; do
+    assert_runs "${step}" "manual"
+done
+
+printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"
+test "${FAIL}" -eq 0


### PR DESCRIPTION
## What changed

- let mode-specific installer steps reach their dedicated `should_skip_step` cases
- preserve Keep-All upgrade behavior in each dedicated case
- add a focused shell regression test for Quick Start, non-interactive, Embedded, Keep-All, and manual routing

## Why

Bash `case` statements stop at the first matching pattern. The Keep-All pattern also listed `step_manager_runtime`, `step_e2ee`, `step_docker_proxy`, `step_idle`, and `step_hostshare`, so their later mode-specific cases were unreachable.

As a result, Quick Start did not skip four advanced prompts, the non-interactive routing contract failed for five steps, and Embedded mode did not skip Docker proxy configuration at the router level. Some step functions had defensive non-interactive guards, but Quick Start still reached interactive prompts and the routing helper contradicted its own rules.

## Validation

- the new test against `origin/main` fails 10 assertions (19/29 pass)
- `bash install/tests/test-step-routing.sh` passes 29/29 on this branch
- `bash -n` passes for every tracked shell script
- ShellCheck error-level scan passes for both changed scripts
- `git diff --check`
