### PR TITLE
test: honor AgentTeams GitHub token env

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -76,7 +76,7 @@ make test SKIP_INSTALL=1
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `HICLAW_LLM_API_KEY` | Yes | LLM API key for Agent behavior |
-| `HICLAW_GITHUB_TOKEN` | No | GitHub PAT for tests 08-11 |
+| `AGENTTEAMS_GITHUB_TOKEN` | No | GitHub PAT for tests 08-13 (`HICLAW_GITHUB_TOKEN` remains supported) |
 
 ## Helper Libraries
 

--- a/tests/lib/test-helpers.sh
+++ b/tests/lib/test-helpers.sh
@@ -40,6 +40,9 @@ export TEST_GATEWAY_PORT="${TEST_GATEWAY_PORT:-18080}"
 export TEST_CONSOLE_PORT="${TEST_CONSOLE_PORT:-18001}"
 export TEST_ELEMENT_PORT="${TEST_ELEMENT_PORT:-18088}"
 
+# Prefer the current installer contract while retaining test and legacy overrides.
+export TEST_GITHUB_TOKEN="${TEST_GITHUB_TOKEN:-${AGENTTEAMS_GITHUB_TOKEN:-${HICLAW_GITHUB_TOKEN:-}}}"
+
 # Internal container URLs — always fixed; all callers use exec_in_manager
 export TEST_MATRIX_DIRECT_URL="http://127.0.0.1:6167"
 export TEST_MINIO_URL="http://127.0.0.1:9000"

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -31,6 +31,7 @@ export TEST_REGISTRATION_TOKEN="${TEST_REGISTRATION_TOKEN:-test-reg-token-$(open
 export TEST_MATRIX_DOMAIN="${TEST_MATRIX_DOMAIN:-matrix-local.agentteams.io:18080}"
 export TEST_MANAGER_HOST="${TEST_MANAGER_HOST:-127.0.0.1}"
 export HICLAW_LLM_API_KEY="${HICLAW_LLM_API_KEY:-${AGENTTEAMS_LLM_API_KEY:-}}"
+export TEST_GITHUB_TOKEN="${TEST_GITHUB_TOKEN:-${AGENTTEAMS_GITHUB_TOKEN:-${HICLAW_GITHUB_TOKEN:-}}}"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -60,6 +61,7 @@ load_env_file() {
                 AGENTTEAMS_REGISTRATION_TOKEN)  export TEST_REGISTRATION_TOKEN="${value}" ;;
                 AGENTTEAMS_MATRIX_DOMAIN)       export TEST_MATRIX_DOMAIN="${value}" ;;
                 AGENTTEAMS_LLM_API_KEY)         [ -z "${HICLAW_LLM_API_KEY}" ] && export HICLAW_LLM_API_KEY="${value}" ;;
+                AGENTTEAMS_GITHUB_TOKEN)        [ -z "${TEST_GITHUB_TOKEN}" ] && export TEST_GITHUB_TOKEN="${value}" ;;
                 AGENTTEAMS_PORT_GATEWAY)        export TEST_GATEWAY_PORT="${value}" ;;
                 AGENTTEAMS_PORT_CONSOLE)        export TEST_CONSOLE_PORT="${value}" ;;
                 HICLAW_ADMIN_USER)          export TEST_ADMIN_USER="${value}" ;;
@@ -69,6 +71,7 @@ load_env_file() {
                 HICLAW_REGISTRATION_TOKEN)  export TEST_REGISTRATION_TOKEN="${value}" ;;
                 HICLAW_MATRIX_DOMAIN)       export TEST_MATRIX_DOMAIN="${value}" ;;
                 HICLAW_LLM_API_KEY)         [ -z "${HICLAW_LLM_API_KEY}" ] && export HICLAW_LLM_API_KEY="${value}" ;;
+                HICLAW_GITHUB_TOKEN)        [ -z "${TEST_GITHUB_TOKEN}" ] && export TEST_GITHUB_TOKEN="${value}" ;;
                 HICLAW_PORT_GATEWAY)        export TEST_GATEWAY_PORT="${value}" ;;
                 HICLAW_PORT_CONSOLE)        export TEST_CONSOLE_PORT="${value}" ;;
             esac

