### PR TITLE
fix(manager): reject MCP options during runtime switches

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,3 +4,4 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 ---
 
+- fix(manager): reject `--mcp-servers` during Worker runtime switches because MCP authorization must be applied separately after the replacement container converges. ([#1053](https://github.com/agentscope-ai/AgentTeams/pull/1053))

--- a/manager/agent/skills/worker-management/SKILL.md
+++ b/manager/agent/skills/worker-management/SKILL.md
@@ -89,7 +89,7 @@ To migrate a Worker between runtimes (e.g. openclaw → copaw, copaw → qwenpaw
 bash /opt/agentteams/agent/skills/worker-management/scripts/update-worker-config.sh \
   --name <NAME> \
   --runtime <openclaw|copaw|qwenpaw|hermes|openhuman> \
-  [--model <MODEL>] [--skills s1,s2] [--mcp-servers s1,s2]
+  [--model <MODEL>] [--skills s1,s2]
 ```
 
 What happens behind the scenes:
@@ -100,5 +100,5 @@ What happens behind the scenes:
 
 Constraints:
 
-- `--package-dir` and `--channel-policy` cannot be combined with `--runtime` — apply those separately after the runtime switch settles
+- `--package-dir`, `--channel-policy`, and `--mcp-servers` cannot be combined with `--runtime` — apply those separately after the runtime switch settles
 - The wrapper preserves Matrix account/room/credentials/MinIO data but loses container-local ephemeral state — see the runtime gotcha above

--- a/manager/agent/skills/worker-management/scripts/update-worker-config.sh
+++ b/manager/agent/skills/worker-management/scripts/update-worker-config.sh
@@ -17,7 +17,7 @@
 #
 # Usage:
 #   update-worker-config.sh --name <NAME> [--model <MODEL_ID>] [--skills s1,s2] [--mcp-servers s1,s2] [--package-dir <DIR>]
-#   update-worker-config.sh --name <NAME> --runtime <openclaw|copaw|qwenpaw|hermes|openhuman> [--model <MODEL_ID>] [--skills s1,s2] [--mcp-servers s1,s2]
+#   update-worker-config.sh --name <NAME> --runtime <openclaw|copaw|qwenpaw|hermes|openhuman> [--model <MODEL_ID>] [--skills s1,s2]
 #
 # Prerequisites:
 #   - Worker must already exist (created via create-worker.sh)
@@ -65,7 +65,7 @@ done
 
 if [ -z "${WORKER_NAME}" ]; then
     echo "Usage: update-worker-config.sh --name <NAME> [--model <MODEL>] [--skills s1,s2] [--mcp-servers s1,s2] [--package-dir <DIR>]"
-    echo "       update-worker-config.sh --name <NAME> --runtime <openclaw|copaw|qwenpaw|hermes|openhuman> [--model <MODEL>] [--skills s1,s2] [--mcp-servers s1,s2]"
+    echo "       update-worker-config.sh --name <NAME> --runtime <openclaw|copaw|qwenpaw|hermes|openhuman> [--model <MODEL>] [--skills s1,s2]"
     exit 1
 fi
 
@@ -92,6 +92,9 @@ if [ -n "${RUNTIME}" ]; then
     if [ -n "${CHANNEL_POLICY_JSON}" ]; then
         _fail "--channel-policy cannot be combined with --runtime. Apply the channel-policy separately (without --runtime) after the runtime switch settles."
     fi
+    if [ -n "${MCP_SERVERS}" ]; then
+        _fail "--mcp-servers cannot be combined with --runtime. Reauthorize MCP servers separately (without --runtime) after the runtime switch settles."
+    fi
 
     log "=== Switching runtime for Worker: ${WORKER_NAME} -> ${RUNTIME} ==="
     log "  WARNING: existing container will be destroyed and recreated."
@@ -101,7 +104,6 @@ if [ -n "${RUNTIME}" ]; then
     CLI_ARGS=(update worker --name "${WORKER_NAME}" --runtime "${RUNTIME}")
     [ -n "${MODEL_ID}" ]      && CLI_ARGS+=(--model "${MODEL_ID}")
     [ -n "${WORKER_SKILLS}" ] && CLI_ARGS+=(--skills "${WORKER_SKILLS}")
-    [ -n "${MCP_SERVERS}" ]   && CLI_ARGS+=(--mcp-servers "${MCP_SERVERS}")
 
     log "Step 1: Calling: agt ${CLI_ARGS[*]}"
     if ! CLI_OUT=$(agt "${CLI_ARGS[@]}" 2>&1); then

--- a/manager/tests/test-update-worker-runtime.sh
+++ b/manager/tests/test-update-worker-runtime.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+TMPDIR_ROOT=$(mktemp -d)
+trap 'rm -rf "${TMPDIR_ROOT}"' EXIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+UPDATE_SCRIPT="${PROJECT_ROOT}/manager/agent/skills/worker-management/scripts/update-worker-config.sh"
+TEST_SCRIPT="${TMPDIR_ROOT}/update-worker-config.sh"
+MOCK_BIN="${TMPDIR_ROOT}/bin"
+AGT_LOG="${TMPDIR_ROOT}/agt.log"
+
+pass() {
+    echo "  PASS: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo "  FAIL: $1"
+    echo "       expected: $2"
+    echo "       got:      $3"
+    FAIL=$((FAIL + 1))
+}
+
+assert_eq() {
+    local description="$1" expected="$2" actual="$3"
+    if [ "${expected}" = "${actual}" ]; then
+        pass "${description}"
+    else
+        fail "${description}" "${expected}" "${actual}"
+    fi
+}
+
+assert_contains() {
+    local description="$1" needle="$2" actual="$3"
+    if printf '%s\n' "${actual}" | grep -qF -- "${needle}"; then
+        pass "${description}"
+    else
+        fail "${description}" "contains ${needle}" "${actual}"
+    fi
+}
+
+# Runtime-switch mode does not use the shared environment helpers. Replace the
+# production source line only in this isolated copy.
+sed 's|^source /opt/agentteams/scripts/lib/agentteams-env.sh$|: # environment supplied by test|' \
+    "${UPDATE_SCRIPT}" >"${TEST_SCRIPT}"
+chmod +x "${TEST_SCRIPT}"
+
+mkdir -p "${MOCK_BIN}"
+cat >"${MOCK_BIN}/agt" <<'MOCK'
+#!/bin/sh
+case "$1 $2" in
+    "update worker")
+        printf '%s\n' "$@" >"${TEST_AGT_LOG:?}"
+        echo "worker updated"
+        ;;
+    "get workers")
+        printf '%s\n' '{"workers":[{"name":"alice","phase":"Running","runtime":"hermes"}]}'
+        ;;
+    *)
+        echo "unexpected agt command: $*" >&2
+        exit 2
+        ;;
+esac
+MOCK
+chmod +x "${MOCK_BIN}/agt"
+
+echo "=== Runtime switch rejects the unsupported MCP combination ==="
+if REJECT_OUTPUT=$(PATH="${MOCK_BIN}:${PATH}" \
+    TEST_AGT_LOG="${AGT_LOG}" \
+    bash "${TEST_SCRIPT}" --name alice --runtime hermes --mcp-servers github 2>&1); then
+    fail "runtime and MCP options are rejected before the CLI call" \
+        "non-zero exit" "exit 0"
+else
+    assert_contains "rejection explains the incompatible options" \
+        "--mcp-servers cannot be combined with --runtime" "${REJECT_OUTPUT}"
+fi
+
+if [ -e "${AGT_LOG}" ]; then
+    fail "rejected options do not invoke agt" "no command log" "$(cat "${AGT_LOG}")"
+else
+    pass "rejected options do not invoke agt"
+fi
+
+echo "=== Runtime switch forwards supported update flags unchanged ==="
+RUNTIME_OUTPUT=$(PATH="${MOCK_BIN}:${PATH}" \
+    TEST_AGT_LOG="${AGT_LOG}" \
+    bash "${TEST_SCRIPT}" \
+        --name alice \
+        --runtime hermes \
+        --model qwen3.6-plus \
+        --skills code-review)
+
+EXPECTED_ARGS=$(printf '%s\n' \
+    update worker \
+    --name alice \
+    --runtime hermes \
+    --model qwen3.6-plus \
+    --skills code-review)
+assert_eq "supported runtime arguments match agt update worker" \
+    "${EXPECTED_ARGS}" "$(cat "${AGT_LOG}")"
+assert_contains "runtime switch still reports completion" \
+    '"status": "runtime_switched"' "${RUNTIME_OUTPUT}"
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [ "${FAIL}" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- reject `--mcp-servers` with `--runtime` before invoking the controller CLI
- document that MCP authorization must be updated separately after a runtime switch
- add a command-stub regression for rejected and supported runtime-switch arguments

## Root cause

`update-worker-config.sh` exposes `--mcp-servers` for its in-place authorization path, but the runtime-switch branch forwarded the same option to `agt update worker`. The Go CLI does not implement that flag and keeps MCP authorization in a separate flow, so the documented combined command could not succeed.

## Scope

The rebased PR is limited to the runtime-switch wrapper, agent-facing documentation, one focused regression test, and the current changelog entry.

## Validation

- `bash manager/tests/test-update-worker-runtime.sh` — 4 passed, 0 failed
- `/bin/bash manager/tests/test-update-worker-runtime.sh` on macOS Bash 3.2 — 4 passed, 0 failed
- `bash -n` and `/bin/bash -n` for the changed script and test
- `git diff --check origin/main...HEAD`
- one commit based on current `origin/main` (`aa650cca`)
- GitHub CI — 15 successful checks, 0 failures, 2 skipped (7 image builds and 5 integration-test variants passed)
