### PR TITLE
feat(install): integrate agentteams-dashboard as optional component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ OPENHUMAN_WORKER_IMAGE ?= $(REGISTRY)/$(REPO)/agentteams-openhuman-worker
 OPENCLAW_BASE_IMAGE  ?= $(REGISTRY)/$(REPO)/openclaw-base
 CONTROLLER_IMAGE     ?= $(REGISTRY)/$(REPO)/agentteams-controller
 EMBEDDED_IMAGE       ?= $(REGISTRY)/$(REPO)/agentteams-embedded
+DASHBOARD_CONTEXT    ?= ./agentteams-dashboard/
 
 MANAGER_TAG        ?= $(MANAGER_IMAGE):$(VERSION)
 MANAGER_COPAW_TAG  ?= $(MANAGER_COPAW_IMAGE):$(VERSION)
@@ -116,7 +117,7 @@ LINES          ?= 50
         push-native-qwenpaw-worker \
         buildx-setup \
         test test-quick test-installed test-embedded \
-        install install-embedded uninstall uninstall-embedded replay replay-log \
+        install install-embedded uninstall uninstall-embedded replay replay-log install-dashboard update-dashboard uninstall-dashboard wait-dashboard-ready \
         verify wait-ready wait-ready-embedded \
         generate sync-crds check-crd-sync \
         status logs \
@@ -174,6 +175,15 @@ build-embedded: build-agentteams-controller ## Build embedded all-in-one control
 		-f agentteams-controller/Dockerfile.embedded \
 		-t $(LOCAL_EMBEDDED) \
 		.
+
+build-dashboard: ## Build agentteams-dashboard image
+	@if [ ! -d "$(DASHBOARD_CONTEXT)" ]; then \
+		echo "ERROR: DASHBOARD_CONTEXT directory not found: $(DASHBOARD_CONTEXT)"; \
+		echo "Set DASHBOARD_CONTEXT to the agentteams-dashboard source directory."; \
+		exit 1; \
+	fi
+	@echo "==> Building agentteams-dashboard image"
+	$(MAKE) -C $(DASHBOARD_CONTEXT) build
 
 build-worker: ## Build Worker image
 	@echo "==> Building Worker image: $(LOCAL_WORKER) (registry: $(HIGRESS_REGISTRY))"
@@ -737,6 +747,40 @@ uninstall-embedded: ## Stop and remove embedded containers
 		rm -rf "$${HOME}/agentteams-manager" && echo "  Cleaned workspace: ~/agentteams-manager"; \
 	fi
 	@echo "==> AgentTeams (embedded) uninstalled"
+
+# --- agentteams-dashboard standalone management ---
+.PHONY: install-dashboard update-dashboard uninstall-dashboard wait-dashboard-ready
+
+install-dashboard: ## Install agentteams-dashboard standalone
+	@if [ ! -d "$(DASHBOARD_CONTEXT)" ]; then \
+		echo "ERROR: DASHBOARD_CONTEXT not found: $(DASHBOARD_CONTEXT)"; exit 1; \
+	fi
+	@bash $(DASHBOARD_CONTEXT)/install/agentteams-dashboard.sh
+	@$(MAKE) wait-dashboard-ready
+
+update-dashboard: ## Update agentteams-dashboard (pull latest & recreate)
+	@if [ ! -d "$(DASHBOARD_CONTEXT)" ]; then \
+		echo "ERROR: DASHBOARD_CONTEXT not found: $(DASHBOARD_CONTEXT)"; exit 1; \
+	fi
+	@bash $(DASHBOARD_CONTEXT)/install/agentteams-dashboard.sh update
+	@$(MAKE) wait-dashboard-ready
+
+uninstall-dashboard: ## Uninstall agentteams-dashboard
+	@if [ ! -d "$(DASHBOARD_CONTEXT)" ]; then \
+		echo "ERROR: DASHBOARD_CONTEXT not found: $(DASHBOARD_CONTEXT)"; exit 1; \
+	fi
+	@bash $(DASHBOARD_CONTEXT)/install/agentteams-dashboard.sh uninstall
+
+wait-dashboard-ready: ## Wait for dashboard HTTP endpoint to respond
+	@echo "Waiting for agentteams-dashboard to be ready..."
+	@PORT=$${AGENTTEAMS_PORT_DASHBOARD:-13000}; \
+	for i in $$(seq 1 30); do \
+		if curl -sf -o /dev/null --max-time 3 http://127.0.0.1:$$PORT/ 2>/dev/null; then \
+			echo "Dashboard is ready!"; exit 0; \
+		fi; \
+		sleep 2; \
+	done; \
+	echo "ERROR: Dashboard did not respond within 60s"; exit 1
 
 # ---------- Replay ----------
 

