### PR TITLE
[codex] prepare v1.2.0 changelog

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -1,25 +1,83 @@
 # Changelog (Unreleased)
 
-Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `openclaw-base/`, `agentteams-controller/`, and release-facing install/chart changes here before the next release.
+Target release: `v1.2.0`
+
+Comparison baseline: `v1.2.0-beta.1`
+
+Record release-facing changes here before the next release.
 
 ---
 
+**Breaking Changes / Migration Notes**
+
+- **AgentTeams naming is now the only active runtime contract**: Installer and Helm entrypoints, controller packages, the `agt` CLI, environment variables, runtime paths, resource names, and storage prefixes use the AgentTeams contract end to end. Retired HiClaw wrappers and active-source compatibility branches have been removed; deployments upgrading from older manifests or scripts must move to the AgentTeams names. ([#1063](https://github.com/agentscope-ai/AgentTeams/pull/1063), [#1065](https://github.com/agentscope-ai/AgentTeams/pull/1065))
+- **Team and Worker resources use the final v1.2 contract**: Team resources reference independently managed Worker CRs through `spec.workerMembers`. Inline Worker members, registry migration paths, and dependent legacy scripts are no longer supported. ([#1072](https://github.com/agentscope-ai/AgentTeams/pull/1072))
+
+**What's New**
+
+- **Optional AgentTeams Dashboard**: Local installation can deploy the AgentTeams Dashboard for visual Worker, Team, Human, Manager, and Matrix management. Dashboard versioning remains independent from the AgentTeams release. ([#1075](https://github.com/agentscope-ai/AgentTeams/pull/1075), [#1081](https://github.com/agentscope-ai/AgentTeams/pull/1081))
+
 **Bug Fixes**
 
-- **Worker storage sync I/O amplification**: Upload changed workspace files once per successful watermark, keep jq 1.7 fallback pulls alive, and limit embedded Controller mirrors to control-plane configuration. ([#1107](https://github.com/agentscope-ai/AgentTeams/issues/1107))
-- **CoPaw Worker workspace projection**: Write Worker prompts, skills, tool configuration, and Matrix agent settings into CoPaw's default workspace so Team Leaders load their assigned role and join the Team Room. ([9074def](https://github.com/agentscope-ai/AgentTeams/commit/9074def3))
-- **Team Worker room boundary convergence**: Remove Manager again after standalone Worker infrastructure reconciliation restores regular Team Worker personal-room membership. ([b5b0add](https://github.com/agentscope-ai/AgentTeams/commit/b5b0add))
-- **Team Worker reference enforcement**: Keep referenced Worker CRs protected during direct deletion and reject Team API members whose required role is empty. ([d96f1ed](https://github.com/agentscope-ai/AgentTeams/commit/d96f1ed))
-- **Team Worker room membership**: Force Manager out of regular Team Worker personal rooms when equal Matrix power levels prevent a normal kick. ([43545c2](https://github.com/agentscope-ai/AgentTeams/commit/43545c2))
-- **CoPaw Team assignment localparts**: Route Team Leader assignments that mention a Team Worker by Matrix localpart from Leader DM to Team Room. ([973e291](https://github.com/agentscope-ai/AgentTeams/commit/973e291))
-- **CoPaw Team coordination routing**: Route Team Leader worker assignments sent through the `message` tool from Leader DM to Team Room, matching the Matrix channel send path. ([92c8145](https://github.com/agentscope-ai/AgentTeams/commit/92c8145))
-- **Pinned OpenClaw source fetch**: Fetch the pinned OpenClaw commit directly so the base image build does not depend on a retired-brand external branch name. ([b0081c2](https://github.com/agentscope-ai/AgentTeams/commit/b0081c2))
+- **Worker storage sync I/O amplification**: Upload changed workspace files once per successful watermark, keep jq 1.7 fallback pulls alive, and limit embedded Controller mirrors to control-plane configuration. Concurrent Worker creation and large unknown workspace paths retain their existing persistence semantics without repeated whole-workspace mirrors. ([#1110](https://github.com/agentscope-ai/AgentTeams/pull/1110))
+- **CoPaw Team routing and workspace projection**: Route Team Leader assignments to the Team Room, including localpart mentions, and project Worker prompts, skills, tool configuration, and Matrix settings into CoPaw's default workspace. ([#1060](https://github.com/agentscope-ai/AgentTeams/pull/1060), [9074def](https://github.com/agentscope-ai/AgentTeams/commit/9074def3), [973e291](https://github.com/agentscope-ai/AgentTeams/commit/973e291), [92c8145](https://github.com/agentscope-ai/AgentTeams/commit/92c8145))
+- **Team room and Worker lifecycle convergence**: Keep referenced Worker CRs protected, enforce required Team roles, remove Manager from regular Team Worker personal rooms, and restore standalone membership when a Worker leaves a Team. ([d96f1ed](https://github.com/agentscope-ai/AgentTeams/commit/d96f1ed), [43545c2](https://github.com/agentscope-ai/AgentTeams/commit/43545c2), [b5b0add](https://github.com/agentscope-ai/AgentTeams/commit/b5b0add), [a5d6435](https://github.com/agentscope-ai/AgentTeams/commit/a5d6435))
+- **Pre-v1.2 installer compatibility**: Select the legacy environment contract and storage prefix for v1.1.2 images while keeping the canonical AgentTeams contract for v1.2.0 and newer images. Custom version input such as `1.2.0.beta.1` is normalized to the published tag form. ([#1079](https://github.com/agentscope-ai/AgentTeams/pull/1079), [#1100](https://github.com/agentscope-ai/AgentTeams/pull/1100))
+- **Dashboard installation reliability**: Preserve quick-start and keep-all behavior, restore Worker credentials during upgrade, improve gateway probing and verification, and clean up Dashboard data on uninstall. ([#1081](https://github.com/agentscope-ai/AgentTeams/pull/1081))
+- **Tooling and diagnostics safety**: Reject unsafe plugin archive links, redact complete Matrix events in debug bundles, generate runnable Worker ZIP import commands, analyze current OpenClaw cron files, capture immediate replay replies, and persist containerized skopeo authentication. ([#1043](https://github.com/agentscope-ai/AgentTeams/pull/1043), [#1045](https://github.com/agentscope-ai/AgentTeams/pull/1045), [#1047](https://github.com/agentscope-ai/AgentTeams/pull/1047), [#1048](https://github.com/agentscope-ai/AgentTeams/pull/1048), [#1049](https://github.com/agentscope-ai/AgentTeams/pull/1049), [#1050](https://github.com/agentscope-ai/AgentTeams/pull/1050))
 
-**Branding and Compatibility**
+---
 
-- **Pre-v1.2 installer storage prefix**: Select the legacy `hiclaw/agentteams-storage` prefix for v1.1.2 images while keeping the AgentTeams prefix for v1.2 and newer images. ([ed81b7b](https://github.com/agentscope-ai/AgentTeams/commit/ed81b7b9))
-- **Complete AgentTeams runtime rename**: Rename installer and Helm entrypoints, the controller Go module and CLI, and container filesystem paths to AgentTeams while preserving thin compatibility aliases and upgrade migration for existing HiClaw installations. ([3121f5f](https://github.com/agentscope-ai/AgentTeams/commit/3121f5f))
-- **Hard-cut AgentTeams naming**: Remove retired-brand installer wrappers, environment fallbacks, CLI aliases, Helm naming branches, runtime path migrations, and active source paths so fresh AgentTeams deployments use one canonical contract end to end. ([d20e606](https://github.com/agentscope-ai/AgentTeams/commit/d20e606617edefbbc42c28c1201c5629fa73fd88))
-- **Hard-cut Team and Worker resources**: Make Worker CRs the sole owners of runtime configuration and lifecycle, make Team CRs reference existing Workers through `spec.workerMembers`, and remove inline-member, registry, migration, and dependent-script compatibility paths. ([b3cf360](https://github.com/agentscope-ai/AgentTeams/commit/b3cf360))
-- **Terminal Team API consumers**: Preserve Team admin and human-member fields in `agt` JSON output, and update integration cleanup and Team DAG setup for independently managed Worker CRs. ([cd05efe](https://github.com/agentscope-ai/AgentTeams/commit/cd05efe))
-- **Terminal Team room topology**: Remove Manager from regular Team Worker personal rooms while retaining the Leader room, and restore Manager membership when Workers return to standalone operation. ([a5d6435](https://github.com/agentscope-ai/AgentTeams/commit/a5d6435))
+**破坏性变更 / 升级说明**
+
+- **AgentTeams 命名成为唯一生效的运行时契约**：安装器与 Helm 入口、Controller 包、`agt` CLI、环境变量、运行时路径、资源名称和存储前缀已端到端统一为 AgentTeams。旧 HiClaw wrapper 和活跃源码中的兼容分支已移除；从旧清单或脚本升级时必须切换到 AgentTeams 命名。([#1063](https://github.com/agentscope-ai/AgentTeams/pull/1063), [#1065](https://github.com/agentscope-ai/AgentTeams/pull/1065))
+- **Team 与 Worker 资源使用 v1.2 最终契约**：Team 通过 `spec.workerMembers` 引用独立管理的 Worker CR；不再支持内联 Worker 成员、registry 迁移路径及其依赖的旧脚本。([#1072](https://github.com/agentscope-ai/AgentTeams/pull/1072))
+
+**新增功能**
+
+- **可选 AgentTeams Dashboard**：本地安装可部署 AgentTeams Dashboard，用于可视化管理 Worker、Team、Human、Manager 和 Matrix；Dashboard 版本继续与 AgentTeams 版本独立。([#1075](https://github.com/agentscope-ai/AgentTeams/pull/1075), [#1081](https://github.com/agentscope-ai/AgentTeams/pull/1081))
+
+**Bug 修复**
+
+- **Worker 存储同步 I/O 放大**：基于成功 watermark 只上传变化文件，保持 jq 1.7 fallback pull 存活，并将 embedded Controller mirror 限定为控制面配置。并发创建 Worker 和未知工作目录仍保持原有持久化语义，不再反复执行全量 workspace mirror。([#1110](https://github.com/agentscope-ai/AgentTeams/pull/1110))
+- **CoPaw Team 路由与 workspace 投影**：将 Team Leader 分配（包括 localpart mention）路由到 Team Room，并把 Worker prompt、skills、工具配置和 Matrix 设置投影到 CoPaw 默认 workspace。([#1060](https://github.com/agentscope-ai/AgentTeams/pull/1060), [9074def](https://github.com/agentscope-ai/AgentTeams/commit/9074def3), [973e291](https://github.com/agentscope-ai/AgentTeams/commit/973e291), [92c8145](https://github.com/agentscope-ai/AgentTeams/commit/92c8145))
+- **Team Room 与 Worker 生命周期收敛**：保护被引用的 Worker CR，强制校验 Team 必填角色，将 Manager 移出普通 Team Worker 的个人房间，并在 Worker 离开 Team 后恢复 standalone 成员关系。([d96f1ed](https://github.com/agentscope-ai/AgentTeams/commit/d96f1ed), [43545c2](https://github.com/agentscope-ai/AgentTeams/commit/43545c2), [b5b0add](https://github.com/agentscope-ai/AgentTeams/commit/b5b0add), [a5d6435](https://github.com/agentscope-ai/AgentTeams/commit/a5d6435))
+- **v1.2 之前镜像的安装兼容**：v1.1.2 镜像使用旧环境变量契约和存储前缀，v1.2.0 及更新镜像使用 AgentTeams 契约；`1.2.0.beta.1` 等自定义输入会规范化为已发布的 Tag 格式。([#1079](https://github.com/agentscope-ai/AgentTeams/pull/1079), [#1100](https://github.com/agentscope-ai/AgentTeams/pull/1100))
+- **Dashboard 安装可靠性**：保留 quick-start 与 keep-all 行为，升级时恢复 Worker 凭据，改进网关探测与安装验证，并在卸载时清理 Dashboard 数据。([#1081](https://github.com/agentscope-ai/AgentTeams/pull/1081))
+- **工具与诊断安全性**：拒绝不安全的插件归档链接，完整脱敏调试包中的 Matrix 事件，生成可直接运行的 Worker ZIP 导入命令，识别当前 OpenClaw cron 格式，捕获即时 replay 回复，并持久化容器化 skopeo 的认证信息。([#1043](https://github.com/agentscope-ai/AgentTeams/pull/1043), [#1045](https://github.com/agentscope-ai/AgentTeams/pull/1045), [#1047](https://github.com/agentscope-ai/AgentTeams/pull/1047), [#1048](https://github.com/agentscope-ai/AgentTeams/pull/1048), [#1049](https://github.com/agentscope-ai/AgentTeams/pull/1049), [#1050](https://github.com/agentscope-ai/AgentTeams/pull/1050))
+
+---
+
+**Change list / 变更列表**
+
+- `688ec362` fix(cli): reject unsafe plugin archive links (#1043)
+- `dc4aafb4` fix(scripts): redact complete Matrix events (#1047)
+- `31d89998` fix(migrate): analyze current cron job format (#1049)
+- `ced0f183` fix(migrate): print runnable ZIP import command (#1048)
+- `47b4d07a` fix(replay): capture immediate manager replies (#1045)
+- `bdc4f640` fix(hack): persist containerized skopeo auth (#1050)
+- `ad941d26` chore: archive changelog for v1.2.0-beta.1 (#1058)
+- `82ef6d24` fix(copaw): route Team Leader assignments to Team Room (#1060)
+- `e84c67ad` fix(install): allow selecting the docker.sock mounted by the installer (#553)
+- `c6249864` docs: clarify Element homeserver port (#978)
+- `ad3f661c` docs: clarify Higress AI route matching (#980)
+- `f301d4d2` docs: clarify OpenAI-compatible provider setup (#1013)
+- `e6fa64c0` refactor: complete AgentTeams runtime rename (#1063)
+- `687b6d94` refactor: complete the AgentTeams hard-cut rename (#1065)
+- `2540c968` docs: add v1.2.0-beta.1 release news (#1066)
+- `0ff89f07` ci: make integration tests safe for fork PRs (#1073)
+- `37c31b77` refactor: hard cut Team and Worker CR contracts (#1072)
+- `82cbd5fe` feat(install): integrate AgentTeams Dashboard as an optional component (#1075)
+- `785c2db5` fix(install): support pre-v1.2 image environment contract (#1079)
+- `8de237da` fix(dashboard): quick-start, Worker credential, and verification follow-ups (#1081)
+- `c789b706` docs: update Chinese README with new features and releases (#1092)
+- `be1f0481` docs: add AgentLoop integration to README (#1093)
+- `fcd4297e` fix(install): use legacy storage prefix for pre-v1.2 images (#1100)
+- `7ba2efba` docs: update AgentLoop link in Chinese README (#1108)
+- `5aec8d96` docs: update AgentLoop link in English README (#1109)
+- `45fd4db2` fix: remove Worker storage sync I/O amplification (#1110)
+
+**Also in this window / 同期其他变更**
+
+- Documentation clarifies Element homeserver ports, Higress AI route matching, OpenAI-compatible provider setup, AgentLoop integration, and the v1.2.0-beta.1 release experience. ([#978](https://github.com/agentscope-ai/AgentTeams/pull/978), [#980](https://github.com/agentscope-ai/AgentTeams/pull/980), [#1013](https://github.com/agentscope-ai/AgentTeams/pull/1013), [#1066](https://github.com/agentscope-ai/AgentTeams/pull/1066), [#1092](https://github.com/agentscope-ai/AgentTeams/pull/1092), [#1093](https://github.com/agentscope-ai/AgentTeams/pull/1093))
+- Integration Tests now use the unprivileged `pull_request` context for fork and Dependabot changes while preserving the complete trusted-branch matrix. ([#1073](https://github.com/agentscope-ai/AgentTeams/pull/1073))

--- a/install/agentteams-install.sh
+++ b/install/agentteams-install.sh
@@ -59,7 +59,7 @@
 set -e
 
 AGENTTEAMS_VERSION="${AGENTTEAMS_VERSION:-}"
-AGENTTEAMS_KNOWN_STABLE_VERSION="v1.1.2"   # fallback if GitHub API is unreachable
+AGENTTEAMS_KNOWN_STABLE_VERSION="v1.2.0"   # fallback if GitHub API is unreachable
 
 _normalize_version() {
     local version="$1"


### PR DESCRIPTION
## Summary

- prepare bilingual `v1.2.0` release notes for the `v1.2.0-beta.1..main` window
- document the AgentTeams and Team/Worker CR hard-cut migration boundaries
- include Dashboard, CoPaw, installer compatibility, and Worker storage sync fixes
- bump `AGENTTEAMS_KNOWN_STABLE_VERSION` to `v1.2.0`

## Validation

- `bash -n install/agentteams-install.sh`
- `bash tests/check-installer-pre-1.2-env-compat.sh`
- `bash tests/check-agentteams-rename-defaults.sh`
- release-note extraction shape checked
- all 26 commits in the release window are represented
- `git diff --check`

## Release gate

After this PR is reviewed, green, and explicitly approved for merge, tag `v1.2.0` from the resulting `main` commit and track Release, image, Helm, integration-test, PyPI, and changelog-archive automation.