### PR TITLE
fix(install): skip QwenPaw pull and update dashboard default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -910,11 +910,11 @@ help: ## Show this help
 # Variables:
 #   DASHBOARD_CONTEXT   Path to dashboard source tree (default: ../agentteams-dashboard)
 #   DASHBOARD_IMAGE     Override dashboard image (derived from DASHBOARD_VERSION by default)
-#   DASHBOARD_VERSION   Dashboard version tag (default: v1.2.0-beta.1)
+#   DASHBOARD_VERSION   Dashboard version tag (default: v1.2.0-beta.2)
 #   AGENTTEAMS_PORT_DASHBOARD   Dashboard host port (default: 13000)
 
 DASHBOARD_CONTEXT ?= ../agentteams-dashboard
-DASHBOARD_VERSION ?= v1.2.0-beta.1
+DASHBOARD_VERSION ?= v1.2.0-beta.2
 DASHBOARD_IMAGE ?= $(REGISTRY)/$(REPO)/agentteams-dashboard:$(DASHBOARD_VERSION)
 AGENTTEAMS_PORT_DASHBOARD ?= 13000
 

--- a/install/agentteams-dashboard-tests.sh
+++ b/install/agentteams-dashboard-tests.sh
@@ -91,8 +91,8 @@ fi
 
 # Test 1c: Default dashboard version is independent of AGENTTEAMS_VERSION
 dashboard_version_line=$(grep -E 'AGENTTEAMS_DASHBOARD_VERSION=.*:-' "${INSTALL_SCRIPT}" | head -1)
-if echo "${dashboard_version_line}" | grep -q 'v1\.2\.0-beta\.1'; then
-    pass "Dashboard has independent default version (v1.2.0-beta.1)"
+if echo "${dashboard_version_line}" | grep -q 'v1\.2\.0-beta\.2'; then
+    pass "Dashboard has independent default version (v1.2.0-beta.2)"
 else
     fail "Dashboard default version line: ${dashboard_version_line}"
 fi
@@ -205,6 +205,11 @@ else
             fail "Makefile missing ${target} target"
         fi
     done
+    if grep -q '^DASHBOARD_VERSION ?= v1\.2\.0-beta\.2$' "${MAKEFILE}"; then
+        pass "Makefile dashboard default version = v1.2.0-beta.2"
+    else
+        fail "Makefile dashboard default version is not v1.2.0-beta.2"
+    fi
 fi
 
 # ---------- Test 8: PowerShell limitation documented ----------
@@ -458,8 +463,8 @@ if echo "${_exec_result}" | grep -q "EXTRACTION_FAILED\|FUNCTION_NOT_FOUND"; the
     fail "Exec non-interactive enabled: cannot verify (extraction failed)"
 else
     # Test 15a: Version is correct
-    if echo "${_exec_result}" | grep -q "RESULT_VERSION=v1.2.0-beta.1"; then
-        pass "Exec non-interactive: default version = v1.2.0-beta.1"
+    if echo "${_exec_result}" | grep -q "RESULT_VERSION=v1.2.0-beta.2"; then
+        pass "Exec non-interactive: default version = v1.2.0-beta.2"
     else
         fail "Exec non-interactive: wrong version (got: $(echo "${_exec_result}" | grep RESULT_VERSION))"
     fi
@@ -472,7 +477,7 @@ else
     fi
 
     # Test 15c: Image contains correct tag
-    if echo "${_exec_result}" | grep -q "RESULT_IMAGE=.*agentteams-dashboard:v1.2.0-beta.1"; then
+    if echo "${_exec_result}" | grep -q "RESULT_IMAGE=.*agentteams-dashboard:v1.2.0-beta.2"; then
         pass "Exec non-interactive: image tag matches version"
     else
         fail "Exec non-interactive: wrong image tag"
@@ -831,7 +836,7 @@ else
     else
         fail "Exec quick-start: wrong port (got: $(echo "${_qs_result}" | grep RESULT_PORT))"
     fi
