### PR TITLE
fix(install): support pre-v1.2 image env contract

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -4,8 +4,10 @@ on:
   pull_request:
     paths:
       - 'helm/**'
+      - 'install/agentteams-install.sh'
       - 'openhuman/scripts/openhuman-worker-entrypoint.sh'
       - 'tests/check-agentteams-rename-defaults.sh'
+      - 'tests/check-installer-pre-1.2-env-compat.sh'
       - 'tests/check-helm-agentteams.sh'
   workflow_dispatch: ~
 
@@ -18,6 +20,9 @@ jobs:
 
       - name: Check AgentTeams rename contracts
         run: bash tests/check-agentteams-rename-defaults.sh
+
+      - name: Check pre-v1.2 installer compatibility
+        run: bash tests/check-installer-pre-1.2-env-compat.sh
 
       - name: Set up Helm
         uses: azure/setup-helm@v4

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -368,7 +368,7 @@ jobs:
           if [ -z "$FILTER" ]; then
             FILTER="${{ env[matrix.filter_env] }}"
           fi
-          SKIP_BUILD=1 make test-embedded \
+          AGENTTEAMS_VERSION=v1.2.0-beta.1 SKIP_BUILD=1 make test-embedded \
             TEST_FILTER="$FILTER"
 
       # ============================================================

--- a/install/agentteams-install.sh
+++ b/install/agentteams-install.sh
@@ -67,6 +67,14 @@ _use_legacy_image_env() {
         _ver_lt "$1" "v1.2.0"
     fi
 }
+
+_controller_env_prefix() {
+    if _use_legacy_image_env "$1"; then
+        printf '%s%s' 'HIC' 'LAW_'
+    else
+        printf '%s' 'AGENTTEAMS_'
+    fi
+}
 AGENTTEAMS_NON_INTERACTIVE="${AGENTTEAMS_NON_INTERACTIVE:-0}"
 AGENTTEAMS_MOUNT_SOCKET="${AGENTTEAMS_MOUNT_SOCKET:-1}"
 AGENTTEAMS_DOCKER_PROXY="${AGENTTEAMS_DOCKER_PROXY:-1}"
@@ -3416,42 +3424,53 @@ CREDEOF
         case "${_fs_domain}" in *:*) ;; *) _fs_domain="${_fs_domain}:${_internal_gw_port}" ;; esac
 
         # Controller env args