--- a/install/agentteams-install.sh
+++ b/install/agentteams-install.sh
@@ -869,6 +869,25 @@ msg() {
         "success.other_consoles.en") text="--- Other Consoles ---" ;;
         "success.higress_console.zh") text="  Higress 控制台: http://localhost:%s（用户名: %s / 密码: %s）" ;;
         "success.higress_console.en") text="  Higress Console: http://localhost:%s (Username: %s / Password: %s)" ;;
+        # --- Dashboard wizard ---
+        "dash.prompt.zh")        text="是否安装 agentteams-dashboard 管理面板?" ;;
+        "dash.prompt.en")        text="Install agentteams-dashboard management UI?" ;;
+        "dash.port_prompt.zh")   text="Dashboard 端口号" ;;
+        "dash.port_prompt.en")   text="Dashboard port" ;;
+        "dash.image_prompt.zh")  text="Dashboard 镜像" ;;
+        "dash.image_prompt.en")  text="Dashboard image" ;;
+        "dash.version_prompt.zh") text="Dashboard 版本" ;;
+        "dash.version_prompt.en") text="Dashboard version" ;;
+        "dash.skip.zh")          text="跳过 Dashboard 安装" ;;
+        "dash.skip.en")          text="Skipping Dashboard installation" ;;
+        "dash.ready.zh")         text="Dashboard 已就绪" ;;
+        "dash.ready.en")         text="Dashboard is ready" ;;
+        "dash.not_ready.zh")     text="Dashboard 启动超时，请检查日志" ;;
+        "dash.not_ready.en")     text="Dashboard did not become ready, check logs" ;;
+        "dash.starting.zh")      text="正在启动 Dashboard..." ;;
+        "dash.starting.en")      text="Starting Dashboard..." ;;
+        "dash.success.zh")       text="  agentteams-dashboard 管理面板: http://localhost:%s/" ;;
+        "dash.success.en")       text="  agentteams-dashboard: http://localhost:%s/" ;;
         "success.manager_console.zh") text="  Manager 控制台（本地）: http://localhost:%s（无需登录）" ;;
         "success.manager_console.en") text="  Manager Console (local): http://localhost:%s (no login required)" ;;
         "success.manager_console_gateway.zh") text="  Manager 控制台（网关）: http://console-local.agentteams.io（用户名: %s / 密码: %s）" ;;
@@ -1602,7 +1621,7 @@ should_skip_step() {
             [ ! -f "${_env}" ] && return 0
             ;;
         # Keep-All upgrade mode: skip all config steps (step_volume/step_workspace handled separately)
-        step_llm|step_admin|step_network|step_ports|step_domains|step_github|step_skills|step_runtime|step_manager_runtime|step_e2ee|step_docker_proxy|step_idle|step_hostshare)
+        step_llm|step_admin|step_network|step_ports|step_domains|step_github|step_skills|step_runtime|step_manager_runtime|step_e2ee|step_docker_proxy|step_idle|step_hostshare|step_dashboard)
             [ "${AGENTTEAMS_UPGRADE}" = "1" ] && [ "${AGENTTEAMS_UPGRADE_KEEP_ALL}" = "1" ] && return 0
             ;;
         step_volume|step_workspace)
@@ -1672,6 +1691,7 @@ clear_step_vars() {
         step_docker_proxy) unset AGENTTEAMS_DOCKER_PROXY; unset AGENTTEAMS_PROXY_ALLOWED_REGISTRIES ;;
         step_idle)      unset AGENTTEAMS_WORKER_IDLE_TIMEOUT ;;
         step_hostshare) unset AGENTTEAMS_HOST_SHARE_DIR ;;
