### PR TITLE
fix(migrate): print runnable ZIP import command

### DIFF
--- a/migrate/skill/scripts/generate-zip.sh
+++ b/migrate/skill/scripts/generate-zip.sh
@@ -38,6 +38,11 @@ fi
 # Normalize name
 WORKER_NAME=$(echo "${WORKER_NAME}" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9-')
 
+if [[ ! "${WORKER_NAME}" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+    echo "ERROR: Invalid worker name: must start with a lowercase letter or digit and contain only lowercase letters, digits, and hyphens"
+    exit 1
+fi
+
 mkdir -p "${OUTPUT_DIR}"
 
 log() { echo "[hiclaw-import $(date '+%H:%M:%S')] $1"; }

--- a/migrate/skill/scripts/generate-zip.sh
+++ b/migrate/skill/scripts/generate-zip.sh
@@ -444,7 +444,7 @@ log "  Size: ${ZIP_SIZE}"
 log "  Worker name: ${WORKER_NAME}"
 log ""
 log "Transfer this file to the HiClaw Manager host and run:"
-log "  bash hiclaw-import.sh --zip ${ZIP_NAME}"
+log "  bash hiclaw-import.sh worker --name ${WORKER_NAME} --zip ${ZIP_NAME}"
 log ""
 
 echo "${ZIP_PATH}"

--- a/migrate/skill/tests/test-generate-zip.sh
+++ b/migrate/skill/tests/test-generate-zip.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GENERATOR="${GENERATOR:-${SCRIPT_DIR}/../scripts/generate-zip.sh}"
+
+for command in jq zip; do
+    if ! command -v "${command}" >/dev/null 2>&1; then
+        echo "SKIP: ${command} is required"
+        exit 0
+    fi
+done
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+STATE_DIR="${TMP_DIR}/state"
+WORKSPACE_DIR="${STATE_DIR}/workspace"
+OUTPUT_DIR="${TMP_DIR}/output"
+ANALYSIS_FILE="${TMP_DIR}/tool-analysis.json"
+mkdir -p "${WORKSPACE_DIR}" "${OUTPUT_DIR}"
+
+jq -n --arg workspace "${WORKSPACE_DIR}" '{
+    meta: {lastTouchedVersion: "test"},
+    agents: {defaults: {workspace: $workspace}}
+}' > "${STATE_DIR}/openclaw.json"
+
+jq -n '{
+    apt_packages: [],
+    pip_packages: [],
+    npm_packages: [],
+    unknown_binaries: []
+}' > "${ANALYSIS_FILE}"
+
+output=$(bash "${GENERATOR}" \
+    --name test-worker \
+    --state-dir "${STATE_DIR}" \
+    --analysis "${ANALYSIS_FILE}" \
+    --output "${OUTPUT_DIR}")
+
+zip_path=$(printf '%s\n' "${output}" | tail -n 1)
+zip_name=$(basename "${zip_path}")
+expected="bash hiclaw-import.sh worker --name test-worker --zip ${zip_name}"
+
+if [ ! -f "${zip_path}" ]; then
+    echo "FAIL: migration ZIP was not created: ${zip_path}" >&2
+    exit 1
+fi
+
+if ! printf '%s\n' "${output}" | grep -Fq "${expected}"; then
+    echo "FAIL: generated instructions did not include the runnable import command" >&2
+    echo "Expected: ${expected}" >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+fi
+
+echo "PASS: generated instructions include worker type, name, and ZIP"

--- a/migrate/skill/tests/test-generate-zip.sh
+++ b/migrate/skill/tests/test-generate-zip.sh
@@ -55,4 +55,21 @@ if ! printf '%s\n' "${output}" | grep -Fq "${expected}"; then
     exit 1
 fi
 
-echo "PASS: generated instructions include worker type, name, and ZIP"
+for invalid_name in '!!!' '-worker'; do
+    if invalid_output=$(bash "${GENERATOR}" \
+        --name "${invalid_name}" \
+        --state-dir "${STATE_DIR}" \
+        --analysis "${ANALYSIS_FILE}" \
+        --output "${OUTPUT_DIR}" 2>&1); then
+        echo "FAIL: invalid worker name was accepted: ${invalid_name}" >&2
+        exit 1
+    fi
+
+    if ! printf '%s\n' "${invalid_output}" | grep -Fq 'ERROR: Invalid worker name'; then
+        echo "FAIL: invalid worker name did not produce a clear error: ${invalid_name}" >&2
+        printf '%s\n' "${invalid_output}" >&2
+        exit 1
+    fi
+done
+
+echo "PASS: generated instructions are runnable and invalid worker names are rejected"


### PR DESCRIPTION
## Summary

- include the required `worker` resource type and Worker name in generated ZIP import instructions
- reject normalized Worker names that the `hiclaw` CLI cannot accept
- add an end-to-end regression test for the import command and invalid names

## Problem

`generate-zip.sh` currently tells users to run `bash hiclaw-import.sh --zip ...`. The current import wrapper treats its first argument as a resource type, so that command fails with `Unknown resource type: --zip`.

The generator can also normalize inputs such as `!!!` to an empty name or preserve a leading hyphen, then build a package and print an import command that `hiclaw apply worker` rejects. The generated instructions should be directly runnable and follow the CLI's Worker-name contract.

## Testing

- baseline generator completes the ZIP but fails the new command assertion
- `bash migrate/skill/tests/test-generate-zip.sh`
- `shellcheck migrate/skill/tests/test-generate-zip.sh`
- `bash -n migrate/skill/scripts/generate-zip.sh migrate/skill/tests/test-generate-zip.sh`
- `git diff --check`

Full ShellCheck on the existing generator reports only its pre-existing SC2018/SC2019 `tr` warnings. This does not modify the import wrappers changed by #1044; it fixes their standalone migration-package caller.