+        local _ctrl_env_prefix
+        _ctrl_env_prefix="$(_controller_env_prefix "${AGENTTEAMS_VERSION}")"
         local _ctrl_env_args=(
-            -e "AGENTTEAMS_ADMIN_USER=${AGENTTEAMS_ADMIN_USER}"
-            -e "AGENTTEAMS_ADMIN_PASSWORD=${AGENTTEAMS_ADMIN_PASSWORD}"
-            -e "AGENTTEAMS_MANAGER_PASSWORD=${AGENTTEAMS_MANAGER_PASSWORD}"
-            -e "AGENTTEAMS_REGISTRATION_TOKEN=${AGENTTEAMS_REGISTRATION_TOKEN}"
-            -e "AGENTTEAMS_MINIO_USER=${AGENTTEAMS_MINIO_USER}"
-            -e "AGENTTEAMS_MINIO_PASSWORD=${AGENTTEAMS_MINIO_PASSWORD}"
-            -e "AGENTTEAMS_LLM_PROVIDER=${AGENTTEAMS_LLM_PROVIDER}"
-            -e "AGENTTEAMS_LLM_API_KEY=${AGENTTEAMS_LLM_API_KEY}"
-            -e "AGENTTEAMS_DEFAULT_MODEL=${AGENTTEAMS_DEFAULT_MODEL}"
-            -e "AGENTTEAMS_MANAGER_GATEWAY_KEY=${AGENTTEAMS_MANAGER_GATEWAY_KEY}"
-            -e "AGENTTEAMS_MANAGER_RUNTIME=${AGENTTEAMS_MANAGER_RUNTIME:-copaw}"
-            -e "AGENTTEAMS_MANAGER_IMAGE=$([ "${AGENTTEAMS_MANAGER_RUNTIME}" = "copaw" ] && echo "${MANAGER_COPAW_IMAGE}" || echo "${MANAGER_IMAGE}")"
-            -e "AGENTTEAMS_DEFAULT_WORKER_RUNTIME=${AGENTTEAMS_DEFAULT_WORKER_RUNTIME:-copaw}"
-            -e "AGENTTEAMS_WORKER_IMAGE=${WORKER_IMAGE}"
-            -e "AGENTTEAMS_COPAW_WORKER_IMAGE=${COPAW_WORKER_IMAGE}"
-            -e "AGENTTEAMS_HERMES_WORKER_IMAGE=${HERMES_WORKER_IMAGE}"
-            -e "AGENTTEAMS_MATRIX_DOMAIN=${_matrix_domain}"
-            -e "AGENTTEAMS_ELEMENT_HOMESERVER_URL=http://127.0.0.1:${AGENTTEAMS_PORT_GATEWAY}"
-            -e "AGENTTEAMS_MATRIX_URL=http://127.0.0.1:6167"
-            -e "AGENTTEAMS_MATRIX_E2EE=${AGENTTEAMS_MATRIX_E2EE:-0}"
-            -e "AGENTTEAMS_MATRIX_APPSERVICE_ENABLED=${AGENTTEAMS_MATRIX_APPSERVICE_ENABLED:-true}"
-            -e "AGENTTEAMS_MATRIX_APPSERVICE_AS_TOKEN=${AGENTTEAMS_MATRIX_APPSERVICE_AS_TOKEN:-}"
-            -e "AGENTTEAMS_MATRIX_APPSERVICE_HS_TOKEN=${AGENTTEAMS_MATRIX_APPSERVICE_HS_TOKEN:-}"
-            -e "AGENTTEAMS_MINIO_ENDPOINT=http://127.0.0.1:9000"
-            -e "AGENTTEAMS_MINIO_BUCKET=agentteams-storage"
-            -e "AGENTTEAMS_STORAGE_PREFIX=agentteams/agentteams-storage"
-            -e "AGENTTEAMS_FS_ENDPOINT=http://127.0.0.1:9000"
-            -e "AGENTTEAMS_AI_GATEWAY_URL=http://${_aigw_domain}"
-            -e "AGENTTEAMS_CONTROLLER_URL=http://agentteams-controller:8090"
-            -e "AGENTTEAMS_DOCKER_NETWORK=agentteams-net"
-            -e "AGENTTEAMS_WORKSPACE_DIR=${AGENTTEAMS_WORKSPACE_DIR}"
-            -e "AGENTTEAMS_HOST_SHARE_DIR=${AGENTTEAMS_HOST_SHARE_DIR}"
-            -e "AGENTTEAMS_MANAGER_ENABLED=true"
-            -e "AGENTTEAMS_PORT_MANAGER_CONSOLE=${AGENTTEAMS_PORT_MANAGER_CONSOLE:-18888}"
+            -e "${_ctrl_env_prefix}ADMIN_USER=${AGENTTEAMS_ADMIN_USER}"
+            -e "${_ctrl_env_prefix}ADMIN_PASSWORD=${AGENTTEAMS_ADMIN_PASSWORD}"
+            -e "${_ctrl_env_prefix}MANAGER_PASSWORD=${AGENTTEAMS_MANAGER_PASSWORD}"
+            -e "${_ctrl_env_prefix}REGISTRATION_TOKEN=${AGENTTEAMS_REGISTRATION_TOKEN}"
+            -e "${_ctrl_env_prefix}MINIO_USER=${AGENTTEAMS_MINIO_USER}"
+            -e "${_ctrl_env_prefix}MINIO_PASSWORD=${AGENTTEAMS_MINIO_PASSWORD}"
+            -e "${_ctrl_env_prefix}LLM_PROVIDER=${AGENTTEAMS_LLM_PROVIDER}"
+            -e "${_ctrl_env_prefix}LLM_API_KEY=${AGENTTEAMS_LLM_API_KEY}"
+            -e "${_ctrl_env_prefix}DEFAULT_MODEL=${AGENTTEAMS_DEFAULT_MODEL}"
+            -e "${_ctrl_env_prefix}MANAGER_GATEWAY_KEY=${AGENTTEAMS_MANAGER_GATEWAY_KEY}"
+            -e "${_ctrl_env_prefix}MANAGER_RUNTIME=${AGENTTEAMS_MANAGER_RUNTIME:-copaw}"
+            -e "${_ctrl_env_prefix}MANAGER_IMAGE=$([ "${AGENTTEAMS_MANAGER_RUNTIME}" = "copaw" ] && echo "${MANAGER_COPAW_IMAGE}" || echo "${MANAGER_IMAGE}")"
+            -e "${_ctrl_env_prefix}DEFAULT_WORKER_RUNTIME=${AGENTTEAMS_DEFAULT_WORKER_RUNTIME:-copaw}"
+            -e "${_ctrl_env_prefix}WORKER_IMAGE=${WORKER_IMAGE}"
+            -e "${_ctrl_env_prefix}COPAW_WORKER_IMAGE=${COPAW_WORKER_IMAGE}"
+            -e "${_ctrl_env_prefix}HERMES_WORKER_IMAGE=${HERMES_WORKER_IMAGE}"
+            -e "${_ctrl_env_prefix}MATRIX_DOMAIN=${_matrix_domain}"
+            -e "${_ctrl_env_prefix}ELEMENT_HOMESERVER_URL=http://127.0.0.1:${AGENTTEAMS_PORT_GATEWAY}"
+            -e "${_ctrl_env_prefix}MATRIX_URL=http://127.0.0.1:6167"
+            -e "${_ctrl_env_prefix}MATRIX_E2EE=${AGENTTEAMS_MATRIX_E2EE:-0}"
+            -e "${_ctrl_env_prefix}MINIO_ENDPOINT=http://127.0.0.1:9000"
+            -e "${_ctrl_env_prefix}MINIO_BUCKET=agentteams-storage"
+            -e "${_ctrl_env_prefix}STORAGE_PREFIX=agentteams/agentteams-storage"
+            -e "${_ctrl_env_prefix}FS_ENDPOINT=http://127.0.0.1:9000"
+            -e "${_ctrl_env_prefix}AI_GATEWAY_URL=http://${_aigw_domain}"
+            -e "${_ctrl_env_prefix}CONTROLLER_URL=http://agentteams-controller:8090"
+            -e "${_ctrl_env_prefix}DOCKER_NETWORK=agentteams-net"
+            -e "${_ctrl_env_prefix}WORKSPACE_DIR=${AGENTTEAMS_WORKSPACE_DIR}"
+            -e "${_ctrl_env_prefix}HOST_SHARE_DIR=${AGENTTEAMS_HOST_SHARE_DIR}"
+            -e "${_ctrl_env_prefix}MANAGER_ENABLED=true"
+            -e "${_ctrl_env_prefix}PORT_MANAGER_CONSOLE=${AGENTTEAMS_PORT_MANAGER_CONSOLE:-18888}"
         )
+        if _use_legacy_image_env "${AGENTTEAMS_VERSION}"; then
+            _ctrl_env_args+=(
+                -e "${_ctrl_env_prefix}FS_BUCKET=agentteams-storage"
+                -e "${_ctrl_env_prefix}RESOURCE_PREFIX=agentteams-"
+            )
+        else
+            _ctrl_env_args+=(
+                -e "${_ctrl_env_prefix}MATRIX_APPSERVICE_ENABLED=${AGENTTEAMS_MATRIX_APPSERVICE_ENABLED:-true}"
+                -e "${_ctrl_env_prefix}MATRIX_APPSERVICE_AS_TOKEN=${AGENTTEAMS_MATRIX_APPSERVICE_AS_TOKEN:-}"
+                -e "${_ctrl_env_prefix}MATRIX_APPSERVICE_HS_TOKEN=${AGENTTEAMS_MATRIX_APPSERVICE_HS_TOKEN:-}"
+            )
+        fi
 
         # Timezone
         if [ -n "${AGENTTEAMS_TIMEZONE:-}" ]; then
