### PR TITLE
fix: enforce LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Shell scripts must remain executable by Unix shells after Windows checkouts.
+*.sh text eol=lf


### PR DESCRIPTION
## Summary

- add a root `.gitattributes` rule for tracked Shell scripts
- keep `*.sh` files on LF when cloned with Git for Windows and `core.autocrlf=true`
- prevent WSL and Git Bash parser failures caused by CRLF working-tree files

Closes #1133

## Validation

- confirmed all 141 tracked `*.sh` files report `w/lf`
- ran `bash -n` successfully against all 141 tracked Shell scripts
- verified `install/agentteams-install.sh` and `install/agentteams-apply.sh` individually return syntax-check exit code 0
- confirmed the staged change contains only `.gitattributes`