### PR TITLE
fix(import): align wrappers with current CLI flags

### DIFF
--- a/docs/import-worker.md
+++ b/docs/import-worker.md
@@ -310,8 +310,7 @@ Create a Worker directly with a model and optional built-in skills, no ZIP neede
 
 ```bash
 bash agentteams-import.sh worker --name bob --model claude-sonnet-4-6 \
-    --skills github-operations,git-delegation \
-    --mcp-servers github
+    --skills github-operations,git-delegation
 ```
 
 Or via YAML (preferred for repeatable deployments):
@@ -391,7 +390,6 @@ bash agentteams-import.sh -f <resource.yaml>   # forwards to agentteams-apply.sh
 | `--package <uri>` | Remote package URI (`nacos://`, `http://`, `oss://`) | — |
 | `--model <model>` | LLM model ID | `qwen3.5-plus` |
 | `--skills <s1,s2>` | Comma-separated built-in skills | — |
-| `--mcp-servers <m1,m2>` | Comma-separated MCP servers | — |
 | `--runtime <runtime>` | Agent runtime (`openclaw`\|`qwenpaw`\|`copaw`\|`hermes`\|`openhuman`) | `qwenpaw` |
 | `--yes` | Skip interactive confirmations (swallowed by wrapper when unsupported) | off |
 
@@ -400,11 +398,13 @@ bash agentteams-import.sh -f <resource.yaml>   # forwards to agentteams-apply.sh
 ### agentteams-import.ps1 (PowerShell — Windows)
 
 ```powershell
-.\agentteams-import.ps1 worker -Name <name> [-Zip <path-or-url>] [-Package <uri>] [-Model MODEL] [-Skills s1,s2] [-McpServers m1,m2] [-Runtime rt] [-Yes]
+.\agentteams-import.ps1 worker -Name <name> [-Zip <path-or-url>] [-Package <uri>] [-Model MODEL] [-Skills s1,s2] [-Runtime rt] [-Yes]
 .\agentteams-import.ps1 -File <resource.yaml>
 ```
 
-Parameters mirror the Bash version (no `-Prune`/`-DryRun` on YAML path).
+Parameters mirror the Bash version. Configure `mcpServers` through a YAML
+manifest because each entry requires structured `name`, `url`, and `transport`
+fields.
 
 ### agentteams-apply.sh (Bash — macOS/Linux)
 