@@ -3460,7 +3479,7 @@ CREDEOF
 
         # Yolo mode
         if [ "${AGENTTEAMS_YOLO:-}" = "1" ]; then
-            _ctrl_env_args+=(-e "AGENTTEAMS_YOLO=1")
+            _ctrl_env_args+=(-e "${_ctrl_env_prefix}YOLO=1")
         fi
 
         # Matrix-plugin debug tracing — propagated to every manager + worker
@@ -3468,100 +3487,45 @@ CREDEOF
         # by the container entrypoints. Use this to diagnose
         # "worker did not join" / "manager replied empty" hangs.
         if [ "${AGENTTEAMS_MATRIX_DEBUG:-}" = "1" ]; then
-            _ctrl_env_args+=(-e "AGENTTEAMS_MATRIX_DEBUG=1")
+            _ctrl_env_args+=(-e "${_ctrl_env_prefix}MATRIX_DEBUG=1")
         fi
 
         # Optional: GitHub token
         if [ -n "${AGENTTEAMS_GITHUB_TOKEN:-}" ]; then
-            _ctrl_env_args+=(-e "AGENTTEAMS_GITHUB_TOKEN=${AGENTTEAMS_GITHUB_TOKEN}")
+            _ctrl_env_args+=(-e "${_ctrl_env_prefix}GITHUB_TOKEN=${AGENTTEAMS_GITHUB_TOKEN}")
         fi
 
         # Optional: embedding model
         if [ -n "${AGENTTEAMS_EMBEDDING_MODEL:-}" ]; then
-            _ctrl_env_args+=(-e "AGENTTEAMS_EMBEDDING_MODEL=${AGENTTEAMS_EMBEDDING_MODEL}")
+            _ctrl_env_args+=(-e "${_ctrl_env_prefix}EMBEDDING_MODEL=${AGENTTEAMS_EMBEDDING_MODEL}")
         fi
 
         # Optional: OpenAI-compatible base URL
         if [ -n "${AGENTTEAMS_OPENAI_BASE_URL:-}" ]; then
-            _ctrl_env_args+=(-e "AGENTTEAMS_OPENAI_BASE_URL=${AGENTTEAMS_OPENAI_BASE_URL}")
+            _ctrl_env_args+=(-e "${_ctrl_env_prefix}OPENAI_BASE_URL=${AGENTTEAMS_OPENAI_BASE_URL}")
         fi
         # Optional: language
         if [ -n "${AGENTTEAMS_LANGUAGE:-}" ]; then
-            _ctrl_env_args+=(-e "AGENTTEAMS_LANGUAGE=${AGENTTEAMS_LANGUAGE}")
+            _ctrl_env_args+=(-e "${_ctrl_env_prefix}LANGUAGE=${AGENTTEAMS_LANGUAGE}")
         fi
 
         # Optional: CMS/ARMS observability. In embedded mode the controller
         # spawns the Manager and Workers, so it must receive these settings.
-        _ctrl_env_args+=(-e "AGENTTEAMS_CMS_TRACES_ENABLED=${AGENTTEAMS_CMS_TRACES_ENABLED:-false}")
-        _ctrl_env_args+=(-e "AGENTTEAMS_CMS_SERVICE_NAME=${AGENTTEAMS_CMS_SERVICE_NAME:-agentteams-manager}")
-        _ctrl_env_args+=(-e "AGENTTEAMS_CMS_METRICS_ENABLED=${AGENTTEAMS_CMS_METRICS_ENABLED:-false}")
+        _ctrl_env_args+=(-e "${_ctrl_env_prefix}CMS_TRACES_ENABLED=${AGENTTEAMS_CMS_TRACES_ENABLED:-false}")
+        _ctrl_env_args+=(-e "${_ctrl_env_prefix}CMS_SERVICE_NAME=${AGENTTEAMS_CMS_SERVICE_NAME:-agentteams-manager}")
+        _ctrl_env_args+=(-e "${_ctrl_env_prefix}CMS_METRICS_ENABLED=${AGENTTEAMS_CMS_METRICS_ENABLED:-false}")
         if [ -n "${AGENTTEAMS_CMS_ENDPOINT:-}" ]; then
-            _ctrl_env_args+=(-e "AGENTTEAMS_CMS_ENDPOINT=${AGENTTEAMS_CMS_ENDPOINT}")
+            _ctrl_env_args+=(-e "${_ctrl_env_prefix}CMS_ENDPOINT=${AGENTTEAMS_CMS_ENDPOINT}")
         fi
         if [ -n "${AGENTTEAMS_CMS_LICENSE_KEY:-}" ]; then
-            _ctrl_env_args+=(-e "AGENTTEAMS_CMS_LICENSE_KEY=${AGENTTEAMS_CMS_LICENSE_KEY}")
+            _ctrl_env_args+=(-e "${_ctrl_env_prefix}CMS_LICENSE_KEY=${AGENTTEAMS_CMS_LICENSE_KEY}")
         fi
         if [ -n "${AGENTTEAMS_CMS_PROJECT:-}" ]; then
-            _ctrl_env_args+=(-e "AGENTTEAMS_CMS_PROJECT=${AGENTTEAMS_CMS_PROJECT}")
+            _ctrl_env_args+=(-e "${_ctrl_env_prefix}CMS_PROJECT=${AGENTTEAMS_CMS_PROJECT}")
         fi
         if [ -n "${AGENTTEAMS_CMS_WORKSPACE:-}" ]; then
-            _ctrl_env_args+=(-e "AGENTTEAMS_CMS_WORKSPACE=${AGENTTEAMS_CMS_WORKSPACE}")
+            _ctrl_env_args+=(-e "${_ctrl_env_prefix}CMS_WORKSPACE=${AGENTTEAMS_CMS_WORKSPACE}")
         fi
