### PR TITLE
feat(install): integrate agentteams-dashboard as optional component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ OPENHUMAN_WORKER_IMAGE ?= $(REGISTRY)/$(REPO)/agentteams-openhuman-worker
 OPENCLAW_BASE_IMAGE  ?= $(REGISTRY)/$(REPO)/openclaw-base
 CONTROLLER_IMAGE     ?= $(REGISTRY)/$(REPO)/agentteams-controller
 EMBEDDED_IMAGE       ?= $(REGISTRY)/$(REPO)/agentteams-embedded
+DASHBOARD_CONTEXT    ?= ./agentteams-dashboard/
 
 MANAGER_TAG        ?= $(MANAGER_IMAGE):$(VERSION)
 MANAGER_COPAW_TAG  ?= $(MANAGER_COPAW_IMAGE):$(VERSION)
@@ -133,6 +134,7 @@ LINES          ?= 50
         buildx-setup \
         test test-quick test-installed test-embedded \
         install install-embedded uninstall uninstall-embedded replay replay-log \
+        install-dashboard update-dashboard uninstall-dashboard \
         verify wait-ready wait-ready-embedded \
         generate sync-crds check-crd-sync \
         status logs \
@@ -195,6 +197,10 @@ build-embedded: build-hiclaw-controller ## Build embedded all-in-one controller 
 		-t $(LOCAL_EMBEDDED) \
 		-t $(LOCAL_EMBEDDED_LEGACY) \
 		.
+
+build-dashboard: ## Build agentteams-dashboard image
+	@echo "==> Building agentteams-dashboard image"
+	$(MAKE) -C $(DASHBOARD_CONTEXT) build
 
 build-worker: ## Build Worker image
 	@echo "==> Building Worker image: $(LOCAL_WORKER) (registry: $(HIGRESS_REGISTRY))"
@@ -361,6 +367,18 @@ else
 		--push \
 		-f hiclaw-controller/Dockerfile.embedded .
 endif
+
+# --- agentteams-dashboard standalone ---
+.PHONY: install-dashboard update-dashboard uninstall-dashboard
+
+install-dashboard: build-dashboard ## Install agentteams-dashboard standalone
+	@bash $(DASHBOARD_CONTEXT)/install/agentteams-dashboard.sh
+
+update-dashboard: ## Update agentteams-dashboard (pull latest & recreate)
+	@bash $(DASHBOARD_CONTEXT)/install/agentteams-dashboard.sh update
+
+uninstall-dashboard: ## Uninstall agentteams-dashboard
+	@bash $(DASHBOARD_CONTEXT)/install/agentteams-dashboard.sh uninstall
 
 push-manager: push-hiclaw-controller buildx-setup ## Build + push multi-arch Manager image (OpenClaw)
 	@echo "==> Building + pushing multi-arch Manager: $(MANAGER_TAG) [$(MULTIARCH_PLATFORMS)]"

--- a/install/hiclaw-install.sh
+++ b/install/hiclaw-install.sh
@@ -46,6 +46,10 @@
 #   AGENTTEAMS_PORT_ELEMENT_WEB   Host port for Element Web direct access (default: 18088)
 #   AGENTTEAMS_PORT_MANAGER_CONSOLE  Host port for Manager console (default: 18888)
 #   AGENTTEAMS_WORKER_IDLE_TIMEOUT  Worker idle timeout in minutes (default: 720, i.e. 12 hours)
+#   AGENTTEAMS_DASHBOARD              Install agentteams-dashboard management UI (default: 1)
+#   AGENTTEAMS_PORT_DASHBOARD         Dashboard host port (default: 13000)
+#   AGENTTEAMS_DASHBOARD_IMAGE        Override dashboard image
+#   AGENTTEAMS_AI_GATEWAY_ADMIN_URL   Higress Console URL for shared auth (auto-detected)
 
 set -e
 