@@ -416,7 +416,8 @@ bash agentteams-apply.sh -f <resource.yaml> [-- additional args passed to agt ap
 |--------|-------------|---------|
 | `-f <path>` | YAML resource file (required) | — |
 
-The install script header may mention **`--prune` / `--dry-run` / `--watch`** — those are **not** implemented in `agt apply` today; use explicit deletes instead.
+The wrapper advertises only `-f`/`--file`. **`--prune`**, **`--dry-run`**, and
+**`--watch`** are not implemented in `agt apply`; use explicit deletes instead.
 
 ## Troubleshooting
 

--- a/docs/zh-cn/declarative-resource-management.md
+++ b/docs/zh-cn/declarative-resource-management.md
@@ -591,7 +591,7 @@ bash install/agentteams-import.sh worker --name alice --package nacos://host:884
 
 # 不带包，直接创建
 bash install/agentteams-import.sh worker --name bob --model claude-sonnet-4-6 \
-    --skills github-operations,git-delegation --mcp-servers github
+    --skills github-operations,git-delegation
 ```
 
 ### agt CLI — 容器内管理

--- a/docs/zh-cn/import-worker.md
+++ b/docs/zh-cn/import-worker.md
@@ -307,8 +307,7 @@ bash agentteams-import.sh worker --name devops-alice --package nacos://host:8848
 
 ```bash
 bash agentteams-import.sh worker --name bob --model claude-sonnet-4-6 \
-    --skills github-operations,git-delegation \
-    --mcp-servers github
+    --skills github-operations,git-delegation
 ```
 
 或通过 YAML（推荐用于可重复部署）：
@@ -388,7 +387,6 @@ bash agentteams-import.sh -f <resource.yaml>   # 转发到 agentteams-apply.sh�
 | `--package <URI>` | 远程包 URI（`nacos://`、`http://`、`oss://`） | — |
 | `--model <模型>` | LLM 模型 ID | `qwen3.5-plus` |
 | `--skills <s1,s2>` | 逗号分隔的内置技能 | — |
-| `--mcp-servers <m1,m2>` | 逗号分隔的 MCP Server | — |
 | `--runtime <运行时>` | Agent 运行时（`openclaw`\|`copaw`\|`hermes`） | `openclaw` |
 | `--yes` | 跳过交互确认（包装脚本可能在底层吞掉） | 关闭 |
 
@@ -397,11 +395,12 @@ bash agentteams-import.sh -f <resource.yaml>   # 转发到 agentteams-apply.sh�
 ### agentteams-import.ps1（PowerShell — Windows）
 
 ```powershell
-.\agentteams-import.ps1 worker -Name <名称> [-Zip <路径或URL>] [-Package <URI>] [-Model 模型] [-Skills s1,s2] [-McpServers m1,m2] [-Runtime rt] [-Yes]
+.\agentteams-import.ps1 worker -Name <名称> [-Zip <路径或URL>] [-Package <URI>] [-Model 模型] [-Skills s1,s2] [-Runtime rt] [-Yes]
 .\agentteams-import.ps1 -File <resource.yaml>
 ```
 
-参数与 Bash 版本一致（YAML 路径无 `-Prune`/`-DryRun`）。
+参数与 Bash 版本一致。`mcpServers` 的每个条目都需要结构化的 `name`、`url`
+和 `transport` 字段，因此请通过 YAML 清单配置。
 
 ### agentteams-apply.sh（Bash — macOS/Linux）
 
@@ -413,7 +412,8 @@ bash agentteams-apply.sh -f <resource.yaml> [-- 其余参数原样传给 agt app
 |------|------|--------|
 | `-f <路径>` | YAML 资源文件（必需） | — |
 
-安装脚本头部若仍提到 **`--prune` / `--dry-run` / `--watch`**，请以当前 **`agt apply` 实现为准**（未实现上述开关），改用显式 `agt delete`。
+包装脚本只公开 `-f`/`--file`。当前 **`agt apply`** 未实现 **`--prune`**、
+**`--dry-run`** 或 **`--watch`**，请改用显式 `agt delete`。
 
 ## 故障排查
 

--- a/install/agentteams-apply.sh
+++ b/install/agentteams-apply.sh
@@ -6,9 +6,9 @@
 #
 # Usage:
 #   ./agentteams-apply.sh -f resource.yaml              # incremental apply
-#   ./agentteams-apply.sh -f resource.yaml --prune      # full sync (delete extras)
-#   ./agentteams-apply.sh -f resource.yaml --dry-run    # show diff only
-#   ./agentteams-apply.sh -f resource.yaml --watch      # watch file changes
+#
+# The current `agt apply` command supports -f/--file only. Delete stale
+# resources explicitly with `agt delete`.
 #
 # Environment:
 #   AGENTTEAMS_CONTAINER_CMD   Override container runtime (docker/podman)

--- a/install/agentteams-import.ps1
+++ b/install/agentteams-import.ps1
@@ -7,8 +7,8 @@
 #   .\agentteams-import.ps1 worker -Name <name> -Zip <path-or-url>
 #   .\agentteams-import.ps1 worker -Name <name> -Package <nacos://...> [-Model MODEL]
 #   .\agentteams-import.ps1 worker -Name <name>                        # auto-imports package <name>
-#   .\agentteams-import.ps1 worker -Name <name> -Model MODEL [-Skills s1,s2] [-McpServers m1,m2]
-#   .\agentteams-import.ps1 -File <resource.yaml> [-Prune] [-DryRun]
+#   .\agentteams-import.ps1 worker -Name <name> -Model MODEL [-Skills s1,s2] [-Runtime RUNTIME]
+#   .\agentteams-import.ps1 -File <resource.yaml>
 
 param(
     [Parameter(Position = 0)]
@@ -19,11 +19,8 @@ param(
     [string]$Zip = "",
     [string]$Package = "",
     [string]$Skills = "",
-    [string]$McpServers = "",
     [string]$Runtime = "",
     [string]$File = "",
-    [switch]$Prune,
-    [switch]$DryRun,
     [switch]$Yes
 )
 
@@ -81,8 +78,6 @@ if ($File) {
     Write-Host "[AgentTeams Import] Copied $FileName -> container:/tmp/import/" -ForegroundColor Cyan
 
     $agentteamsArgs = @("apply", "-f", "/tmp/import/$FileName")
-    if ($Prune) { $agentteamsArgs += "--prune" }
-    if ($DryRun) { $agentteamsArgs += "--dry-run" }
     # Accept -Yes for wrapper compatibility, but do not forward it because the
     # container-internal AgentTeams CLI does not support --yes.
 
@@ -141,9 +136,7 @@ switch ($ResourceType) {
         if ($Model) { $agentteamsArgs += @("--model", $Model) }
         if ($Package) { $agentteamsArgs += @("--package", $Package) }
         if ($Skills) { $agentteamsArgs += @("--skills", $Skills) }
-        if ($McpServers) { $agentteamsArgs += @("--mcp-servers", $McpServers) }
         if ($Runtime) { $agentteamsArgs += @("--runtime", $Runtime) }
-        if ($DryRun) { $agentteamsArgs += "--dry-run" }
 
         & $ContainerCmd exec agentteams-manager agt @agentteamsArgs
         exit $LASTEXITCODE
@@ -154,8 +147,8 @@ switch ($ResourceType) {
         Write-Host "  .\agentteams-import.ps1 worker -Name <name> -Zip <path-or-url>"
         Write-Host "  .\agentteams-import.ps1 worker -Name <name> -Package <nacos://...> [-Model MODEL]"
         Write-Host "  .\agentteams-import.ps1 worker -Name <name>                        # auto-import package <name>"
-        Write-Host "  .\agentteams-import.ps1 worker -Name <name> -Model MODEL [-Skills s1,s2] [-McpServers m1,m2]"
-        Write-Host "  .\agentteams-import.ps1 -File <resource.yaml> [-Prune] [-DryRun]"
+        Write-Host "  .\agentteams-import.ps1 worker -Name <name> -Model MODEL [-Skills s1,s2] [-Runtime RUNTIME]"
+        Write-Host "  .\agentteams-import.ps1 -File <resource.yaml>"
         exit 0
     }
 

--- a/install/agentteams-import.sh
+++ b/install/agentteams-import.sh
@@ -8,8 +8,8 @@
 #   ./agentteams-import.sh worker --name <name> --zip <path-or-url> [--yes]
 #   ./agentteams-import.sh worker --name <name> --package <nacos://...> [--model MODEL]
 #   ./agentteams-import.sh worker --name <name>                         # auto-imports package <name>
-#   ./agentteams-import.sh worker --name <name> --model MODEL [--skills s1,s2] [--mcp-servers m1,m2]
-#   ./agentteams-import.sh -f <resource.yaml> [--prune] [--dry-run]
+#   ./agentteams-import.sh worker --name <name> --model MODEL [--skills s1,s2] [--runtime RUNTIME]
+#   ./agentteams-import.sh -f <resource.yaml>
 #
 # Environment variables (for automation):
 #   AGENTTEAMS_NON_INTERACTIVE       Skip all prompts (same as --yes)
@@ -84,10 +84,8 @@ case "${RESOURCE_TYPE}" in
                     PACKAGE_URI="$2"
                     AGENTTEAMS_ARGS+=("$1" "$2")
                     shift 2 ;;
-                --model|--skills|--mcp-servers|--runtime)
+                --model|--skills|--runtime)
                     AGENTTEAMS_ARGS+=("$1" "$2"); shift 2 ;;
-                --dry-run)
-                    AGENTTEAMS_ARGS+=("$1"); shift ;;
                 --yes)
                     shift ;;
                 *) echo "Unknown option: $1"; exit 1 ;;
