### PR TITLE
Prevent duplicate team creation from informational queries

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -4,3 +4,14 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 ---
 
+**Bug Fixes**
+
+- **Duplicate Team creation guard**: Treat relationship and topology questions as read-only, verify a requested Team name against a valid current Team list, and fail closed when that lookup cannot be completed. ([#987](https://github.com/agentscope-ai/AgentTeams/issues/987))
+
+---
+
+**Bug 修复**
+
+- **重复 Team 创建防护**：将关系与拓扑问题视为只读查询，创建前使用有效的当前 Team 列表核验目标名称，并在列表查询失败时停止创建。([#987](https://github.com/agentscope-ai/AgentTeams/issues/987))
+
+---

--- a/manager/agent/skills/team-management/SKILL.md
+++ b/manager/agent/skills/team-management/SKILL.md
@@ -7,6 +7,16 @@ description: Use when admin requests creating a team, importing a team, managing
 
 A Team consists of 1 Team Leader + N Workers. The Team Leader is a special Worker with management skills that handles task decomposition and assignment within the team. Manager delegates tasks to Team Leaders, not directly to team workers.
 
+## ⚠️ Informational Queries — Read This First
+
+When the admin asks about team structure, relationships, or status (e.g., "what's the relationship between Team X, Leader Y, and Worker Z?", "how are my teams organized?", "explain the team topology"):
+
+1. **DO NOT create or modify teams.** Answer the question directly using `agt get teams -o json` and `agt get workers -o json` to gather facts.
+2. **DO NOT interpret a question as a creation request.** Only create teams when the admin explicitly asks to create a new team ("create a team", "set up a team", "build a team").
+3. **Check before creating.** Run `agt get teams -o json` first to confirm the target team name does not already exist. If the lookup fails, do not create the Team.
+
+If the admin's intent is ambiguous, ask: "Do you want me to create a new team, or are you asking about the existing team structure?"
+
 ## Quick Create
 
 ```bash
@@ -17,6 +27,17 @@ agt create team \
   --workers <w1>,<w2>
 
 # 2. @mention the Leader in Leader Room to assign task
+```
+
+**Pre-flight check before creation:**
+
+```bash
+# Verify no duplicate team exists
+EXISTING=$(agt get teams -o json | jq -r '.teams[] | select(.name == "<team-name>") | .name')
+if [ -n "$EXISTING" ]; then
+  echo "Team already exists: $EXISTING. Skipping creation."
+  # Report existing team info to admin instead of creating duplicate
+fi
 ```
 
 The Team command fails if a referenced Worker does not exist. Configure model, runtime, image, resources, identity, skills, MCP, channel policy, and lifecycle on each Worker CR. After Team reconciliation, @mention the Leader in the Leader Room; the Leader will coordinate referenced workers in the Team Room.
@@ -36,6 +57,7 @@ If admin asks for CPU or memory requests/limits, update `Worker.spec.resources`.
 - **Team Admin defaults to Global Admin** — if `--team-admin` not specified
 - **Delegated tasks use `--delegated-to-team`** — so heartbeat knows to check with Leader, not workers
 - **Team never owns Worker runtime configuration or lifecycle** — update the referenced Worker CR directly
+- **Never create duplicate teams** — always check `agt get teams -o json` before creating; informational queries about team structure do NOT warrant team creation
 
 ## Operation Reference
 

--- a/manager/agent/skills/team-management/scripts/create-team.sh
+++ b/manager/agent/skills/team-management/scripts/create-team.sh
@@ -31,6 +31,24 @@ if [ -z "${TEAM_NAME}" ] || [ -z "${LEADER_NAME}" ]; then
     exit 2
 fi
 
+if ! TEAMS_JSON=$(agt get teams -o json); then
+    echo "ERROR: Failed to list existing teams; refusing to create '${TEAM_NAME}' without a duplicate check." >&2
+    exit 1
+fi
+if ! EXISTING=$(jq -r --arg name "${TEAM_NAME}" '
+    if (.teams | type) != "array" then error("teams must be an array")
+    else .teams[] | select(.name == $name) | .name
+    end
+' <<<"${TEAMS_JSON}"); then
+    echo "ERROR: Failed to parse the existing team list; refusing to create '${TEAM_NAME}'." >&2
+    exit 1
+fi
+if [ -n "${EXISTING}" ]; then
+    echo "ERROR: Team '${TEAM_NAME}' already exists. Skipping creation to avoid duplicate." >&2
+    echo "Use 'agt get teams ${TEAM_NAME} -o json' to inspect the existing team." >&2
+    exit 1
+fi
+
 agt get workers "${LEADER_NAME}" -o json >/dev/null
 IFS=',' read -ra workers <<< "${WORKERS_CSV}"
 for worker in "${workers[@]}"; do

--- a/manager/tests/test-create-team-duplicate-check.sh
+++ b/manager/tests/test-create-team-duplicate-check.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CREATE_TEAM="${SCRIPT_DIR}/../agent/skills/team-management/scripts/create-team.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+cat >"${TMP_DIR}/agt" <<'MOCK'
+#!/bin/bash
+set -euo pipefail
+
+case "$*" in
+    "get teams -o json")
+        if [ "${MOCK_LIST_MODE}" = "fail" ]; then
+            echo "controller unavailable" >&2
+            exit 42
+        fi
+        printf '%s\n' "${MOCK_TEAMS_JSON}"
+        ;;
+    "get workers leader -o json")
+        printf '{"name":"leader"}\n'
+        ;;
+    "get workers worker -o json")
+        printf '{"name":"worker"}\n'
+        ;;
+    "create team --name target --leader-name leader --peer-mentions=true --workers worker")
+        : >"${MOCK_CREATE_LOG}"
+        ;;
+    "get teams target -o json")
+        printf '{"name":"target"}\n'
+        ;;
+    *)
+        echo "unexpected agt invocation: $*" >&2
+        exit 99
+        ;;
+esac
+MOCK
+chmod +x "${TMP_DIR}/agt"
+
+run_create() {
+    PATH="${TMP_DIR}:${PATH}" \
+        MOCK_LIST_MODE="$1" \
+        MOCK_TEAMS_JSON="$2" \
+        MOCK_CREATE_LOG="${TMP_DIR}/created" \
+        bash "${CREATE_TEAM}" --name target --leader leader --workers worker
+}
+
+rm -f "${TMP_DIR}/created"
+if run_create ok '{"teams":[{"name":"target"}]}' >"${TMP_DIR}/out" 2>"${TMP_DIR}/err"; then
+    echo "FAIL: existing Team was created" >&2
+    exit 1
+fi
+grep -q "Team 'target' already exists" "${TMP_DIR}/err"
+grep -q "agt get teams target -o json" "${TMP_DIR}/err"
+test ! -e "${TMP_DIR}/created"
+
+rm -f "${TMP_DIR}/created"
+if ! run_create ok '{"teams":[{"name":"other"}]}' >"${TMP_DIR}/out" 2>"${TMP_DIR}/err"; then
+    cat "${TMP_DIR}/err" >&2
+    echo "FAIL: missing Team could not be created" >&2
+    exit 1
+fi
+test -e "${TMP_DIR}/created"
+
+rm -f "${TMP_DIR}/created"
+if run_create fail '{"teams":[]}' >"${TMP_DIR}/out" 2>"${TMP_DIR}/err"; then
+    echo "FAIL: Team was created after the list command failed" >&2
+    exit 1
+fi
+grep -q "Failed to list existing teams" "${TMP_DIR}/err"
+test ! -e "${TMP_DIR}/created"
+
+rm -f "${TMP_DIR}/created"
+if run_create ok '{}' >"${TMP_DIR}/out" 2>"${TMP_DIR}/err"; then
+    echo "FAIL: Team was created from an invalid list response" >&2
+    exit 1
+fi
+grep -q "Failed to parse the existing team list" "${TMP_DIR}/err"
+test ! -e "${TMP_DIR}/created"
+
+echo "PASS: create-team duplicate checks fail closed"


### PR DESCRIPTION
## Summary
- **Bug fix**: Manager incorrectly created duplicate teams when asked about team relationships
- **Root cause**: No guardrail in team-management skill to distinguish informational queries from explicit creation requests
- **Fix**: Added guardrails in SKILL.md + duplicate name detection in create-team.sh

## Changes
- `manager/agent/skills/team-management/SKILL.md`: Added ⚠️ Informational Queries section with explicit rules against creating/modifying teams in response to questions. Added pre-flight check example. Added duplicate creation reminder in Gotchas.
- `manager/agent/skills/team-management/scripts/create-team.sh`: Added duplicate name detection that fails fast with a clear error message if a team with the same name already exists
- `changelog/current.md`: Added changelog entry

## Test plan
- [x] Shell syntax validation (`bash -n`)
- [ ] CI run on GitHub
- [ ] Manual: ask Manager about team relationships, verify no duplicate creation

Closes #987