@@ -829,6 +833,26 @@ msg() {
         "install.welcome_msg.timeout_inspect.en") text="Inspect status: docker exec agentteams-controller hiclaw get managers default" ;;
         "install.welcome_msg.poll_unavailable.zh") text="提示: agentteams-manager 内未找到 hiclaw CLI，跳过 welcome 等待（旧镜像？）" ;;
         "install.welcome_msg.poll_unavailable.en") text="Note: hiclaw CLI not found inside agentteams-manager; skipping welcome wait (old image?)" ;;
+        # --- Dashboard wizard ---
+        "dash.prompt.zh")        text="是否安装 agentteams-dashboard 管理面板?" ;;
+        "dash.prompt.en")        text="Install agentteams-dashboard management UI?" ;;
+        "dash.port_prompt.zh")   text="Dashboard 端口号" ;;
+        "dash.port_prompt.en")   text="Dashboard port" ;;
+        "dash.image_prompt.zh")  text="Dashboard 镜像" ;;
+        "dash.image_prompt.en")  text="Dashboard image" ;;
+        "dash.gateway_prompt.zh") text="Higress Console URL (用于共享登录)" ;;
+        "dash.gateway_prompt.en") text="Higress Console URL (for shared login)" ;;
+        "dash.skip.zh")          text="跳过 Dashboard 安装" ;;
+        "dash.skip.en")          text="Skipping Dashboard installation" ;;
+        "dash.auto_url.zh")      text="自动检测到 Higress Console URL" ;;
+        "dash.auto_url.en")      text="Auto-detected Higress Console URL" ;;
+        "dash.auto_url_fail.zh") text="无法自动检测 Higress Console URL，请手动输入" ;;
+        "dash.auto_url_fail.en") text="Cannot auto-detect Higress Console URL, please enter manually" ;;
+        "dash.summary.zh")       text="Dashboard 配置: 端口=%s 镜像=%s" ;;
+        "dash.summary.en")       text="Dashboard config: port=%s image=%s" ;;
+        # --- Dashboard success ---
+        "success.dashboard.zh") text="  agentteams-dashboard 管理面板: http://localhost:%s/" ;;
+        "success.dashboard.en") text="  agentteams-dashboard: http://localhost:%s/" ;;
         # --- Final output panel ---
         "success.title.zh") text="=== AgentTeams Manager 已启动！===" ;;
         "success.title.en") text="=== AgentTeams Manager Started! ===" ;;
@@ -1604,7 +1628,7 @@ should_skip_step() {
             [ ! -f "${_env}" ] && return 0
             ;;
         # Keep-All upgrade mode: skip all config steps (step_volume/step_workspace handled separately)
-        step_llm|step_admin|step_network|step_ports|step_domains|step_github|step_skills|step_runtime|step_manager_runtime|step_e2ee|step_docker_proxy|step_idle|step_hostshare)
+        step_llm|step_admin|step_network|step_ports|step_domains|step_github|step_skills|step_runtime|step_manager_runtime|step_dashboard|step_e2ee|step_docker_proxy|step_idle|step_hostshare)
             [ "${AGENTTEAMS_UPGRADE}" = "1" ] && [ "${AGENTTEAMS_UPGRADE_KEEP_ALL}" = "1" ] && return 0
             ;;
         step_volume|step_workspace)
@@ -1668,6 +1692,7 @@ clear_step_vars() {
         step_skills)    unset AGENTTEAMS_SKILLS_API_URL ;;
         step_volume)    unset AGENTTEAMS_DATA_DIR ;;
         step_workspace) unset AGENTTEAMS_WORKSPACE_DIR ;;
+        step_dashboard) unset AGENTTEAMS_DASHBOARD AGENTTEAMS_PORT_DASHBOARD AGENTTEAMS_DASHBOARD_IMAGE AGENTTEAMS_AI_GATEWAY_ADMIN_URL ;;
         step_runtime)   unset AGENTTEAMS_DEFAULT_WORKER_RUNTIME ;;
         step_manager_runtime) unset AGENTTEAMS_MANAGER_RUNTIME ;;
         step_e2ee)      unset AGENTTEAMS_MATRIX_E2EE ;;
@@ -2437,6 +2462,71 @@ step_workspace() {
     log "$(msg workspace.dir_label "${AGENTTEAMS_WORKSPACE_DIR}")"
 }
 
