### PR TITLE
fix(cli): encode exposed Worker ports as integers

### DIFF
--- a/agentteams-controller/cmd/agt/apply.go
+++ b/agentteams-controller/cmd/agt/apply.go
@@ -289,6 +289,14 @@ func applyWorkerParams(name, model, runtime, image, identity, soul, soulFile,
 			return err
 		}
 	}
+	var exposePorts []map[string]interface{}
+	if expose != "" {
+		var err error
+		exposePorts, err = parseExposePorts(expose)
+		if err != nil {
+			return err
+		}
+	}
 
 	client := NewAPIClient()
 
@@ -309,7 +317,7 @@ func applyWorkerParams(name, model, runtime, image, identity, soul, soulFile,
 		req["skills"] = splitCSV(skills)
 	}
 	if expose != "" {
-		req["expose"] = parseExposePorts(expose)
+		req["expose"] = exposePorts
 	}
 
 	var resp map[string]interface{}

--- a/agentteams-controller/cmd/agt/create.go
+++ b/agentteams-controller/cmd/agt/create.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -92,7 +93,11 @@ func createWorkerCmd() *cobra.Command {
 				req["skills"] = splitCSV(skills)
 			}
 			if expose != "" {
-				req["expose"] = parseExposePorts(expose)
+				ports, err := parseExposePorts(expose)
+				if err != nil {
+					return err
+				}
+				req["expose"] = ports
 			}
 
 			client := NewAPIClient()
@@ -475,13 +480,22 @@ func splitCSV(s string) []string {
 	return result
 }
 
