### PR TITLE
fix(copaw): fall back to static mc alias in local k8s mode

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -6,6 +6,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 **Bug Fixes**
 
+- **CoPaw k8s worker static alias fallback**: When running in local K8s with self-hosted MinIO, `_ensure_alias()` now falls through to static `mc alias set` if `MC_HOST_{alias}` is not already set by the cloud STS path. Fixes #957.
 - **Team Worker room boundary convergence**: Remove Manager again after standalone Worker infrastructure reconciliation restores regular Team Worker personal-room membership. ([b5b0add](https://github.com/agentscope-ai/AgentTeams/commit/b5b0add))
 - **Team Worker reference enforcement**: Keep referenced Worker CRs protected during direct deletion and reject Team API members whose required role is empty. ([d96f1ed](https://github.com/agentscope-ai/AgentTeams/commit/d96f1ed))
 - **Team Worker room membership**: Force Manager out of regular Team Worker personal rooms when equal Matrix power levels prevent a normal kick. ([43545c2](https://github.com/agentscope-ai/AgentTeams/commit/43545c2))

--- a/copaw/src/copaw_worker/sync.py
+++ b/copaw/src/copaw_worker/sync.py
@@ -320,9 +320,17 @@ class FileSync:
             controller_url,
         )
         if self._k8s_mode:
-            logger.info("_ensure_alias: k8s mode, skipping mc alias set (mc-wrapper handles credentials)")
-            self._alias_set = True
-            return
+            if mc_host_set:
+                logger.info(
+                    "_ensure_alias: k8s mode, MC_HOST_%s already set (cloud STS), skipping mc alias set",
+                    _MC_ALIAS,
+                )
+                self._alias_set = True
+                return
+            logger.info(
+                "_ensure_alias: k8s mode, MC_HOST_%s not set (local MinIO), falling through to static alias setup",
+                _MC_ALIAS,
+            )
         if self._cloud_mode:
             logger.info("_ensure_alias: credential path=sts, refreshing MC_HOST_%s", _MC_ALIAS)
             self._refresh_cloud_credentials()

--- a/copaw/tests/test_sync.py
+++ b/copaw/tests/test_sync.py
@@ -527,3 +527,29 @@ async def test_push_loop_reports_bridge_failure_as_bridge_health(tmp_path, monke
     assert message == "runtime-to-standard bridge failed: runtime bridge failed"
     assert details["operation"] == "bridge_runtime_to_standard"
     assert details["error_type"] == "BridgeRuntimeError"
+
+
+def test_ensure_alias_k8s_with_mc_host_set_skips_static(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENTTEAMS_RUNTIME", "k8s")
+    monkeypatch.setenv("MC_HOST_agentteams", "http://key:secret@minio:9000")
+    sync = _sync(tmp_path)
+    sync._ensure_alias()
+    assert sync._alias_set is True
+
+
+def test_ensure_alias_k8s_without_mc_host_falls_through_static(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENTTEAMS_RUNTIME", "k8s")
+    monkeypatch.delenv("MC_HOST_agentteams", raising=False)
+    sync = _sync(tmp_path)
+    monkeypatch.setattr("copaw_worker.sync._mc", lambda *_args, **_kwargs: None)
+    sync._ensure_alias()
+    assert sync._alias_set is True
+
+
+def test_ensure_alias_non_k8s_uses_static(monkeypatch, tmp_path):
+    monkeypatch.delenv("AGENTTEAMS_RUNTIME", raising=False)
+    monkeypatch.delenv("MC_HOST_agentteams", raising=False)
+    sync = _sync(tmp_path)
+    monkeypatch.setattr("copaw_worker.sync._mc", lambda *_args, **_kwargs: None)
+    sync._ensure_alias()
+    assert sync._alias_set is True


### PR DESCRIPTION
## Summary

This PR fixes #957 by adding a fallback path in `_ensure_alias()` for local K8s deployments with self-hosted MinIO.

## Problem

In v1.1.2, commit `fc1b934` added k8s mode detection that unconditionally skipped mc alias setup when `AGENTTEAMS_RUNTIME=k8s`. This assumed `mc-wrapper.sh` would always provide STS credentials via `MC_HOST_*` environment variables. However, this assumption only holds for Aliyun cloud deployments (RRSA/STS).

In **local K8s deployments with self-hosted MinIO**:
1. `HICLAW_RUNTIME=k8s` → k8s mode = True → alias setup skipped
2. `mc-wrapper.sh` does not set `MC_HOST_hiclaw` (no STS provider)
3. `mc mirror hiclaw/...` fails with alias not found
4. copaw-worker startup fails

## Fix

When `AGENTTEAMS_RUNTIME=k8s`, check if `MC_HOST_{alias}` is already set:
- **If set** (cloud STS mode): skip alias setup as before
- **If not set** (local K8s): fall through to the static `mc alias set` path

## Changes

- `copaw/src/copaw_worker/sync.py`: Modified `_ensure_alias()` to conditionally skip in k8s mode
- `copaw/tests/test_sync.py`: Added 3 unit tests covering:
  1. k8s + MC_HOST set → skip static (cloud STS)
  2. k8s + MC_HOST not set → fall through to static (local MinIO)
  3. non-k8s → use static (unchanged behavior)

## Testing

- [x] `pytest tests/test_sync.py::test_ensure_alias_k8s_with_mc_host_set_skips_static` PASSED
- [x] `pytest tests/test_sync.py::test_ensure_alias_k8s_without_mc_host_falls_through_static` PASSED
- [x] `pytest tests/test_sync.py::test_ensure_alias_non_k8s_uses_static` PASSED