+step_dashboard() {
+    AGENTTEAMS_DASHBOARD="${AGENTTEAMS_DASHBOARD:-1}"
+    AGENTTEAMS_PORT_DASHBOARD="${AGENTTEAMS_PORT_DASHBOARD:-13000}"
+    AGENTTEAMS_DASHBOARD_IMAGE="${AGENTTEAMS_DASHBOARD_IMAGE:-${AGENTTEAMS_REGISTRY}/agentteams/agentteams-dashboard:${AGENTTEAMS_VERSION}}"
+    AGENTTEAMS_AI_GATEWAY_ADMIN_URL="${AGENTTEAMS_AI_GATEWAY_ADMIN_URL:-}"
+
+    if [ "${AGENTTEAMS_NON_INTERACTIVE}" = "1" ]; then
+        AGENTTEAMS_DASHBOARD="${AGENTTEAMS_DASHBOARD:-1}"
+        if [ "${AGENTTEAMS_DASHBOARD}" = "1" ]; then
+            log "$(msg dash.summary "${AGENTTEAMS_PORT_DASHBOARD}" "${AGENTTEAMS_DASHBOARD_IMAGE}") (non-interactive)"
+        else
+            log "$(msg dash.skip) (non-interactive)"
+        fi
+        export AGENTTEAMS_DASHBOARD AGENTTEAMS_PORT_DASHBOARD AGENTTEAMS_DASHBOARD_IMAGE AGENTTEAMS_AI_GATEWAY_ADMIN_URL
+        return 0
+    fi
+
+    if [ "${AGENTTEAMS_UPGRADE}" = "1" ] && [ "${AGENTTEAMS_UPGRADE_KEEP_ALL}" = "1" ]; then
+        log "$(msg prompt.upgrade_keep "" "${AGENTTEAMS_DASHBOARD}") dashboard=${AGENTTEAMS_DASHBOARD} port=${AGENTTEAMS_PORT_DASHBOARD}"
+        export AGENTTEAMS_DASHBOARD AGENTTEAMS_PORT_DASHBOARD AGENTTEAMS_DASHBOARD_IMAGE AGENTTEAMS_AI_GATEWAY_ADMIN_URL
+        return 0
+    fi
+
+    local _input
+    echo ""
+    read -p "$(msg dash.prompt) [Y/n]: " _input
+    case "${_input:-}" in
+        [nN0]) AGENTTEAMS_DASHBOARD=0 ;;
+        *)     AGENTTEAMS_DASHBOARD=1 ;;
+    esac
+    if [ "${_input}" = "b" ]; then STEP_RESULT="back"; return 0; fi
+
+    if [ "${AGENTTEAMS_DASHBOARD}" != "1" ]; then
+        log "$(msg dash.skip)"
+        export AGENTTEAMS_DASHBOARD AGENTTEAMS_PORT_DASHBOARD AGENTTEAMS_DASHBOARD_IMAGE AGENTTEAMS_AI_GATEWAY_ADMIN_URL
+        return 0
+    fi
+
+    # Dashboard port
+    local _current_port="${AGENTTEAMS_PORT_DASHBOARD}"
+    read -p "$(msg dash.port_prompt) [${_current_port}]: " _input
+    AGENTTEAMS_PORT_DASHBOARD="${_input:-${_current_port}}"
+
+    # Dashboard image
+    local _current_image="${AGENTTEAMS_DASHBOARD_IMAGE}"
+    read -p "$(msg dash.image_prompt) [${_current_image}]: " _input
+    AGENTTEAMS_DASHBOARD_IMAGE="${_input:-${_current_image}}"
+
+    # Higress Console URL (auto-detect or manual)
+    local _higress_url="${AGENTTEAMS_AI_GATEWAY_ADMIN_URL}"
+    if [ -z "${_higress_url}" ]; then
+        if ${DOCKER_CMD} ps --format '{{.Names}}' | grep -q "^agentteams-controller$"; then
+            if ${DOCKER_CMD} exec agentteams-controller curl -sf --max-time 2 http://127.0.0.1:8001/ >/dev/null 2>&1; then
+                _higress_url="http://agentteams-controller:8001"
+                log "$(msg dash.auto_url): ${_higress_url}"
+            fi
+        fi
+    fi
+    read -p "$(msg dash.gateway_prompt) [${_higress_url:-<skip>}]: " _input
+    AGENTTEAMS_AI_GATEWAY_ADMIN_URL="${_input:-${_higress_url}}"
+
+    log "$(msg dash.summary "${AGENTTEAMS_PORT_DASHBOARD}" "${AGENTTEAMS_DASHBOARD_IMAGE}")"
+    export AGENTTEAMS_DASHBOARD AGENTTEAMS_PORT_DASHBOARD AGENTTEAMS_DASHBOARD_IMAGE AGENTTEAMS_AI_GATEWAY_ADMIN_URL
+}
+
 step_runtime() {
     log "$(msg worker_runtime.title)"
     echo ""
@@ -2835,6 +2925,97 @@ WantedBy=default.target"
 }
 
 # ============================================================