+        step_dashboard) unset AGENTTEAMS_DASHBOARD AGENTTEAMS_PORT_DASHBOARD AGENTTEAMS_DASHBOARD_IMAGE AGENTTEAMS_DASHBOARD_VERSION ;;
         step_podman_autostart) unset AGENTTEAMS_PODMAN_AUTOSTART ;;
     esac
 }
@@ -2435,6 +2455,57 @@ step_workspace() {
     log "$(msg workspace.dir_label "${AGENTTEAMS_WORKSPACE_DIR}")"
 }
 
+step_dashboard() {
+    AGENTTEAMS_DASHBOARD="${AGENTTEAMS_DASHBOARD:-1}"
+    AGENTTEAMS_PORT_DASHBOARD="${AGENTTEAMS_PORT_DASHBOARD:-13000}"
+    AGENTTEAMS_DASHBOARD_VERSION="${AGENTTEAMS_DASHBOARD_VERSION:-latest}"
+    AGENTTEAMS_DASHBOARD_IMAGE="${AGENTTEAMS_DASHBOARD_IMAGE:-${AGENTTEAMS_REGISTRY}/agentteams/agentteams-dashboard:${AGENTTEAMS_DASHBOARD_VERSION}}"
+
+    if [ "${AGENTTEAMS_NON_INTERACTIVE}" = "1" ]; then
+        AGENTTEAMS_DASHBOARD="${AGENTTEAMS_DASHBOARD:-1}"
+        if [ "${AGENTTEAMS_DASHBOARD}" = "1" ]; then
+            log "$(msg dash.success "${AGENTTEAMS_PORT_DASHBOARD}") (non-interactive)"
+        else
+            log "$(msg dash.skip) (non-interactive)"
+        fi
+        export AGENTTEAMS_DASHBOARD AGENTTEAMS_PORT_DASHBOARD AGENTTEAMS_DASHBOARD_IMAGE AGENTTEAMS_DASHBOARD_VERSION
+        return 0
+    fi
+
+    if [ "${AGENTTEAMS_UPGRADE}" = "1" ] && [ "${AGENTTEAMS_UPGRADE_KEEP_ALL}" = "1" ]; then
+        log "upgrade keep-all: dashboard=${AGENTTEAMS_DASHBOARD} port=${AGENTTEAMS_PORT_DASHBOARD} version=${AGENTTEAMS_DASHBOARD_VERSION}"
+        export AGENTTEAMS_DASHBOARD AGENTTEAMS_PORT_DASHBOARD AGENTTEAMS_DASHBOARD_IMAGE AGENTTEAMS_DASHBOARD_VERSION
+        return 0
+    fi
+
+    local _input
+    echo ""
+    read -p "$(msg dash.prompt) [Y/n]: " _input
+    case "${_input:-}" in
+        [nN0]) AGENTTEAMS_DASHBOARD=0 ;;
+        *)     AGENTTEAMS_DASHBOARD=1 ;;
+    esac
+    if [ "${_input}" = "b" ]; then STEP_RESULT="back"; return 0; fi
+
+    if [ "${AGENTTEAMS_DASHBOARD}" != "1" ]; then
+        log "$(msg dash.skip)"
+        export AGENTTEAMS_DASHBOARD AGENTTEAMS_PORT_DASHBOARD AGENTTEAMS_DASHBOARD_IMAGE AGENTTEAMS_DASHBOARD_VERSION
+        return 0
+    fi
+
+    local _current_port="${AGENTTEAMS_PORT_DASHBOARD}"
+    read -p "$(msg dash.port_prompt) [${_current_port}]: " _input
+    AGENTTEAMS_PORT_DASHBOARD="${_input:-${_current_port}}"
+
+    local _current_ver="${AGENTTEAMS_DASHBOARD_VERSION}"
+    read -p "$(msg dash.version_prompt) [${_current_ver}]: " _input
+    AGENTTEAMS_DASHBOARD_VERSION="${_input:-${_current_ver}}"
+    AGENTTEAMS_DASHBOARD_IMAGE="${AGENTTEAMS_REGISTRY}/agentteams/agentteams-dashboard:${AGENTTEAMS_DASHBOARD_VERSION}"
+
+    log "Dashboard: port=${AGENTTEAMS_PORT_DASHBOARD} image=${AGENTTEAMS_DASHBOARD_IMAGE}"
+    export AGENTTEAMS_DASHBOARD AGENTTEAMS_PORT_DASHBOARD AGENTTEAMS_DASHBOARD_IMAGE AGENTTEAMS_DASHBOARD_VERSION
+}
+
 step_runtime() {
     log "$(msg worker_runtime.title)"
     echo ""
@@ -2833,6 +2904,139 @@ WantedBy=default.target"
 }
 
 # ============================================================
