### PR TITLE
chore: prepare v1.2.1 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,9 +62,7 @@ jobs:
           echo "sha_short=${SHA_SHORT}" >> $GITHUB_OUTPUT
           if [[ "${{ github.ref }}" == refs/tags/* ]]; then
             echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
-            # Keep QwenPaw available for explicit workflow_dispatch builds, but
-            # defer publishing it as part of the automatic release set.
-            echo "targets=openclaw-base agentteams-controller embedded manager manager-qwenpaw worker copaw-worker hermes-worker" >> $GITHUB_OUTPUT
+            echo "targets=openclaw-base agentteams-controller embedded manager manager-qwenpaw worker copaw-worker qwenpaw-worker hermes-worker" >> $GITHUB_OUTPUT
           else
             # workflow_dispatch: use inputs
             VERSION="${{ inputs.version }}"
@@ -146,6 +144,7 @@ jobs:
           MANAGER_QWENPAW_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-manager-qwenpaw
           WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-worker
           COPAW_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-copaw-worker
+          QWENPAW_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-qwenpaw-worker
           HERMES_WORKER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-hermes-worker
           CONTROLLER_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-controller
           EMBEDDED_IMAGE: ${{ env.REGISTRY }}/${{ env.REPO }}/agentteams-embedded
@@ -159,6 +158,7 @@ jobs:
           echo "- Manager CoPaw: \`${MANAGER_QWENPAW_IMAGE}:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Worker: \`${WORKER_IMAGE}:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
           echo "- CoPaw Worker: \`${COPAW_WORKER_IMAGE}:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- QwenPaw Worker: \`${QWENPAW_WORKER_IMAGE}:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Hermes Worker: \`${HERMES_WORKER_IMAGE}:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Controller: \`${CONTROLLER_IMAGE}:${VERSION}\`" >> $GITHUB_STEP_SUMMARY
           echo "- Embedded: \`${EMBEDDED_IMAGE}:${VERSION}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,9 @@ jobs:
           # Worker
           docker pull ${REGISTRY}/${REPO}/agentteams-worker:${VERSION}
 
+          # QwenPaw Worker
+          docker pull ${REGISTRY}/${REPO}/agentteams-qwenpaw-worker:${VERSION}
+
           # Controller (used standalone in k8s; bundled inside agentteams-embedded for docker installs)
           docker pull ${REGISTRY}/${REPO}/agentteams-controller:${VERSION}
           \`\`\`

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -1,19 +1,23 @@
 # Changelog (Unreleased)
 
-Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `openclaw-base/`, and `agentteams-controller/` here before the next release.
+Target release: `v1.2.1`
+
+Comparison baseline: `v1.2.0`
+
+Record release-facing changes here before the next release.
 
 ---
 
 **What's New**
 
-- **QwenPaw 2.0 runtime unification**: Migrate the Manager container from copaw 1.0.2 to QwenPaw 2.0.1 on a single venv, register projectflow/taskflow/message/filesync tools through a QwenPaw plugin instead of monkey-patching CoPawAgent, replace the physical Matrix channel overlay with the QwenPaw plugin system, read Matrix credentials directly from agent.json so the manager tools work without importing copaw at runtime, align CMS observability packages and env vars with the Worker image, inject session-file privacy policy into prompt files, set approval_level=AUTO in the agent template, bridge YOLO mode to Qwenpaw approval_level=OFF, disable the built-in QA Agent, replace start-copaw-manager.sh with start-qwenpaw-manager.sh, add explicit qwenpaw Manager and Worker runtime values alongside copaw while keeping user-facing installer defaults and image pulls on CoPaw until the QwenPaw release, make task assignment state and Matrix notification atomic with room membership validation and m.mentions delivery, preserve m.mentions metadata in streamed/edit events, make the TeamHarness MCP `delegate_task` path atomic too (validate assignee room membership — strictly `join`, not `invite` — prepare → stable-txn notification → commit assigned + event_id; the initial file publish gates the notification and the assigned/eventId commit gates success, both returning a retryable failure so an idempotent retry finishes the sync instead of reporting success with stale shared storage), and migrate a legacy Worker `.copaw` working dir to `.qwenpaw` on the qwenpaw_worker startup path only (idempotent; the migration follows the target runtime — an explicitly configured copaw Worker keeps `.copaw` and never migrates before a switch).
+- **QwenPaw 2.0 runtime unification**: Migrate the Manager container from copaw 1.0.2 to QwenPaw 2.0.1 on a single venv, register projectflow/taskflow/message/filesync tools through a QwenPaw plugin instead of monkey-patching CoPawAgent, replace the physical Matrix channel overlay with the QwenPaw plugin system, read Matrix credentials directly from agent.json so the manager tools work without importing copaw at runtime, align CMS observability packages and env vars with the Worker image, inject session-file privacy policy into prompt files, set approval_level=AUTO in the agent template, bridge YOLO mode to Qwenpaw approval_level=OFF, disable the built-in QA Agent, replace start-copaw-manager.sh with start-qwenpaw-manager.sh, publish the QwenPaw Worker image as part of the stable release set, make task assignment state and Matrix notification atomic with room membership validation and m.mentions delivery, preserve m.mentions metadata in streamed/edit events, make the TeamHarness MCP `delegate_task` path atomic too (validate assignee room membership — strictly `join`, not `invite` — prepare → stable-txn notification → commit assigned + event_id; the initial file publish gates the notification and the assigned/eventId commit gates success, both returning a retryable failure so an idempotent retry finishes the sync instead of reporting success with stale shared storage), and migrate a legacy Worker `.copaw` working dir to `.qwenpaw` on the qwenpaw_worker startup path only (idempotent; the migration follows the target runtime — an explicitly configured copaw Worker keeps `.copaw` and never migrates before a switch).
 - **Custom model capability overrides**: `AGENTTEAMS_MODEL_VISION` and `AGENTTEAMS_MODEL_REASONING` env vars let deployments override vision and reasoning capabilities for custom models not in the built-in presets table (e.g. local multimodal models like `qwen3.6-27b-fp8`).
 
 **Bug Fixes**
 
 - **QwenPaw Worker runtime management**: Recognize `qwenpaw` as a valid Worker runtime in Manager guidance and runtime-switch validation, invoke the installed `agt` CLI for runtime changes, and align Worker CLI help with the Controller's supported runtimes.
 - **CoPaw Team Worker resolution**: Resolve task assignment Matrix IDs from the Controller-owned `runtime.yaml` Team roster before falling back to legacy `AGENTS.md`, so a running Team Leader can delegate after late Team context injection without relying on a stale prompt copy.
-- **CoPaw to QwenPaw Worker state migration**: Restore Worker storage before creating any QwenPaw directories, migrate and verify both `.copaw` runtime state and `.copaw.secret` credentials with legacy state authoritative on conflicts, honor QwenPaw's configured secret directory (including relative paths) while rejecting targets outside persistent Worker storage, rebase migrated workspace metadata to `.qwenpaw`, persist migrated files before the idempotency marker, and cover a real CoPaw persistence → QwenPaw runtime switch in E2E tests. ([c0b4bac](https://github.com/agentscope-ai/AgentTeams/commit/c0b4bac68ea94fa0887cf14747d368916986c347))
+- **CoPaw to QwenPaw Worker state migration**: Restore Worker storage before creating any QwenPaw directories, migrate and verify both `.copaw` runtime state and `.copaw.secret` credentials with legacy state authoritative on conflicts, honor QwenPaw's configured secret directory (including relative paths) while rejecting targets outside persistent Worker storage, rebase migrated workspace metadata to `.qwenpaw`, persist migrated files before the idempotency marker, and cover a real CoPaw persistence → QwenPaw runtime switch in E2E tests. ([#1131](https://github.com/agentscope-ai/AgentTeams/pull/1131))
 - **Team deletion idempotency**: Verify the target user's current Matrix room membership when Tuwunel returns the ambiguous `joined or banned` invite error, allowing already-joined members to complete Team cleanup without suppressing real bans.
 - **CoPaw Team assignment handoff**: `taskflow(delegate_task)` sends the Worker assignment automatically with `m.mentions` in the Team Room (atomic pending → prepared → assigned state, stable Matrix txn_id for idempotent retries, normalize Worker aliases from the Team roster, refresh Controller-managed runtime context every minute, and reroute assignment replies from non-Team rooms to the Team Room). ([#1120](https://github.com/agentscope-ai/AgentTeams/pull/1120), [#1095](https://github.com/agentscope-ai/AgentTeams/pull/1095))
 - **Docker Worker ServiceAccount token rotation**: Project short-lived tokens into per-Worker Docker volumes, refresh the token file atomically without recreating running Workers, and remove the credential volume with the Worker.
@@ -33,11 +37,16 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 ---
 
+**新增功能**
+
+- **QwenPaw 2.0 运行时统一**：Manager 迁移到 QwenPaw 2.0.1 和原生插件体系，正式发布 QwenPaw Worker 多架构镜像，并完善任务分配原子性、TeamHarness 委派、Matrix mention、运行时策略与 CoPaw 状态迁移。
+- **自定义模型能力覆盖**：可通过 `AGENTTEAMS_MODEL_VISION` 和 `AGENTTEAMS_MODEL_REASONING` 为内置预设表之外的模型显式声明视觉与推理能力。
+
 **Bug 修复**
 
 - **QwenPaw Worker 运行时管理**：在 Manager 指引和运行时切换校验中将 `qwenpaw` 识别为合法 Worker runtime，切换时调用镜像内实际安装的 `agt` CLI，并使 Worker CLI 帮助与 Controller 实际支持的运行时保持一致。
 - **CoPaw Team Worker 解析**：任务分配优先从 Controller 管理的 `runtime.yaml` Team roster 获取 Matrix ID，仅在旧部署缺少该 roster 时回退 `AGENTS.md`，避免运行中的 Team Leader 因 prompt 副本过期而无法委派任务。
-- **CoPaw 到 QwenPaw Worker 状态迁移**：在创建任何 QwenPaw 目录前先恢复 Worker 存储，迁移并校验 `.copaw` 运行时状态和 `.copaw.secret` 凭据，冲突时以旧 CoPaw 状态为准，遵循 QwenPaw 配置的 secret 目录（包括相对路径）并拒绝持久化 Worker 目录之外的目标，将工作区元数据改写到 `.qwenpaw`，先持久化迁移数据再写入幂等标记，并增加真实 CoPaw 持久化后切换 QwenPaw 的 E2E 覆盖。([c0b4bac](https://github.com/agentscope-ai/AgentTeams/commit/c0b4bac68ea94fa0887cf14747d368916986c347))
+- **CoPaw 到 QwenPaw Worker 状态迁移**：在创建任何 QwenPaw 目录前先恢复 Worker 存储，迁移并校验 `.copaw` 运行时状态和 `.copaw.secret` 凭据，冲突时以旧 CoPaw 状态为准，遵循 QwenPaw 配置的 secret 目录（包括相对路径）并拒绝持久化 Worker 目录之外的目标，将工作区元数据改写到 `.qwenpaw`，先持久化迁移数据再写入幂等标记，并增加真实 CoPaw 持久化后切换 QwenPaw 的 E2E 覆盖。([#1131](https://github.com/agentscope-ai/AgentTeams/pull/1131))
 - **Team 删除幂等性**：当 Tuwunel 返回含义不明确的 `joined or banned` 邀请错误时，核验目标用户当前的 Matrix Room 成员状态，使已加入成员能够继续完成 Team 清理，同时不吞掉真实的封禁错误。
 - **CoPaw Team 任务分配交接**：由 `taskflow(delegate_task)` 返回必须执行的 Team Room `message` 动作，根据 Team roster 规范化 Worker 别名，每分钟刷新 Controller 管理的运行时上下文，并将非 Team Room 中的任务分配回复重定向到 Team Room。([#1120](https://github.com/agentscope-ai/AgentTeams/pull/1120))
 - **Worker 端口暴露 CLI**：将 `--expose` 参数编码为数值端口，并在创建、更新或应用请求到达 Controller 前拒绝无效或越界输入。
@@ -47,4 +56,20 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 **Change list / 变更列表**
 
-- `90c9fd4f` fix(manager): stop repeated diagnostic loops (#975)
+- `a6c98182` fix(manager): stop repeated diagnostic loops (#975)
+- `fb3a40be` feat(qwenpaw): adapt worker runtime to QwenPaw 2.0 (#1077)
+- `ce3a4770` fix(install): skip QwenPaw pull and update dashboard default (#1115)
+- `99131d6e` chore: update default dashboard version to v1.2.0 (#1118)
+- `47c8f284` chore: archive changelog for v1.2.0 (#1112)
+- `1145f796` docs: add v1.2.0 release news (#1121)
+- `00a5d20c` fix(cli): encode exposed Worker ports as integers (#1123)
+- `ba161a85` fix(controller): rotate Docker Worker ServiceAccount token files (#1120)
+- `2ea02740` fix(controller): enable multimodal for custom models with env override + openclaw.json injection (#1103)
+- `124f06d1` feat(manager): migrate Manager runtime from copaw to qwenpaw 2.0 (#1095)
+- `2fd9ddde` fix(qwenpaw): preserve CoPaw state during runtime migration (#1131)
+- `062f1c8d` fix(controller): make Team deletion invite idempotent (#1140)
+
+**Also in this window / 同期其他变更**
+
+- Update the bundled Dashboard default to v1.2.0 and publish the v1.2.0 release news. ([#1118](https://github.com/agentscope-ai/AgentTeams/pull/1118), [#1121](https://github.com/agentscope-ai/AgentTeams/pull/1121))
+- Archive the v1.2.0 changelog before collecting the v1.2.1 release window. ([#1112](https://github.com/agentscope-ai/AgentTeams/pull/1112))

--- a/install/agentteams-install.sh
+++ b/install/agentteams-install.sh
@@ -59,7 +59,7 @@
 set -e
 
 AGENTTEAMS_VERSION="${AGENTTEAMS_VERSION:-}"
-AGENTTEAMS_KNOWN_STABLE_VERSION="v1.2.0"   # fallback if GitHub API is unreachable
+AGENTTEAMS_KNOWN_STABLE_VERSION="v1.2.1"   # fallback if GitHub API is unreachable
 
 _normalize_version() {
     local version="$1"

--- a/tests/check-installer-qwenpaw-release-gate.sh
+++ b/tests/check-installer-qwenpaw-release-gate.sh
@@ -6,6 +6,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BASH_INSTALLER="${ROOT_DIR}/install/agentteams-install.sh"
 POWERSHELL_INSTALLER="${ROOT_DIR}/install/agentteams-install.ps1"
 INTEGRATION_WORKFLOW="${ROOT_DIR}/.github/workflows/test-integration.yml"
+BUILD_WORKFLOW="${ROOT_DIR}/.github/workflows/build.yml"
+RELEASE_WORKFLOW="${ROOT_DIR}/.github/workflows/release.yml"
 
 fail() {
     echo "FAIL: $*" >&2
@@ -26,7 +28,7 @@ eval "$(extract_bash_function step_manager_runtime)"
 
 AGENTTEAMS_NON_INTERACTIVE=1
 AGENTTEAMS_UPGRADE=0
-AGENTTEAMS_VERSION=v1.2.0
+AGENTTEAMS_VERSION=v1.2.1
 AGENTTEAMS_DEFAULT_WORKER_RUNTIME=""
 AGENTTEAMS_MANAGER_RUNTIME=""
 
@@ -34,9 +36,9 @@ step_runtime >/dev/null
 step_manager_runtime >/dev/null
 
 [ "${AGENTTEAMS_DEFAULT_WORKER_RUNTIME}" = "copaw" ] ||
-    fail "Bash installer must keep CoPaw as the default Worker runtime before QwenPaw is released"
+    fail "Bash installer must keep CoPaw as the default Worker runtime while QwenPaw remains opt-in"
 [ "${AGENTTEAMS_MANAGER_RUNTIME}" = "copaw" ] ||
-    fail "Bash installer must keep CoPaw as the default Manager runtime before QwenPaw is released"
+    fail "Bash installer must keep CoPaw as the default Manager runtime while QwenPaw remains opt-in"
 
 bash_runtime_blocks="$(
     extract_bash_function step_runtime
@@ -47,10 +49,10 @@ grep -Fq 'worker_runtime.copaw' <<<"${bash_runtime_blocks}" ||
 grep -Fq 'manager_runtime.copaw' <<<"${bash_runtime_blocks}" ||
     fail "Bash installer Manager menu must expose CoPaw"
 if grep -Fq 'runtime.qwenpaw' <<<"${bash_runtime_blocks}"; then
-    fail "Bash installer must not expose QwenPaw in runtime menus before release"
+    fail "Bash installer must not expose QwenPaw in runtime menus while it remains opt-in"
 fi
-if grep -E '_pull_image.*QWENPAW' "${BASH_INSTALLER}" | grep -Eqv '^[[:space:]]*#'; then
-    fail "Bash installer must not pull a QwenPaw image before release"
+if grep -E '_pull_image.*QWENPAW_WORKER_IMAGE' "${BASH_INSTALLER}" | grep -Eqv '^[[:space:]]*#'; then
+    fail "Bash installer must keep the QwenPaw Worker pull gated until the release image is verified"
 fi
 
 powershell_runtime_blocks="$(
@@ -62,15 +64,21 @@ grep -Fq "worker_runtime.copaw" <<<"${powershell_runtime_blocks}" ||
 grep -Fq "manager_runtime.copaw" <<<"${powershell_runtime_blocks}" ||
     fail "PowerShell installer Manager menu must expose CoPaw"
 if grep -Fq 'runtime.qwenpaw' <<<"${powershell_runtime_blocks}"; then
-    fail "PowerShell installer must not expose QwenPaw in runtime menus before release"
+    fail "PowerShell installer must not expose QwenPaw in runtime menus while it remains opt-in"
 fi
 if grep -Ei 'qwenpaw.*MANAGER_QWENPAW_IMAGE' "${POWERSHELL_INSTALLER}" | grep -Eqv '^[[:space:]]*#'; then
-    fail "PowerShell installer must not select a QwenPaw Manager image before release"
+    fail "PowerShell installer must not expose a separate QwenPaw Manager selection"
 fi
 powershell_worker_images="$(sed -n '/\$workerImages = @(/,/^    )/p' "${POWERSHELL_INSTALLER}")"
 if grep -F 'QWENPAW_WORKER_IMAGE' <<<"${powershell_worker_images}" | grep -Eqv '^[[:space:]]*#'; then
-    fail "PowerShell installer must not pull a QwenPaw Worker image before release"
+    fail "PowerShell installer must keep the QwenPaw Worker pull gated until the release image is verified"
 fi
+
+grep -F 'echo "targets=' "${BUILD_WORKFLOW}" | grep -Fq 'qwenpaw-worker' ||
+    fail "Tag-triggered image builds must publish qwenpaw-worker"
+grep -Fq 'docker pull ${REGISTRY}/${REPO}/agentteams-qwenpaw-worker:${VERSION}' \
+    "${RELEASE_WORKFLOW}" ||
+    fail "Release notes must list the versioned QwenPaw Worker image"
 
 for manager_crd in \
     "${ROOT_DIR}/agentteams-controller/config/crd/managers.agentteams.io.yaml" \
@@ -79,10 +87,10 @@ for manager_crd in \
         fail "Manager CRD must keep accepting CoPaw while the installer defaults to CoPaw: ${manager_crd}"
 done
 
-# Fork CI must exercise the PR-built QwenPaw Manager explicitly without
-# changing the public installer's CoPaw default or registry pull behavior.
+# Fork CI must exercise the PR-built QwenPaw Manager explicitly while the
+# public installer keeps CoPaw as the compatibility label and default runtime.
 grep -Fq 'AGENTTEAMS_INSTALL_MANAGER_COPAW_IMAGE: agentteams/manager-qwenpaw:latest' \
     "${INTEGRATION_WORKFLOW}" ||
     fail "Integration CI must explicitly map the CoPaw compatibility label to the PR-built QwenPaw Manager image"
 
-echo "PASS: installers keep QwenPaw behind the release gate"
+echo "PASS: QwenPaw Worker is published while installer pulls remain gated"


### PR DESCRIPTION
## Summary

- prepare the bilingual `v1.2.1` release notes against `v1.2.0`
- update the installer stable-version fallback to `v1.2.1`
- include `qwenpaw-worker` in tag-triggered multi-architecture image publishing and release image documentation
- keep Bash and PowerShell installer pulls for QwenPaw Worker gated until the published registry image is verified
- update the release-gate regression check for the new publish-before-enable sequence

## Verification

- `bash tests/check-installer-qwenpaw-release-gate.sh`
- `bash -n install/agentteams-install.sh`
- PowerShell parser validation for `install/agentteams-install.ps1`
- Ruby YAML parsing for `.github/workflows/build.yml` and `.github/workflows/release.yml`
- `git diff --check`
- `make -n push-qwenpaw-worker VERSION=v1.2.1` produces `v1.2.1` and `latest` tags for `linux/amd64,linux/arm64`

## Release boundary

This PR does not create or push the `v1.2.1` tag. The tag should be pushed only after this PR is merged and the refreshed `main` release gates pass.