+# Dashboard startup (called after controller is ready)
+# ============================================================
+
+_start_dashboard() {
+    if [ "${AGENTTEAMS_DASHBOARD:-0}" != "1" ]; then
+        return 0
+    fi
+
+    # Dashboard requires the embedded architecture (controller container).
+    # In legacy all-in-one mode the controller API is not available.
+    if [ "${AGENTTEAMS_USE_EMBEDDED:-0}" != "1" ]; then
+        log "Skipping Dashboard: requires embedded architecture (agentteams-controller), not available in legacy mode."
+        log "Use Quick Start (embedded) mode to enable agentteams-dashboard."
+        return 0
+    fi
+
+    if ! ${DOCKER_CMD} ps --format '{{.Names}}' | grep -q "^agentteams-controller$"; then
+        log "Skipping Dashboard: agentteams-controller container not found."
+        return 0
+    fi
+
+    AGENTTEAMS_PORT_DASHBOARD="${AGENTTEAMS_PORT_DASHBOARD:-13000}"
+    AGENTTEAMS_DASHBOARD_IMAGE="${AGENTTEAMS_DASHBOARD_IMAGE:-${AGENTTEAMS_REGISTRY}/agentteams/agentteams-dashboard:${AGENTTEAMS_VERSION}}"
+    AGENTTEAMS_AI_GATEWAY_ADMIN_URL="${AGENTTEAMS_AI_GATEWAY_ADMIN_URL:-}"
+    local DASHBOARD_CONTAINER="agentteams-dashboard"
+
+    log ""
+    log "Starting agentteams-dashboard..."
+
+    # Remove existing dashboard container if present
+    if ${DOCKER_CMD} ps -a --format '{{.Names}}' | grep -qx "${DASHBOARD_CONTAINER}"; then
+        ${DOCKER_CMD} rm -f "${DASHBOARD_CONTAINER}" >/dev/null 2>&1 || true
+    fi
+
+    # Pull or use local image
+    if ! ${DOCKER_CMD} image inspect "${AGENTTEAMS_DASHBOARD_IMAGE}" >/dev/null 2>&1; then
+        log "Pulling dashboard image: ${AGENTTEAMS_DASHBOARD_IMAGE}"
+        ${DOCKER_CMD} pull "${AGENTTEAMS_DASHBOARD_IMAGE}" 2>/dev/null || {
+            log "WARNING: Could not pull dashboard image. Skipping."
+            return 0
+        }
+    fi
+
+    # Build env args
+    local _dash_env=()
+
+    # The dashboard authenticates its API proxy calls to the controller with the
+    # controller's admin CLI token (minted at controller startup and written to
+    # /var/run/hiclaw/cli-token).
+    # Auto-detect it when the caller did not provide one — without it every
+    # dashboard data API returns 401 and workers/teams/rooms appear empty.
+    if [ -z "${AGENTTEAMS_AUTH_TOKEN:-}" ] && ${DOCKER_CMD} ps --format '{{.Names}}' | grep -q "^agentteams-controller$"; then
+        AGENTTEAMS_AUTH_TOKEN=$(${DOCKER_CMD} exec agentteams-controller sh -c 'cat /var/run/hiclaw/cli-token 2>/dev/null' | tr -d '\n' || true)
+        [ -z "${AGENTTEAMS_AUTH_TOKEN}" ] && log "WARNING: Could not read controller auth token (cli-token); dashboard API calls will be unauthenticated."
+    fi
+
+    _dash_env+=(-e "AGENTTEAMS_CONTROLLER_URL=http://agentteams-controller:8090")
+    _dash_env+=(-e "NEXT_PUBLIC_MATRIX_API_URL=http://agentteams-controller:6167")
+    _dash_env+=(-e "MATRIX_HOMESERVER_ALLOWLIST=agentteams-controller,matrix-local.agentteams.io,matrix.org")
+    _dash_env+=(-e "NEXT_PUBLIC_BASE_PATH=")
+    [ -n "${AGENTTEAMS_AI_GATEWAY_ADMIN_URL:-}" ] && _dash_env+=(-e "AGENTTEAMS_AI_GATEWAY_ADMIN_URL=${AGENTTEAMS_AI_GATEWAY_ADMIN_URL}")
+    [ -n "${AGENTTEAMS_AUTH_TOKEN:-}" ] && _dash_env+=(-e "AGENTTEAMS_AUTH_TOKEN=${AGENTTEAMS_AUTH_TOKEN}")
+    # Admin credentials (from step_admin) let the dashboard bootstrap the Higress
+    # AI gateway (setup/ensure-ai) with the same account as the Console.
+    [ -n "${AGENTTEAMS_ADMIN_USER:-}" ] && _dash_env+=(-e "AGENTTEAMS_ADMIN_USER=${AGENTTEAMS_ADMIN_USER}")
+    [ -n "${AGENTTEAMS_ADMIN_PASSWORD:-}" ] && _dash_env+=(-e "AGENTTEAMS_ADMIN_PASSWORD=${AGENTTEAMS_ADMIN_PASSWORD}")
+
+    # Detect Higress admin URL from controller
+    if [ -z "${AGENTTEAMS_AI_GATEWAY_ADMIN_URL:-}" ] && ${DOCKER_CMD} ps --format '{{.Names}}' | grep -q "^agentteams-controller$"; then
+        if ${DOCKER_CMD} exec agentteams-controller curl -sf --max-time 2 http://127.0.0.1:8001/ >/dev/null 2>&1; then
+            _dash_env+=(-e "AGENTTEAMS_AI_GATEWAY_ADMIN_URL=http://agentteams-controller:8001")
+        fi
+    fi
+
+    # Build port prefix (local-only vs public)
+    local _dash_prefix=""
+    [ "${AGENTTEAMS_LOCAL_ONLY:-1}" = "1" ] && _dash_prefix="127.0.0.1:"
+
+    ${DOCKER_CMD} run -d \
+        --name "${DASHBOARD_CONTAINER}" \
+        --network agentteams-net \
+        --network-alias dashboard.agentteams.io \
+        --restart unless-stopped \
+        -p "${_dash_prefix}${AGENTTEAMS_PORT_DASHBOARD}:3000" \
+        "${_dash_env[@]}" \
+        "${AGENTTEAMS_DASHBOARD_IMAGE}"
+
+    log "Dashboard started on port ${AGENTTEAMS_PORT_DASHBOARD}"
+}
+
+# ============================================================
 # Manager Installation (Interactive)
 # ============================================================
 
