### PR TITLE
fix(replay): capture immediate manager replies

### DIFF
--- a/scripts/replay-task.sh
+++ b/scripts/replay-task.sh
@@ -205,11 +205,7 @@ wait_for_manager_reply() {
     local timeout="${4:-${REPLY_TIMEOUT}}"
     local elapsed=0
 
-    # Snapshot the latest event_id from manager before we start waiting
-    local baseline_event
-    baseline_event=$(read_messages "${token}" "${room_id}" 5 2>/dev/null | \
-        jq -r --arg user "@${MANAGER_USER}:" \
-        '[.chunk[] | select(.sender | contains($user)) | .event_id] | first // ""' 2>/dev/null)
+    local baseline_event="${after_event}"
 
     echo -e "\033[36m[replay]\033[0m Waiting for Manager reply (timeout: ${timeout}s)..." >&2
 
@@ -362,14 +358,23 @@ if ! echo "${MEMBERS}" | grep -q "${MANAGER_FULL_ID}" 2>/dev/null; then
 fi
 
 # Step 4: Send message
+BASELINE_MANAGER_EVENT=""
+if [ "${WAIT_FOR_REPLY}" = "1" ]; then
+    # Capture the boundary before sending so an immediate reply cannot become the baseline.
+    if ! BASELINE_MANAGER_EVENT=$(read_messages "${ACCESS_TOKEN}" "${ROOM_ID}" 5 2>/dev/null | \
+        jq -r --arg user "@${MANAGER_USER}:" \
+        '[.chunk[] | select(.sender | contains($user)) | .event_id] | first // ""' 2>/dev/null); then
+        error "Failed to read the Manager message boundary before sending the task."
+    fi
+fi
+
 log "Sending task message..."
 send_message "${ACCESS_TOKEN}" "${ROOM_ID}" "${TASK_MSG}"
 log "Message sent"
 
 # Step 5: Wait for reply
 if [ "${WAIT_FOR_REPLY}" = "1" ]; then
-    REPLY=$(wait_for_manager_reply "${ACCESS_TOKEN}" "${ROOM_ID}" "" "${REPLY_TIMEOUT}")
-    REPLY_STATUS=$?
+    REPLY=$(wait_for_manager_reply "${ACCESS_TOKEN}" "${ROOM_ID}" "${BASELINE_MANAGER_EVENT}" "${REPLY_TIMEOUT}")
 
     # ============================================================
     # Collect room messages into the log file

--- a/scripts/tests/test-replay-fast-reply.sh
+++ b/scripts/tests/test-replay-fast-reply.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REPLAY_SCRIPT="${ROOT_DIR}/scripts/replay-task.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/agentteams-replay-fast-reply.XXXXXX")"
+trap 'rm -rf "${TEST_ROOT}"' EXIT
+
+FAKE_BIN="${TEST_ROOT}/bin"
+FAKE_STATE="${TEST_ROOT}/manager-replied"
+MESSAGES_CAPTURE="${TEST_ROOT}/messages-called"
+TEST_HOME="${TEST_ROOT}/home"
+LOG_DIR="${TEST_ROOT}/logs"
+mkdir -p "${FAKE_BIN}" "${TEST_HOME}" "${LOG_DIR}"
+
+cat > "${FAKE_BIN}/docker" <<'EOF'
+#!/usr/bin/env bash
+set -e
+
+if [ "${1:-}" = "exec" ] && [ "${3:-}" = "openclaw" ]; then
+    printf '{"ok":true}\n'
+    exit 0
+fi
+
+printf 'unexpected docker invocation: %s\n' "$*" >&2
+exit 1
+EOF
+
+cat > "${FAKE_BIN}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -e
+
+url="${!#}"
+case "${url}" in
+    */_matrix/client/v3/login)
+        printf '{"access_token":"test-token"}\n'
+        ;;
+    */_matrix/client/v3/joined_rooms)
+        printf '{"joined_rooms":["!dm:matrix.test"]}\n'
+        ;;
+    */_matrix/client/v3/rooms/*/members)
+        printf '{"chunk":[{"state_key":"@admin:matrix.test"},{"state_key":"@manager:matrix.test"}]}\n'
+        ;;
+    */_matrix/client/v3/rooms/*/messages*)
+        printf 'called\n' >> "${REPLAY_MESSAGES_CAPTURE}"
+        if [ -f "${REPLAY_FAKE_STATE}" ]; then
+            printf '%s\n' '{"chunk":[{"sender":"@manager:matrix.test","event_id":"$new","origin_server_ts":2,"content":{"body":"fast reply"}},{"sender":"@manager:matrix.test","event_id":"$old","origin_server_ts":1,"content":{"body":"old reply"}}]}'
+        else
+            printf '%s\n' '{"chunk":[{"sender":"@manager:matrix.test","event_id":"$old","origin_server_ts":1,"content":{"body":"old reply"}}]}'
+        fi
+        ;;
+    */send/m.room.message/*)
+        : > "${REPLAY_FAKE_STATE}"
+        printf '{"event_id":"$sent"}\n'
+        ;;
+    *)
+        printf 'unexpected curl URL: %s\n' "${url}" >&2
+        exit 1
+        ;;
+esac
+EOF
+
+cat > "${FAKE_BIN}/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+chmod +x "${FAKE_BIN}/docker" "${FAKE_BIN}/curl" "${FAKE_BIN}/sleep"
+
+set +e
+OUTPUT="$({
+    env \
+        HOME="${TEST_HOME}" \
+        PATH="${FAKE_BIN}:${PATH}" \
+        REPLAY_FAKE_STATE="${FAKE_STATE}" \
+        REPLAY_MESSAGES_CAPTURE="${MESSAGES_CAPTURE}" \
+        REPLAY_LOG_DIR="${LOG_DIR}" \
+        REPLAY_TIMEOUT=1 \
+        REPLAY_READY_TIMEOUT=1 \
+        AGENTTEAMS_ADMIN_PASSWORD=test-password \
+        AGENTTEAMS_MATRIX_DOMAIN=matrix.test \
+        TEST_REGISTRATION_TOKEN=test-token \
+        bash "${REPLAY_SCRIPT}" "fast task"
+} 2>&1)"
+RC=$?
+set -e
+
+if [ "${RC}" -ne 0 ]; then
+    printf 'FAIL: replay command exited %d\n%s\n' "${RC}" "${OUTPUT}" >&2
+    exit 1
+fi
+
+if [[ "${OUTPUT}" != *"fast reply"* ]]; then
+    printf 'FAIL: replay command did not capture the immediate reply\n%s\n' "${OUTPUT}" >&2
+    exit 1
+fi
+
+printf 'PASS: replay command captures a reply that arrives immediately after send\n'
+
+rm -f "${FAKE_STATE}" "${MESSAGES_CAPTURE}"
+set +e
+OUTPUT="$({
+    env \
+        HOME="${TEST_HOME}" \
+        PATH="${FAKE_BIN}:${PATH}" \
+        REPLAY_FAKE_STATE="${FAKE_STATE}" \
+        REPLAY_MESSAGES_CAPTURE="${MESSAGES_CAPTURE}" \
+        REPLAY_LOG_DIR="${LOG_DIR}" \
+        REPLAY_WAIT=0 \
+        REPLAY_READY_TIMEOUT=1 \
+        AGENTTEAMS_ADMIN_PASSWORD=test-password \
+        AGENTTEAMS_MATRIX_DOMAIN=matrix.test \
+        TEST_REGISTRATION_TOKEN=test-token \
+        bash "${REPLAY_SCRIPT}" "fire and forget"
+} 2>&1)"
+RC=$?
+set -e
+
+if [ "${RC}" -ne 0 ]; then
+    printf 'FAIL: no-wait replay command exited %d\n%s\n' "${RC}" "${OUTPUT}" >&2
+    exit 1
+fi
+
+if [ -e "${MESSAGES_CAPTURE}" ]; then
+    printf 'FAIL: no-wait replay command fetched message history\n%s\n' "${OUTPUT}" >&2
+    exit 1
+fi
+
+printf 'PASS: no-wait replay command does not fetch message history\n'


### PR DESCRIPTION
## Summary

- snapshot the latest Manager event before sending a replay task
- pass that event through the existing `after_event` boundary so an immediate reply is recognized as new
- avoid the history request in `REPLAY_WAIT=0` mode and add a deterministic command-stub regression

## Root cause

`wait_for_manager_reply` read its baseline after `send_message`. If the Manager replied before that read completed, the new reply became the baseline and the script waited until timeout for another event. The function already accepted an `after_event` argument, but never used it.

## Validation

- regression on `origin/main`: exits 1 with `Timeout: no reply` even though the fake Matrix API already contains `fast reply`
- `scripts/tests/test-replay-fast-reply.sh` (2/2 assertions pass after the fix)
- `bash -n scripts/replay-task.sh scripts/tests/test-replay-fast-reply.sh`
- `shellcheck -S warning scripts/replay-task.sh scripts/tests/test-replay-fast-reply.sh`
- `git diff --check`

## Overlap check

PR #569 changes the runtime-readiness block in the same script but does not touch the send/reply event boundary. This focused patch is behaviorally independent.