+# Dashboard startup (called after controller is ready)
+# ============================================================
+
+_start_dashboard() {
+    if [ "${AGENTTEAMS_DASHBOARD:-0}" != "1" ]; then
+        return 0
+    fi
+
+    # Dashboard requires the embedded architecture (controller container).
+    if [ "${AGENTTEAMS_USE_EMBEDDED:-0}" != "1" ]; then
+        log "Skipping Dashboard: requires embedded architecture (agentteams-controller)."
+        return 0
+    fi
+
+    if ! ${DOCKER_CMD} ps --format '{{.Names}}' | grep -q "^agentteams-controller$"; then
+        log "Skipping Dashboard: agentteams-controller container not found."
+        return 0
+    fi
+
+    AGENTTEAMS_PORT_DASHBOARD="${AGENTTEAMS_PORT_DASHBOARD:-13000}"
+    AGENTTEAMS_DASHBOARD_VERSION="${AGENTTEAMS_DASHBOARD_VERSION:-latest}"
+    AGENTTEAMS_DASHBOARD_IMAGE="${AGENTTEAMS_DASHBOARD_IMAGE:-${AGENTTEAMS_REGISTRY}/agentteams/agentteams-dashboard:${AGENTTEAMS_DASHBOARD_VERSION}}"
+    local DASHBOARD_CONTAINER="agentteams-dashboard"
+
+    log ""
+    log "$(msg dash.starting)"
+
+    # Remove existing dashboard container if present
+    if ${DOCKER_CMD} ps -a --format '{{.Names}}' | grep -qx "${DASHBOARD_CONTAINER}"; then
+        ${DOCKER_CMD} rm -f "${DASHBOARD_CONTAINER}" >/dev/null 2>&1 || true
+    fi
+
+    # Pull image if not present locally
+    if ! ${DOCKER_CMD} image inspect "${AGENTTEAMS_DASHBOARD_IMAGE}" >/dev/null 2>&1; then
+        log "Pulling dashboard image: ${AGENTTEAMS_DASHBOARD_IMAGE}"
+        if ! ${DOCKER_CMD} pull "${AGENTTEAMS_DASHBOARD_IMAGE}" 2>/dev/null; then
+            log "WARNING: Could not pull dashboard image. Skipping Dashboard."
+            return 1
+        fi
+    fi
+
+    # Build env args
+    local _dash_env=()
+
+    # Read controller auth token
+    if [ -z "${AGENTTEAMS_AUTH_TOKEN:-}" ]; then
+        AGENTTEAMS_AUTH_TOKEN=$(${DOCKER_CMD} exec agentteams-controller sh -c 'cat /var/run/hiclaw/cli-token 2>/dev/null' | tr -d '\n' || true)
+    fi
+
+    _dash_env+=(-e "AGENTTEAMS_CONTROLLER_URL=http://agentteams-controller:8090")
+    _dash_env+=(-e "NEXT_PUBLIC_MATRIX_API_URL=http://agentteams-controller:6167")
+    _dash_env+=(-e "MATRIX_HOMESERVER_ALLOWLIST=agentteams-controller,matrix-local.agentteams.io,matrix.org")
+    _dash_env+=(-e "DATABASE_URL=file:/app/db/dashboard.db")
+    _dash_env+=(-e "NEXT_PUBLIC_BASE_PATH=")
+
+    [ -n "${AGENTTEAMS_AUTH_TOKEN:-}" ] && _dash_env+=(-e "AGENTTEAMS_AUTH_TOKEN=${AGENTTEAMS_AUTH_TOKEN}")
+    [ -n "${AGENTTEAMS_ADMIN_USER:-}" ] && _dash_env+=(-e "AGENTTEAMS_ADMIN_USER=${AGENTTEAMS_ADMIN_USER}")
+    [ -n "${AGENTTEAMS_ADMIN_PASSWORD:-}" ] && _dash_env+=(-e "AGENTTEAMS_ADMIN_PASSWORD=${AGENTTEAMS_ADMIN_PASSWORD}")
+
+    # Detect Higress Console URL
+    if ${DOCKER_CMD} exec agentteams-controller curl -sf --max-time 2 http://127.0.0.1:8001/ >/dev/null 2>&1; then
+        _dash_env+=(-e "AGENTTEAMS_AI_GATEWAY_ADMIN_URL=http://agentteams-controller:8001")
+    fi
+
+    # Detect MinIO env from controller container
+    local _ctrl_env
+    _ctrl_env=$(${DOCKER_CMD} inspect agentteams-controller --format='{{range .Config.Env}}{{.}}{{"\n"}}{{end}}' 2>/dev/null || true)
+
+    local _fs_endpoint _fs_access _fs_secret _fs_bucket
+    _fs_bucket=$(echo "$_ctrl_env" | sed -n 's/^AGENTTEAMS_FS_BUCKET=//p')
+    [ -z "$_fs_bucket" ] && _fs_bucket=$(echo "$_ctrl_env" | sed -n 's/^AGENTTEAMS_MINIO_BUCKET=//p')
+    _fs_access=$(echo "$_ctrl_env" | sed -n 's/^AGENTTEAMS_FS_ACCESS_KEY=//p')
+    [ -z "$_fs_access" ] && _fs_access=$(echo "$_ctrl_env" | sed -n 's/^AGENTTEAMS_MINIO_USER=//p')
+    _fs_secret=$(echo "$_ctrl_env" | sed -n 's/^AGENTTEAMS_FS_SECRET_KEY=//p')
+    [ -z "$_fs_secret" ] && _fs_secret=$(echo "$_ctrl_env" | sed -n 's/^AGENTTEAMS_MINIO_PASSWORD=//p')
+    _fs_endpoint=$(echo "$_ctrl_env" | sed -n 's/^AGENTTEAMS_FS_ENDPOINT=//p')
+    [ -z "$_fs_endpoint" ] && _fs_endpoint=$(echo "$_ctrl_env" | sed -n 's/^AGENTTEAMS_MINIO_ENDPOINT=//p')
+    if [ -n "$_fs_endpoint" ]; then
+        _fs_endpoint=$(echo "$_fs_endpoint" | sed -e "s|127\\.0\\.0\\.1|agentteams-controller|" -e "s|localhost|agentteams-controller|")
+    else
+        _fs_endpoint="http://agentteams-controller:9000"
+    fi
+
+    [ -n "$_fs_endpoint" ] && _dash_env+=(-e "AGENTTEAMS_FS_ENDPOINT=${_fs_endpoint}")
+    [ -n "$_fs_access" ] && _dash_env+=(-e "AGENTTEAMS_FS_ACCESS_KEY=${_fs_access}")
+    [ -n "$_fs_secret" ] && _dash_env+=(-e "AGENTTEAMS_FS_SECRET_KEY=${_fs_secret}")
+    [ -n "$_fs_bucket" ] && _dash_env+=(-e "AGENTTEAMS_FS_BUCKET=${_fs_bucket}")
+
+    # Detect LLM env from controller
+    local _llm_provider _llm_key _llm_url _llm_model
+    _llm_provider=$(echo "$_ctrl_env" | sed -n 's/^AGENTTEAMS_LLM_PROVIDER=//p')
+    _llm_key=$(echo "$_ctrl_env" | sed -n 's/^AGENTTEAMS_LLM_API_KEY=//p')
+    _llm_url=$(echo "$_ctrl_env" | sed -n 's/^AGENTTEAMS_OPENAI_BASE_URL=//p')
+    _llm_model=$(echo "$_ctrl_env" | sed -n 's/^AGENTTEAMS_DEFAULT_MODEL=//p')
+    [ -n "$_llm_provider" ] && _dash_env+=(-e "AGENTTEAMS_LLM_PROVIDER=${_llm_provider}")
+    [ -n "$_llm_key" ] && _dash_env+=(-e "AGENTTEAMS_LLM_API_KEY=${_llm_key}")
+    [ -n "$_llm_url" ] && _dash_env+=(-e "AGENTTEAMS_OPENAI_BASE_URL=${_llm_url}")
+    [ -n "$_llm_model" ] && _dash_env+=(-e "AGENTTEAMS_DEFAULT_MODEL=${_llm_model}")
+
+    # Default to local-only binding
+    local _dash_prefix="127.0.0.1:"
+    [ "${AGENTTEAMS_LOCAL_ONLY:-1}" = "0" ] && _dash_prefix=""
+
+    local _data_volume="agentteams-dashboard-data"
+    ${DOCKER_CMD} volume create "${_data_volume}" >/dev/null 2>&1 || true
+
+    ${DOCKER_CMD} run -d \
+        --name "${DASHBOARD_CONTAINER}" \
+        --network agentteams-net \
+        --restart unless-stopped \
+        -p "${_dash_prefix}${AGENTTEAMS_PORT_DASHBOARD}:3000" \
+        "${_dash_env[@]}" \
+        -v "${_data_volume}:/app/db" \
+        "${AGENTTEAMS_DASHBOARD_IMAGE}"
+
+    # Wait for Dashboard to be ready (HTTP 200 on root)
+    log "Waiting for Dashboard to become ready..."
+    local _max_wait=60 _elapsed=0
+    while [ ${_elapsed} -lt ${_max_wait} ]; do
+        if curl -sf -o /dev/null --max-time 3 "http://127.0.0.1:${AGENTTEAMS_PORT_DASHBOARD}/" 2>/dev/null; then
+            log "$(msg dash.ready)"
+            return 0
+        fi
+        sleep 2
+        _elapsed=$((_elapsed + 2))
+    done
+
+    log "$(msg dash.not_ready)"
+    ${DOCKER_CMD} logs --tail 20 "${DASHBOARD_CONTAINER}" 2>/dev/null || true
+    return 1
+}
+
+# ============================================================
 # Manager Installation (Interactive)
 # ============================================================
 
