### PR TITLE
fix(manager): emit runnable template install commands

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -27,6 +27,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `openclaw-bas
 
 **Bug Fixes**
 
+- **Worker template install CLI contract**: Nacos template imports now emit only flags supported by `hiclaw apply worker`; dry-run previews remain runnable, and unsupported command-line MCP overrides are no longer advertised.
 - **Legacy Team channel policy**: Legacy Team reconciliation now writes final Matrix channel allow-lists to member runtime config and re-adds the Team Leader to the Manager allow-list so controller integration tests observe durable policy state.
 - **Sandbox worker-deps hardening**: Sandbox-backed Workers now prepare controller-owned worker-deps env/token/data material before claim creation, recycle stale SandboxClaims and bound Sandboxes on runtime-affecting changes, and use bounded ServiceAccount token projection for built-in SandboxClaim mounts.
 - **CLI AgentTeams auth env**: The `hiclaw` CLI now discovers `AGENTTEAMS_CONTROLLER_URL`, `AGENTTEAMS_AUTH_TOKEN`, `AGENTTEAMS_AUTH_TOKEN_FILE`, and `AGENTTEAMS_CLUSTER_ID` while preserving legacy `HICLAW_*` fallbacks, so Manager and Worker containers can use the terminal env names for controller calls.

--- a/manager/agent/skills/hiclaw-find-worker/references/import-worker-template.md
+++ b/manager/agent/skills/hiclaw-find-worker/references/import-worker-template.md
@@ -79,12 +79,13 @@ bash /opt/hiclaw/agent/skills/hiclaw-find-worker/scripts/install-worker-template
   --template <TEMPLATE_NAME> \
   --worker-name <WORKER_NAME> \
   --model <MODEL_ID> \
-  --runtime openclaw|copaw \
-  --skills s1,s2 \
-  --mcp-servers m1,m2
+  --runtime openclaw|copaw|hermes|openhuman \
+  --skills s1,s2
 ```
 
 This script delegates to `hiclaw apply worker --package nacos://...`.
+The current CLI cannot override `mcpServers` from command-line parameters;
+use the servers already defined by the confirmed template package.
 
 If the install command fails:
 

--- a/manager/agent/skills/hiclaw-find-worker/scripts/install-worker-template.sh
+++ b/manager/agent/skills/hiclaw-find-worker/scripts/install-worker-template.sh
@@ -14,7 +14,6 @@ PACKAGE_URI=""
 VERSION=""
 MODEL=""
 SKILLS=""
-MCP_SERVERS=""
 RUNTIME=""
 DRY_RUN=false
 NACOS_REGISTRY_URI="${AGENTTEAMS_NACOS_REGISTRY_URI:-nacos://market.agentteams.io:80/public}"
@@ -23,7 +22,7 @@ NACOS_PORT=""
 NACOS_NAMESPACE=""
 
 usage() {
-    echo "Usage: $0 (--template <template-name> | --package-uri <nacos://...>) --worker-name <name> [--version <v>] [--model <model>] [--skills s1,s2] [--mcp-servers m1,m2] [--runtime openclaw|copaw] [--dry-run]" >&2
+    echo "Usage: $0 (--template <template-name> | --package-uri <nacos://...>) --worker-name <name> [--version <v>] [--model <model>] [--skills s1,s2] [--runtime openclaw|copaw|hermes|openhuman] [--dry-run]" >&2
     exit 1
 }
 
@@ -51,10 +50,6 @@ while [[ $# -gt 0 ]]; do
             ;;
         --skills)
             SKILLS="${2:-}"
-            shift 2
-            ;;
-        --mcp-servers)
-            MCP_SERVERS="${2:-}"
             shift 2
             ;;
         --runtime)
@@ -128,14 +123,8 @@ fi
 if [[ -n "$SKILLS" ]]; then
     AGENTTEAMS_ARGS+=(--skills "$SKILLS")
 fi
-if [[ -n "$MCP_SERVERS" ]]; then
-    AGENTTEAMS_ARGS+=(--mcp-servers "$MCP_SERVERS")
-fi
 if [[ -n "$RUNTIME" ]]; then
     AGENTTEAMS_ARGS+=(--runtime "$RUNTIME")
-fi
-if [[ "$DRY_RUN" == true ]]; then
-    AGENTTEAMS_ARGS+=(--dry-run)
 fi
 
 if [[ "$DRY_RUN" == true ]]; then
@@ -145,7 +134,6 @@ if [[ "$DRY_RUN" == true ]]; then
         --arg package_uri "$PACKAGE_URI" \
         --arg model "$MODEL" \
         --arg skills "$SKILLS" \
-        --arg mcp_servers "$MCP_SERVERS" \
         --arg runtime "$RUNTIME" \
         --argjson hiclaw_args "$(printf '%s\n' "${AGENTTEAMS_ARGS[@]}" | jq -R . | jq -s .)" \
         '{
