### PR TITLE
fix(copaw): route Team Leader assignments to Team Room

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,3 +4,6 @@ Record image-affecting changes to `manager/`, `worker/`, `openclaw-base/` here b
 
 ---
 
+**Bug Fixes**
+
+- **CoPaw Team coordination routing**: Route Team Leader worker assignments sent through the `message` tool from Leader DM to Team Room, matching the Matrix channel send path.

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -6,4 +6,4 @@ Record image-affecting changes to `manager/`, `worker/`, `openclaw-base/` here b
 
 **Bug Fixes**
 
-- **CoPaw Team coordination routing**: Route Team Leader worker assignments sent through the `message` tool from Leader DM to Team Room, matching the Matrix channel send path.
+- **CoPaw Team coordination routing**: Route Team Leader worker assignments sent through the `message` tool from Leader DM to Team Room, matching the Matrix channel send path. ([92c8145](https://github.com/agentscope-ai/AgentTeams/commit/92c8145))

--- a/copaw/src/copaw_worker/hooks/message_filter.py
+++ b/copaw/src/copaw_worker/hooks/message_filter.py
@@ -72,6 +72,28 @@ def extract_matrix_mentions(text: str) -> list[str]:
     return list(dict.fromkeys(_MATRIX_USER_ID_RE.findall(text or "")))
 
 
+def resolve_team_leader_assignment_room(text: str, room_id: str) -> str:
+    """Route Team Leader worker assignments from Leader DM to Team Room."""
+    if _runtime_config_field("member", "role") != "team_leader":
+        return room_id
+
+    team_room_id = _runtime_config_field("team", "teamRoomId")
+    leader_dm_room_id = _runtime_config_field("team", "leaderDmRoomId")
+    team_name = _runtime_config_field("team", "name")
+    if not team_room_id or room_id != leader_dm_room_id:
+        return room_id
+    if not _TEAM_LEADER_WORKER_ASSIGNMENT_RE.search(text or ""):
+        return room_id
+
+    for mxid in extract_matrix_mentions(text):
+        localpart = mxid.removeprefix("@").split(":", 1)[0]
+        if localpart.endswith("-lead"):
+            continue
+        if not team_name or localpart.startswith(f"{team_name}-"):
+            return team_room_id
+    return room_id
+
+
 def _low_information_key(text: str) -> str:
     """Normalize short ACK text by dropping punctuation, emoji, and spacing."""
     return "".join(

--- a/copaw/src/copaw_worker/hooks/tools/message.py
+++ b/copaw/src/copaw_worker/hooks/tools/message.py
@@ -18,6 +18,7 @@ from agentscope.tool import ToolResponse
 from copaw_worker.hooks.message_filter import (
     extract_matrix_mentions,
     filter_outgoing_matrix_message,
+    resolve_team_leader_assignment_room,
 )
 
 logger = logging.getLogger(__name__)
@@ -424,11 +425,23 @@ async def message(
                 "user targets are not supported yet; use a room target",
             )
 
+        room_id = resolve_team_leader_assignment_room(
+            filtered_message,
+            parsed_target.identifier,
+        )
+        if room_id != parsed_target.identifier:
+            logger.info(
+                "message tool: rerouting team assignment from Leader DM %s "
+                "to Team Room %s",
+                parsed_target.identifier,
+                room_id,
+            )
+
         result: dict[str, Any] = {
             "channel": "matrix",
             "target": target,
             "targetKind": parsed_target.kind,
-            "roomId": parsed_target.identifier,
+            "roomId": room_id,
             "mentions": mentions,
         }
 
@@ -436,7 +449,7 @@ async def message(
             return _ok(dryRun=True, content=content, **result)
 
         event_id = await _send_matrix_room_message(
-            room_id=parsed_target.identifier,
+            room_id=room_id,
             content=content,
             account_id=accountId or "default",
         )
@@ -444,7 +457,7 @@ async def message(
         warning = None
         try:
             session_recorded = await _record_matrix_outbound_to_session(
-                room_id=parsed_target.identifier,
+                room_id=room_id,
                 text=filtered_message,
                 message_id=event_id,
                 account_id=accountId or "default",

--- a/copaw/tests/test_message_tool.py
+++ b/copaw/tests/test_message_tool.py
@@ -185,6 +185,47 @@ def test_validate_matrix_message_policy_keeps_team_leader_worker_assignment(
     assert filtered.startswith("@dag-team-1-dev:hs.local Task assigned")
 
 
+@pytest.mark.asyncio
+async def test_message_tool_routes_team_leader_assignment_to_team_room(
+    tmp_path,
+    monkeypatch,
+):
+    sent_room_ids = []
+
+    async def fake_send_matrix_room_message(*, room_id, content, account_id):
+        sent_room_ids.append(room_id)
+        return "$assignment"
+
+    monkeypatch.setenv("COPAW_WORKING_DIR", str(_write_team_leader_runtime(tmp_path)))
+    monkeypatch.setattr(
+        "copaw_worker.hooks.tools.message._send_matrix_room_message",
+        fake_send_matrix_room_message,
+    )
+
+    response = await message(
+        action="send",
+        channel="matrix",
+        target="room:!leader-dm:hs.local",
+        message=(
+            "@dag-team-1-dev:hs.local You have been assigned task "
+            "**todo-rest-api-001-01**: Design REST API endpoints."
+        ),
+    )
+    payload = _response_json(response)
+
+    assert payload["ok"] is True
+    assert payload["roomId"] == "!team-room:hs.local"
+    assert sent_room_ids == ["!team-room:hs.local"]
+    session_path = _matrix_session_path(
+        working_dir=tmp_path / "leader" / ".copaw",
+        room_id="!team-room:hs.local",
+        account_id="default",
+    )
+    session = json.loads(session_path.read_text(encoding="utf-8"))
+    recorded_msg, _ = session["agent"]["memory"]["content"][-1]
+    assert recorded_msg["metadata"]["room_id"] == "!team-room:hs.local"
+
+
 def test_validate_matrix_message_policy_blocks_roster_preamble_with_mxids(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- route concrete Team Leader worker assignments sent through the CoPaw `message` tool from Leader DM to Team Room
- record the outbound event in the effective Team Room session
- add a regression test reproducing the beta1 Integration Tests failure

## Root cause
Integration Tests run 29590753647 showed the Leader using the `message` tool to assign a worker, but the tool sent directly to the requested Leader DM and bypassed the Matrix channel reroute.

## Validation
- `PYTHONPATH=src .venv/bin/pytest tests/test_message_tool.py tests/test_worker_matrix_channel.py -q` (27 passed)
- `git diff --check`

## Dependency
This branch is stacked on #1058 so the image-affecting fix is recorded in the fresh post-beta1 `changelog/current.md`. Merge #1058 first; its archive diff will then disappear from this PR.