-    if echo "${_qs_result}" | grep -q "RESULT_IMAGE=.*agentteams-dashboard:v1.2.0-beta.1"; then
+    if echo "${_qs_result}" | grep -q "RESULT_IMAGE=.*agentteams-dashboard:v1.2.0-beta.2"; then
         pass "Exec quick-start: image tag matches default version"
     else
         fail "Exec quick-start: wrong image (got: $(echo "${_qs_result}" | grep RESULT_IMAGE))"

--- a/install/agentteams-install.ps1
+++ b/install/agentteams-install.ps1
@@ -399,7 +399,7 @@ $script:Messages = @{
     # --- Default worker runtime ---
     "worker_runtime.title" = @{ zh = "--- 默认 Worker 运行时 ---"; en = "--- Default Worker Runtime ---" }
     "worker_runtime.openclaw" = @{ zh = "OpenClaw"; en = "OpenClaw" }
-    "worker_runtime.copaw" = @{ zh = "QwenPaw"; en = "QwenPaw" }
+    "worker_runtime.copaw" = @{ zh = "CoPaw"; en = "CoPaw" }
     "worker_runtime.hermes" = @{ zh = "Hermes"; en = "Hermes" }
     "worker_runtime.choice" = @{ zh = "请选择 [1/2/3]"; en = "Enter choice [1/2/3]" }
     "worker_runtime.selected" = @{ zh = "默认 Worker 运行时: {0}"; en = "Default Worker runtime: {0}" }
@@ -408,7 +408,7 @@ $script:Messages = @{
     # --- Manager runtime ---
     "manager_runtime.title" = @{ zh = "--- Manager 运行时 ---"; en = "--- Manager Runtime ---" }
     "manager_runtime.openclaw" = @{ zh = "OpenClaw"; en = "OpenClaw" }
-    "manager_runtime.copaw" = @{ zh = "QwenPaw"; en = "QwenPaw" }
+    "manager_runtime.copaw" = @{ zh = "CoPaw"; en = "CoPaw" }
     "manager_runtime.choice" = @{ zh = "请选择 [1/2]"; en = "Enter choice [1/2]" }
     "manager_runtime.selected" = @{ zh = "Manager 运行时: {0}"; en = "Manager runtime: {0}" }
     "manager_runtime.title_short" = @{ zh = "Manager 运行时"; en = "Manager Runtime" }
@@ -561,7 +561,7 @@ $script:Messages = @{
     "success.higress_console" = @{ zh = "  Higress 控制台: http://localhost:{0}（用户名: {1} / 密码: {2}）"; en = "  Higress Console: http://localhost:{0} (Username: {1} / Password: {2})" }
     "success.manager_console" = @{ zh = "  Manager 控制台（本地）: http://localhost:{0}（无需登录）"; en = "  Manager Console (local): http://localhost:{0} (no login required)" }
     "success.manager_console_gateway" = @{ zh = "  Manager 控制台（网关）: http://console-local.agentteams.io（用户名: {0} / 密码: {1}）"; en = "  Manager Console (gateway): http://console-local.agentteams.io (Username: {0} / Password: {1})" }
-    "success.copaw_console" = @{ zh = "  QwenPaw 控制台（本地）: http://localhost:{0}（无需登录）"; en = "  QwenPaw Console (local): http://localhost:{0} (no login required)" }
+    "success.copaw_console" = @{ zh = "  CoPaw 控制台（本地）: http://localhost:{0}（无需登录）"; en = "  CoPaw Console (local): http://localhost:{0} (no login required)" }
     "success.switch_llm.title" = @{ zh = "--- 切换 LLM 提供商 ---"; en = "--- Switch LLM Providers ---" }
     "success.switch_llm.hint" = @{ zh = "  您可以通过 Higress 控制台切换到其他 LLM 提供商（OpenAI、Anthropic 等）。"; en = "  You can switch to other LLM providers (OpenAI, Anthropic, etc.) via Higress Console." }
     "success.switch_llm.docs" = @{ zh = "  详细说明请参阅:"; en = "  For detailed instructions, see:" }
@@ -2849,7 +2849,14 @@ function Install-Manager {
     }
 
     # Pull all worker runtime images (workers may use any runtime regardless of the default)
-    foreach ($workerImg in @($script:WORKER_IMAGE, $script:COPAW_WORKER_IMAGE, $script:QWENPAW_WORKER_IMAGE, $script:HERMES_WORKER_IMAGE)) {
+    $workerImages = @(
+        $script:WORKER_IMAGE
+        $script:COPAW_WORKER_IMAGE
+        # Temporarily disabled until the QwenPaw worker image is published.
+        # $script:QWENPAW_WORKER_IMAGE
+        $script:HERMES_WORKER_IMAGE
+    )
+    foreach ($workerImg in $workerImages) {
         if ($workerImg -match $LocalImagePattern) {
             if (Test-LocalImage $workerImg) {
                 Write-Log (Get-Msg "install.image.worker_exists" -f $workerImg)

--- a/install/agentteams-install.sh
+++ b/install/agentteams-install.sh
@@ -51,7 +51,7 @@
 #   AGENTTEAMS_PORT_MANAGER_CONSOLE  Host port for Manager console (default: 18888)
 #   AGENTTEAMS_WORKER_IDLE_TIMEOUT  Worker idle timeout in minutes (default: 720, i.e. 12 hours)
 #   AGENTTEAMS_DASHBOARD              Install agentteams-dashboard management UI (default: 1)
-#   AGENTTEAMS_DASHBOARD_VERSION      Dashboard version (default: v1.2.0-beta.1, independent of AgentTeams version)
+#   AGENTTEAMS_DASHBOARD_VERSION      Dashboard version (default: v1.2.0-beta.2, independent of AgentTeams version)
 #   AGENTTEAMS_PORT_DASHBOARD         Dashboard host port (default: 13000)
 #   AGENTTEAMS_DASHBOARD_IMAGE        Override dashboard image (default: <registry>/agentteams/agentteams-dashboard:<DASHBOARD_VERSION>)
 #   AGENTTEAMS_AI_GATEWAY_ADMIN_URL   Higress Console URL for shared auth (auto-detected)
@@ -534,8 +534,8 @@ msg() {
         "port.element_prompt.en") text="Host port for Element Web direct access (8088 inside container)" ;;
         "port.manager_console_prompt.zh") text="Manager 控制台主机端口（容器内 18888）" ;;
         "port.manager_console_prompt.en") text="Host port for Manager console (18888 inside container)" ;;
-        "port.copaw_app_prompt.zh") text="QwenPaw App API 主机端口（容器内 18799）" ;;
-        "port.copaw_app_prompt.en") text="Host port for QwenPaw App API (18799 inside container)" ;;
+        "port.copaw_app_prompt.zh") text="CoPaw App API 主机端口（容器内 18799）" ;;
+        "port.copaw_app_prompt.en") text="Host port for CoPaw App API (18799 inside container)" ;;
         # --- Local-only binding ---
         "port.local_only.title.zh") text="--- 网络访问模式 ---" ;;
         "port.local_only.title.en") text="--- Network Access Mode ---" ;;
