### PR TITLE
fix(controller): join Team members to Team Room

### DIFF
--- a/agentteams-controller/internal/controller/team_controller.go
+++ b/agentteams-controller/internal/controller/team_controller.go
@@ -403,17 +403,26 @@ func (r *TeamReconciler) reconcileTeam(ctx context.Context, t *v1beta1.Team, pat
 				fmt.Sprintf("record team membership for %s: %v", member.runtimeName, err),
 			)
 		}
-		if _, err := r.Provisioner.RefreshWorkerCredentials(
+		credentials, err := r.Provisioner.RefreshWorkerCredentials(
 			ctx,
 			member.ref.Name,
 			member.runtimeName,
 			teamRuntimeName,
-		); err != nil {
+		)
+		if err != nil {
 			return r.failTeam(
 				ctx,
 				t,
 				patchBase,
 				fmt.Sprintf("refresh team storage access for %s: %v", member.runtimeName, err),
+			)
+		}
+		if err := r.Provisioner.JoinRoomAs(ctx, rooms.TeamRoomID, credentials.MatrixToken); err != nil {
+			return r.failTeam(
+				ctx,
+				t,
+				patchBase,
+				fmt.Sprintf("join %s to team room: %v", member.runtimeName, err),
 			)
 		}
 	}

--- a/agentteams-controller/internal/controller/team_controller_test.go
+++ b/agentteams-controller/internal/controller/team_controller_test.go
@@ -854,6 +854,15 @@ func TestReconcileTeamTeamReferences_RoleAwareChannelPolicy(t *testing.T) {
 	provisioner.MatrixUserIDFn = func(name string) string {
 		return "@" + name + ":matrix.local"
 	}
+	type roomJoin struct {
+		roomID string
+		token  string
+	}
+	var roomJoins []roomJoin
+	provisioner.JoinRoomAsFn = func(_ context.Context, roomID, token string) error {
+		roomJoins = append(roomJoins, roomJoin{roomID: roomID, token: token})
+		return nil
+	}
 	r := &TeamReconciler{
 		Client:        c,
 		Provisioner:   provisioner,
@@ -880,6 +889,20 @@ func TestReconcileTeamTeamReferences_RoleAwareChannelPolicy(t *testing.T) {
 		}
 		if got := worker.Annotations[v1beta1.AnnotationWorkerTeamName]; got != "team-a" {
 			t.Errorf("worker %q team annotation=%q, want team-a", workerName, got)
+		}
+	}
+
+	if len(roomJoins) != 3 {
+		t.Fatalf("JoinRoomAs calls=%d, want 3", len(roomJoins))
+	}
+	joinedTokens := map[string]string{}
+	for _, join := range roomJoins {
+		joinedTokens[join.token] = join.roomID
+	}
+	for _, workerName := range []string{"lead", "dev", "qa"} {
+		token := "mock-token-" + workerName
+		if got := joinedTokens[token]; got != "!team-team-a:localhost" {
+			t.Errorf("JoinRoomAs room for %q = %q, want !team-team-a:localhost", token, got)
 		}
 	}
 

--- a/agentteams-controller/internal/service/interfaces.go
+++ b/agentteams-controller/internal/service/interfaces.go
@@ -51,6 +51,9 @@ type WorkerProvisioner interface {
 	// InviteToRoom invites userID to roomID using the admin token.
 	// Idempotent: returns nil when the user is already joined/invited.
 	InviteToRoom(ctx context.Context, roomID, userID string) error
+	// JoinRoomAs accepts a room invite using the invited user's token.
+	// Idempotent: returns nil when the user has already joined.
+	JoinRoomAs(ctx context.Context, roomID, userToken string) error
 	// KickFromRoom removes userID from roomID using the admin token.
 	// Idempotent: returns nil when the user is not a member.
 	KickFromRoom(ctx context.Context, roomID, userID, reason string) error

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -15,6 +15,7 @@ Record release-facing changes here before the next release.
 
 **Bug Fixes**
 
+- **Team Room membership convergence**: Explicitly join Team Leaders and Workers with their own Matrix tokens after invitation, so pending invites cannot leave a Team Active while Hermes members remain unreachable. ([#1142](https://github.com/agentscope-ai/AgentTeams/issues/1142))
 - **QwenPaw Worker runtime management**: Recognize `qwenpaw` as a valid Worker runtime in Manager guidance and runtime-switch validation, invoke the installed `agt` CLI for runtime changes, and align Worker CLI help with the Controller's supported runtimes.
 - **CoPaw Team Worker resolution**: Resolve task assignment Matrix IDs from the Controller-owned `runtime.yaml` Team roster before falling back to legacy `AGENTS.md`, so a running Team Leader can delegate after late Team context injection without relying on a stale prompt copy.
 - **CoPaw to QwenPaw Worker state migration**: Restore Worker storage before creating any QwenPaw directories, migrate and verify both `.copaw` runtime state and `.copaw.secret` credentials with legacy state authoritative on conflicts, honor QwenPaw's configured secret directory (including relative paths) while rejecting targets outside persistent Worker storage, rebase migrated workspace metadata to `.qwenpaw`, persist migrated files before the idempotency marker, and cover a real CoPaw persistence → QwenPaw runtime switch in E2E tests. ([#1131](https://github.com/agentscope-ai/AgentTeams/pull/1131))
@@ -44,6 +45,7 @@ Record release-facing changes here before the next release.
 
 **Bug 修复**
 
+- **Team Room 成员收敛**：邀请 Team Leader 和 Worker 后，使用各自的 Matrix token 显式加入 Team Room，避免 Team 已处于 Active 状态时 Hermes 成员仍停留在 invite、无法接收消息。([#1142](https://github.com/agentscope-ai/AgentTeams/issues/1142))
 - **QwenPaw Worker 运行时管理**：在 Manager 指引和运行时切换校验中将 `qwenpaw` 识别为合法 Worker runtime，切换时调用镜像内实际安装的 `agt` CLI，并使 Worker CLI 帮助与 Controller 实际支持的运行时保持一致。
 - **CoPaw Team Worker 解析**：任务分配优先从 Controller 管理的 `runtime.yaml` Team roster 获取 Matrix ID，仅在旧部署缺少该 roster 时回退 `AGENTS.md`，避免运行中的 Team Leader 因 prompt 副本过期而无法委派任务。
 - **CoPaw 到 QwenPaw Worker 状态迁移**：在创建任何 QwenPaw 目录前先恢复 Worker 存储，迁移并校验 `.copaw` 运行时状态和 `.copaw.secret` 凭据，冲突时以旧 CoPaw 状态为准，遵循 QwenPaw 配置的 secret 目录（包括相对路径）并拒绝持久化 Worker 目录之外的目标，将工作区元数据改写到 `.qwenpaw`，先持久化迁移数据再写入幂等标记，并增加真实 CoPaw 持久化后切换 QwenPaw 的 E2E 覆盖。([#1131](https://github.com/agentscope-ai/AgentTeams/pull/1131))
@@ -68,6 +70,7 @@ Record release-facing changes here before the next release.
 - `124f06d1` feat(manager): migrate Manager runtime from copaw to qwenpaw 2.0 (#1095)
 - `2fd9ddde` fix(qwenpaw): preserve CoPaw state during runtime migration (#1131)
 - `062f1c8d` fix(controller): make Team deletion invite idempotent (#1140)
+- `41f6e517` fix(controller): join Team members to Team Room (#1142)
 
 **Also in this window / 同期其他变更**
 

--- a/manager/agent/skills/matrix-server-management/SKILL.md
+++ b/manager/agent/skills/matrix-server-management/SKILL.md
@@ -11,7 +11,7 @@ Manage the Tuwunel Matrix Homeserver at `${AGENTTEAMS_MATRIX_URL}`. User ID form
 
 - **Workers IGNORE messages without `m.mentions`** — they have `requireMention: true`. You MUST include `m.mentions.user_ids` with the full Matrix user ID for Workers to process the message (MSC3952)
 - **User IDs in body text and `m.mentions.user_ids` must match exactly** — partial or mismatched IDs cause silent failures
-- **`trusted_private_chat` preset auto-joins all invited members** — no invite acceptance needed
+- **`trusted_private_chat` only invites members** — you must ensure each invited user accepts with `POST /join`; Controller-managed Worker and Team flows do this on the user's behalf
 - **Matrix accounts cannot be deleted via API** — reuse the same username on reset
 - **Do NOT use this skill for Worker/project creation** — `create-worker.sh` and `create-project.sh` handle Matrix operations internally
 

--- a/manager/agent/skills/matrix-server-management/references/api-reference.md
+++ b/manager/agent/skills/matrix-server-management/references/api-reference.md
@@ -34,7 +34,7 @@ curl -X POST ${MATRIX_URL}/_matrix/client/v3/login \
 
 ### Create room (3-party: Human + Manager + Worker)
 
-Use `trusted_private_chat` for auto-join. Override power levels: Admin + Manager = 100, Workers = 0.
+Use `trusted_private_chat` for a private room, then ensure each invited user accepts with `POST /join`. Override power levels: Admin + Manager = 100, Workers = 0.
 
 ```bash
 curl -X POST ${MATRIX_URL}/_matrix/client/v3/createRoom \

--- a/tests/lib/matrix-client.sh
+++ b/tests/lib/matrix-client.sh
@@ -370,9 +370,9 @@ matrix_wait_for_reply_matching() {
 #     callbacks (copaw/src/matrix/channel.py::_sync_loop) so that historical
 #     messages aren't replayed on container restart. Any message that arrives
 #     between "join" and "next_batch persisted" is silently dropped.
-#   - Hermes: hermes-agent's matrix adapter doesn't auto-join invited rooms,
-#     so the controller pre-joins on its behalf — which means the room shows
-#     "join" before the worker container has even booted its sync loop.
+#   - Hermes: invites present before the initial sync are not reliably dispatched
+#     to its invite handler, so the controller pre-joins on its behalf — which
+#     means the room shows "join" before the worker container has even booted.
 #   - OpenClaw: smaller window but not zero — the matrix plugin still needs
 #     to register message handlers after login.
 #


### PR DESCRIPTION
## Summary

- explicitly join Team Leaders and Workers to the Team Room with their Matrix tokens after invitation
- add regression coverage for every referenced Team member
- correct Matrix documentation that treated trusted_private_chat invitations as automatic joins

## Tests

- go test ./internal/controller ./internal/service -count=1

Fixes #1142