### PR TITLE
fix(controller): auto-migrate legacy hiclaw.db to agentteams.db on ki…

### DIFF
--- a/agentteams-controller/internal/store/kine.go
+++ b/agentteams-controller/internal/store/kine.go
@@ -3,6 +3,8 @@ package store
 import (
 	"context"
 	"fmt"
+	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"time"
@@ -39,6 +41,17 @@ func StartKine(ctx context.Context, cfg Config) (*KineServer, error) {
 		return nil, fmt.Errorf("failed to create data dir %s: %w", cfg.DataDir, err)
 	}
 
+	// v1.2.0 renamed the kine database from hiclaw.db to agentteams.db without
+	// migrating existing data. Detect a legacy DB and copy it to the new name
+	// (copy, not rename, so the old file is preserved as a rollback).
+	migrated, err := ensureKineDBMigration(cfg.DataDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to migrate legacy kine database: %w", err)
+	}
+	if migrated {
+		log.Printf("kine database migrated from hiclaw.db to agentteams.db in %s", cfg.DataDir)
+	}
+
 	dbPath := filepath.Join(cfg.DataDir, "agentteams.db")
 	dsn := fmt.Sprintf("sqlite://%s?_journal=WAL&cache=shared&_busy_timeout=30000", dbPath)
 
@@ -52,4 +65,70 @@ func StartKine(ctx context.Context, cfg Config) (*KineServer, error) {
 	}
 
 	return &KineServer{ETCDConfig: etcdCfg}, nil
+}
+
+// ensureKineDBMigration copies a legacy hiclaw.db (plus its SQLite WAL/SHM
+// sidecar files) to agentteams.db when the legacy DB exists and the new DB
+// does not. It is idempotent: if agentteams.db already exists, nothing is
+// touched. Returns true when a migration was performed.
+func ensureKineDBMigration(dataDir string) (bool, error) {
+	oldDB := filepath.Join(dataDir, "hiclaw.db")
+	newDB := filepath.Join(dataDir, "agentteams.db")
+
+	if _, err := os.Stat(oldDB); err != nil {
+		if os.IsNotExist(err) {
+			// No legacy DB: fresh install, nothing to migrate.
+			return false, nil
+		}
+		return false, fmt.Errorf("stat legacy db %s: %w", oldDB, err)
+	}
+
+	if _, err := os.Stat(newDB); err == nil {
+		// New DB already present: user may have migrated manually. Do not
+		// overwrite it.
+		return false, nil
+	} else if !os.IsNotExist(err) {
+		return false, fmt.Errorf("stat new db %s: %w", newDB, err)
+	}
+
+	if err := copyFile(oldDB, newDB); err != nil {
+		return false, fmt.Errorf("copy %s to %s: %w", oldDB, newDB, err)
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		oldSidecar := oldDB + suffix
+		newSidecar := newDB + suffix
+		if _, err := os.Stat(oldSidecar); err == nil {
+			if err := copyFile(oldSidecar, newSidecar); err != nil {
+				return false, fmt.Errorf("copy %s to %s: %w", oldSidecar, newSidecar, err)
+			}
+		} else if !os.IsNotExist(err) {
+			return false, fmt.Errorf("stat %s: %w", oldSidecar, err)
+		}
+	}
+	return true, nil
+}
+
+// copyFile copies a file, preserving its permission bits.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
 }

--- a/agentteams-controller/internal/store/kine_migration_test.go
+++ b/agentteams-controller/internal/store/kine_migration_test.go
@@ -1,0 +1,113 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeFile creates a file with the given content, failing the test on error.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// readFileOrFail reads a file, failing the test on error.
+func readFileOrFail(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func TestEnsureKineDBMigration_OldDBOnly(t *testing.T) {
+	dataDir := t.TempDir()
+
+	// Old database with WAL and SHM sidecars present, new DB absent.
+	writeFile(t, filepath.Join(dataDir, "hiclaw.db"), "old-data")
+	writeFile(t, filepath.Join(dataDir, "hiclaw.db-wal"), "old-wal")
+	writeFile(t, filepath.Join(dataDir, "hiclaw.db-shm"), "old-shm")
+
+	migrated, err := ensureKineDBMigration(dataDir)
+	if err != nil {
+		t.Fatalf("ensureKineDBMigration returned error: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected migration to run (old DB present, new DB absent)")
+	}
+
+	// New DB and sidecars must exist with old content.
+	if got := readFileOrFail(t, filepath.Join(dataDir, "agentteams.db")); got != "old-data" {
+		t.Fatalf("agentteams.db content = %q, want %q", got, "old-data")
+	}
+	if got := readFileOrFail(t, filepath.Join(dataDir, "agentteams.db-wal")); got != "old-wal" {
+		t.Fatalf("agentteams.db-wal content = %q, want %q", got, "old-wal")
+	}
+	if got := readFileOrFail(t, filepath.Join(dataDir, "agentteams.db-shm")); got != "old-shm" {
+		t.Fatalf("agentteams.db-shm content = %q, want %q", got, "old-shm")
+	}
+
+	// Old DB must be preserved (copy, not rename) for rollback.
+	if got := readFileOrFail(t, filepath.Join(dataDir, "hiclaw.db")); got != "old-data" {
+		t.Fatalf("hiclaw.db content = %q, want %q (old DB should be preserved)", got, "old-data")
+	}
+}
+
+func TestEnsureKineDBMigration_NewDBExistsSkips(t *testing.T) {
+	dataDir := t.TempDir()
+
+	// Both old and new DB present: user may already have migrated manually.
+	writeFile(t, filepath.Join(dataDir, "hiclaw.db"), "old-data")
+	writeFile(t, filepath.Join(dataDir, "agentteams.db"), "new-data")
+
+	migrated, err := ensureKineDBMigration(dataDir)
+	if err != nil {
+		t.Fatalf("ensureKineDBMigration returned error: %v", err)
+	}
+	if migrated {
+		t.Fatal("expected migration to be skipped when new DB already exists")
+	}
+
+	// New DB content must NOT be overwritten by old DB.
+	if got := readFileOrFail(t, filepath.Join(dataDir, "agentteams.db")); got != "new-data" {
+		t.Fatalf("agentteams.db content = %q, want %q (existing new DB must not be overwritten)", got, "new-data")
+	}
+}
+
+func TestEnsureKineDBMigration_NoOldDB(t *testing.T) {
+	dataDir := t.TempDir()
+
+	// Fresh install: no old DB, no new DB.
+	migrated, err := ensureKineDBMigration(dataDir)
+	if err != nil {
+		t.Fatalf("ensureKineDBMigration returned error: %v", err)
+	}
+	if migrated {
+		t.Fatal("expected no migration when old DB is absent")
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "agentteams.db")); !os.IsNotExist(err) {
+		t.Fatal("agentteams.db should not be created when there is nothing to migrate")
+	}
+}
+
+func TestEnsureKineDBMigration_OldDBSidecarOnly(t *testing.T) {
+	dataDir := t.TempDir()
+
+	// Old DB missing but sidecar files exist (unusual): should not error, no migration.
+	writeFile(t, filepath.Join(dataDir, "hiclaw.db-wal"), "orphan-wal")
+
+	migrated, err := ensureKineDBMigration(dataDir)
+	if err != nil {
+		t.Fatalf("ensureKineDBMigration returned error: %v", err)
+	}
+	if migrated {
+		t.Fatal("expected no migration when old DB file itself is absent")
+	}
+}