@@ -2909,7 +3113,7 @@ install_manager() {
     # ── State machine ─────────────────────────────────────────────────────────
     local _STEPS=( step_lang step_mode step_version step_existing step_llm step_manager_runtime step_runtime step_admin step_network
                    step_ports step_domains step_github step_skills step_volume
-                   step_workspace step_e2ee step_docker_proxy step_idle step_hostshare step_podman_autostart )
+                   step_workspace step_dashboard step_e2ee step_docker_proxy step_idle step_hostshare step_podman_autostart )
     local _STEP_HISTORY=()
     local _step_idx=0
     while [ "${_step_idx}" -lt "${#_STEPS[@]}" ]; do
@@ -3105,6 +3309,12 @@ AGENTTEAMS_DATA_DIR=${AGENTTEAMS_DATA_DIR:-agentteams-data}
 AGENTTEAMS_WORKSPACE_DIR=${AGENTTEAMS_WORKSPACE_DIR:-}
 # Host directory sharing
 AGENTTEAMS_HOST_SHARE_DIR=${AGENTTEAMS_HOST_SHARE_DIR:-}
+
+# agentteams-dashboard (management UI)
+AGENTTEAMS_DASHBOARD=${AGENTTEAMS_DASHBOARD:-1}
+AGENTTEAMS_PORT_DASHBOARD=${AGENTTEAMS_PORT_DASHBOARD:-13000}
+AGENTTEAMS_DASHBOARD_VERSION=${AGENTTEAMS_DASHBOARD_VERSION:-latest}
+AGENTTEAMS_DASHBOARD_IMAGE=${AGENTTEAMS_DASHBOARD_IMAGE:-${AGENTTEAMS_REGISTRY}/agentteams/agentteams-dashboard:${AGENTTEAMS_DASHBOARD_VERSION}}
 EOF
 
     chmod 600 "${ENV_FILE}"
