### PR TITLE
fix(hack): persist containerized skopeo auth

### DIFF
--- a/hack/mirror-images.sh
+++ b/hack/mirror-images.sh
@@ -27,6 +27,9 @@
 #
 #   # Override target registry / namespace
 #   TARGET_REGISTRY=my-registry.example.com TARGET_NS=myns ./hack/mirror-images.sh
+#
+#   # Override the persistent auth file used in container mode
+#   SKOPEO_AUTH_FILE=/path/to/auth.json USE_CONTAINER=1 ./hack/mirror-images.sh
 
 set -euo pipefail
 
@@ -42,6 +45,7 @@ DATE_TAG="${DATE_TAG:-$(date +%Y%m%d)}"
 DRY_RUN="${DRY_RUN:-}"
 USE_CONTAINER="${USE_CONTAINER:-}"
 SKOPEO_IMAGE="${SKOPEO_IMAGE:-quay.io/skopeo/stable:latest}"
+SKOPEO_AUTH_FILE="${SKOPEO_AUTH_FILE:-${HOME}/.config/containers/auth.json}"
 
 # ============================================================
 # Image mapping: SOURCE -> TARGET_NAME:TAG
@@ -75,10 +79,24 @@ ok()    { echo -e "${GREEN}[  OK  ]${NC} $1"; }
 fail()  { echo -e "${RED}[ FAIL ]${NC} $1"; }
 warn()  { echo -e "${YELLOW}[ WARN ]${NC} $1"; }
 