@@ -2911,7 +3092,7 @@ install_manager() {
     # ── State machine ─────────────────────────────────────────────────────────
     local _STEPS=( step_lang step_mode step_version step_existing step_llm step_manager_runtime step_runtime step_admin step_network
                    step_ports step_domains step_github step_skills step_volume
-                   step_workspace step_e2ee step_docker_proxy step_idle step_hostshare step_podman_autostart )
+                   step_workspace step_dashboard step_e2ee step_docker_proxy step_idle step_hostshare step_podman_autostart )
     local _STEP_HISTORY=()
     local _step_idx=0
     while [ "${_step_idx}" -lt "${#_STEPS[@]}" ]; do
@@ -3107,6 +3288,12 @@ AGENTTEAMS_DATA_DIR=${AGENTTEAMS_DATA_DIR:-agentteams-data}
 AGENTTEAMS_WORKSPACE_DIR=${AGENTTEAMS_WORKSPACE_DIR:-}
 # Host directory sharing
 AGENTTEAMS_HOST_SHARE_DIR=${AGENTTEAMS_HOST_SHARE_DIR:-}
+
+# agentteams-dashboard (management UI)
+AGENTTEAMS_DASHBOARD=${AGENTTEAMS_DASHBOARD:-1}
+AGENTTEAMS_PORT_DASHBOARD=${AGENTTEAMS_PORT_DASHBOARD:-13000}
+AGENTTEAMS_DASHBOARD_IMAGE=${AGENTTEAMS_DASHBOARD_IMAGE:-${AGENTTEAMS_REGISTRY}/agentteams/agentteams-dashboard:${AGENTTEAMS_VERSION}}
+AGENTTEAMS_AI_GATEWAY_ADMIN_URL=${AGENTTEAMS_AI_GATEWAY_ADMIN_URL:-}
 EOF
 
     chmod 600 "${ENV_FILE}"
