### PR TITLE
fix(cli): reject unsafe plugin archive links

### DIFF
--- a/plugins/cli/src/agentteams_cli/plugin_manager.py
+++ b/plugins/cli/src/agentteams_cli/plugin_manager.py
@@ -67,6 +67,8 @@ def _safe_extract_tar(package: Path, target: Path) -> None:
                     raise ValueError(f"unsafe tar member: {member.name}")
                 if member.name.startswith("/") or ".." in Path(member.name).parts:
                     raise ValueError(f"unsafe tar member: {member.name}")
+                if not (member.isfile() or member.isdir()):
+                    raise ValueError(f"unsafe tar member type: {member.name}")
             archive.extractall(target)
     except tarfile.TarError as exc:
         raise ValueError(f"invalid tar package: {exc}") from exc

--- a/plugins/tests/cli/test_agentteams_plugin_cli.py
+++ b/plugins/tests/cli/test_agentteams_plugin_cli.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import subprocess
@@ -196,6 +197,30 @@ class AgentTeamsPluginCliTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("ERROR:", result.stdout + result.stderr)
         self.assertNotIn("Traceback", result.stdout + result.stderr)
+
+    def test_cli_rejects_tar_symlink_escape(self) -> None:
+        package = self.project / "symlink-escape.tar.gz"
+        outside = self.project / "outside"
+        outside.mkdir()
+        payload = b"escaped\n"
+
+        with tarfile.open(package, "w:gz") as archive:
+            link = tarfile.TarInfo("teamharness/escape")
+            link.type = tarfile.SYMTYPE
+            link.linkname = str(outside)
+            archive.addfile(link)
+
+            member = tarfile.TarInfo("teamharness/escape/pwned.txt")
+            member.size = len(payload)
+            archive.addfile(member, io.BytesIO(payload))
+
+        result = self.run_agentteams(
+            "plugin", "install", "teamharness", "--package", str(package)
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unsafe tar member", result.stdout + result.stderr)
+        self.assertFalse((outside / "pwned.txt").exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- reject symbolic links, hard links, and special-file members before extracting plugin tarballs
- add a CLI regression that attempts a real symlink-based write outside the extraction directory

## Root cause

`_safe_extract_tar` validated every member path before calling `extractall`, but a link member can change how a later, otherwise valid member path resolves during extraction. A crafted plugin package could therefore write outside the temporary extraction directory.

The plugin package contract only needs regular files and directories, so rejecting all other member types closes this path without changing normal TeamHarness packages.

## Validation

- New regression on `origin/main`: fails after creating `outside/pwned.txt`
- New regression on this branch: passes and leaves the outside path untouched
- Existing unaffected CLI package/install/update/uninstall paths: 5/5 pass
- Full CLI suite with the non-overlapping #1035 assertion correction applied: 6/6 pass
- Production module compiles with Python 3.8 and Python 3.11
- `git apply --check` confirms #1035 remains independently applicable
- `git diff --check`