+container_auth_dir() {
+    dirname "${SKOPEO_AUTH_FILE}"
+}
+
+container_auth_file() {
+    printf '/auth/%s' "$(basename "${SKOPEO_AUTH_FILE}")"
+}
+
 run_skopeo() {
     if [ -n "${USE_CONTAINER}" ]; then
+        local auth_dir auth_file
+        auth_dir=$(container_auth_dir)
+        auth_file=$(container_auth_file)
+        mkdir -p "${auth_dir}"
+
         docker run --rm \
-            -v "${HOME}/.config/containers:/.config/containers:ro" \
+            -e "REGISTRY_AUTH_FILE=${auth_file}" \
+            -v "${auth_dir}:/auth:ro" \
             "${SKOPEO_IMAGE}" \
             "$@"
     else
@@ -100,7 +118,12 @@ check_login() {
 
     warn "Not authenticated. Please login:"
     if [ -n "${USE_CONTAINER}" ]; then
-        echo "  docker run -it --rm ${SKOPEO_IMAGE} login ${TARGET_REGISTRY}"
+        local auth_dir auth_file
+        auth_dir=$(container_auth_dir)
+        auth_file=$(container_auth_file)
+        mkdir -p "${auth_dir}"
+
+        echo "  docker run -it --rm -e REGISTRY_AUTH_FILE=${auth_file} -v ${auth_dir}:/auth ${SKOPEO_IMAGE} login ${TARGET_REGISTRY}"
         echo ""
         echo "Or set USE_CONTAINER= and login locally:"
         echo "  skopeo login ${TARGET_REGISTRY}"
@@ -113,7 +136,8 @@ check_login() {
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         if [ -n "${USE_CONTAINER}" ]; then
             docker run -it --rm \
-                -v "${HOME}/.config/containers:/.config/containers" \
+                -e "REGISTRY_AUTH_FILE=${auth_file}" \
+                -v "${auth_dir}:/auth" \
                 "${SKOPEO_IMAGE}" \
                 login "${TARGET_REGISTRY}"
         else

--- a/hack/mirror-images.sh
+++ b/hack/mirror-images.sh
@@ -111,7 +111,7 @@ run_skopeo() {
 check_login() {
     log "Checking authentication to ${TARGET_REGISTRY}..."
 
-    if run_skopeo inspect "docker://${TARGET_REGISTRY}/${TARGET_NS}/all-in-one:latest" > /dev/null 2>&1; then
+    if run_skopeo login --get-login "${TARGET_REGISTRY}" > /dev/null 2>&1; then
         ok "Already authenticated to ${TARGET_REGISTRY}"
         return 0
     fi

--- a/hack/tests/test-mirror-container-auth.sh
+++ b/hack/tests/test-mirror-container-auth.sh
@@ -20,6 +20,13 @@ set -euo pipefail
 printf '%s\n' "$*" >> "${DOCKER_LOG}"
 
 case " $* " in
+    *" login --get-login "*)
+        if [ -f "${HOME}/.config/containers/auth.json" ]; then
+            echo "test-user"
+            exit 0
+        fi
+        exit 1
+        ;;
     *" inspect "*)
         exit 1
         ;;
@@ -31,15 +38,19 @@ esac
 STUB
 chmod +x "${BIN_DIR}/docker"
 
-HOME="${HOME_DIR}" \
-PATH="${BIN_DIR}:${PATH}" \
-DOCKER_LOG="${DOCKER_LOG}" \
-USE_CONTAINER=1 \
-SKOPEO_IMAGE="quay.io/skopeo/stable:test" \
-TARGET_REGISTRY="registry.example.com" \
-TARGET_NS="example" \
-DATE_TAG="20260716" \
-bash "${MIRROR_SCRIPT}" tuwunel <<< "y" >/dev/null
+run_mirror() {
+    HOME="${HOME_DIR}" \
+    PATH="${BIN_DIR}:${PATH}" \
+    DOCKER_LOG="${DOCKER_LOG}" \
+    USE_CONTAINER=1 \
+    SKOPEO_IMAGE="quay.io/skopeo/stable:test" \
+    TARGET_REGISTRY="registry.example.com" \
+    TARGET_NS="example" \
+    DATE_TAG="20260716" \
+    bash "${MIRROR_SCRIPT}" tuwunel <<< "${1}" >/dev/null
+}
+
+run_mirror "y"
 
 AUTH_DIR="${HOME_DIR}/.config/containers"
 AUTH_FILE="${AUTH_DIR}/auth.json"
@@ -67,4 +78,25 @@ if ! grep -Fq -- "-v ${AUTH_DIR}:/auth quay.io/skopeo/stable:test login registry
     exit 1
 fi
 
-echo "PASS: containerized skopeo reuses persistent login credentials"
+: > "${DOCKER_LOG}"
+run_mirror "n"
+
+if [ "$(grep -c 'REGISTRY_AUTH_FILE=/auth/auth.json' "${DOCKER_LOG}")" -ne 2 ]; then
+    echo "FAIL: authenticated check and copy did not share the auth file" >&2
+    cat "${DOCKER_LOG}" >&2
+    exit 1
+fi
+
+if ! grep -Fq -- "login --get-login registry.example.com" "${DOCKER_LOG}"; then
+    echo "FAIL: authentication was not checked from the persisted credentials" >&2
+    cat "${DOCKER_LOG}" >&2
+    exit 1
+fi
+
+if grep -Fq -- "run -it" "${DOCKER_LOG}"; then
+    echo "FAIL: valid persisted credentials triggered another interactive login" >&2
+    cat "${DOCKER_LOG}" >&2
+    exit 1
+fi
+
+echo "PASS: containerized skopeo persists and reuses login credentials"

--- a/hack/tests/test-mirror-container-auth.sh
+++ b/hack/tests/test-mirror-container-auth.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIRROR_SCRIPT="${MIRROR_SCRIPT:-${SCRIPT_DIR}/../mirror-images.sh}"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+HOME_DIR="${TMP_DIR}/home"
+BIN_DIR="${TMP_DIR}/bin"
+DOCKER_LOG="${TMP_DIR}/docker.log"
+mkdir -p "${HOME_DIR}" "${BIN_DIR}"
+
+cat > "${BIN_DIR}/docker" <<'STUB'
+#!/bin/bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "${DOCKER_LOG}"
+
+case " $* " in
+    *" inspect "*)
+        exit 1
+        ;;
+    *" login "*)
+        mkdir -p "${HOME}/.config/containers"
+        printf '%s\n' '{"auths":{"registry.example.com":{}}}' > "${HOME}/.config/containers/auth.json"
+        ;;
+esac
+STUB
+chmod +x "${BIN_DIR}/docker"
+
+HOME="${HOME_DIR}" \
+PATH="${BIN_DIR}:${PATH}" \
+DOCKER_LOG="${DOCKER_LOG}" \
+USE_CONTAINER=1 \
+SKOPEO_IMAGE="quay.io/skopeo/stable:test" \
+TARGET_REGISTRY="registry.example.com" \
+TARGET_NS="example" \
+DATE_TAG="20260716" \
+bash "${MIRROR_SCRIPT}" tuwunel <<< "y" >/dev/null
+
+AUTH_DIR="${HOME_DIR}/.config/containers"
+AUTH_FILE="${AUTH_DIR}/auth.json"
+
+if [ ! -f "${AUTH_FILE}" ]; then
+    echo "FAIL: container login credentials did not persist on the host" >&2
+    exit 1
+fi
+
+if [ "$(grep -c 'REGISTRY_AUTH_FILE=/auth/auth.json' "${DOCKER_LOG}")" -ne 3 ]; then
+    echo "FAIL: inspect, login, and copy did not share the container auth file" >&2
+    cat "${DOCKER_LOG}" >&2
+    exit 1
+fi
+
+if ! grep -Fq -- "-v ${AUTH_DIR}:/auth:ro" "${DOCKER_LOG}"; then
+    echo "FAIL: non-interactive skopeo calls did not mount auth read-only" >&2
+    cat "${DOCKER_LOG}" >&2
+    exit 1
+fi
+
+if ! grep -Fq -- "-v ${AUTH_DIR}:/auth quay.io/skopeo/stable:test login registry.example.com" "${DOCKER_LOG}"; then
+    echo "FAIL: skopeo login did not mount persistent auth read-write" >&2
+    cat "${DOCKER_LOG}" >&2
+    exit 1
+fi
+
+echo "PASS: containerized skopeo reuses persistent login credentials"


### PR DESCRIPTION
## Summary

- mount a persistent host auth directory for containerized skopeo
- explicitly point `REGISTRY_AUTH_FILE` at the mounted auth file
- keep inspect/copy mounts read-only and login mounts read-write
- check stored credentials with `skopeo login --get-login` instead of probing a fixed image tag
- allow overriding the host file with `SKOPEO_AUTH_FILE`

## Problem

The current `quay.io/skopeo/stable:latest` image sets `REGISTRY_AUTH_FILE=/tmp/auth.json`, while `mirror-images.sh` mounts the host credentials at `/.config/containers`. The image therefore ignores that mount: interactive login writes into its temporary filesystem, the credentials disappear when the container exits, and the following copy cannot reuse them.

The old login check also inspects `${TARGET_NS}/all-in-one:latest`. Valid credentials are misreported as missing whenever that repository or tag does not exist. The fix mounts the auth file parent at `/auth`, overrides `REGISTRY_AUTH_FILE` for every container invocation, and asks skopeo directly whether the registry has a stored login. Mounting the directory permits skopeo to atomically create or replace `auth.json`.

## Testing

- baseline command-stub run records all inspect/login/copy calls using the ignored `/.config/containers` mount and fails the persistence assertion
- the fixed test performs an initial login, then verifies a second run reuses credentials without another interactive prompt even though image inspection would fail
- `bash hack/tests/test-mirror-container-auth.sh`
- `shellcheck -S warning hack/mirror-images.sh hack/tests/test-mirror-container-auth.sh`
- `bash -n hack/mirror-images.sh hack/tests/test-mirror-container-auth.sh`
- `git diff --check`

The regression verifies that all calls share `/auth/auth.json`, login is read-write, later use is read-only, and the auth file remains on the host.