@@ -606,8 +606,8 @@ msg() {
         "worker_runtime.title.en") text="--- Default Worker Runtime ---" ;;
         "worker_runtime.openclaw.zh") text="OpenClaw" ;;
         "worker_runtime.openclaw.en") text="OpenClaw" ;;
-        "worker_runtime.copaw.zh") text="QwenPaw" ;;
-        "worker_runtime.copaw.en") text="QwenPaw" ;;
+        "worker_runtime.copaw.zh") text="CoPaw" ;;
+        "worker_runtime.copaw.en") text="CoPaw" ;;
         "worker_runtime.hermes.zh") text="Hermes" ;;
         "worker_runtime.hermes.en") text="Hermes" ;;
         "worker_runtime.choice.zh") text="请选择 [1/2/3]" ;;
@@ -620,8 +620,8 @@ msg() {
         "manager_runtime.title.en") text="--- Manager Runtime ---" ;;
         "manager_runtime.openclaw.zh") text="OpenClaw" ;;
         "manager_runtime.openclaw.en") text="OpenClaw" ;;
-        "manager_runtime.copaw.zh") text="QwenPaw" ;;
-        "manager_runtime.copaw.en") text="QwenPaw" ;;
+        "manager_runtime.copaw.zh") text="CoPaw" ;;
+        "manager_runtime.copaw.en") text="CoPaw" ;;
         "manager_runtime.choice.zh") text="请选择 [1/2]" ;;
         "manager_runtime.choice.en") text="Enter choice [1/2]" ;;
         "manager_runtime.selected.zh") text="Manager 运行时: %s" ;;