@@ -3788,6 +3975,9 @@ CREDEOF
     fi
     unset _port_prefix
 
+    # ── Start Dashboard (optional) ────────────────────────────────────
+    _start_dashboard
+
     # Apply Podman autostart if selected and environment matches
     if [ "${DOCKER_CMD}" = "podman" ] && [ "${AGENTTEAMS_PODMAN_AUTOSTART:-0}" = "1" ]; then
         setup_podman_autostart
@@ -3836,6 +4026,9 @@ CREDEOF
     log ""
     log "$(msg success.other_consoles)"
     log "$(msg success.higress_console "${AGENTTEAMS_PORT_CONSOLE}" "${AGENTTEAMS_ADMIN_USER}" "${AGENTTEAMS_ADMIN_PASSWORD}")"
+    if [ "${AGENTTEAMS_DASHBOARD:-0}" = "1" ]; then
+        log "$(msg success.dashboard "${AGENTTEAMS_PORT_DASHBOARD:-13000}")"
+    fi
     if [ "${AGENTTEAMS_USE_EMBEDDED}" != "1" ]; then
         log "$(msg success.manager_console "${AGENTTEAMS_PORT_MANAGER_CONSOLE:-18888}")"
         log "$(msg success.manager_console_gateway "${AGENTTEAMS_ADMIN_USER}" "${AGENTTEAMS_ADMIN_PASSWORD}")"
@@ -4074,6 +4267,13 @@ uninstall_hiclaw() {
             ${DOCKER_CMD} rm -f "${w}" >/dev/null 2>&1 || true
             log "$(msg uninstall.removed "${w}")"
         done
+    fi
+
+    # Stop and remove the dashboard container (installed via step_dashboard)
+    if ${DOCKER_CMD} ps -a --format '{{.Names}}' 2>/dev/null | grep -q "^agentteams-dashboard$"; then
+        log "Stopping and removing agentteams-dashboard..."
+        ${DOCKER_CMD} stop agentteams-dashboard >/dev/null 2>&1 || true
+        ${DOCKER_CMD} rm agentteams-dashboard >/dev/null 2>&1 || true
     fi
 
     # Stop and remove docker-proxy (legacy ≤ v1.0.x; current arch uses

--- a/install/hiclaw-verify.sh
+++ b/install/hiclaw-verify.sh
@@ -59,8 +59,10 @@ fi
 container_env=$("${DOCKER_CMD}" exec "${CONTAINER}" printenv 2>/dev/null) || container_env=""
 PORT_GATEWAY=$(echo "$container_env" | grep ^AGENTTEAMS_PORT_GATEWAY= | cut -d= -f2-)
 PORT_CONSOLE=$(echo "$container_env" | grep ^AGENTTEAMS_PORT_CONSOLE= | cut -d= -f2-)
+PORT_DASHBOARD=$(echo "$container_env" | grep ^AGENTTEAMS_PORT_DASHBOARD= | cut -d= -f2-)
 PORT_GATEWAY="${PORT_GATEWAY:-18080}"
 PORT_CONSOLE="${PORT_CONSOLE:-18001}"
+PORT_DASHBOARD="${PORT_DASHBOARD:-13000}"
 
 # ---------- Result tracking ----------
 
@@ -161,6 +163,21 @@ else
     else
         check_fail "OpenClaw Agent healthy (output: ${agent_output:-<empty>})"
     fi
+fi
+
+# 7. Dashboard accessible (if enabled)
+DASHBOARD_ENABLED=$(echo "$container_env" | grep ^AGENTTEAMS_DASHBOARD= | cut -d= -f2-)
+DASHBOARD_ENABLED="${DASHBOARD_ENABLED:-1}"
+if [ "${DASHBOARD_ENABLED}" = "1" ]; then
+    dash_status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+        "http://127.0.0.1:${PORT_DASHBOARD}/" 2>/dev/null) || dash_status="000"
+    if [ "${dash_status}" = "200" ]; then
+        check_pass "Dashboard accessible on port ${PORT_DASHBOARD}"
+    else
+        check_fail "Dashboard accessible on port ${PORT_DASHBOARD} (HTTP ${dash_status})"
+    fi
+else
+    echo "  [SKIP] Dashboard disabled"
 fi
 
 # ---------- Summary ----------