@@ -3762,6 +3972,9 @@ CREDEOF
         setup_podman_autostart
     fi
 
+    # ── Start Dashboard (optional) ────────────────────────────────────
+    _start_dashboard || warn "Dashboard startup failed — see logs above"
+
     log ""
     log "$(msg success.title)"
     log ""
@@ -3805,6 +4018,9 @@ CREDEOF
     log ""
     log "$(msg success.other_consoles)"
     log "$(msg success.higress_console "${AGENTTEAMS_PORT_CONSOLE}" "${AGENTTEAMS_ADMIN_USER}" "${AGENTTEAMS_ADMIN_PASSWORD}")"
+    if [ "${AGENTTEAMS_DASHBOARD:-0}" = "1" ]; then
+        log "$(msg dash.success "${AGENTTEAMS_PORT_DASHBOARD:-13000}")"
+    fi
     if [ "${AGENTTEAMS_USE_EMBEDDED}" != "1" ]; then
         log "$(msg success.manager_console "${AGENTTEAMS_PORT_MANAGER_CONSOLE:-18888}")"
         log "$(msg success.manager_console_gateway "${AGENTTEAMS_ADMIN_USER}" "${AGENTTEAMS_ADMIN_PASSWORD}")"
@@ -4069,6 +4285,13 @@ uninstall_agentteams() {
         log "$(msg uninstall.stopping_controller)"
         ${DOCKER_CMD} stop agentteams-controller >/dev/null 2>&1 || true
         ${DOCKER_CMD} rm agentteams-controller >/dev/null 2>&1 || true
+    fi
+
+    # Stop and remove the dashboard container
+    if ${DOCKER_CMD} ps -a --format '{{.Names}}' 2>/dev/null | grep -q "^agentteams-dashboard$"; then
+        log "Stopping and removing agentteams-dashboard..."
+        ${DOCKER_CMD} stop agentteams-dashboard >/dev/null 2>&1 || true
+        ${DOCKER_CMD} rm agentteams-dashboard >/dev/null 2>&1 || true
     fi
 
     # Read env file for data/workspace info before removing

--- a/install/agentteams-verify.sh
+++ b/install/agentteams-verify.sh
@@ -163,6 +163,29 @@ else
     fi
 fi
 
+# 7. Dashboard accessible (if the dashboard container is running)
+PORT_DASHBOARD="${AGENTTEAMS_PORT_DASHBOARD:-13000}"
+if ${DOCKER_CMD} ps --format '{{.Names}}' 2>/dev/null | grep -q "^agentteams-dashboard$"; then
+    # Read the host port mapping from the dashboard container itself
+    _dash_port=$(${DOCKER_CMD} port agentteams-dashboard 3000 2>/dev/null | head -1 | sed 's/.*://')
+    [ -n "${_dash_port}" ] && PORT_DASHBOARD="${_dash_port}"
+    dash_status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+        "http://127.0.0.1:${PORT_DASHBOARD}/" 2>/dev/null) || dash_status="000"
+    if [ "${dash_status}" = "200" ]; then
+        check_pass "Dashboard accessible on port ${PORT_DASHBOARD}"
+    else
+        check_fail "Dashboard accessible on port ${PORT_DASHBOARD} (HTTP ${dash_status})"
+    fi
+else
+    # Dashboard container not running; check if it was enabled in env file
+    _env_file="${HOME}/agentteams-manager.env"
+    if [ -f "${_env_file}" ] && grep -q '^AGENTTEAMS_DASHBOARD=1' "${_env_file}" 2>/dev/null; then
+        check_fail "Dashboard was enabled but container is not running"
+    else
+        echo "  [SKIP] Dashboard not installed"
+    fi
+fi
+
 # ---------- Summary ----------
 
 TOTAL=$((PASS + FAIL))