-
-        # Begin pre-v1.2 image compatibility
-        # v1.1.x embedded images still read the former environment contract.
-        # Pass both contracts so the renamed installer can boot those images.
-        if _use_legacy_image_env "${AGENTTEAMS_VERSION}"; then
-            _ctrl_env_args+=(
-                -e "HICLAW_ADMIN_USER=${AGENTTEAMS_ADMIN_USER}"
-                -e "HICLAW_ADMIN_PASSWORD=${AGENTTEAMS_ADMIN_PASSWORD}"
-                -e "HICLAW_MANAGER_PASSWORD=${AGENTTEAMS_MANAGER_PASSWORD}"
-                -e "HICLAW_REGISTRATION_TOKEN=${AGENTTEAMS_REGISTRATION_TOKEN}"
-                -e "HICLAW_MINIO_USER=${AGENTTEAMS_MINIO_USER}"
-                -e "HICLAW_MINIO_PASSWORD=${AGENTTEAMS_MINIO_PASSWORD}"
-                -e "HICLAW_LLM_PROVIDER=${AGENTTEAMS_LLM_PROVIDER}"
-                -e "HICLAW_LLM_API_KEY=${AGENTTEAMS_LLM_API_KEY}"
-                -e "HICLAW_DEFAULT_MODEL=${AGENTTEAMS_DEFAULT_MODEL}"
-                -e "HICLAW_MANAGER_GATEWAY_KEY=${AGENTTEAMS_MANAGER_GATEWAY_KEY}"
-                -e "HICLAW_MANAGER_RUNTIME=${AGENTTEAMS_MANAGER_RUNTIME:-copaw}"
-                -e "HICLAW_MANAGER_IMAGE=$([ "${AGENTTEAMS_MANAGER_RUNTIME}" = "copaw" ] && echo "${MANAGER_COPAW_IMAGE}" || echo "${MANAGER_IMAGE}")"
-                -e "HICLAW_DEFAULT_WORKER_RUNTIME=${AGENTTEAMS_DEFAULT_WORKER_RUNTIME:-copaw}"
-                -e "HICLAW_WORKER_IMAGE=${WORKER_IMAGE}"
-                -e "HICLAW_COPAW_WORKER_IMAGE=${COPAW_WORKER_IMAGE}"
-                -e "HICLAW_HERMES_WORKER_IMAGE=${HERMES_WORKER_IMAGE}"
-                -e "HICLAW_MATRIX_DOMAIN=${_matrix_domain}"
-                -e "HICLAW_ELEMENT_HOMESERVER_URL=http://127.0.0.1:${AGENTTEAMS_PORT_GATEWAY}"
-                -e "HICLAW_MATRIX_URL=http://127.0.0.1:6167"
-                -e "HICLAW_MATRIX_E2EE=${AGENTTEAMS_MATRIX_E2EE:-0}"
-                -e "HICLAW_MINIO_ENDPOINT=http://127.0.0.1:9000"
-                -e "HICLAW_MINIO_BUCKET=agentteams-storage"
-                -e "HICLAW_FS_BUCKET=agentteams-storage"
-                -e "HICLAW_STORAGE_PREFIX=agentteams/agentteams-storage"
-                -e "HICLAW_FS_ENDPOINT=http://127.0.0.1:9000"
-                -e "HICLAW_AI_GATEWAY_URL=http://${_aigw_domain}"
-                -e "HICLAW_CONTROLLER_URL=http://agentteams-controller:8090"
-                -e "HICLAW_DOCKER_NETWORK=agentteams-net"
-                -e "HICLAW_WORKSPACE_DIR=${AGENTTEAMS_WORKSPACE_DIR}"
-                -e "HICLAW_HOST_SHARE_DIR=${AGENTTEAMS_HOST_SHARE_DIR}"
-                -e "HICLAW_MANAGER_ENABLED=true"
-                -e "HICLAW_PORT_MANAGER_CONSOLE=${AGENTTEAMS_PORT_MANAGER_CONSOLE:-18888}"
-                -e "HICLAW_RESOURCE_PREFIX=agentteams-"
-                -e "HICLAW_CMS_TRACES_ENABLED=${AGENTTEAMS_CMS_TRACES_ENABLED:-false}"
-                -e "HICLAW_CMS_SERVICE_NAME=${AGENTTEAMS_CMS_SERVICE_NAME:-agentteams-manager}"
-                -e "HICLAW_CMS_METRICS_ENABLED=${AGENTTEAMS_CMS_METRICS_ENABLED:-false}"
-            )
-            [ "${AGENTTEAMS_YOLO:-}" = "1" ] && _ctrl_env_args+=(-e "HICLAW_YOLO=1")
-            [ "${AGENTTEAMS_MATRIX_DEBUG:-}" = "1" ] && _ctrl_env_args+=(-e "HICLAW_MATRIX_DEBUG=1")
-            [ -n "${AGENTTEAMS_GITHUB_TOKEN:-}" ] && _ctrl_env_args+=(-e "HICLAW_GITHUB_TOKEN=${AGENTTEAMS_GITHUB_TOKEN}")
-            [ -n "${AGENTTEAMS_EMBEDDING_MODEL:-}" ] && _ctrl_env_args+=(-e "HICLAW_EMBEDDING_MODEL=${AGENTTEAMS_EMBEDDING_MODEL}")
-            [ -n "${AGENTTEAMS_OPENAI_BASE_URL:-}" ] && _ctrl_env_args+=(-e "HICLAW_OPENAI_BASE_URL=${AGENTTEAMS_OPENAI_BASE_URL}")
-            [ -n "${AGENTTEAMS_LANGUAGE:-}" ] && _ctrl_env_args+=(-e "HICLAW_LANGUAGE=${AGENTTEAMS_LANGUAGE}")
-            [ -n "${AGENTTEAMS_CMS_ENDPOINT:-}" ] && _ctrl_env_args+=(-e "HICLAW_CMS_ENDPOINT=${AGENTTEAMS_CMS_ENDPOINT}")
-            [ -n "${AGENTTEAMS_CMS_LICENSE_KEY:-}" ] && _ctrl_env_args+=(-e "HICLAW_CMS_LICENSE_KEY=${AGENTTEAMS_CMS_LICENSE_KEY}")
-            [ -n "${AGENTTEAMS_CMS_PROJECT:-}" ] && _ctrl_env_args+=(-e "HICLAW_CMS_PROJECT=${AGENTTEAMS_CMS_PROJECT}")
-            [ -n "${AGENTTEAMS_CMS_WORKSPACE:-}" ] && _ctrl_env_args+=(-e "HICLAW_CMS_WORKSPACE=${AGENTTEAMS_CMS_WORKSPACE}")
-        fi
-        # End pre-v1.2 image compatibility
 
         # shellcheck disable=SC2086
         ${DOCKER_CMD} run -d \