### PR DESCRIPTION
## 描述

将 agentteams-dashboard 作为可选组件集成到 AgentTeams 安装脚本中。

agentteams-dashboard 是一个基于 Next.js 的 Web 管理面板，用于可视化管理 AgentTeams 集群中的 Worker、Team、Human、Manager 等资源，同时集成 Matrix 聊天能力。

## 变更内容

### 1. `install/hiclaw-install.sh`
- 添加 Dashboard 安装向导步骤 (`step_dashboard`)
- 支持配置端口号（默认 13000）、镜像名称、Higress Console URL
- 自动检测 Higress Console URL 实现共用登录
- 容器启动后自动等待就绪
- 支持中英文双语消息
- 默认绑定 0.0.0.0 支持局域网访问

### 2. `install/hiclaw-verify.sh`
- 添加 Dashboard 可访问性检查
- 验证 HTTP 200 响应

### 3. `Makefile`
- 添加 `install-dashboard` 目标
- 添加 `update-dashboard` 目标
- 添加 `uninstall-dashboard` 目标

## 环境变量

| 变量 | 默认值 | 说明 |
|------|--------|------|
| `AGENTTEAMS_DASHBOARD` | `1` | 是否安装 Dashboard (1=是, 0=否) |
| `AGENTTEAMS_PORT_DASHBOARD` | `13000` | Dashboard 主机端口 |
| `AGENTTEAMS_DASHBOARD_IMAGE` | `${AGENTTEAMS_REGISTRY}/agentteams/agentteams-dashboard:${AGENTTEAMS_VERSION}` | Dashboard 镜像 |
| `AGENTTEAMS_AI_GATEWAY_ADMIN_URL` | 自动检测 | Higress Console URL (共用登录) |

## 测试步骤

```bash
# 1. 安装 AgentTeams（包含 Dashboard）
bash install/hiclaw-install.sh

# 2. 验证 Dashboard 可访问
curl -s http://localhost:13000/ | head -5

# 3. 验证安装脚本
bash install/hiclaw-verify.sh

# 4. 使用 Makefile
make install-dashboard
make update-dashboard
make uninstall-dashboard
```

## 检查清单

- [x] 支持非交互模式 (`AGENTTEAMS_NON_INTERACTIVE=1`)
- [x] 支持中英文双语
- [x] 容器使用 Docker 网络连接
- [x] 自动等待容器就绪
- [x] 添加验证检查
- [x] Makefile 目标可用

## 相关链接

- agentteams-dashboard 仓库: https://github.com/agentteams-group/agentteams-dashboard
- 安装脚本: https://github.com/agentteams-group/agentteams-dashboard/blob/main/install/agentteams-dashboard.sh
- 集成文档: https://github.com/agentteams-group/agentteams-dashboard/blob/main/install/AGENTTEAMS_PATCH.md