### PR TITLE
fix(migrate): analyze current cron job format

### DIFF
--- a/migrate/skill/scripts/analyze.sh
+++ b/migrate/skill/scripts/analyze.sh
@@ -249,10 +249,10 @@ fi
 log "Step 7: Generating tool-analysis.json..."
 
 # Build JSON using jq
-APT_JSON=$(printf '%s\n' "${APT_PACKAGES[@]}" 2>/dev/null | jq -R . | jq -s . 2>/dev/null || echo '[]')
-PIP_JSON=$(printf '%s\n' "${PIP_PACKAGES[@]}" 2>/dev/null | jq -R . | jq -s . 2>/dev/null || echo '[]')
-NPM_JSON=$(printf '%s\n' "${NPM_PACKAGES[@]}" 2>/dev/null | jq -R . | jq -s . 2>/dev/null || echo '[]')
-UNKNOWN_JSON=$(printf '%s\n' "${UNKNOWN_BINARIES[@]}" 2>/dev/null | jq -R . | jq -s . 2>/dev/null || echo '[]')
+APT_JSON=$(jq -cn --args '$ARGS.positional' "${APT_PACKAGES[@]}" 2>/dev/null || echo '[]')
+PIP_JSON=$(jq -cn --args '$ARGS.positional' "${PIP_PACKAGES[@]}" 2>/dev/null || echo '[]')
+NPM_JSON=$(jq -cn --args '$ARGS.positional' "${NPM_PACKAGES[@]}" 2>/dev/null || echo '[]')
+UNKNOWN_JSON=$(jq -cn --args '$ARGS.positional' "${UNKNOWN_BINARIES[@]}" 2>/dev/null || echo '[]')
 
 # Count commands per source
 SKILL_COUNT=$(wc -l < "${SKILL_CMDS_FILE}" 2>/dev/null | tr -d ' ')

--- a/migrate/skill/scripts/analyze.sh
+++ b/migrate/skill/scripts/analyze.sh
@@ -134,9 +134,9 @@ CRON_CMDS_FILE="${OUTPUT_DIR}/cron-commands.txt"
 CRON_FILE="${STATE_DIR}/cron/jobs.json"
 if [ -f "${CRON_FILE}" ] && command -v jq &>/dev/null; then
     # Extract text from agentTurn payloads and scan for command references
-    jq -r '.[].payload.agentTurn.parts[]?.text // empty' "${CRON_FILE}" 2>/dev/null | \
+    jq -r '(if type == "object" then (.jobs // []) else . end)[] | .payload.agentTurn.parts[]?.text // empty' "${CRON_FILE}" 2>/dev/null | \
         grep -oE '`[a-zA-Z_][a-zA-Z0-9_-]*`' | tr -d '`' >> "${CRON_CMDS_FILE}" || true
-    jq -r '.[].payload.agentTurn.parts[]?.text // empty' "${CRON_FILE}" 2>/dev/null | \
+    jq -r '(if type == "object" then (.jobs // []) else . end)[] | .payload.agentTurn.parts[]?.text // empty' "${CRON_FILE}" 2>/dev/null | \
         grep -oE '^\s*[a-zA-Z_][a-zA-Z0-9_-]*' | sed 's/^[[:space:]]*//' >> "${CRON_CMDS_FILE}" || true
 fi
 

--- a/migrate/skill/tests/test-analyze-cron.sh
+++ b/migrate/skill/tests/test-analyze-cron.sh
@@ -74,4 +74,22 @@ if ! jq -e '
     exit 1
 fi
 
-echo "PASS: current and legacy cron dependencies are included in the analysis"
+jq -n '{version: 1, jobs: []}' > "${STATE_DIR}/cron/jobs.json"
+
+HOME="${HOME_DIR}" PATH="${BIN_DIR}:${PATH}" bash "${ANALYZER}" \
+    --state-dir "${STATE_DIR}" \
+    --output "${OUTPUT_DIR}" >/dev/null
+
+if ! jq -e '
+    .apt_packages == [] and
+    .pip_packages == [] and
+    .npm_packages == [] and
+    .unknown_binaries == [] and
+    .analysis_sources.cron_payload_commands == 0
+' "${OUTPUT_DIR}/tool-analysis.json" >/dev/null; then
+    echo "FAIL: empty dependency categories were not emitted as empty arrays" >&2
+    cat "${OUTPUT_DIR}/tool-analysis.json" >&2
+    exit 1
+fi
+
+echo "PASS: cron formats and empty dependency arrays are analyzed correctly"