--- a/install/agentteams-install.sh
+++ b/install/agentteams-install.sh
@@ -52,6 +52,17 @@ set -e
 AGENTTEAMS_VERSION="${AGENTTEAMS_VERSION:-}"
 AGENTTEAMS_KNOWN_STABLE_VERSION="v1.1.2"   # fallback if GitHub API is unreachable
 
+_normalize_version() {
+    local version="$1"
+    case "${version}" in
+        [0-9]*.[0-9]*.[0-9]*) version="v${version}" ;;
+    esac
+    case "${version}" in
+        v[0-9]*.[0-9]*.[0-9]*.beta.[0-9]*) version="${version/.beta./-beta.}" ;;
+    esac
+    printf '%s' "${version}"
+}
+
 # Returns 0 (true) if $1 < $2 using semver order; "latest" is treated as greatest
 _ver_lt() {
     [ "$1" = "latest" ] && return 1
@@ -1040,6 +1051,7 @@ HERMES_WORKER_IMAGE="${AGENTTEAMS_INSTALL_HERMES_WORKER_IMAGE:-}"
 CONTROLLER_IMAGE="${AGENTTEAMS_INSTALL_CONTROLLER_IMAGE:-}"
 
 resolve_image_tags() {
+    AGENTTEAMS_VERSION="$(_normalize_version "${AGENTTEAMS_VERSION}")"
     MANAGER_IMAGE="${AGENTTEAMS_INSTALL_MANAGER_IMAGE:-${AGENTTEAMS_REGISTRY}/agentteams/agentteams-manager:${AGENTTEAMS_VERSION}}"
     MANAGER_COPAW_IMAGE="${AGENTTEAMS_INSTALL_MANAGER_COPAW_IMAGE:-${AGENTTEAMS_REGISTRY}/agentteams/agentteams-manager-copaw:${AGENTTEAMS_VERSION}}"
     WORKER_IMAGE="${AGENTTEAMS_INSTALL_WORKER_IMAGE:-${AGENTTEAMS_REGISTRY}/agentteams/agentteams-worker:${AGENTTEAMS_VERSION}}"

--- a/install/agentteams-install.sh
+++ b/install/agentteams-install.sh
@@ -59,6 +59,14 @@ _ver_lt() {
     [ "$1" = "$2" ] && return 1
     [ "$(printf '%s\n%s' "$1" "$2" | sort -V | head -1)" = "$1" ]
 }
+
+_use_legacy_image_env() {
+    if [ "$1" = "latest" ]; then
+        _ver_lt "${AGENTTEAMS_KNOWN_STABLE_VERSION}" "v1.2.0"
+    else
+        _ver_lt "$1" "v1.2.0"
+    fi
+}
 AGENTTEAMS_NON_INTERACTIVE="${AGENTTEAMS_NON_INTERACTIVE:-0}"
 AGENTTEAMS_MOUNT_SOCKET="${AGENTTEAMS_MOUNT_SOCKET:-1}"
 AGENTTEAMS_DOCKER_PROXY="${AGENTTEAMS_DOCKER_PROXY:-1}"
@@ -3499,6 +3507,61 @@ CREDEOF
         if [ -n "${AGENTTEAMS_CMS_WORKSPACE:-}" ]; then
             _ctrl_env_args+=(-e "AGENTTEAMS_CMS_WORKSPACE=${AGENTTEAMS_CMS_WORKSPACE}")
         fi
+
+        # Begin pre-v1.2 image compatibility
+        # v1.1.x embedded images still read the former environment contract.
+        # Pass both contracts so the renamed installer can boot those images.
+        if _use_legacy_image_env "${AGENTTEAMS_VERSION}"; then
+            _ctrl_env_args+=(
+                -e "HICLAW_ADMIN_USER=${AGENTTEAMS_ADMIN_USER}"
+                -e "HICLAW_ADMIN_PASSWORD=${AGENTTEAMS_ADMIN_PASSWORD}"
+                -e "HICLAW_MANAGER_PASSWORD=${AGENTTEAMS_MANAGER_PASSWORD}"
+                -e "HICLAW_REGISTRATION_TOKEN=${AGENTTEAMS_REGISTRATION_TOKEN}"
+                -e "HICLAW_MINIO_USER=${AGENTTEAMS_MINIO_USER}"
+                -e "HICLAW_MINIO_PASSWORD=${AGENTTEAMS_MINIO_PASSWORD}"
+                -e "HICLAW_LLM_PROVIDER=${AGENTTEAMS_LLM_PROVIDER}"
+                -e "HICLAW_LLM_API_KEY=${AGENTTEAMS_LLM_API_KEY}"
+                -e "HICLAW_DEFAULT_MODEL=${AGENTTEAMS_DEFAULT_MODEL}"
+                -e "HICLAW_MANAGER_GATEWAY_KEY=${AGENTTEAMS_MANAGER_GATEWAY_KEY}"
+                -e "HICLAW_MANAGER_RUNTIME=${AGENTTEAMS_MANAGER_RUNTIME:-copaw}"
+                -e "HICLAW_MANAGER_IMAGE=$([ "${AGENTTEAMS_MANAGER_RUNTIME}" = "copaw" ] && echo "${MANAGER_COPAW_IMAGE}" || echo "${MANAGER_IMAGE}")"
+                -e "HICLAW_DEFAULT_WORKER_RUNTIME=${AGENTTEAMS_DEFAULT_WORKER_RUNTIME:-copaw}"
+                -e "HICLAW_WORKER_IMAGE=${WORKER_IMAGE}"
+                -e "HICLAW_COPAW_WORKER_IMAGE=${COPAW_WORKER_IMAGE}"
+                -e "HICLAW_HERMES_WORKER_IMAGE=${HERMES_WORKER_IMAGE}"
+                -e "HICLAW_MATRIX_DOMAIN=${_matrix_domain}"
+                -e "HICLAW_ELEMENT_HOMESERVER_URL=http://127.0.0.1:${AGENTTEAMS_PORT_GATEWAY}"
+                -e "HICLAW_MATRIX_URL=http://127.0.0.1:6167"
+                -e "HICLAW_MATRIX_E2EE=${AGENTTEAMS_MATRIX_E2EE:-0}"
+                -e "HICLAW_MINIO_ENDPOINT=http://127.0.0.1:9000"
+                -e "HICLAW_MINIO_BUCKET=agentteams-storage"
+                -e "HICLAW_FS_BUCKET=agentteams-storage"
+                -e "HICLAW_STORAGE_PREFIX=agentteams/agentteams-storage"
+                -e "HICLAW_FS_ENDPOINT=http://127.0.0.1:9000"
+                -e "HICLAW_AI_GATEWAY_URL=http://${_aigw_domain}"
+                -e "HICLAW_CONTROLLER_URL=http://agentteams-controller:8090"
+                -e "HICLAW_DOCKER_NETWORK=agentteams-net"
+                -e "HICLAW_WORKSPACE_DIR=${AGENTTEAMS_WORKSPACE_DIR}"
+                -e "HICLAW_HOST_SHARE_DIR=${AGENTTEAMS_HOST_SHARE_DIR}"
+                -e "HICLAW_MANAGER_ENABLED=true"
+                -e "HICLAW_PORT_MANAGER_CONSOLE=${AGENTTEAMS_PORT_MANAGER_CONSOLE:-18888}"
+                -e "HICLAW_RESOURCE_PREFIX=agentteams-"
+                -e "HICLAW_CMS_TRACES_ENABLED=${AGENTTEAMS_CMS_TRACES_ENABLED:-false}"
+                -e "HICLAW_CMS_SERVICE_NAME=${AGENTTEAMS_CMS_SERVICE_NAME:-agentteams-manager}"
+                -e "HICLAW_CMS_METRICS_ENABLED=${AGENTTEAMS_CMS_METRICS_ENABLED:-false}"
+            )
+            [ "${AGENTTEAMS_YOLO:-}" = "1" ] && _ctrl_env_args+=(-e "HICLAW_YOLO=1")
+            [ "${AGENTTEAMS_MATRIX_DEBUG:-}" = "1" ] && _ctrl_env_args+=(-e "HICLAW_MATRIX_DEBUG=1")
+            [ -n "${AGENTTEAMS_GITHUB_TOKEN:-}" ] && _ctrl_env_args+=(-e "HICLAW_GITHUB_TOKEN=${AGENTTEAMS_GITHUB_TOKEN}")
+            [ -n "${AGENTTEAMS_EMBEDDING_MODEL:-}" ] && _ctrl_env_args+=(-e "HICLAW_EMBEDDING_MODEL=${AGENTTEAMS_EMBEDDING_MODEL}")
+            [ -n "${AGENTTEAMS_OPENAI_BASE_URL:-}" ] && _ctrl_env_args+=(-e "HICLAW_OPENAI_BASE_URL=${AGENTTEAMS_OPENAI_BASE_URL}")
+            [ -n "${AGENTTEAMS_LANGUAGE:-}" ] && _ctrl_env_args+=(-e "HICLAW_LANGUAGE=${AGENTTEAMS_LANGUAGE}")
+            [ -n "${AGENTTEAMS_CMS_ENDPOINT:-}" ] && _ctrl_env_args+=(-e "HICLAW_CMS_ENDPOINT=${AGENTTEAMS_CMS_ENDPOINT}")
+            [ -n "${AGENTTEAMS_CMS_LICENSE_KEY:-}" ] && _ctrl_env_args+=(-e "HICLAW_CMS_LICENSE_KEY=${AGENTTEAMS_CMS_LICENSE_KEY}")
+            [ -n "${AGENTTEAMS_CMS_PROJECT:-}" ] && _ctrl_env_args+=(-e "HICLAW_CMS_PROJECT=${AGENTTEAMS_CMS_PROJECT}")
+            [ -n "${AGENTTEAMS_CMS_WORKSPACE:-}" ] && _ctrl_env_args+=(-e "HICLAW_CMS_WORKSPACE=${AGENTTEAMS_CMS_WORKSPACE}")
+        fi
+        # End pre-v1.2 image compatibility
 
         # shellcheck disable=SC2086
         ${DOCKER_CMD} run -d \

--- a/tests/check-agentteams-rename-defaults.sh
+++ b/tests/check-agentteams-rename-defaults.sh
@@ -6,6 +6,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT_DIR}"
 
 legacy_brand='hi''claw'
+legacy_brand_title='Hi''Claw'
 archive_paths=(
     ':(exclude)blog/**'
     ':(exclude)changelog/**'
@@ -14,9 +15,27 @@ archive_paths=(
 )
 
 if matches="$(git grep -nIi "${legacy_brand}" -- . "${archive_paths[@]}" 2>/dev/null)"; then
-    echo "FAIL: active files still contain the retired brand:" >&2
-    echo "${matches}" >&2
-    exit 1
+    unexpected_matches=""
+    while IFS= read -r match; do
+        case "${match}" in
+            install/agentteams-dashboard-tests.sh:*)
+                ;;
+            install/agentteams-install.sh:*"${legacy_brand}-controller"* | \
+            install/agentteams-install.sh:*"/var/run/${legacy_brand}/cli-token"* | \
+            install/agentteams-install.sh:*"older ${legacy_brand_title} images"* | \
+            install/agentteams-install.sh:*"AgentTeams/${legacy_brand_title} images"*)
+                ;;
+            *)
+                unexpected_matches="${unexpected_matches}${unexpected_matches:+$'\n'}${match}"
+                ;;
+        esac
+    done <<< "${matches}"
+
+    if [ -n "${unexpected_matches}" ]; then
+        echo "FAIL: active files still contain the retired brand:" >&2
+        echo "${unexpected_matches}" >&2
+        exit 1
+    fi
 fi
 
 if paths="$(git ls-files | grep -i "${legacy_brand}" || true)" && [ -n "${paths}" ]; then