@@ -939,8 +939,8 @@ msg() {
         "success.manager_console.en") text="  Manager Console (local): http://localhost:%s (no login required)" ;;
         "success.manager_console_gateway.zh") text="  Manager 控制台（网关）: http://console-local.agentteams.io（用户名: %s / 密码: %s）" ;;
         "success.manager_console_gateway.en") text="  Manager Console (gateway): http://console-local.agentteams.io (Username: %s / Password: %s)" ;;
-        "success.copaw_console.zh") text="  QwenPaw App API: http://localhost:%s（无需登录）" ;;
-        "success.copaw_console.en") text="  QwenPaw App API: http://localhost:%s (no login required)" ;;
+        "success.copaw_console.zh") text="  CoPaw App API: http://localhost:%s（无需登录）" ;;
+        "success.copaw_console.en") text="  CoPaw App API: http://localhost:%s (no login required)" ;;
         "success.switch_llm.title.zh") text="--- 切换 LLM 提供商 ---" ;;
         "success.switch_llm.title.en") text="--- Switch LLM Providers ---" ;;
         "success.switch_llm.hint.zh") text="  您可以通过 Higress 控制台切换到其他 LLM 提供商（OpenAI、Anthropic 等）。" ;;
@@ -2514,7 +2514,7 @@ step_workspace() {
 
 step_dashboard() {
     AGENTTEAMS_DASHBOARD="${AGENTTEAMS_DASHBOARD:-1}"
-    AGENTTEAMS_DASHBOARD_VERSION="${AGENTTEAMS_DASHBOARD_VERSION:-v1.2.0-beta.1}"
+    AGENTTEAMS_DASHBOARD_VERSION="${AGENTTEAMS_DASHBOARD_VERSION:-v1.2.0-beta.2}"
     AGENTTEAMS_PORT_DASHBOARD="${AGENTTEAMS_PORT_DASHBOARD:-13000}"
     AGENTTEAMS_AI_GATEWAY_ADMIN_URL="${AGENTTEAMS_AI_GATEWAY_ADMIN_URL:-}"
 
@@ -3102,7 +3102,7 @@ _start_dashboard() {
     fi
 
     AGENTTEAMS_PORT_DASHBOARD="${AGENTTEAMS_PORT_DASHBOARD:-13000}"
-    AGENTTEAMS_DASHBOARD_VERSION="${AGENTTEAMS_DASHBOARD_VERSION:-v1.2.0-beta.1}"
+    AGENTTEAMS_DASHBOARD_VERSION="${AGENTTEAMS_DASHBOARD_VERSION:-v1.2.0-beta.2}"
     AGENTTEAMS_DASHBOARD_IMAGE="${AGENTTEAMS_DASHBOARD_IMAGE:-${AGENTTEAMS_REGISTRY}/agentteams/agentteams-dashboard:${AGENTTEAMS_DASHBOARD_VERSION}}"
 
     log ""
@@ -3538,7 +3538,7 @@ AGENTTEAMS_HOST_SHARE_DIR=${AGENTTEAMS_HOST_SHARE_DIR:-}
 
 # agentteams-dashboard (management UI)
 AGENTTEAMS_DASHBOARD=${AGENTTEAMS_DASHBOARD:-1}
-AGENTTEAMS_DASHBOARD_VERSION=${AGENTTEAMS_DASHBOARD_VERSION:-v1.2.0-beta.1}
+AGENTTEAMS_DASHBOARD_VERSION=${AGENTTEAMS_DASHBOARD_VERSION:-v1.2.0-beta.2}
 AGENTTEAMS_PORT_DASHBOARD=${AGENTTEAMS_PORT_DASHBOARD:-13000}
 AGENTTEAMS_DASHBOARD_IMAGE=${AGENTTEAMS_DASHBOARD_IMAGE:-${AGENTTEAMS_REGISTRY}/agentteams/agentteams-dashboard:${AGENTTEAMS_DASHBOARD_VERSION}}
 AGENTTEAMS_AI_GATEWAY_ADMIN_URL=${AGENTTEAMS_AI_GATEWAY_ADMIN_URL:-}
@@ -3675,7 +3675,8 @@ EOF
     # Pull all worker runtime images (workers may use any runtime regardless of the default)
     _pull_image "${WORKER_IMAGE}" "install.image.worker_exists" "install.image.pulling_worker"
     _pull_image "${COPAW_WORKER_IMAGE}" "install.image.worker_exists" "install.image.pulling_worker"
-    _pull_image "${QWENPAW_WORKER_IMAGE}" "install.image.worker_exists" "install.image.pulling_worker"
+    # Temporarily disabled until the QwenPaw worker image is published.
+    # _pull_image "${QWENPAW_WORKER_IMAGE}" "install.image.worker_exists" "install.image.pulling_worker"
     _pull_image "${HERMES_WORKER_IMAGE}" "install.image.worker_exists" "install.image.pulling_worker"
 
     # --- Pre-upgrade: extract Matrix passwords from running old containers ---
@@ -4642,7 +4643,7 @@ case "${1:-}" in
         check_container_runtime
         load_current_params_from_env
         AGENTTEAMS_DASHBOARD="${AGENTTEAMS_DASHBOARD:-1}"
-        AGENTTEAMS_DASHBOARD_VERSION="${AGENTTEAMS_DASHBOARD_VERSION:-v1.2.0-beta.1}"
+        AGENTTEAMS_DASHBOARD_VERSION="${AGENTTEAMS_DASHBOARD_VERSION:-v1.2.0-beta.2}"
         AGENTTEAMS_PORT_DASHBOARD="${AGENTTEAMS_PORT_DASHBOARD:-13000}"
         AGENTTEAMS_DASHBOARD_IMAGE="${AGENTTEAMS_DASHBOARD_IMAGE:-${AGENTTEAMS_REGISTRY}/agentteams/agentteams-dashboard:${AGENTTEAMS_DASHBOARD_VERSION}}"
         AGENTTEAMS_USE_EMBEDDED=1


### PR DESCRIPTION
## Summary

- temporarily skip pre-pulling the unavailable QwenPaw worker image in the Bash and PowerShell installers
- rename user-facing QwenPaw installation labels to CoPaw
- update the default Dashboard version and installation hints to v1.2.0-beta.2

## Context

This is a same-repository replacement for #1114 so the `pull_request` integration workflow can use repository CI secrets.

The original commit is preserved verbatim. Original contribution by @NingHua-jzp.

## Testing

- `bash -n install/agentteams-install.sh`
- `bash tests/check-installer-pre-1.2-env-compat.sh`
- `bash tests/check-agentteams-rename-defaults.sh`
- `bash install/agentteams-dashboard-tests.sh` (48/48 passed)