@@ -155,7 +143,6 @@ if [[ "$DRY_RUN" == true ]]; then
             overrides: {
                 model: (if $model == "" then null else $model end),
                 skills: (if $skills == "" then null else ($skills | split(",")) end),
-                mcp_servers: (if $mcp_servers == "" then null else ($mcp_servers | split(",")) end),
                 runtime: (if $runtime == "" then null else $runtime end)
             },
             hiclaw_args: $hiclaw_args

--- a/manager/tests/test-install-worker-template.sh
+++ b/manager/tests/test-install-worker-template.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Regression tests for the Nacos Worker template installer CLI contract.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+TMPDIR_ROOT=$(mktemp -d)
+trap 'rm -rf "${TMPDIR_ROOT}"' EXIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+INSTALL_SCRIPT="${PROJECT_ROOT}/manager/agent/skills/hiclaw-find-worker/scripts/install-worker-template.sh"
+
+pass() {
+    echo "  PASS: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo "  FAIL: $1"
+    echo "       expected: $2"
+    echo "       got:      $3"
+    FAIL=$((FAIL + 1))
+}
+
+assert_eq() {
+    local description="$1" expected="$2" actual="$3"
+    if [ "${expected}" = "${actual}" ]; then
+        pass "${description}"
+    else
+        fail "${description}" "${expected}" "${actual}"
+    fi
+}
+
+echo "=== Dry-run output contains a runnable hiclaw command ==="
+DRY_RUN_OUTPUT=$(bash "${INSTALL_SCRIPT}" \
+    --package-uri nacos://registry.example:8848/public/reviewer \
+    --worker-name alice \
+    --model qwen3.6-plus \
+    --skills github-operations \
+    --runtime hermes \
+    --dry-run)
+
+EXPECTED_ARGS='["apply","worker","--name","alice","--package","nacos://registry.example:8848/public/reviewer","--model","qwen3.6-plus","--skills","github-operations","--runtime","hermes"]'
+assert_eq "dry-run reports only supported apply worker flags" \
+    "${EXPECTED_ARGS}" \
+    "$(printf '%s\n' "${DRY_RUN_OUTPUT}" | jq -c '.hiclaw_args')"
+
+echo "=== Removed MCP override fails before invoking hiclaw ==="
+if MCP_OUTPUT=$(bash "${INSTALL_SCRIPT}" \
+    --package-uri nacos://registry.example:8848/public/reviewer \
+    --worker-name alice \
+    --mcp-servers github 2>&1); then
+    fail "unsupported MCP override is rejected" "non-zero exit" "exit 0"
+elif printf '%s\n' "${MCP_OUTPUT}" | grep -qF 'Unknown option: --mcp-servers'; then
+    pass "unsupported MCP override is rejected"
+else
+    fail "unsupported MCP override explains the invalid option" \
+        "Unknown option: --mcp-servers" "${MCP_OUTPUT}"
+fi
+
+echo "=== Normal install forwards supported flags unchanged ==="
+MOCK_BIN="${TMPDIR_ROOT}/bin"
+HICLAW_LOG="${TMPDIR_ROOT}/hiclaw.log"
+mkdir -p "${MOCK_BIN}"
+cat > "${MOCK_BIN}/hiclaw" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$@" > "${TEST_HICLAW_LOG:?}"
+EOF
+chmod +x "${MOCK_BIN}/hiclaw"
+
+PATH="${MOCK_BIN}:${PATH}" \
+TEST_HICLAW_LOG="${HICLAW_LOG}" \
+AGENTTEAMS_NACOS_REGISTRY_URI="nacos://registry.example:8848/team" \
+bash "${INSTALL_SCRIPT}" \
+    --template reviewer \
+    --version v1 \
+    --worker-name bob \
+    --model qwen3.6-plus \
+    --skills git-delegation \
+    --runtime openhuman
+
+EXPECTED_LOG=$(printf '%s\n' \
+    apply worker \
+    --name bob \
+    --package nacos://registry.example:8848/team/reviewer/v1 \
+    --model qwen3.6-plus \
+    --skills git-delegation \
+    --runtime openhuman)
+assert_eq "normal install forwards the supported CLI contract" \
+    "${EXPECTED_LOG}" "$(cat "${HICLAW_LOG}")"
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [ "${FAIL}" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- stop accepting and forwarding the unsupported `--mcp-servers` override from the Nacos Worker template installer
- keep the wrapper's own `--dry-run` preview without adding an unsupported flag to the reported `hiclaw_args`
- align the agent-facing runtime list with the current CLI and add a focused command-stub regression

## Root cause

`hiclaw apply worker` supports package, model, skills, and runtime overrides, but it has no `--mcp-servers` or `--dry-run` flags. The installer advertised both: a normal MCP override failed in Cobra, while dry-run JSON presented a command that could not be executed. Structured MCP configuration remains part of the confirmed template package.

## Verification

- `bash manager/tests/test-install-worker-template.sh` (3/3)
- baseline dry-run output contains both unsupported flags; patched output contains neither
- `go run ./cmd/hiclaw apply worker --help` confirms the supported flag set
- Bash syntax and warning-level ShellCheck pass for the script and regression test
- `git diff --check`