--- a/tests/check-agentteams-rename-defaults.sh
+++ b/tests/check-agentteams-rename-defaults.sh
@@ -14,17 +14,6 @@ archive_paths=(
 )
 
 if matches="$(git grep -nIi "${legacy_brand}" -- . "${archive_paths[@]}" 2>/dev/null)"; then
-    compat_start="$(grep -n '^        # Begin pre-v1.2 image compatibility$' install/agentteams-install.sh | cut -d: -f1)"
-    compat_end="$(grep -n '^        # End pre-v1.2 image compatibility$' install/agentteams-install.sh | cut -d: -f1)"
-    matches="$(
-        awk -F: -v start="${compat_start}" -v end="${compat_end}" '
-            $1 == "install/agentteams-install.sh" && $2 >= start && $2 <= end { next }
-            { print }
-        ' <<<"${matches}"
-    )"
-fi
-
-if [ -n "${matches:-}" ]; then
     echo "FAIL: active files still contain the retired brand:" >&2
     echo "${matches}" >&2
     exit 1

--- a/tests/check-agentteams-rename-defaults.sh
+++ b/tests/check-agentteams-rename-defaults.sh
@@ -14,6 +14,17 @@ archive_paths=(
 )
 
 if matches="$(git grep -nIi "${legacy_brand}" -- . "${archive_paths[@]}" 2>/dev/null)"; then