--- a/tests/skills/hiclaw-test/SKILL.md
+++ b/tests/skills/hiclaw-test/SKILL.md
@@ -48,7 +48,7 @@ Test cases:
 - **test-04**: Human intervention with additional instructions
 - **test-05**: Heartbeat query mechanism
 - **test-06**: Multi-Worker collaboration
-- **test-08~14**: GitHub/MCP related tests (requires HICLAW_GITHUB_TOKEN)
+- **test-08~14**: GitHub/MCP related tests (requires `AGENTTEAMS_GITHUB_TOKEN`)
 
 ### Step 3: Individual Install/Uninstall
 
@@ -165,7 +165,7 @@ timeout 1200 ./tests/run-all-tests.sh --skip-build --use-existing
 [36m[TEST INFO][0m SKIP: No GitHub token configured
 ```
 
-Requires `HICLAW_GITHUB_TOKEN` environment variable.
+Set `AGENTTEAMS_GITHUB_TOKEN` before running these tests. The legacy `HICLAW_GITHUB_TOKEN` variable remains supported.
 
 ### Metrics Files
 

--- a/tests/unit/test-github-token-env.sh
+++ b/tests/unit/test-github-token-env.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${HELPER:-${SCRIPT_DIR}/../lib/test-helpers.sh}"
+ORCHESTRATOR="${ORCHESTRATOR:-${SCRIPT_DIR}/../run-all-tests.sh}"
+
+assert_token() {
+    local expected="$1"
+    local test_token="$2"
+    local agentteams_token="$3"
+    local legacy_token="$4"
+    local actual
+
+    actual=$(TEST_GITHUB_TOKEN="${test_token}" \
+        AGENTTEAMS_GITHUB_TOKEN="${agentteams_token}" \
+        HICLAW_GITHUB_TOKEN="${legacy_token}" \
+        HELPER="${HELPER}" \
+        bash -c 'docker() { return 1; }; source "${HELPER}"; printf "%s" "${TEST_GITHUB_TOKEN}"')
+
+    if [ "${actual}" != "${expected}" ]; then
+        echo "FAIL: expected token ${expected}, got ${actual:-<empty>}" >&2
+        exit 1
+    fi
+}
+
+assert_token canonical '' canonical legacy
+assert_token explicit explicit canonical legacy
+assert_token legacy '' '' legacy
+
+if ! grep -q 'AGENTTEAMS_GITHUB_TOKEN)' "${ORCHESTRATOR}"; then
+    echo "FAIL: orchestrator does not load AGENTTEAMS_GITHUB_TOKEN from the env file" >&2
+    exit 1
+fi
+
+echo "PASS: GitHub test token honors explicit, AgentTeams, and legacy inputs"


### PR DESCRIPTION
## Summary

- normalize GitHub test credentials into `TEST_GITHUB_TOKEN`, preferring the current `AGENTTEAMS_GITHUB_TOKEN` contract
- load both current and legacy GitHub token names from an existing installation's env file
- document the current variable and add a focused precedence regression test

## Problem

The installers persist and pass `AGENTTEAMS_GITHUB_TOKEN`, but integration tests 08-13 only recognize `TEST_GITHUB_TOKEN` or the retired `HICLAW_GITHUB_TOKEN`. Running the suite with the generated AgentTeams env therefore reports that no GitHub token is configured and skips those tests.

The normalization preserves explicit test overrides and the legacy variable while making the current installer output work directly.

## Testing

- the regression pointed at `origin/main` fails with `expected token canonical, got <empty>`
- `bash tests/unit/test-github-token-env.sh`
- direct test 08 with only `AGENTTEAMS_GITHUB_TOKEN` reaches the later LLM prerequisite instead of the GitHub-token skip
- `bash -n tests/lib/test-helpers.sh tests/run-all-tests.sh tests/unit/test-github-token-env.sh`
- `shellcheck -S error tests/lib/test-helpers.sh tests/run-all-tests.sh tests/unit/test-github-token-env.sh`
- `git diff --check`