--- a/migrate/skill/tests/test-analyze-cron.sh
+++ b/migrate/skill/tests/test-analyze-cron.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ANALYZER="${ANALYZER:-${SCRIPT_DIR}/../scripts/analyze.sh}"
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "SKIP: jq is required"
+    exit 0
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+HOME_DIR="${TMP_DIR}/home"
+STATE_DIR="${TMP_DIR}/state"
+WORKSPACE_DIR="${STATE_DIR}/workspace"
+OUTPUT_DIR="${TMP_DIR}/output"
+BIN_DIR="${TMP_DIR}/bin"
+mkdir -p "${HOME_DIR}" "${WORKSPACE_DIR}" "${STATE_DIR}/cron" "${OUTPUT_DIR}" "${BIN_DIR}"
+
+jq -n --arg workspace "${WORKSPACE_DIR}" '{
+    agents: {defaults: {workspace: $workspace}}
+}' > "${STATE_DIR}/openclaw.json"
+
+jq -n '{
+    version: 1,
+    jobs: [{
+        payload: {
+            agentTurn: {
+                parts: [{text: "`customcron`"}]
+            }
+        }
+    }]
+}' > "${STATE_DIR}/cron/jobs.json"
+
+printf '%s\n' '#!/bin/sh' 'exit 0' > "${BIN_DIR}/customcron"
+printf '%s\n' '#!/bin/sh' 'exit 0' > "${BIN_DIR}/legacycron"
+chmod +x "${BIN_DIR}/customcron"
+chmod +x "${BIN_DIR}/legacycron"
+
+HOME="${HOME_DIR}" PATH="${BIN_DIR}:${PATH}" bash "${ANALYZER}" \
+    --state-dir "${STATE_DIR}" \
+    --output "${OUTPUT_DIR}" >/dev/null
+
+if ! jq -e '
+    .unknown_binaries == ["customcron"] and
+    .analysis_sources.cron_payload_commands == 1
+' "${OUTPUT_DIR}/tool-analysis.json" >/dev/null; then
+    echo "FAIL: current-format cron dependency was not analyzed" >&2
+    cat "${OUTPUT_DIR}/tool-analysis.json" >&2
+    exit 1
+fi
+
+jq -n '[{
+    payload: {
+        agentTurn: {
+            parts: [{text: "`legacycron`"}]
+        }
+    }
+}]' > "${STATE_DIR}/cron/jobs.json"
+
+HOME="${HOME_DIR}" PATH="${BIN_DIR}:${PATH}" bash "${ANALYZER}" \
+    --state-dir "${STATE_DIR}" \
+    --output "${OUTPUT_DIR}" >/dev/null
+
+if ! jq -e '
+    .unknown_binaries == ["legacycron"] and
+    .analysis_sources.cron_payload_commands == 1
+' "${OUTPUT_DIR}/tool-analysis.json" >/dev/null; then
+    echo "FAIL: legacy-format cron dependency was not analyzed" >&2
+    cat "${OUTPUT_DIR}/tool-analysis.json" >&2
+    exit 1
+fi
+
+echo "PASS: current and legacy cron dependencies are included in the analysis"


### PR DESCRIPTION
## Summary

- read current OpenClaw cron files from their `jobs` array
- retain support for legacy top-level job arrays
- emit genuinely empty dependency categories as `[]`, not `[""]`
- add end-to-end analysis regressions for both cron formats and an empty environment

## Problem

`generate-zip.sh` already documents the current cron schema as `{"version":1,"jobs":[...]}`, but `analyze.sh` still evaluates `.[].payload...` as if the root were a job array. jq errors are intentionally suppressed by the heuristic scanner, so current-format cron commands silently disappear from `tool-analysis.json` and their required binaries are omitted from migration planning.

The JSON serialization also pipes empty Bash arrays through `printf`, which emits one blank line and turns every empty dependency category into `[""]`. That pollutes the analysis report and downstream migration manifest with a fake package/binary entry.

## Testing

- the regression reports `cron_payload_commands: 0` and misses the cron-only binary on current `main`
- an empty baseline analysis produces `[""]` for apt, pip, npm, and unknown binaries; the fixed output uses `[]`
- `bash migrate/skill/tests/test-analyze-cron.sh`
- `shellcheck -S warning migrate/skill/tests/test-analyze-cron.sh`
- `bash -n migrate/skill/scripts/analyze.sh migrate/skill/tests/test-analyze-cron.sh`
- `git diff --check`

The test verifies current object-wrapped jobs, legacy top-level arrays, and an environment with no detected dependencies. This is separate from #1048, which only corrects the final generated import command.