+    compat_start="$(grep -n '^        # Begin pre-v1.2 image compatibility$' install/agentteams-install.sh | cut -d: -f1)"
+    compat_end="$(grep -n '^        # End pre-v1.2 image compatibility$' install/agentteams-install.sh | cut -d: -f1)"
+    matches="$(
+        awk -F: -v start="${compat_start}" -v end="${compat_end}" '
+            $1 == "install/agentteams-install.sh" && $2 >= start && $2 <= end { next }
+            { print }
+        ' <<<"${matches}"
+    )"
+fi
+
+if [ -n "${matches:-}" ]; then
     echo "FAIL: active files still contain the retired brand:" >&2
     echo "${matches}" >&2
     exit 1

--- a/tests/check-installer-pre-1.2-env-compat.sh
+++ b/tests/check-installer-pre-1.2-env-compat.sh
@@ -10,6 +10,7 @@ eval "$(
     sed -n \
         -e '/^_ver_lt()/,/^}/p' \
         -e '/^_use_legacy_image_env()/,/^}/p' \
+        -e '/^_controller_env_prefix()/,/^}/p' \
         "${INSTALLER}"
 )"
 
@@ -37,9 +38,27 @@ AGENTTEAMS_KNOWN_STABLE_VERSION="v1.2.0"
 assert_current "latest"
 
 legacy_prefix='HIC''LAW_'
-compat_block="$(
+assert_prefix() {
+    local version="$1"
+    local expected="$2"
+    local actual
+    actual="$(_controller_env_prefix "${version}")"
+    if [ "${actual}" != "${expected}" ]; then
+        echo "FAIL: expected ${version} to use ${expected}, got ${actual}" >&2
+        exit 1
+    fi
+}
+
+AGENTTEAMS_KNOWN_STABLE_VERSION="v1.1.2"
+assert_prefix "v1.1.2" "${legacy_prefix}"
+assert_prefix "latest" "${legacy_prefix}"
+assert_prefix "v1.2.0" "AGENTTEAMS_"
+assert_prefix "v1.2.0-beta.1" "AGENTTEAMS_"
+assert_prefix "v1.3.0" "AGENTTEAMS_"
+
+controller_env_block="$(
     sed -n \
-        '/# Begin pre-v1.2 image compatibility/,/# End pre-v1.2 image compatibility/p' \
+        '/        # Controller env args/,/        # shellcheck disable=SC2086/p' \
         "${INSTALLER}"
 )"
 
@@ -59,10 +78,15 @@ for suffix in \
     DOCKER_NETWORK \
     RESOURCE_PREFIX
 do
-    if ! grep -Fq "${legacy_prefix}${suffix}=" <<<"${compat_block}"; then
-        echo "FAIL: legacy compatibility block is missing ${legacy_prefix}${suffix}" >&2
+    if ! grep -Fq "\${_ctrl_env_prefix}${suffix}=" <<<"${controller_env_block}"; then
+        echo "FAIL: controller env block does not select ${suffix} through one versioned prefix" >&2
+        exit 1
+    fi
+    if grep -Fq "\"AGENTTEAMS_${suffix}=" <<<"${controller_env_block}" ||
+        grep -Fq "\"${legacy_prefix}${suffix}=" <<<"${controller_env_block}"; then
+        echo "FAIL: controller env block injects an additional fixed-prefix ${suffix}" >&2
         exit 1
     fi
 done
 
-echo "PASS: installer injects legacy image env only below v1.2.0"
+echo "PASS: installer selects exactly one controller env contract by image version"

--- a/tests/check-installer-pre-1.2-env-compat.sh
+++ b/tests/check-installer-pre-1.2-env-compat.sh
@@ -8,11 +8,28 @@ AGENTTEAMS_KNOWN_STABLE_VERSION="v1.1.2"
 
 eval "$(
     sed -n \
+        -e '/^_normalize_version()/,/^}/p' \
         -e '/^_ver_lt()/,/^}/p' \
         -e '/^_use_legacy_image_env()/,/^}/p' \
         -e '/^_controller_env_prefix()/,/^}/p' \
         "${INSTALLER}"
 )"