### PR DESCRIPTION
## 描述

将 agentteams-dashboard 作为可选组件集成到 AgentTeams 安装流程中。

agentteams-dashboard 是基于 Next.js 的 Web 管理面板，提供 Worker、Team、Human、Manager 等资源的可视化管理，以及 Matrix 实时聊天能力。

## 变更内容

### `install/agentteams-install.sh`
- 新增 `step_dashboard()` 向导步骤：配置端口（默认 13000）、版本（默认 latest）、镜像
- 新增 `_start_dashboard()` 启动函数：
  - 独立 `AGENTTEAMS_DASHBOARD_VERSION`，不复用 `AGENTTEAMS_VERSION`，避免引用未发布的镜像标签
  - 自动从 controller 容器检测并注入 MinIO 环境变量（`AGENTTEAMS_FS_ENDPOINT/ACCESS_KEY/SECRET_KEY/BUCKET`）
  - 自动注入 LLM 环境变量（`AGENTTEAMS_LLM_PROVIDER/LLM_API_KEY/OPENAI_BASE_URL/DEFAULT_MODEL`）
  - 注入 `DATABASE_URL` 确保 SQLite 存储正常
  - 容器启动后 HTTP 就绪检查（60s 超时），失败输出日志并返回非零
  - 默认绑定 `127.0.0.1`（本地安全），需显式设置 `AGENTTEAMS_LOCAL_ONLY=0` 才暴露到 LAN