@@ -125,8 +123,8 @@ case "${RESOURCE_TYPE}" in
         echo "  $0 worker --name <name> --zip <path-or-url>"
         echo "  $0 worker --name <name> --package <nacos://...> [--model MODEL]"
         echo "  $0 worker --name <name>                         # auto-import package <name>"
-        echo "  $0 worker --name <name> --model MODEL [--skills s1,s2] [--mcp-servers m1,m2]"
-        echo "  $0 -f <resource.yaml> [--prune] [--dry-run]"
+        echo "  $0 worker --name <name> --model MODEL [--skills s1,s2] [--runtime RUNTIME]"
+        echo "  $0 -f <resource.yaml>"
         exit 0
         ;;
 

--- a/install/tests/test-import-wrapper-contract.sh
+++ b/install/tests/test-import-wrapper-contract.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BASH_IMPORT="${ROOT_DIR}/install/agentteams-import.sh"
+POWERSHELL_IMPORT="${ROOT_DIR}/install/agentteams-import.ps1"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/agentteams-import-contract.XXXXXX")"
+trap 'rm -rf "${TEST_ROOT}"' EXIT
+
+FAKE_BIN="${TEST_ROOT}/bin"
+CAPTURE="${TEST_ROOT}/docker-args.txt"
+TEST_HOME="${TEST_ROOT}/home"
+mkdir -p "${FAKE_BIN}" "${TEST_HOME}/cache" "${TEST_HOME}/config" "${TEST_HOME}/data"
+export CAPTURE
+
+cat >"${FAKE_BIN}/docker" <<'MOCK'
+#!/usr/bin/env bash
+set -e
+case "${1:-}" in
+    info) exit 0 ;;
+    ps) printf '%s\n' agentteams-manager ;;
+    cp) exit 0 ;;
+    exec)
+        if [ "${3:-}" = "mkdir" ]; then
+            exit 0
+        fi
+        printf '%s\n' "$@" >"${CAPTURE}"
+        ;;
+    *) echo "unexpected docker invocation: $*" >&2; exit 1 ;;
+esac
+MOCK
+chmod +x "${FAKE_BIN}/docker"
+
+PASS=0
+FAIL=0
+RUN_OUTPUT=""
+RUN_RC=0
+
+pass() { printf 'PASS: %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf 'FAIL: %s\n' "$1" >&2; FAIL=$((FAIL + 1)); }
+
+run_bash_import() {
+    set +e
+    RUN_OUTPUT="$(PATH="${FAKE_BIN}:${PATH}" bash "${BASH_IMPORT}" "$@" 2>&1)"
+    RUN_RC=$?
+    set -e
+}
+
+assert_rejected() {
+    local label="$1" expected="$2"
+    if [ "${RUN_RC}" -ne 0 ] && [[ "${RUN_OUTPUT}" == *"${expected}"* ]]; then
+        pass "${label}"
+    else
+        fail "${label}: rc=${RUN_RC}, output=${RUN_OUTPUT}"
+    fi
+}
+
+run_bash_import worker --name alice --skills github-operations
+if [ "${RUN_RC}" -eq 0 ] && grep -Fxq -- '--skills' "${CAPTURE}"; then
+    pass "Bash forwards supported worker flags"
+else
+    fail "Bash did not forward supported worker flags"
+fi
+
+run_bash_import worker --name alice --mcp-servers github
+assert_rejected "Bash rejects removed --mcp-servers" "Unknown option: --mcp-servers"
+run_bash_import worker --name alice --dry-run
+assert_rejected "Bash rejects unimplemented --dry-run" "Unknown option: --dry-run"
+
+run_bash_import --help
+for flag in --mcp-servers --dry-run --prune; do
+    if [[ "${RUN_OUTPUT}" == *"${flag}"* ]]; then
+        fail "Bash help still advertises ${flag}"
+    else
+        pass "Bash help omits ${flag}"
+    fi
+done
+
+if grep -Eq -- '--prune|--dry-run|--watch' "${ROOT_DIR}/install/agentteams-apply.sh"; then
+    fail "Bash apply wrapper still advertises unimplemented flags"
+else
+    pass "Bash apply wrapper omits unimplemented flags"
+fi
+
+PWSH_BIN="${PWSH_BIN:-$(command -v pwsh || true)}"
+if [ -n "${PWSH_BIN}" ]; then
+    run_pwsh() {
+        set +e
+        RUN_OUTPUT="$(
+            HOME="${TEST_HOME}" \
+            XDG_CACHE_HOME="${TEST_HOME}/cache" \
+            XDG_CONFIG_HOME="${TEST_HOME}/config" \
+            XDG_DATA_HOME="${TEST_HOME}/data" \
+            POWERSHELL_TELEMETRY_OPTOUT=1 \
+            PATH="${FAKE_BIN}:${PATH}" \
+            "${PWSH_BIN}" -NoProfile -File "${POWERSHELL_IMPORT}" "$@" 2>&1
+        )"
+        RUN_RC=$?
+        set -e
+    }
+    for flag in McpServers DryRun Prune; do
+        run_pwsh worker -Name alice "-${flag}" value
+        assert_rejected "PowerShell rejects -${flag}" "parameter name '${flag}'"
+    done
+else
+    printf 'SKIP: pwsh is unavailable; PowerShell runtime assertions skipped\n'
+fi
+
+printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"
+test "${FAIL}" -eq 0


### PR DESCRIPTION
## Summary

- stop Bash and PowerShell import wrappers from advertising or forwarding flags that the current `hiclaw` CLI does not implement
- document structured `mcpServers` configuration through YAML and align English/Chinese examples
- add a recording regression test for supported forwarding, unsupported rejection, and wrapper help

## Root cause

The wrappers lagged behind the current Go CLI contract after its apply/import behavior changed. They still accepted `--mcp-servers`, `--dry-run`, and `--prune`, so users only saw a failure after the arguments reached the container CLI.

## Validation

- `PWSH_BIN=/tmp/powershell-7.6.3/pwsh install/tests/test-import-wrapper-contract.sh` (`14 passed, 0 failed`; baseline was `2 passed, 8 failed`)
- existing import package tests with PR #1034 applied (`6 passed, 0 failed`)
- `bash -n install/hiclaw-import.sh install/hiclaw-apply.sh install/tests/test-import-wrapper-contract.sh`
- `shellcheck -S warning install/hiclaw-import.sh install/hiclaw-apply.sh install/tests/test-import-wrapper-contract.sh`
- PowerShell AST parse
- `go run ./cmd/hiclaw apply worker --help` confirms the removed flags are absent
- `git diff --check`