+
+assert_normalized_version() {
+    local input="$1"
+    local expected="$2"
+    local actual
+    actual="$(_normalize_version "${input}")"
+    if [ "${actual}" != "${expected}" ]; then
+        echo "FAIL: expected ${input} to normalize to ${expected}, got ${actual}" >&2
+        exit 1
+    fi
+}
+
+assert_normalized_version "1.2.0.beta.1" "v1.2.0-beta.1"
+assert_normalized_version "v1.2.0-beta.1" "v1.2.0-beta.1"
+assert_normalized_version "1.1.2" "v1.1.2"
+assert_normalized_version "latest" "latest"
 
 assert_legacy() {
     if ! _use_legacy_image_env "$1"; then
@@ -54,6 +71,7 @@ assert_prefix "v1.1.2" "${legacy_prefix}"
 assert_prefix "latest" "${legacy_prefix}"
 assert_prefix "v1.2.0" "AGENTTEAMS_"
 assert_prefix "v1.2.0-beta.1" "AGENTTEAMS_"
+assert_prefix "$(_normalize_version "1.2.0.beta.1")" "AGENTTEAMS_"
 assert_prefix "v1.3.0" "AGENTTEAMS_"
 
 controller_env_block="$(

--- a/tests/check-installer-pre-1.2-env-compat.sh
+++ b/tests/check-installer-pre-1.2-env-compat.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALLER="${ROOT_DIR}/install/agentteams-install.sh"
+AGENTTEAMS_KNOWN_STABLE_VERSION="v1.1.2"
+
+eval "$(
+    sed -n \
+        -e '/^_ver_lt()/,/^}/p' \
+        -e '/^_use_legacy_image_env()/,/^}/p' \
+        "${INSTALLER}"
+)"
+
+assert_legacy() {
+    if ! _use_legacy_image_env "$1"; then
+        echo "FAIL: expected legacy env compatibility for $1" >&2
+        exit 1
+    fi
+}
+
+assert_current() {
+    if _use_legacy_image_env "$1"; then
+        echo "FAIL: did not expect legacy env compatibility for $1" >&2
+        exit 1
+    fi
+}
+
+assert_legacy "v1.1.2"
+assert_legacy "v1.1.9"
+assert_legacy "latest"
+assert_current "v1.2.0"
+assert_current "v1.2.0-beta.1"
+assert_current "v1.3.0"
+AGENTTEAMS_KNOWN_STABLE_VERSION="v1.2.0"
+assert_current "latest"
+
+legacy_prefix='HIC''LAW_'
+compat_block="$(
+    sed -n \
+        '/# Begin pre-v1.2 image compatibility/,/# End pre-v1.2 image compatibility/p' \
+        "${INSTALLER}"
+)"
+
+for suffix in \
+    REGISTRATION_TOKEN \
+    MINIO_USER \
+    MINIO_PASSWORD \
+    MANAGER_IMAGE \
+    WORKER_IMAGE \
+    COPAW_WORKER_IMAGE \
+    HERMES_WORKER_IMAGE \
+    MATRIX_DOMAIN \
+    MATRIX_URL \
+    MINIO_ENDPOINT \
+    FS_BUCKET \
+    CONTROLLER_URL \
+    DOCKER_NETWORK \
+    RESOURCE_PREFIX
+do
+    if ! grep -Fq "${legacy_prefix}${suffix}=" <<<"${compat_block}"; then
+        echo "FAIL: legacy compatibility block is missing ${legacy_prefix}${suffix}" >&2
+        exit 1
+    fi
+done
+
+echo "PASS: installer injects legacy image env only below v1.2.0"


### PR DESCRIPTION
## What changed

- select exactly one controller environment contract from the requested image version
  - images older than v1.2.0 receive only the legacy environment prefix
  - v1.2.0 and newer images receive only `AGENTTEAMS_*`
- treat `latest` according to the known stable release, so the current v1.1.2 `latest` tag uses the legacy contract
- keep legacy resource names aligned with the renamed installer by using the `agentteams-` resource prefix, network, controller URL, and storage settings
- keep Matrix AppService variables exclusive to the new contract and legacy storage/resource variables exclusive to the old contract
- normalize manual `1.2.0.beta.1` input to the published `v1.2.0-beta.1` image tag
- add a version-boundary regression test and run it in CI

## Why

The v1.1.2 images were mirrored into the new AgentTeams image repository without changing their runtime contract. The current installer injected only `AGENTTEAMS_*`, while those images still read the legacy environment prefix. As a result, Tuwunel received an empty registration token and MinIO received invalid credentials, causing installation to stop while waiting for Matrix.

Selecting one contract by image version fixes old images without mixing old and new runtime configuration in the same container.

## User impact

Users can install the mirrored v1.1.2 images, including the current `latest` tag, with the renamed AgentTeams installer. Images from v1.2.0 onward continue to receive only the new environment contract.

Users may enter either the published `v1.2.0-beta.1` tag or the shorthand `1.2.0.beta.1` in the custom-version prompt.

## Validation

- `bash tests/check-installer-pre-1.2-env-compat.sh`
- `bash tests/check-agentteams-rename-defaults.sh`
- `bash -n install/agentteams-install.sh`
- `git diff --check`
- isolated end-to-end installer smoke using real Matrix and LLM conversations
  - `latest` pulled the v1.1.2 embedded digest
  - v1.1.2 controller environment: legacy prefix present, `AGENTTEAMS_*` absent
  - Tuwunel server-version endpoint responded successfully
  - MinIO live-health endpoint responded successfully
  - the v1.1.2 CoPaw Manager container was created and reached `running`
  - v1.1.2 Manager replied `LATEST_112_SMOKE_OK`
  - manual `1.2.0.beta.1` input pulled `v1.2.0-beta.1` images
  - beta1 controller environment: `AGENTTEAMS_*` present, legacy prefix absent
  - beta1 Manager completed onboarding and replied `BETA_DOT_DIALOGUE_OK`