- 容器卸载时自动清理 dashboard 容器
- 中英文双语消息
- 支持非交互模式和升级保留配置

### `install/agentteams-verify.sh`
- 新增 Dashboard 可达性检查（第 7 项）：检查 dashboard 容器是否运行 → 读取实际端口映射 → HTTP 200 探测
- 容器未运行但配置启用时报 FAIL，未安装时 SKIP

### `Makefile`
- 新增 `build-dashboard`：调用子目录 Makefile 构建镜像
- 新增 `install-dashboard`：安装 + 等待就绪
- 新增 `update-dashboard`：更新镜像并重建
- 新增 `uninstall-dashboard`：移除容器
- 新增 `wait-dashboard-ready`：HTTP 就绪探针（端口可通过 `AGENTTEAMS_PORT_DASHBOARD` 配置）
- `DASHBOARD_CONTEXT` 变量可覆盖，目录不存在时报错

## 环境变量

| 变量 | 默认值 | 说明 |
|------|--------|------|
| `AGENTTEAMS_DASHBOARD` | `1` | 是否安装 Dashboard |
| `AGENTTEAMS_PORT_DASHBOARD` | `13000` | Dashboard 主机端口 |
| `AGENTTEAMS_DASHBOARD_VERSION` | `latest` | Dashboard 镜像版本（独立于主版本） |
| `AGENTTEAMS_DASHBOARD_IMAGE` | `${REGISTRY}/agentteams/agentteams-dashboard:${DASHBOARD_VERSION}` | 镜像地址 |

## 测试

```bash
# 1. 全新安装（embedded 模式）
bash install/agentteams-install.sh
# -> Dashboard 向导步骤出现，默认安装

# 2. 验证
bash install/agentteams-verify.sh
# -> 第 7 项检查 Dashboard accessible on port 13000: PASS

# 3. 访问
curl -s http://127.0.0.1:13000/ | head -5

# 4. Makefile 目标
make install-dashboard DASHBOARD_CONTEXT=../agentteams-dashboard
make wait-dashboard-ready
make uninstall-dashboard
```

## 检查清单

- [x] 基于 main 最新代码（commit 2540c96）生成
- [x] `git apply --check` 在全新 clone 上通过
- [x] 补丁后脚本 `bash -n` 语法正确
- [x] 非交互模式支持
- [x] 升级保留配置
- [x] 卸载时清理容器
- [x] 双语消息
- [x] MinIO/LLM 环境变量自动注入
- [x] 独立版本号，不依赖 AGENTTEAMS_VERSION

## 相关链接

- Dashboard 仓库：https://github.com/agentteams-group/agentteams-dashboard
- 独立安装脚本：https://github.com/agentteams-group/agentteams-dashboard/blob/main/install/agentteams-dashboard.sh
