### PR TITLE
fix(scripts): redact complete Matrix events

### DIFF
--- a/scripts/export-debug-log.py
+++ b/scripts/export-debug-log.py
@@ -72,6 +72,14 @@ _PII_PATTERNS: list[tuple[str, re.Pattern]] = [
     ("SSN",           re.compile(r'\b\d{3}-\d{2}-\d{4}\b')),
 ]
 
+_SECRET_FIELD_PATTERN = re.compile(
+    r'(?i)^(?:password|passwd|pwd|secret|token|api[_-]?key'
+    r'|access[_-]?key(?:[_-]?secret)?|secret[_-]?access[_-]?key'
+    r'|secret[_-]?key|private[_-]?key|credential|app[_-]?key'
+    r'|app[_-]?secret|auth[_-]?token|signing[_-]?key'
+    r'|client[_-]?secret|master[_-]?key)$'
+)
+
 
 def redact_pii(text: str) -> str:
     if not text:
@@ -90,7 +98,13 @@ def redact_json_strings(obj):
     if isinstance(obj, list):
         return [redact_json_strings(v) for v in obj]
     if isinstance(obj, dict):
-        return {k: redact_json_strings(v) for k, v in obj.items()}
+        redacted = {}
+        for key, value in obj.items():
+            if isinstance(key, str) and _SECRET_FIELD_PATTERN.fullmatch(key):
+                redacted[key] = "****"
+            else:
+                redacted[key] = redact_json_strings(value)
+        return redacted
     return obj
 
 

--- a/scripts/export-debug-log.py
+++ b/scripts/export-debug-log.py
@@ -229,8 +229,7 @@ def format_event(event: dict, redact: bool) -> dict:
     }
     if event.get("type") == "m.room.message":
         record["msgtype"] = content.get("msgtype")
-        body = content.get("body")
-        record["body"] = redact_pii(body) if redact else body
+        record["body"] = content.get("body")
         if content.get("format"):
             record["format"] = content["format"]
         if content.get("url"):
@@ -239,7 +238,7 @@ def format_event(event: dict, redact: bool) -> dict:
             record["relates_to"] = content["m.relates_to"]
     else:
         record["content"] = content
-    return record
+    return redact_json_strings(record) if redact else record
 
 
 def export_matrix_messages(out_dir: Path, since_epoch: float, redact: bool,

--- a/scripts/tests/test_export_debug_log.py
+++ b/scripts/tests/test_export_debug_log.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "export-debug-log.py"
+SPEC = importlib.util.spec_from_file_location("export_debug_log", SCRIPT)
+assert SPEC and SPEC.loader
+export_debug_log = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(export_debug_log)
+
+
+class FormatEventTest(unittest.TestCase):
+    def test_redacts_all_matrix_event_fields(self):
+        event = {
+            "event_id": "$event",
+            "type": "m.room.member",
+            "sender": "@13800138000:matrix.example",
+            "origin_server_ts": 1_700_000_000_000,
+            "content": {
+                "displayname": "alice@example.com",
+                "avatar_url": "http://192.0.2.10/avatar.png",
+                "auth_token": "syt_abcdefghijklmnopqrstuvwxyz",
+            },
+        }
+
+        record = export_debug_log.format_event(event, redact=True)
+
+        self.assertEqual(record["sender"], "@****:matrix.example")
+        self.assertEqual(record["content"]["displayname"], "****")
+        self.assertEqual(record["content"]["avatar_url"], "http://****/avatar.png")
+        self.assertEqual(record["content"]["auth_token"], "****")
+
+    def test_preserves_all_matrix_event_fields_when_redaction_is_disabled(self):
+        event = {
+            "event_id": "$event",
+            "type": "m.room.message",
+            "sender": "@alice:matrix.example",
+            "origin_server_ts": 1_700_000_000_000,
+            "content": {
+                "msgtype": "m.image",
+                "body": "alice@example.com",
+                "url": "http://192.0.2.10/image.png",
+                "m.relates_to": {"token": "syt_abcdefghijklmnopqrstuvwxyz"},
+            },
+        }
+
+        record = export_debug_log.format_event(event, redact=False)
+
+        self.assertEqual(record["body"], "alice@example.com")
+        self.assertEqual(record["url"], "http://192.0.2.10/image.png")
+        self.assertEqual(
+            record["relates_to"]["token"],
+            "syt_abcdefghijklmnopqrstuvwxyz",
+        )
+
+    def test_redacts_message_metadata(self):
+        event = {
+            "event_id": "$event",
+            "type": "m.room.message",
+            "sender": "@alice:matrix.example",
+            "origin_server_ts": 1_700_000_000_000,
+            "content": {
+                "msgtype": "m.image",
+                "body": "alice@example.com",
+                "url": "http://192.0.2.10/image.png",
+                "m.relates_to": {"token": "syt_abcdefghijklmnopqrstuvwxyz"},
+            },
+        }
+
+        record = export_debug_log.format_event(event, redact=True)
+
+        self.assertEqual(record["body"], "****")
+        self.assertEqual(record["url"], "http://****/image.png")
+        self.assertEqual(record["relates_to"]["token"], "****")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_export_debug_log.py
+++ b/scripts/tests/test_export_debug_log.py
@@ -12,6 +12,20 @@ export_debug_log = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(export_debug_log)
 
 
+class RedactJsonStringsTest(unittest.TestCase):
+    def test_redacts_values_of_secret_named_fields(self):
+        data = {
+            "password": "short-secret",
+            "nested": [{"apiKey": "brief", "label": "visible"}],
+        }
+
+        redacted = export_debug_log.redact_json_strings(data)
+
+        self.assertEqual(redacted["password"], "****")
+        self.assertEqual(redacted["nested"][0]["apiKey"], "****")
+        self.assertEqual(redacted["nested"][0]["label"], "visible")
+
+
 class FormatEventTest(unittest.TestCase):
     def test_redacts_all_matrix_event_fields(self):
         event = {


### PR DESCRIPTION
## Summary

- apply the existing recursive PII redaction to the complete formatted Matrix event
- cover sender IDs, state-event content, media URLs, and relation metadata
- redact values whose JSON field names identify passwords, tokens, or API credentials even when their values are short or provider-specific
- preserve the explicit `--no-redact` behavior and add focused regression tests

## Problem

The debug exporter advertises PII-safe output by default, but `format_event` only redacted the message body. Matrix sender IDs and non-message content were exported verbatim, while message URLs and relation metadata also bypassed redaction. Recursive string-only handling additionally missed generic secrets represented as JSON fields such as `password` or `apiKey`. These gaps could leak phone numbers, email addresses, IPs, or credentials when debug bundles are shared.

## Testing

- `python3 -m unittest discover -s scripts/tests -p "test_*.py" -v` (4 tests)
- `python3 -m py_compile scripts/export-debug-log.py scripts/tests/test_export_debug_log.py`
- `git diff --check`

Baseline assertions against current `main` reproduce both the Matrix metadata leak and secret-named JSON field leak; the same assertions pass with this change.