-func parseExposePorts(s string) []map[string]interface{} {
+func parseExposePorts(s string) ([]map[string]interface{}, error) {
+	values := splitCSV(s)
+	if len(values) == 0 {
+		return nil, fmt.Errorf("--expose requires at least one port")
+	}
+
 	var ports []map[string]interface{}
-	for _, p := range splitCSV(s) {
-		port := map[string]interface{}{"port": p}
+	for _, raw := range values {
+		value, err := strconv.Atoi(raw)
+		if err != nil || value < 1 || value > 65535 {
+			return nil, fmt.Errorf("invalid --expose port %q: must be an integer between 1 and 65535", raw)
+		}
+		port := map[string]interface{}{"port": value}
 		ports = append(ports, port)
 	}
-	return ports
+	return ports, nil
 }
 
 func setIfNotEmpty(m map[string]interface{}, key, value string) {

--- a/agentteams-controller/cmd/agt/create.go
+++ b/agentteams-controller/cmd/agt/create.go
@@ -481,17 +481,26 @@ func splitCSV(s string) []string {
 }
 
 func parseExposePorts(s string) ([]map[string]interface{}, error) {
-	values := splitCSV(s)
-	if len(values) == 0 {
+	if strings.TrimSpace(s) == "" {
 		return nil, fmt.Errorf("--expose requires at least one port")
 	}
 
-	var ports []map[string]interface{}
+	values := strings.Split(s, ",")
+	ports := make([]map[string]interface{}, 0, len(values))
+	seen := make(map[int]struct{}, len(values))
 	for _, raw := range values {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			return nil, fmt.Errorf("invalid --expose value %q: port entries must not be empty", s)
+		}
 		value, err := strconv.Atoi(raw)
 		if err != nil || value < 1 || value > 65535 {
 			return nil, fmt.Errorf("invalid --expose port %q: must be an integer between 1 and 65535", raw)
 		}
+		if _, exists := seen[value]; exists {
+			return nil, fmt.Errorf("duplicate --expose port %d", value)
+		}
+		seen[value] = struct{}{}
 		port := map[string]interface{}{"port": value}
 		ports = append(ports, port)
 	}

--- a/agentteams-controller/cmd/agt/create_test.go
+++ b/agentteams-controller/cmd/agt/create_test.go
@@ -32,8 +32,38 @@ func TestParseExposePortsProducesNumericJSONValues(t *testing.T) {
 	}
 }
 
+func TestParseExposePortsAcceptsBoundaryValues(t *testing.T) {
+	ports, err := parseExposePorts("1,65535")
+	if err != nil {
+		t.Fatalf("parseExposePorts: %v", err)
+	}
+	if len(ports) != 2 || ports[0]["port"] != 1 || ports[1]["port"] != 65535 {
+		t.Fatalf("parseExposePorts returned %#v, want ports 1 and 65535", ports)
+	}
+}
+
 func TestParseExposePortsRejectsInvalidValues(t *testing.T) {
-	for _, value := range []string{"not-a-port", "0", "65536", ","} {
+	for _, value := range []string{"", "   ", "not-a-port", "-1", "0", "65536", ","} {
+		t.Run(value, func(t *testing.T) {
+			if _, err := parseExposePorts(value); err == nil {
+				t.Fatalf("parseExposePorts(%q) returned nil error", value)
+			}
+		})
+	}
+}
+
+func TestParseExposePortsRejectsEmptyCSVSegments(t *testing.T) {
+	for _, value := range []string{"8080,", ",8080", "8080,,3000", "8080, ,3000"} {
+		t.Run(value, func(t *testing.T) {
+			if _, err := parseExposePorts(value); err == nil {
+				t.Fatalf("parseExposePorts(%q) returned nil error", value)
+			}
+		})
+	}
+}
+
+func TestParseExposePortsRejectsDuplicatePorts(t *testing.T) {
+	for _, value := range []string{"8080,8080", "8080, 8080", "08080,8080"} {
 		t.Run(value, func(t *testing.T) {
 			if _, err := parseExposePorts(value); err == nil {
 				t.Fatalf("parseExposePorts(%q) returned nil error", value)

--- a/agentteams-controller/cmd/agt/create_test.go
+++ b/agentteams-controller/cmd/agt/create_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -9,6 +10,37 @@ import (
 	"testing"
 	"time"
 )
+
+func TestParseExposePortsProducesNumericJSONValues(t *testing.T) {
+	ports, err := parseExposePorts("8080, 3000")
+	if err != nil {
+		t.Fatalf("parseExposePorts: %v", err)
+	}
+	payload, err := json.Marshal(ports)
+	if err != nil {
+		t.Fatalf("marshal expose ports: %v", err)
+	}
+
+	var decoded []struct {
+		Port int `json:"port"`
+	}
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("expose payload cannot be decoded by the controller API: %v (payload: %s)", err, payload)
+	}
+	if len(decoded) != 2 || decoded[0].Port != 8080 || decoded[1].Port != 3000 {
+		t.Fatalf("decoded expose ports = %#v, want [8080 3000]", decoded)
+	}
+}
+
+func TestParseExposePortsRejectsInvalidValues(t *testing.T) {
+	for _, value := range []string{"not-a-port", "0", "65536", ","} {
+		t.Run(value, func(t *testing.T) {
+			if _, err := parseExposePorts(value); err == nil {
+				t.Fatalf("parseExposePorts(%q) returned nil error", value)
+			}
+		})
+	}
+}
 
 func TestDefaultWorkerModel(t *testing.T) {
 	t.Run("falls back to qwen3.6-plus when env var unset", func(t *testing.T) {

--- a/agentteams-controller/cmd/agt/update.go
+++ b/agentteams-controller/cmd/agt/update.go
@@ -70,7 +70,11 @@ func updateWorkerCmd() *cobra.Command {
 				req["skills"] = splitCSV(skills)
 			}
 			if expose != "" {
-				req["expose"] = parseExposePorts(expose)
+				ports, err := parseExposePorts(expose)
+				if err != nil {
+					return err
+				}
+				req["expose"] = ports
 			}
 
 			if len(req) == 0 {

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -6,6 +6,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 **Bug Fixes**
 
+- **Worker port exposure CLI**: Encode `--expose` values as numeric ports and reject invalid or out-of-range inputs before create, update, or apply requests reach the Controller.
 - **QwenPaw MCP policy startup convergence**: Persist built-in plugin MCP policies before runtime desired-state reloads so a replacement QwenPaw workspace cannot retain the pre-policy interactive approval handler.
 - **QwenPaw Team policy and runtime-aware acceptance**: Merge Team and Worker channel-policy overrides into QwenPaw `runtime.yaml`, wait for public plugin/API state before integration assertions, and verify prompt/config files from the runtime location that consumes them.
 - **QwenPaw 2.0 tool execution**: Preserve QwenPaw's asynchronous tool-result stream while sanitizing output, and allow only the built-in TeamHarness and Workerflow MCP drivers to run without an unavailable interactive approval prompt.
@@ -20,6 +21,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 **Bug 修复**
 
+- **Worker 端口暴露 CLI**：将 `--expose` 参数编码为数值端口，并在创建、更新或应用请求到达 Controller 前拒绝无效或越界输入。
 - **Manager 诊断循环**：Manager 提示和 Worker 生命周期指引会停止重复执行无效果的排障命令，并以 `agt get workers` 不再列出目标 Worker 作为删除完成边界，避免继续循环探测 Matrix Room。([#975](https://github.com/agentscope-ai/AgentTeams/pull/975))
 
 ---


### PR DESCRIPTION
Fixes #1122

## Summary

- Parse `--expose` CSV values into integer JSON ports.
- Reject empty, non-numeric, and out-of-range ports before an API request is sent.
- Reuse the same validated encoding in `create worker`, `update worker`, and `apply worker`.
- Add regression coverage and update the current changelog.

## Root cause

`parseExposePorts` previously stored each CSV token directly in `map[string]interface{}`. Since those tokens were Go strings, `encoding/json` produced payloads such as:

```json
{"expose":[{"port":"8080"}]}
```

The Controller's `ExposePort.Port` field is an integer, so otherwise valid `--expose` requests failed during JSON decoding.

## Validation

- `go test ./cmd/agt -count=1`
- `go vet ./cmd/agt`
- `git diff --check`
- Independent code review and verification: no blocking findings

I also ran `go test ./... -count=1`. All affected packages passed; the full suite still reports two pre-existing Windows baseline failures, reproduced on an untouched checkout of `47c8f28`:

- `internal/controller/TestCreateMemberContainerQwenPawWaitsForRuntimeConfig` times out.
- Two `internal/oss` tests cannot execute their temporary extensionless `mc` fixture on Windows.