--- a/tests/check-agentteams-rename-defaults.sh
+++ b/tests/check-agentteams-rename-defaults.sh
@@ -20,6 +20,13 @@ if matches="$(git grep -nIi "${legacy_brand}" -- . "${archive_paths[@]}" 2>/dev/
         case "${match}" in
             install/agentteams-dashboard-tests.sh:*)
                 ;;
+            agentteams-controller/internal/store/kine.go:* | \
+            agentteams-controller/internal/store/kine_migration_test.go:*)
+                # Kine DB migration must reference the retired database
+                # filename to detect and migrate pre-v1.2 data. README
+                # promises in-place upgrades preserve all data; without this
+                # the embedded controller silently loses its full state.
+                ;;
             install/agentteams-install.sh:*"${legacy_brand}-controller"* | \
             install/agentteams-install.sh:*"/var/run/${legacy_brand}/cli-token"* | \
             install/agentteams-install.sh:*"older ${legacy_brand_title} images"* | \


### PR DESCRIPTION
## Problem

v1.2.0 renamed the embedded kine database from `hiclaw.db` to
`agentteams.db` (#1063/#1065) without a migration path. README still
promises "Upgrade to latest (preserves all data)", but after the rename an
in-place upgrade makes the embedded controller read the new DB name while
all existing state (workers, teams, CRDs) lives in the old file — the
controller silently loses its full state.

Reported from a real v1.2.0 → v1.2.1 upgrade: all Workers disappeared after
the upgrade; recovery required manually copying the old DB files to the new
name.

Note: #1063 originally shipped this migration (`agentTeamsDBPath`), but
#1065's hard-cut rename removed it because it referenced the retired brand
name. This PR restores it (as a copy, not a rename) and adds the two store
files to the rename-contract allowlist, following the existing installer
allowlist precedent from #1079.

## Fix

`StartKine` detects a legacy DB before opening the store and migrates it
once, at startup:

- If `hiclaw.db` exists and `agentteams.db` does not → copy it (plus the
  SQLite `-wal`/`-shm` sidecar files) to `agentteams.db`.
- **Idempotent**: an existing `agentteams.db` is never overwritten, so users
  who already migrated manually are untouched.
- **Rollback-safe**: copy instead of rename, so the legacy file is preserved.
- Migration failure aborts startup instead of silently opening an empty store.



---

## 问题背景

v1.2.0 将内嵌 kine 数据库文件名从 `hiclaw.db` 重命名为 `agentteams.db`
（#1063/#1065），但没有提供迁移路径。README 仍承诺 "Upgrade to latest
(preserves all data)"（升级保留所有数据），但重命名后，就地升级会让
内嵌 Controller 读取新库名，而全部既有状态（Worker、Team、CRD）仍在旧
文件中——Controller 会静默丢失全部状态。

来自真实 v1.2.0 → v1.2.1 升级案例：升级后所有 Worker 消失；恢复需要
手动把旧库文件复制为新库名。

说明：#1063 最初自带该迁移逻辑（`agentTeamsDBPath`），但 #1065 的
hard-cut rename 因迁移函数引用了已退役的品牌名而将其删除。本 PR 恢复该
迁移（改用 copy 而非 rename），并按 #1079 的 install 脚本白名单先例，
把两个 store 文件加入 rename-contract 白名单。

## 修复内容

`StartKine` 在打开存储前检测旧库并迁移一次（启动时）：

- 若 `hiclaw.db` 存在且 `agentteams.db` 不存在 → 复制（含 SQLite
  `-wal`/`-shm` 侧车文件）为 `agentteams.db`。
- **幂等**：已存在的 `agentteams.db` 绝不被覆盖，手动迁移过的用户不受影响。
- **可回退**：使用 copy 而非 rename，旧文件保留用于回退。
- 迁移失败会中止启动，而不是静默打开空库。


