### PR TITLE
fix(controller): extend embedded worker token lifetime

### DIFF
--- a/agentteams-controller/internal/apiserver/embedded.go
+++ b/agentteams-controller/internal/apiserver/embedded.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/backend"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -107,6 +108,7 @@ func Start(ctx context.Context, cfg Config) (*rest.Config, error) {
 		"--service-account-key-file=" + saPubFile,
 		"--service-account-signing-key-file=" + saKeyFile,
 		"--service-account-issuer=https://agentteams.local",
+		serviceAccountMaxTokenExpirationArg(),
 		"--token-auth-file=" + tokenFile,
 		"--authorization-mode=AlwaysAllow",
 		"--anonymous-auth=true",
@@ -149,6 +151,11 @@ func Start(ctx context.Context, cfg Config) (*rest.Config, error) {
 	}
 
 	return restCfg, nil
+}
+
+func serviceAccountMaxTokenExpirationArg() string {
+	duration := time.Duration(backend.LongLivedAuthTokenExpirationSeconds) * time.Second
+	return "--service-account-max-token-expiration=" + duration.String()
 }
 
 // waitForReady polls the apiserver until it responds to HTTP requests.

--- a/agentteams-controller/internal/apiserver/embedded_test.go
+++ b/agentteams-controller/internal/apiserver/embedded_test.go
@@ -1,0 +1,10 @@
+package apiserver
+
+import "testing"
+
+func TestServiceAccountMaxTokenExpirationArg(t *testing.T) {
+	const want = "--service-account-max-token-expiration=87600h0m0s"
+	if got := serviceAccountMaxTokenExpirationArg(); got != want {
+		t.Fatalf("serviceAccountMaxTokenExpirationArg()=%q, want %q", got, want)
+	}
+}

--- a/agentteams-controller/internal/backend/interface.go
+++ b/agentteams-controller/internal/backend/interface.go
@@ -43,7 +43,10 @@ const (
 	// built-in worker-deps PV, AgentIdentity resources, and AccessKey Secret.
 	BuiltinSandboxInstanceName        = "agentteams"
 	DefaultAuthTokenExpirationSeconds = int64(3600)
-	MinAuthTokenExpirationSeconds     = int64(600)
+	// LongLivedAuthTokenExpirationSeconds is used where a runtime cannot rotate
+	// a projected token, such as a Docker container with an injected token.
+	LongLivedAuthTokenExpirationSeconds = int64(315360000)
+	MinAuthTokenExpirationSeconds       = int64(600)
 )
 
 func NormalizeAuthTokenExpirationSeconds(seconds int64) int64 {

--- a/agentteams-controller/internal/service/provisioner_sa.go
+++ b/agentteams-controller/internal/service/provisioner_sa.go
@@ -118,7 +118,7 @@ func (p *Provisioner) DeleteManagerServiceAccount(ctx context.Context, managerNa
 	return err
 }
 
-// RequestManagerSAToken issues a short-lived SA token for Manager in non-K8s backends.
+// RequestManagerSAToken issues a long-lived SA token for Manager in non-K8s backends.
 func (p *Provisioner) RequestManagerSAToken(ctx context.Context, managerName string) (string, error) {
 	if p.k8sClient == nil {
 		return "", nil
@@ -128,7 +128,7 @@ func (p *Provisioner) RequestManagerSAToken(ctx context.Context, managerName str
 	if audience == "" {
 		audience = authpkg.DefaultAudience
 	}
-	expSeconds := int64(315360000)
+	expSeconds := backend.LongLivedAuthTokenExpirationSeconds
 
 	tokenReq := &authenticationv1.TokenRequest{
 		Spec: authenticationv1.TokenRequestSpec{
@@ -214,7 +214,7 @@ func (p *Provisioner) RequestAdminSAToken(ctx context.Context) (string, error) {
 	if audience == "" {
 		audience = authpkg.DefaultAudience
 	}
-	expSeconds := int64(315360000)
+	expSeconds := backend.LongLivedAuthTokenExpirationSeconds
 
 	tokenReq := &authenticationv1.TokenRequest{
 		Spec: authenticationv1.TokenRequestSpec{
@@ -232,10 +232,10 @@ func (p *Provisioner) RequestAdminSAToken(ctx context.Context) (string, error) {
 	return result.Status.Token, nil
 }
 
-// RequestSAToken issues a short-lived SA token for non-K8s backends (Docker)
-// and remote-managed Edge workers.
+// RequestSAToken issues a long-lived SA token for non-K8s backends (Docker)
+// and remote-managed Edge workers that cannot rotate projected tokens.
 func (p *Provisioner) RequestSAToken(ctx context.Context, workerName string) (string, time.Time, error) {
-	projection, err := p.ProjectSAToken(ctx, workerName, 3600)
+	projection, err := p.ProjectSAToken(ctx, workerName, backend.LongLivedAuthTokenExpirationSeconds)
 	if err != nil || projection == nil {
 		return "", time.Time{}, err
 	}

--- a/agentteams-controller/internal/service/provisioner_sa_test.go
+++ b/agentteams-controller/internal/service/provisioner_sa_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	v1beta1 "github.com/agentscope-ai/AgentTeams/agentteams-controller/api/v1beta1"
 	authpkg "github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/auth"
@@ -12,9 +13,50 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 )
+
+func TestRequestSATokenUsesLongLivedExpiration(t *testing.T) {
+	client := fakeclient.NewSimpleClientset()
+	var requestedExpiration int64
+	client.Fake.PrependReactor("create", "serviceaccounts", func(action ktesting.Action) (bool, runtime.Object, error) {
+		createAction, ok := action.(ktesting.CreateAction)
+		if !ok || action.GetSubresource() != "token" {
+			return false, nil, nil
+		}
+		request, ok := createAction.GetObject().(*authenticationv1.TokenRequest)
+		if !ok || request.Spec.ExpirationSeconds == nil {
+			t.Fatal("expected TokenRequest with expirationSeconds")
+		}
+		requestedExpiration = *request.Spec.ExpirationSeconds
+		return true, &authenticationv1.TokenRequest{
+			Status: authenticationv1.TokenRequestStatus{
+				Token:               "worker-token",
+				ExpirationTimestamp: metav1.NewTime(time.Now().Add(time.Duration(requestedExpiration) * time.Second)),
+			},
+		}, nil
+	})
+
+	p := NewProvisioner(ProvisionerConfig{
+		K8sClient:      client,
+		Namespace:      "agentteams",
+		ResourcePrefix: authpkg.ResourcePrefix("agentteams-"),
+	})
+
+	token, _, err := p.RequestSAToken(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("RequestSAToken: %v", err)
+	}
+	if token != "worker-token" {
+		t.Fatalf("token=%q, want worker-token", token)
+	}
+	if requestedExpiration != backend.LongLivedAuthTokenExpirationSeconds {
+		t.Fatalf("expirationSeconds=%d, want %d", requestedExpiration, backend.LongLivedAuthTokenExpirationSeconds)
+	}
+}
 
 // TestProvisioner_EnsureServiceAccount_StampsControllerLabel verifies that
 // Worker and Manager SAs created by the Provisioner carry

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -19,6 +19,7 @@ Record release-facing changes here before the next release.
 
 **Bug Fixes**
 
+- **Embedded service-account token lifetime**: Allow the embedded API server and non-Kubernetes Worker, Manager, and Admin service-account tokens to use a common ten-year lifetime so restarted Docker Workers do not reuse one-hour credentials.
 - **QwenPaw MCP policy startup convergence**: Persist built-in plugin MCP policies before runtime desired-state reloads so a replacement QwenPaw workspace cannot retain the pre-policy interactive approval handler.
 - **QwenPaw Team policy and runtime-aware acceptance**: Merge Team and Worker channel-policy overrides into QwenPaw `runtime.yaml`, wait for public plugin/API state before integration assertions, and verify prompt/config files from the runtime location that consumes them.
 - **QwenPaw 2.0 tool execution**: Preserve QwenPaw's asynchronous tool-result stream while sanitizing output, and allow only the built-in TeamHarness and Workerflow MCP drivers to run without an unavailable interactive approval prompt.
@@ -48,6 +49,7 @@ Record release-facing changes here before the next release.
 
 **Bug 修复**
 
+- **Embedded ServiceAccount Token 有效期**：将 embedded API Server 与非 Kubernetes Worker、Manager、Admin ServiceAccount Token 统一为十年有效期，避免 Docker Worker 重启时继续复用一小时凭证。
 - **Worker 存储同步 I/O 放大**：基于成功 watermark 只上传变化文件，保持 jq 1.7 fallback pull 存活，并将 embedded Controller mirror 限定为控制面配置。并发创建 Worker 和未知工作目录仍保持原有持久化语义，不再反复执行全量 workspace mirror。([#1110](https://github.com/agentscope-ai/AgentTeams/pull/1110))
 - **Manager 诊断循环**：Manager 提示和 Worker 生命周期指引会停止重复执行无效果的排障命令，并以 `agt get workers` 不再列出目标 Worker 作为删除完成边界，避免继续循环探测 Matrix Room。([#975](https://github.com/agentscope-ai/AgentTeams/pull/975))
 - **CoPaw Team 路由与 workspace 投影**：将 Team Leader 分配（包括 localpart mention）路由到 Team Room，并把 Worker prompt、skills、工具配置和 Matrix 设置投影到 CoPaw 默认 workspace。([#1060](https://github.com/agentscope-ai/AgentTeams/pull/1060), [9074def](https://github.com/agentscope-ai/AgentTeams/commit/9074def3), [973e291](https://github.com/agentscope-ai/AgentTeams/commit/973e291), [92c8145](https://github.com/agentscope-ai/AgentTeams/commit/92c8145))


### PR DESCRIPTION
## Summary

- use a ten-year service-account token lifetime for non-Kubernetes Workers
- configure the embedded kube-apiserver to accept the same maximum token lifetime
- add unit coverage for Worker TokenRequest expiration and the embedded API server flag

## Testing

- `go test ./internal/service ./internal/apiserver ./internal/backend`
- verified kube-apiserver v1.31.3 parses `--service-account-max-token-expiration=87600h0m0s`
