### PR TITLE
fix(skills): complete manager and worker skill loading

### DIFF
--- a/agentteams-controller/internal/config/config.go
+++ b/agentteams-controller/internal/config/config.go
@@ -169,8 +169,8 @@ type Config struct {
 	Runtime            string
 	ModelContextWindow int
 	ModelMaxTokens     int
-	ModelVision    *bool // nil = use model default; overrides model-level vision capability
-	ModelReasoning *bool // nil = use model default; overrides model-level reasoning capability
+	ModelVision        *bool // nil = use model default; overrides model-level vision capability
+	ModelReasoning     *bool // nil = use model default; overrides model-level reasoning capability
 
 	// LLM provider (for Gateway initialization)
 	LLMProvider                string
@@ -210,6 +210,7 @@ type WorkerEnvDefaults struct {
 	FSEndpoint           string
 	FSBucket             string
 	StoragePrefix        string
+	StorageProvider      string
 	ControllerURL        string
 	AIGatewayURL         string
 	MatrixURL            string
@@ -410,6 +411,7 @@ func LoadConfig() *Config {
 			FSEndpoint:           os.Getenv("AGENTTEAMS_FS_ENDPOINT"),
 			FSBucket:             envOrDefault("AGENTTEAMS_FS_BUCKET", "agentteams-storage"),
 			StoragePrefix:        envOrDefault("AGENTTEAMS_STORAGE_PREFIX", "agentteams/agentteams-storage"),
+			StorageProvider:      envOrDefault("AGENTTEAMS_STORAGE_PROVIDER", "minio"),
 			ControllerURL:        os.Getenv("AGENTTEAMS_CONTROLLER_URL"),
 			AIGatewayURL:         envOrDefault("AGENTTEAMS_AI_GATEWAY_URL", "http://aigw-local.agentteams.io:8080"),
 			MatrixURL:            envOrDefault("AGENTTEAMS_MATRIX_URL", "http://matrix-local.agentteams.io:8080"),

--- a/agentteams-controller/internal/controller/member_reconcile.go
+++ b/agentteams-controller/internal/controller/member_reconcile.go
@@ -376,6 +376,13 @@ func ReconcileMemberConfig(ctx context.Context, d MemberDeps, m MemberContext, s
 			matrixAccessToken = state.ProvResult.MatrixToken
 			gatewayKey = state.ProvResult.GatewayKey
 		}
+		// Put assigned skill files in member storage before publishing the
+		// desired-state snapshot that tells managed runtimes to load them.
+		if len(m.Spec.Skills) > 0 || len(m.Spec.RemoteSkills) > 0 {
+			if err := d.Deployer.PushOnDemandSkills(ctx, m.RuntimeName, m.Spec.Skills, m.Spec.RemoteSkills); err != nil {
+				return fmt.Errorf("push on-demand skills: %w", err)
+			}
+		}
 		if err := d.Deployer.DeployMemberRuntimeConfig(ctx, service.MemberRuntimeConfigDeployRequest{
 			Name:                  m.Name,
 			RuntimeName:           m.RuntimeName,

--- a/agentteams-controller/internal/controller/member_reconcile_test.go
+++ b/agentteams-controller/internal/controller/member_reconcile_test.go
@@ -544,7 +544,7 @@ func TestCreateMemberContainerConflictRequeues(t *testing.T) {
 	}
 }
 
-func TestReconcileMemberConfigQwenPawWritesRuntimeConfigOnly(t *testing.T) {
+func TestReconcileMemberConfigQwenPawDistributesSkillsAndWritesRuntimeConfig(t *testing.T) {
 	deployer := mocks.NewMockDeployer()
 	state := &MemberState{
 		MatrixUserID: "@worker-a:matrix.local",
@@ -591,8 +591,8 @@ func TestReconcileMemberConfigQwenPawWritesRuntimeConfigOnly(t *testing.T) {
 	if req.TeamName != "" || req.TeamRoomID != "" || len(req.TeamMembers) != 0 {
 		t.Fatalf("Worker reconciliation must not inject Team-owned context: %#v", req)
 	}
-	if deployPkg, writeInline, deployConfig, pushSkills, _ := deployer.CallCounts(); deployPkg != 0 || writeInline != 0 || deployConfig != 0 || pushSkills != 0 {
-		t.Fatalf("qwenpaw must skip file-based deploy path, got package=%d inline=%d config=%d skills=%d",
+	if deployPkg, writeInline, deployConfig, pushSkills, _ := deployer.CallCounts(); deployPkg != 0 || writeInline != 0 || deployConfig != 0 || pushSkills != 1 {
+		t.Fatalf("qwenpaw must distribute skills and skip the legacy file-based config path, got package=%d inline=%d config=%d skills=%d",
 			deployPkg, writeInline, deployConfig, pushSkills)
 	}
 }

--- a/agentteams-controller/internal/oss/client_test.go
+++ b/agentteams-controller/internal/oss/client_test.go
@@ -253,6 +253,9 @@ func TestMinIOAdminClient_BuildManagerPolicy(t *testing.T) {
 	if !hasManagerDir {
 		t.Errorf("expected manager directory prefix in list conditions: %v", prefixes)
 	}
+	if !stringSliceContains(prefixes, "agents/*") {
+		t.Errorf("expected Manager to list Worker agent prefixes: %v", prefixes)
+	}
 
 	// Verify manager resource in RW statement
 	rwStmt := policy.Statement[2]
@@ -271,6 +274,9 @@ func TestMinIOAdminClient_BuildManagerPolicy(t *testing.T) {
 	}
 	if !hasManagerDirResource {
 		t.Errorf("expected manager directory resource in RW statement: %v", rwStmt.Resource)
+	}
+	if !stringSliceContains(rwStmt.Resource, "arn:aws:s3:::agentteams-storage/agents/*") {
+		t.Errorf("expected Manager to manage Worker agent objects: %v", rwStmt.Resource)
 	}
 }
 

--- a/agentteams-controller/internal/oss/minio_admin.go
+++ b/agentteams-controller/internal/oss/minio_admin.go
@@ -196,11 +196,13 @@ func (c *MinIOAdminClient) buildWorkerPolicy(workerName, bucket, teamName string
 
 	if isManager {
 		listPrefixes = append(listPrefixes,
+			"agents/*",
 			"manager",
 			"manager/",
 			"manager/*",
 		)
 		rwResources = append(rwResources,
+			fmt.Sprintf("arn:aws:s3:::%s/agents/*", bucket),
 			fmt.Sprintf("arn:aws:s3:::%s/manager", bucket),
 			fmt.Sprintf("arn:aws:s3:::%s/manager/", bucket),
 			fmt.Sprintf("arn:aws:s3:::%s/manager/*", bucket),

--- a/agentteams-controller/internal/service/deployer.go
+++ b/agentteams-controller/internal/service/deployer.go
@@ -759,8 +759,18 @@ func (d *Deployer) PushOnDemandSkills(ctx context.Context, workerName string, sk
 			"worker", workerName, "skills", skills)
 		return nil
 	}
-	_, err := d.executor.RunSimple(ctx, scriptPath, "--worker", workerName, "--no-notify")
-	return err
+	for _, skill := range skills {
+		if _, err := d.executor.RunSimple(
+			ctx,
+			scriptPath,
+			"--worker", workerName,
+			"--skill", skill,
+			"--no-notify",
+		); err != nil {
+			return fmt.Errorf("push skill %q to worker %q: %w", skill, workerName, err)
+		}
+	}
+	return nil
 }
 
 func (d *Deployer) PrepareWorkerDeps(ctx context.Context, req WorkerDepsPrepareRequest) error {

--- a/agentteams-controller/internal/service/deployer_test.go
+++ b/agentteams-controller/internal/service/deployer_test.go
@@ -346,8 +346,13 @@ func TestDeployMemberRuntimeConfigWritesAgentScopedYaml(t *testing.T) {
 			MatrixUserID: "@human:matrix.local",
 		}},
 		Spec: v1beta1.WorkerSpec{
-			Model:    "qwen-plus",
-			Package:  "nacos://registry/ns/dev-worker?version=1.2.0",
+			Model:   "qwen-plus",
+			Package: "nacos://registry/ns/dev-worker?version=1.2.0",
+			Skills:  []string{"competition-skill", "shared-skill"},
+			RemoteSkills: []v1beta1.RemoteSkillSource{{
+				Source: "nacos://registry/ns",
+				Skills: []v1beta1.RemoteSkill{{Name: "shared-skill"}, {Name: "remote-skill"}},
+			}},
 			Identity: "frontend specialist",
 			Soul:     "build accessible user interfaces",
 			Agents:   "follow the project workflow",
@@ -426,6 +431,10 @@ func TestDeployMemberRuntimeConfigWritesAgentScopedYaml(t *testing.T) {
 	}
 
 	desired := doc["desired"].(map[string]any)
+	skills := desired["skills"].([]any)
+	if got := fmt.Sprint(skills); got != "[competition-skill shared-skill remote-skill]" {
+		t.Fatalf("desired.skills=%s", got)
+	}
 	model := desired["model"].(map[string]any)
 	if got := fmt.Sprint(model["model"]); got != "qwen-plus" {
 		t.Fatalf("desired.model.model=%q", got)

--- a/agentteams-controller/internal/service/provisioner.go
+++ b/agentteams-controller/internal/service/provisioner.go
@@ -705,6 +705,17 @@ func (p *Provisioner) RefreshManagerCredentials(ctx context.Context, managerName
 			return nil, fmt.Errorf("persist matrix token: %w", err)
 		}
 	}
+	if p.ossAdmin != nil {
+		if err := p.ossAdmin.EnsureUser(ctx, managerName, creds.MinIOPassword); err != nil {
+			return nil, fmt.Errorf("MinIO Manager user refresh failed: %w", err)
+		}
+		if err := p.ossAdmin.EnsurePolicy(ctx, oss.PolicyRequest{
+			WorkerName: managerName,
+			IsManager:  true,
+		}); err != nil {
+			return nil, fmt.Errorf("MinIO Manager policy refresh failed: %w", err)
+		}
+	}
 
 	return &RefreshResult{
 		MatrixToken:    matrixToken,

--- a/agentteams-controller/internal/service/provisioner_team_test.go
+++ b/agentteams-controller/internal/service/provisioner_team_test.go
@@ -321,6 +321,42 @@ func TestRefreshWorkerCredentialsRestoresMinIOAccess(t *testing.T) {
 	}
 }
 
+func TestRefreshManagerCredentialsRestoresMinIOAccess(t *testing.T) {
+	admin := &fakeStorageAdmin{}
+	creds := fakeCredentialStore{
+		"default": {
+			MatrixToken:   "manager-token",
+			MinIOPassword: "manager-minio-secret",
+			GatewayKey:    "manager-gateway-key",
+		},
+	}
+	p := NewProvisioner(ProvisionerConfig{
+		Matrix:   newFakeTeamMatrix(),
+		Creds:    creds,
+		OSSAdmin: admin,
+	})
+
+	result, err := p.RefreshManagerCredentials(context.Background(), "default")
+	if err != nil {
+		t.Fatalf("RefreshManagerCredentials: %v", err)
+	}
+	if result.MinIOPassword != "manager-minio-secret" {
+		t.Fatalf("MinIOPassword=%q, want manager-minio-secret", result.MinIOPassword)
+	}
+	if len(admin.users) != 1 {
+		t.Fatalf("EnsureUser calls=%d, want 1", len(admin.users))
+	}
+	if got := admin.users[0]; got.name != "default" || got.password != "manager-minio-secret" {
+		t.Fatalf("EnsureUser=%+v, want default/manager-minio-secret", got)
+	}
+	if len(admin.policies) != 1 {
+		t.Fatalf("EnsurePolicy calls=%d, want 1", len(admin.policies))
+	}
+	if got := admin.policies[0]; got.WorkerName != "default" || !got.IsManager {
+		t.Fatalf("EnsurePolicy=%+v, want Manager policy for default", got)
+	}
+}
+
 func TestProvisionWorkerFreshCredentialsRecreatesStaleRoomAlias(t *testing.T) {
 	matrixClient := newFakeTeamMatrix()
 	matrixClient.created = false

--- a/agentteams-controller/internal/service/runtime_config.go
+++ b/agentteams-controller/internal/service/runtime_config.go
@@ -76,6 +76,7 @@ type memberRuntimeConfigDesired struct {
 	AgentIdentity      *v1beta1.AgentIdentitySpec        `json:"agentIdentity,omitempty"`
 	CredentialBindings []v1beta1.CredentialBinding       `json:"credentialBindings,omitempty"`
 	Channels           *memberRuntimeConfigChannels      `json:"channels,omitempty"`
+	Skills             []string                          `json:"skills,omitempty"`
 	State              string                            `json:"state"`
 }
 
@@ -255,6 +256,7 @@ func (d *Deployer) memberRuntimeConfigDocument(req MemberRuntimeConfigDeployRequ
 		ChannelPolicy:      req.Spec.ChannelPolicy,
 		AgentIdentity:      runtimeAgentIdentity(req.Spec),
 		CredentialBindings: copyCredentialBindings(req.Spec.CredentialBindings),
+		Skills:             runtimeSkillNames(req.Spec),
 		State:              req.Spec.DesiredState(),
 	}
 	if req.Spec.Model != "" && !isNativeConfigModel(req.Spec.Model) {
@@ -332,6 +334,31 @@ func (d *Deployer) memberRuntimeConfigDocument(req MemberRuntimeConfigDeployRequ
 	applyRuntimeTeamContext(&doc, req)
 
 	return doc, nil
+}
+
+func runtimeSkillNames(spec v1beta1.WorkerSpec) []string {
+	seen := make(map[string]struct{})
+	var names []string
+	add := func(name string) {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	for _, name := range spec.Skills {
+		add(name)
+	}
+	for _, source := range spec.RemoteSkills {
+		for _, skill := range source.Skills {
+			add(skill.Name)
+		}
+	}
+	return names
 }
 
 func isNativeConfigModel(model string) bool {

--- a/agentteams-controller/internal/service/worker_env.go
+++ b/agentteams-controller/internal/service/worker_env.go
@@ -92,13 +92,14 @@ func (b *WorkerEnvBuilder) BuildManager(managerName string, prov *ManagerProvisi
 
 func (b *WorkerEnvBuilder) applyClusterDefaults(env map[string]string) {
 	for k, v := range map[string]string{
-		"AGENTTEAMS_MATRIX_DOMAIN":  b.defaults.MatrixDomain,
-		"AGENTTEAMS_FS_ENDPOINT":    b.defaults.FSEndpoint,
-		"AGENTTEAMS_FS_BUCKET":      b.defaults.FSBucket,
-		"AGENTTEAMS_STORAGE_PREFIX": b.defaults.StoragePrefix,
-		"AGENTTEAMS_CONTROLLER_URL": b.defaults.ControllerURL,
-		"AGENTTEAMS_AI_GATEWAY_URL": b.defaults.AIGatewayURL,
-		"AGENTTEAMS_MATRIX_URL":     b.defaults.MatrixURL,
+		"AGENTTEAMS_MATRIX_DOMAIN":    b.defaults.MatrixDomain,
+		"AGENTTEAMS_FS_ENDPOINT":      b.defaults.FSEndpoint,
+		"AGENTTEAMS_FS_BUCKET":        b.defaults.FSBucket,
+		"AGENTTEAMS_STORAGE_PREFIX":   b.defaults.StoragePrefix,
+		"AGENTTEAMS_STORAGE_PROVIDER": b.defaults.StorageProvider,
+		"AGENTTEAMS_CONTROLLER_URL":   b.defaults.ControllerURL,
+		"AGENTTEAMS_AI_GATEWAY_URL":   b.defaults.AIGatewayURL,
+		"AGENTTEAMS_MATRIX_URL":       b.defaults.MatrixURL,
 	} {
 		if v != "" {
 			env[k] = v

--- a/agentteams-controller/internal/service/worker_env_test.go
+++ b/agentteams-controller/internal/service/worker_env_test.go
@@ -9,16 +9,17 @@ import (
 
 func TestWorkerEnvBuilderBuildIncludesFinalRuntimeEnv(t *testing.T) {
 	builder := NewWorkerEnvBuilder(config.WorkerEnvDefaults{
-		MatrixDomain:  "matrix.example.com",
-		FSEndpoint:    "http://fs.example.com:9000",
-		FSBucket:      "agentteams-fs",
-		StoragePrefix: "teams/demo",
-		ControllerURL: "http://controller.example.com:8090",
-		AIGatewayURL:  "http://aigw.example.com:8080",
-		MatrixURL:     "http://matrix.example.com:8080",
-		Runtime:       "docker",
-		SkillsAPIURL:  "nacos://skills.example.com:8848/public",
-		NacosAuthType: "sts-agentteams",
+		MatrixDomain:    "matrix.example.com",
+		FSEndpoint:      "http://fs.example.com:9000",
+		FSBucket:        "agentteams-fs",
+		StoragePrefix:   "teams/demo",
+		StorageProvider: "minio",
+		ControllerURL:   "http://controller.example.com:8090",
+		AIGatewayURL:    "http://aigw.example.com:8080",
+		MatrixURL:       "http://matrix.example.com:8080",
+		Runtime:         "docker",
+		SkillsAPIURL:    "nacos://skills.example.com:8848/public",
+		NacosAuthType:   "sts-agentteams",
 	})
 
 	env := builder.Build("alice", &WorkerProvisionResult{
@@ -35,6 +36,7 @@ func TestWorkerEnvBuilderBuildIncludesFinalRuntimeEnv(t *testing.T) {
 		"AGENTTEAMS_FS_ENDPOINT":         "http://fs.example.com:9000",
 		"AGENTTEAMS_FS_BUCKET":           "agentteams-fs",
 		"AGENTTEAMS_STORAGE_PREFIX":      "teams/demo",
+		"AGENTTEAMS_STORAGE_PROVIDER":    "minio",
 		"AGENTTEAMS_CONTROLLER_URL":      "http://controller.example.com:8090",
 		"AGENTTEAMS_AI_GATEWAY_URL":      "http://aigw.example.com:8080",
 		"AGENTTEAMS_MATRIX_URL":          "http://matrix.example.com:8080",
@@ -65,6 +67,7 @@ func TestWorkerEnvBuilderBuildManagerUsesConfiguredRuntimeAndBucket(t *testing.T
 		FSEndpoint:           "http://fs.example.com:9000",
 		FSBucket:             "agentteams-fs",
 		StoragePrefix:        "teams/demo",
+		StorageProvider:      "minio",
 		ControllerURL:        "http://controller.example.com:8090",
 		AIGatewayURL:         "http://aigw.example.com:8080",
 		MatrixURL:            "http://matrix.example.com:8080",
@@ -87,6 +90,7 @@ func TestWorkerEnvBuilderBuildManagerUsesConfiguredRuntimeAndBucket(t *testing.T
 		"AGENTTEAMS_FS_ACCESS_KEY":          "manager",
 		"AGENTTEAMS_FS_SECRET_KEY":          "secret",
 		"AGENTTEAMS_FS_BUCKET":              "agentteams-fs",
+		"AGENTTEAMS_STORAGE_PROVIDER":       "minio",
 		"AGENTTEAMS_RUNTIME":                "docker",
 		"AGENTTEAMS_DEFAULT_WORKER_RUNTIME": "copaw",
 		"AGENTTEAMS_ADMIN_USER":             "admin",

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -8,6 +8,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 - **Worker custom skill loading**: Validate and upload Manager-hosted Worker skill files before updating assignments, grant Managers access to Worker storage prefixes, avoid recursive CR updates during reconciliation, keep local/default MinIO paths off unavailable STS, restore Manager MinIO access after Controller restarts, verify uploaded `SKILL.md` files, restore Worker file-sync notifications, and sync plus enable assigned skills in the native QwenPaw workspace.
 - **QwenPaw Manager custom skill hot loading**: Continuously mirror workspace skills into the native QwenPaw workspace, then refresh and enable additions or updates without restarting the Manager.
+- **QwenPaw Manager Skill attachments**: Initialize the Matrix attachment directory at startup so an admin can send a complete Worker Skill ZIP to the Manager for validation and distribution.
 
 ---
 
@@ -15,3 +16,4 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 - **Worker 自定义 Skill 加载**：更新分配前校验并上传 Manager 托管的 Worker Skill 文件，授予 Manager 对 Worker 存储前缀的访问权限，避免调和期间递归更新 CR，避免本地或默认 MinIO 路径误请求不可用的 STS，Controller 重启后恢复 Manager 的 MinIO 访问并校验已上传的 `SKILL.md`，恢复 Worker 的 file-sync 通知，并在 QwenPaw 原生 workspace 中同步、启用已分配 Skill。
 - **QwenPaw Manager 自定义 Skill 热加载**：持续将 workspace Skill 投影到 QwenPaw 原生 workspace，并自动刷新、启用新增或更新的 Skill，无需重启 Manager。
+- **QwenPaw Manager Skill 附件**：启动时创建 Matrix 附件目录，使管理员可以将完整的 Worker Skill ZIP 发送给 Manager，由其校验并分发。

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -6,10 +6,12 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 **Bug Fixes**
 
-- **Worker custom skill loading**: Validate and upload Manager-hosted Worker skill files before updating assignments, avoid recursive CR updates during reconciliation, and sync plus enable assigned skills in the native QwenPaw workspace.
+- **Worker custom skill loading**: Validate and upload Manager-hosted Worker skill files before updating assignments, grant Managers access to Worker storage prefixes, avoid recursive CR updates during reconciliation, keep local/default MinIO paths off unavailable STS, restore Manager MinIO access after Controller restarts, verify uploaded `SKILL.md` files, restore Worker file-sync notifications, and sync plus enable assigned skills in the native QwenPaw workspace.
+- **QwenPaw Manager custom skill hot loading**: Continuously mirror workspace skills into the native QwenPaw workspace, then refresh and enable additions or updates without restarting the Manager.
 
 ---
 
 **Bug 修复**
 
-- **Worker 自定义 Skill 加载**：更新分配前校验并上传 Manager 托管的 Worker Skill 文件，避免调和期间递归更新 CR，并在 QwenPaw 原生 workspace 中同步、启用已分配 Skill。
+- **Worker 自定义 Skill 加载**：更新分配前校验并上传 Manager 托管的 Worker Skill 文件，授予 Manager 对 Worker 存储前缀的访问权限，避免调和期间递归更新 CR，避免本地或默认 MinIO 路径误请求不可用的 STS，Controller 重启后恢复 Manager 的 MinIO 访问并校验已上传的 `SKILL.md`，恢复 Worker 的 file-sync 通知，并在 QwenPaw 原生 workspace 中同步、启用已分配 Skill。
+- **QwenPaw Manager 自定义 Skill 热加载**：持续将 workspace Skill 投影到 QwenPaw 原生 workspace，并自动刷新、启用新增或更新的 Skill，无需重启 Manager。

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -11,6 +11,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 **Bug Fixes**
 
+- **Worker custom skill loading**: Validate and upload Manager-hosted Worker skill files before updating assignments, avoid recursive CR updates during reconciliation, and sync plus enable assigned skills in the native QwenPaw workspace.
 - **QwenPaw Worker runtime management**: Recognize `qwenpaw` as a valid Worker runtime in Manager guidance and runtime-switch validation, invoke the installed `agt` CLI for runtime changes, and align Worker CLI help with the Controller's supported runtimes.
 - **CoPaw Team Worker resolution**: Resolve task assignment Matrix IDs from the Controller-owned `runtime.yaml` Team roster before falling back to legacy `AGENTS.md`, so a running Team Leader can delegate after late Team context injection without relying on a stale prompt copy.
 - **CoPaw to QwenPaw Worker state migration**: Restore Worker storage before creating any QwenPaw directories, migrate and verify both `.copaw` runtime state and `.copaw.secret` credentials with legacy state authoritative on conflicts, honor QwenPaw's configured secret directory (including relative paths) while rejecting targets outside persistent Worker storage, rebase migrated workspace metadata to `.qwenpaw`, persist migrated files before the idempotency marker, and cover a real CoPaw persistence → QwenPaw runtime switch in E2E tests. ([c0b4bac](https://github.com/agentscope-ai/AgentTeams/commit/c0b4bac68ea94fa0887cf14747d368916986c347))
@@ -34,6 +35,7 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 **Bug 修复**
 
+- **Worker 自定义 Skill 加载**：更新分配前校验并上传 Manager 托管的 Worker Skill 文件，避免调和期间递归更新 CR，并在 QwenPaw 原生 workspace 中同步、启用已分配 Skill。
 - **QwenPaw Worker 运行时管理**：在 Manager 指引和运行时切换校验中将 `qwenpaw` 识别为合法 Worker runtime，切换时调用镜像内实际安装的 `agt` CLI，并使 Worker CLI 帮助与 Controller 实际支持的运行时保持一致。
 - **CoPaw Team Worker 解析**：任务分配优先从 Controller 管理的 `runtime.yaml` Team roster 获取 Matrix ID，仅在旧部署缺少该 roster 时回退 `AGENTS.md`，避免运行中的 Team Leader 因 prompt 副本过期而无法委派任务。
 - **CoPaw 到 QwenPaw Worker 状态迁移**：在创建任何 QwenPaw 目录前先恢复 Worker 存储，迁移并校验 `.copaw` 运行时状态和 `.copaw.secret` 凭据，冲突时以旧 CoPaw 状态为准，遵循 QwenPaw 配置的 secret 目录（包括相对路径）并拒绝持久化 Worker 目录之外的目标，将工作区元数据改写到 `.qwenpaw`，先持久化迁移数据再写入幂等标记，并增加真实 CoPaw 持久化后切换 QwenPaw 的 E2E 覆盖。([c0b4bac](https://github.com/agentscope-ai/AgentTeams/commit/c0b4bac68ea94fa0887cf14747d368916986c347))

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,7 +167,7 @@ The shipped **Manager entrypoint** (`start-manager-agent.sh`) selects:
 ### CRDs (`agentteams.io/v1beta1`)
 
 1. **Worker** — model, runtime, image, skills, MCP servers, optional **expose** ports, **channelPolicy**, **state** (`Running` / `Sleeping` / `Stopped`), **accessEntries** (cloud credential scoping when provider sidecar is used).
-2. **Manager** — model, runtime, image, soul/agents overrides, skills, MCP servers, **config** (heartbeat interval, worker idle timeout, notify channel), **state**, **accessEntries**.
+2. **Manager** — model, runtime, image, soul/agents overrides, MCP servers, **config** (heartbeat interval, worker idle timeout, notify channel), **state**, **accessEntries**.
 3. **Team** — **Leader** + **Workers** specs, optional **admin**, **peerMentions**, team **channelPolicy**; status aggregates member readiness and rooms (**team room**, **leader DM**, per-member **RoomID** with Manager).
 4. **Human** — display name, email, **permissionLevel**, accessible teams/workers; status includes Matrix user, initial password (once), rooms.
 
@@ -207,7 +207,7 @@ These are shared by **OpenClaw** and **QwenPaw** Managers (QwenPaw-specific prom
 ### Worker skills
 
 - **Per-runtime builtins** — templates under **`manager/agent/worker-agent/`** (OpenClaw), **`copaw-worker-agent/`**, and **`hermes-worker-agent/`** include a small **core** set (e.g. **file-sync**, **mcporter**, **find-skills**, **project-participation**, **task-progress**) materialized into each worker workspace on provision.
-- **On-demand / distributable** — **`manager/agent/worker-skills/`** (e.g. **github-operations**, **git-delegation**): the Manager can push selected packages to workers when `spec.skills` references them.
+- **On-demand / distributable** — **`manager/agent/worker-skills/`** (e.g. **github-operations**, **git-delegation**): after an administrator asks the Manager to install a named skill for a Worker, the Manager verifies and uploads the skill before adding it to `spec.skills`.
 
 ### Team Leader skills
 

--- a/docs/declarative-resource-management.md
+++ b/docs/declarative-resource-management.md
@@ -123,6 +123,10 @@ For an existing Worker, the recommended workflow is to put the complete skill di
 
 The Manager uploads and verifies `SKILL.md` before updating `spec.skills`. QwenPaw Workers consume the resulting runtime assignment, synchronize the selected skill into their native workspace, then refresh and enable it automatically.
 
+The assignment can also be checked through conversation instead of a CLI command:
+
+> Check the skills assigned to Worker `amy-ai` and confirm whether `alert-fusion` is included.
+
 You can also use `spec.package` to provide a Worker package containing a `skills/` directory. Package skills and assigned skills are merged without conflict.
 
 ### Worker with Custom Package

--- a/docs/declarative-resource-management.md
+++ b/docs/declarative-resource-management.md
@@ -117,9 +117,11 @@ When both are set, inline fields override the corresponding files in the package
 
 `spec.skills` records the skills assigned to a Worker. A referenced skill can come from the AgentTeams Worker skill library or from a third-party skill placed under `$AGENTTEAMS_WORKSPACE_DIR/worker-skills/<skill-name>/`.
 
-For an existing Worker, the recommended workflow is to put the complete skill directory in the Manager workspace and ask the Manager to install it:
+For an existing Worker, either put the complete Skill directory in the Manager workspace or send the Manager a ZIP attachment containing one complete Skill root. Then ask the Manager to install it:
 
 > Install the `alert-fusion` skill from `~/worker-skills/alert-fusion/` for Worker `amy-ai`. Verify the upload and confirm that the Worker assignment includes the skill.
+
+For an attachment, ask the Manager to safely extract and validate the ZIP before it stages the Skill under `~/worker-skills/` and distributes it.
 
 The Manager uploads and verifies `SKILL.md` before updating `spec.skills`. QwenPaw Workers consume the resulting runtime assignment, synchronize the selected skill into their native workspace, then refresh and enable it automatically.
 

--- a/docs/declarative-resource-management.md
+++ b/docs/declarative-resource-management.md
@@ -94,7 +94,7 @@ spec:
 | `spec.identity` | string | No | — | Worker public identity (OpenClaw: generates IDENTITY.md; QwenPaw: merged into SOUL.md per controller) |
 | `spec.soul` | string | No | — | Worker personality and values (generates SOUL.md) |
 | `spec.agents` | string | No | — | Agent behavior rules, used to generate AGENTS.md |
-| `spec.skills` | []string | No | — | Built-in skills, distributed by Manager |
+| `spec.skills` | []string | No | — | Assigned Worker skills, distributed and verified by Manager |
 | `spec.mcpServers` | []object | No | — | MCP servers callable via mcporter. Each item: `name` (required, map key in mcporter-servers.json), `url` (required, full gateway endpoint), `transport` (`http` default or `sse`). The controller injects `Authorization: Bearer <gatewayKey>`; gateway-side authorization is out of scope. |
 | `spec.package` | string | No | — | Custom package URI: `file://`, `http(s)://`, `nacos://`, or controller-resolved `packages/{name}.zip` after upload |
 | `spec.expose` | []object | No | — | Ports to expose via Higress gateway (see [Service Publishing](#service-publishing)) |
@@ -113,11 +113,17 @@ There are two ways to configure a Worker's identity and behavior:
 
 When both are set, inline fields override the corresponding files in the package. This allows you to use a package as a base template while customizing specific aspects via YAML — for example, importing a shared package but overriding `soul` to give the Worker a unique role definition.
 
-### Built-in Skills vs Custom Skills
+### Worker Skills
 
-`spec.skills` refers to AgentTeams platform built-in capabilities, distributed by the Manager via `push-worker-skills.sh` to the Worker's MinIO space.
+`spec.skills` records the skills assigned to a Worker. A referenced skill can come from the AgentTeams Worker skill library or from a third-party skill placed under `$AGENTTEAMS_WORKSPACE_DIR/worker-skills/<skill-name>/`.
 
-For custom skills, use `spec.package` to provide a ZIP containing a `skills/` directory. Built-in and custom skills are merged without conflict.
+For an existing Worker, the recommended workflow is to put the complete skill directory in the Manager workspace and ask the Manager to install it:
+
+> Install the `alert-fusion` skill from `~/worker-skills/alert-fusion/` for Worker `amy-ai`. Verify the upload and confirm that the Worker assignment includes the skill.
+
+The Manager uploads and verifies `SKILL.md` before updating `spec.skills`. QwenPaw Workers consume the resulting runtime assignment, synchronize the selected skill into their native workspace, then refresh and enable it automatically.
+
+You can also use `spec.package` to provide a Worker package containing a `skills/` directory. Package skills and assigned skills are merged without conflict.
 
 ### Worker with Custom Package
 
@@ -316,7 +322,7 @@ spec:
 
 ## Manager
 
-The **Manager** resource describes the AgentTeams Manager Agent — the coordinator that receives instructions from Admin and orchestrates Workers and Teams. It uses the same API group/version as other resources and is reconciled by `agentteams-controller` (update image, SOUL/AGENTS, skills, MCP authorization, optional package, and desired `state`).
+The **Manager** resource describes the AgentTeams Manager Agent — the coordinator that receives instructions from Admin and orchestrates Workers and Teams. It uses the same API group/version as other resources and is reconciled by `agentteams-controller` (update image, SOUL/AGENTS, MCP authorization, optional package, and desired `state`).
 
 ### Basic configuration
 
@@ -332,8 +338,6 @@ spec:
     # Manager — coordination focus
   agents: |
     # Optional AGENTS.md overrides
-  skills:
-    - worker-management
   mcpServers:
     - name: github
       url: https://gateway.example.com/mcp-servers/github/mcp
@@ -361,7 +365,6 @@ spec:
 | `spec.image` | string | No | — | Custom Manager image; empty uses deployment default |
 | `spec.soul` | string | No | — | Custom SOUL.md content |
 | `spec.agents` | string | No | — | Custom AGENTS.md content |
-| `spec.skills` | []string | No | — | On-demand Manager skills to enable |
 | `spec.mcpServers` | []object | No | — | MCP servers callable via mcporter. Each item: `name`, `url`, `transport` (`http`/`sse`). Gateway-side authorization is out of scope. |
 | `spec.package` | string | No | — | Package URI (`file://`, `http(s)://`, `nacos://`) |
 | `spec.state` | string | No | `Running` | Desired lifecycle: `Running`, `Sleeping`, `Stopped` |
@@ -823,7 +826,7 @@ Reconciler executes scripts (create-worker.sh / create-team.sh / create-human.sh
 | Worker | Create container + Matrix account + MinIO space | model change → regenerate config; skills change → re-push | Stop container + clean up resources |
 | Team | Validate and link existing Workers + create Team Room | `workerMembers` change → update membership and coordination context | Remove Team Room and coordination context; preserve Worker CRs and runtimes |
 | Human | Register Matrix account + configure permissions + send email | permissionLevel change → recalculate groupAllowFrom | Remove from all groupAllowFrom → kick from Rooms |
-| Manager | Provision/update Manager Agent config + runtime | model/skills/package/state → reconcile | Tear down managed Manager resources per backend |
+| Manager | Provision/update Manager Agent config + runtime | model/package/state → reconcile | Tear down managed Manager resources per backend |
 
 All resources use the Kubernetes finalizer pattern to ensure cleanup before deletion.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -247,7 +247,13 @@ Then tell the Manager:
 
 > Install the `alert-fusion` skill from `~/worker-skills/alert-fusion/` for Worker `amy-ai`. Verify the upload and confirm that `amy-ai`'s assigned skills include it.
 
-The Manager uploads the files, verifies the remote `SKILL.md`, and updates the Worker assignment. QwenPaw Workers synchronize and enable the newly assigned skill automatically. Check the final assignment with:
+The Manager uploads the files, verifies the remote `SKILL.md`, and updates the Worker assignment. QwenPaw Workers synchronize and enable the newly assigned skill automatically.
+
+Check the assignment through natural-language conversation:
+
+> List the skills assigned to Worker `amy-ai` and confirm whether `alert-fusion` is included.
+
+For operator-side inspection or troubleshooting, use the equivalent CLI query:
 
 ```bash
 agt get workers amy-ai -o json | jq '.skills'

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,6 +5,7 @@
 - [How to check the current AgentTeams version](#how-to-check-the-current-agentteams-version)
 - [Understanding the new architecture (v1.1.0+)](#understanding-the-new-architecture-v110)
 - [How to use the agt CLI to manage resources](#how-to-use-the-agt-cli-to-manage-resources)
+- [How to install a third-party skill on a Worker through the Manager](#how-to-install-a-third-party-skill-on-a-worker-through-the-manager)
 - [How to configure GitHub credentials for Workers](#how-to-configure-github-credentials-for-workers)
 - [How to connect Feishu/DingTalk/WeCom/Discord/Telegram](#how-to-connect-feishudingtalkwecomdiscordtelegram)
 - [Installation script exits immediately on Windows](#installation-script-exits-immediately-on-windows)
@@ -231,6 +232,28 @@ agt delete human john
 > **Tip:** Most Manager Agent operations (creating workers, switching models, assigning tasks) ultimately call the same `agt` CLI under the hood. Using the CLI directly is useful for debugging, bulk operations, or automation scripts.
 
 For declarative YAML resource definitions, see [Declarative Resource Management](declarative-resource-management.md).
+
+---
+
+## How to install a third-party skill on a Worker through the Manager
+
+Place the complete skill directory under the Manager workspace's `worker-skills/` directory. For example:
+
+```text
+~/agentteams-manager/worker-skills/alert-fusion/SKILL.md
+```
+
+Then tell the Manager:
+
+> Install the `alert-fusion` skill from `~/worker-skills/alert-fusion/` for Worker `amy-ai`. Verify the upload and confirm that `amy-ai`'s assigned skills include it.
+
+The Manager uploads the files, verifies the remote `SKILL.md`, and updates the Worker assignment. QwenPaw Workers synchronize and enable the newly assigned skill automatically. Check the final assignment with:
+
+```bash
+agt get workers amy-ai -o json | jq '.skills'
+```
+
+If installation fails, check that the folder name matches the `name` in `SKILL.md` and that the file is located under `worker-skills/<skill-name>/`. See [Installing a Skill on a Worker through the Manager](manager-guide.md#installing-a-skill-on-a-worker-through-the-manager) for the full workflow.
 
 ---
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -237,7 +237,9 @@ For declarative YAML resource definitions, see [Declarative Resource Management]
 
 ## How to install a third-party skill on a Worker through the Manager
 
-Place the complete skill directory under the Manager workspace's `worker-skills/` directory. For example:
+You can either place the complete Skill directory under the Manager workspace's `worker-skills/` directory, or send a ZIP attachment containing one complete Skill root directly to the Manager.
+
+Workspace example:
 
 ```text
 ~/agentteams-manager/worker-skills/alert-fusion/SKILL.md
@@ -246,6 +248,10 @@ Place the complete skill directory under the Manager workspace's `worker-skills/
 Then tell the Manager:
 
 > Install the `alert-fusion` skill from `~/worker-skills/alert-fusion/` for Worker `amy-ai`. Verify the upload and confirm that `amy-ai`'s assigned skills include it.
+
+After sending a ZIP attachment, you can instead say:
+
+> Install the Skill from the ZIP attachment I just sent for Worker `amy-ai`. Safely extract and validate it, then distribute it and verify the assignment.
 
 The Manager uploads the files, verifies the remote `SKILL.md`, and updates the Worker assignment. QwenPaw Workers synchronize and enable the newly assigned skill automatically.
 

--- a/docs/k8s-native-agent-orch.md
+++ b/docs/k8s-native-agent-orch.md
@@ -170,7 +170,6 @@ spec:
   runtime: openclaw                   # openclaw | qwenpaw
   # soul: | …                         # optional SOUL.md override
   # agents: | …                       # optional AGENTS.md override
-  skills: [worker-management]         # on-demand Manager skills
   mcpServers:
     - name: github
       url: https://gateway.example.com/mcp-servers/github/mcp

--- a/docs/manager-guide.md
+++ b/docs/manager-guide.md
@@ -52,16 +52,32 @@ The Manager Agent's behavior is defined by three files stored in the **`agenttea
 
 If your install still exposes MinIO on localhost, use the MinIO Console; otherwise use `mc` from inside **`agentteams-controller`** or edit the mirrored files under the workspace directory on the host.
 
-### Adding Skills
+### Installing a Skill on a Worker through the Manager
 
-The repo ships **16** built-in Manager skills under `manager/agent/skills/` (synced into the bucket as `agents/manager/skills/<name>/SKILL.md`): **channel-management**, **file-sync-management**, **git-delegation-management**, **agentteams-find-worker**, **human-management**, **matrix-server-management**, **mcp-server-management**, **mcporter**, **model-switch**, **project-management**, **service-publishing**, **task-coordination**, **task-management**, **team-management**, **worker-management**, **worker-model-switch**.
+To add a third-party skill to an existing Worker, first put the complete skill directory in the Manager workspace's Worker skill library. With the default workspace location, the host-side layout is:
 
-Place additional self-contained `SKILL.md` files under `agents/manager/skills/<skill-name>/`. The Manager runtime auto-discovers skills from that directory.
+```text
+~/agentteams-manager/worker-skills/alert-fusion/
+├── SKILL.md
+├── scripts/       # optional
+└── references/    # optional
+```
 
-To add a new skill:
-1. Create directory: `agents/manager/skills/<your-skill-name>/`
-2. Write `SKILL.md` with complete API reference and examples
-3. The Manager Agent will discover it automatically (~300ms)
+If `AGENTTEAMS_WORKSPACE_DIR` uses a custom location, replace `~/agentteams-manager` with that directory. Inside the Manager container, the same skill is available as `~/worker-skills/alert-fusion/`. The directory name and the `name` in `SKILL.md` should match.
+
+Then send the Manager a direct instruction, for example:
+
+> Install the `alert-fusion` skill for Worker `amy-ai`. The skill files are in `~/worker-skills/alert-fusion/`. Verify the installation and confirm that the Worker assignment includes this skill.
+
+The Manager validates the skill source, uploads the complete directory to the Worker's isolated storage, verifies the remote `SKILL.md`, and only then updates the Worker's assigned skills. For a QwenPaw Worker, the runtime pulls the assignment, copies the skill into its native workspace, refreshes skill discovery, and enables the skill. No manual QwenPaw restart is required.
+
+Verify the assignment from the Manager or controller container:
+
+```bash
+agt get workers amy-ai -o json | jq '.skills'
+```
+
+You can also ask the Manager to have `amy-ai` confirm that it can read and use `alert-fusion`. If the Manager reports that the source is missing, check that `SKILL.md` is under `worker-skills/<skill-name>/`, not directly under `worker-skills/`.
 
 ### Managing MCP Servers
 

--- a/docs/manager-guide.md
+++ b/docs/manager-guide.md
@@ -54,7 +54,11 @@ If your install still exposes MinIO on localhost, use the MinIO Console; otherwi
 
 ### Installing a Skill on a Worker through the Manager
 
-To add a third-party skill to an existing Worker, first put the complete skill directory in the Manager workspace's Worker skill library. With the default workspace location, the host-side layout is:
+There are two supported ways to give the Manager the Skill files.
+
+#### Use the Manager workspace
+
+Put the complete skill directory in the Manager workspace's Worker skill library. With the default workspace location, the host-side layout is:
 
 ```text
 ~/agentteams-manager/worker-skills/alert-fusion/
@@ -68,6 +72,14 @@ If `AGENTTEAMS_WORKSPACE_DIR` uses a custom location, replace `~/agentteams-mana
 Then send the Manager a direct instruction, for example:
 
 > Install the `alert-fusion` skill for Worker `amy-ai`. The skill files are in `~/worker-skills/alert-fusion/`. Verify the installation and confirm that the Worker assignment includes this skill.
+
+#### Send a ZIP attachment to the Manager
+
+Package one complete Skill root as a ZIP. The archive must contain `SKILL.md` and may also contain `scripts/` and `references/`. Send the ZIP as a file attachment in a Manager conversation, then send an instruction such as:
+
+> Install the Skill from the ZIP attachment I just sent for Worker `amy-ai`. Safely extract and validate `SKILL.md`, stage the complete Skill under `~/worker-skills/`, distribute it, and verify the final assignment.
+
+The built-in Matrix conversation supports file attachments. The Manager downloads the attachment, rejects unsafe or ambiguous archives, extracts it into a temporary directory, validates the Skill metadata, and then places the complete directory in the Worker skill library before distribution. Send a ZIP rather than separate files when the Skill includes scripts or references.
 
 The Manager validates the skill source, uploads the complete directory to the Worker's isolated storage, verifies the remote `SKILL.md`, and only then updates the Worker's assigned skills. For a QwenPaw Worker, the runtime pulls the assignment, copies the skill into its native workspace, refreshes skill discovery, and enables the skill. No manual QwenPaw restart is required.
 

--- a/docs/manager-guide.md
+++ b/docs/manager-guide.md
@@ -71,13 +71,21 @@ Then send the Manager a direct instruction, for example:
 
 The Manager validates the skill source, uploads the complete directory to the Worker's isolated storage, verifies the remote `SKILL.md`, and only then updates the Worker's assigned skills. For a QwenPaw Worker, the runtime pulls the assignment, copies the skill into its native workspace, refreshes skill discovery, and enables the skill. No manual QwenPaw restart is required.
 
-Verify the assignment from the Manager or controller container:
+You can verify the assignment through natural-language conversation with the Manager:
+
+> Check the skills currently assigned to Worker `amy-ai` and confirm whether `alert-fusion` is included.
+
+To verify runtime availability rather than only the assignment record, ask:
+
+> Ask Worker `amy-ai` to confirm that it can discover and use the `alert-fusion` skill.
+
+For operator-side inspection or troubleshooting, run the equivalent query from the Manager or controller container:
 
 ```bash
 agt get workers amy-ai -o json | jq '.skills'
 ```
 
-You can also ask the Manager to have `amy-ai` confirm that it can read and use `alert-fusion`. If the Manager reports that the source is missing, check that `SKILL.md` is under `worker-skills/<skill-name>/`, not directly under `worker-skills/`.
+If the Manager reports that the source is missing, check that `SKILL.md` is under `worker-skills/<skill-name>/`, not directly under `worker-skills/`.
 
 ### Managing MCP Servers
 

--- a/docs/worker-guide.md
+++ b/docs/worker-guide.md
@@ -60,15 +60,20 @@ The Manager will provide all the specific values in its reply.
 
 ## Installing Skills through the Manager
 
-For an existing Worker, use the Manager conversation as the supported installation entry point:
+For an existing Worker, use the Manager conversation as the supported installation entry point. Provide the Skill in either of these ways:
 
-1. Put the complete third-party skill under `$AGENTTEAMS_WORKSPACE_DIR/worker-skills/<skill-name>/` on the Manager host. The default is `~/agentteams-manager/worker-skills/<skill-name>/`.
-2. Make sure the directory contains `SKILL.md` and that its `name` matches `<skill-name>`.
-3. Ask the Manager to install that skill for a named Worker and verify the assignment.
+1. Put the complete third-party skill under `$AGENTTEAMS_WORKSPACE_DIR/worker-skills/<skill-name>/` on the Manager host. The default is `~/agentteams-manager/worker-skills/<skill-name>/`; or
+2. Send the Manager a ZIP attachment containing one complete Skill root with `SKILL.md` and any optional `scripts/` or `references/`.
+
+Then ask the Manager to install that Skill for a named Worker and verify the assignment. For a ZIP attachment, explicitly ask the Manager to safely extract and validate it before distribution.
 
 For example:
 
 > Install the `alert-fusion` skill from `~/worker-skills/alert-fusion/` for Worker `amy-ai`. Verify that the files were uploaded and the Worker assignment was updated.
+
+Or, after sending the ZIP attachment:
+
+> Install the Skill from the ZIP attachment I just sent for Worker `amy-ai`. Safely extract and validate it, distribute the complete Skill, and verify the Worker assignment.
 
 The Manager uploads and verifies the files before updating `Worker.spec.skills`. This ordering prevents a Worker from receiving an assignment that points to missing content. QwenPaw Workers then synchronize the assigned skill into their native workspace and refresh and enable it automatically.
 

--- a/docs/worker-guide.md
+++ b/docs/worker-guide.md
@@ -72,7 +72,11 @@ For example:
 
 The Manager uploads and verifies the files before updating `Worker.spec.skills`. This ordering prevents a Worker from receiving an assignment that points to missing content. QwenPaw Workers then synchronize the assigned skill into their native workspace and refresh and enable it automatically.
 
-Check the assignment with:
+You can check the assignment by asking the Manager:
+
+> List the skills currently assigned to Worker `amy-ai` and confirm whether `alert-fusion` is included.
+
+For operator-side inspection or troubleshooting, use the equivalent CLI query:
 
 ```bash
 agt get workers amy-ai -o json | jq '.skills'

--- a/docs/worker-guide.md
+++ b/docs/worker-guide.md
@@ -58,6 +58,28 @@ docker run -d --name agentteams-worker-alice \
 
 The Manager will provide all the specific values in its reply.
 
+## Installing Skills through the Manager
+
+For an existing Worker, use the Manager conversation as the supported installation entry point:
+
+1. Put the complete third-party skill under `$AGENTTEAMS_WORKSPACE_DIR/worker-skills/<skill-name>/` on the Manager host. The default is `~/agentteams-manager/worker-skills/<skill-name>/`.
+2. Make sure the directory contains `SKILL.md` and that its `name` matches `<skill-name>`.
+3. Ask the Manager to install that skill for a named Worker and verify the assignment.
+
+For example:
+
+> Install the `alert-fusion` skill from `~/worker-skills/alert-fusion/` for Worker `amy-ai`. Verify that the files were uploaded and the Worker assignment was updated.
+
+The Manager uploads and verifies the files before updating `Worker.spec.skills`. This ordering prevents a Worker from receiving an assignment that points to missing content. QwenPaw Workers then synchronize the assigned skill into their native workspace and refresh and enable it automatically.
+
+Check the assignment with:
+
+```bash
+agt get workers amy-ai -o json | jq '.skills'
+```
+
+Copying files into Worker storage without updating the assignment is not a complete installation. The skill name must also appear in `Worker.spec.skills` so managed runtimes know which skills to load.
+
 ## Troubleshooting
 
 ### Worker won't start

--- a/docs/zh-cn/architecture.md
+++ b/docs/zh-cn/architecture.md
@@ -167,7 +167,7 @@ Helm **`worker.defaultImage`** 会为不同 runtime 提供不同的默认 reposi
 ### CRDs（`agentteams.io/v1beta1`）
 
 1. **Worker**：model、runtime、image、skills、MCP servers、可选 **expose** ports、**channelPolicy**、**state**（`Running` / `Sleeping` / `Stopped`）、**accessEntries**（使用 provider sidecar 时的云凭证作用域）。
-2. **Manager**：model、runtime、image、soul/agents overrides、skills、MCP servers、**config**（heartbeat interval、worker idle timeout、notify channel）、**state**、**accessEntries**。
+2. **Manager**：model、runtime、image、soul/agents overrides、MCP servers、**config**（heartbeat interval、worker idle timeout、notify channel）、**state**、**accessEntries**。
 3. **Team**：**Leader** + **Workers** specs、可选 **admin**、**peerMentions**、team **channelPolicy**；status 聚合成员就绪状态和 rooms（**team room**、**leader DM**、每个成员与 Manager 的 **RoomID**）。
 4. **Human**：display name、email、**permissionLevel**、可访问 teams/workers；status 包含 Matrix user、initial password（一次性）和 rooms。
 
@@ -207,7 +207,7 @@ Skills 是面向 Agent 的 **Markdown**（`SKILL.md`），可带可选的 `scrip
 ### Worker skills
 
 - **按 runtime 内置**：**`manager/agent/worker-agent/`**（OpenClaw）、**`copaw-worker-agent/`** 和 **`hermes-worker-agent/`** 下的模板包含一组小型 **core** skills，例如 **file-sync**、**mcporter**、**find-skills**、**project-participation**、**task-progress**，在 worker provision 时物化到每个 worker workspace。
-- **按需分发**：**`manager/agent/worker-skills/`**（例如 **github-operations**、**git-delegation**）中的包，可由 Manager 在 `spec.skills` 引用时推送给 workers。
+- **按需分发**：**`manager/agent/worker-skills/`**（例如 **github-operations**、**git-delegation**）中的包，由管理员通过对话让 Manager 安装给指定 Worker；Manager 会先校验和上传 Skill，再将其加入 `spec.skills`。
 
 ### Team Leader skills
 

--- a/docs/zh-cn/declarative-resource-management.md
+++ b/docs/zh-cn/declarative-resource-management.md
@@ -105,9 +105,11 @@ spec:
 
 `spec.skills` 记录分配给 Worker 的 Skills。被引用的 Skill 可以来自 AgentTeams 的 Worker Skill 库，也可以是放在 `$AGENTTEAMS_WORKSPACE_DIR/worker-skills/<skill-name>/` 下的第三方 Skill。
 
-对于已有 Worker，推荐先将完整 Skill 目录放入 Manager 工作空间，再通过对话让 Manager 安装：
+对于已有 Worker，可以将完整 Skill 目录放入 Manager 工作空间，也可以直接向 Manager 发送一个包含完整 Skill 根目录的 ZIP 附件，然后通过对话让 Manager 安装：
 
 > 请将 `~/worker-skills/alert-fusion/` 中的 `alert-fusion` Skill 安装给 Worker `amy-ai`。请验证上传结果，并确认 Worker 的 Skill 分配已经包含该 Skill。
+
+如果使用附件，应要求 Manager 在将 Skill 放入 `~/worker-skills/` 并分发之前，先安全解压并校验 ZIP 内容。
 
 Manager 会先上传并验证 `SKILL.md`，再更新 `spec.skills`。QwenPaw Worker 会消费生成的运行时分配，将指定 Skill 同步到原生工作空间，然后自动刷新并启用。
 

--- a/docs/zh-cn/declarative-resource-management.md
+++ b/docs/zh-cn/declarative-resource-management.md
@@ -85,7 +85,7 @@ spec:
 | `spec.identity` | string | 否 | — | Worker 公开身份（OpenClaw：生成 IDENTITY.md；QwenPaw：按实现合并入 SOUL.md） |
 | `spec.soul` | string | 否 | — | Worker 人格与价值观设定，用于生成 SOUL.md |
 | `spec.agents` | string | 否 | — | Agent 行为规则，用于生成 AGENTS.md |
-| `spec.skills` | []string | 否 | — | 内置 skills 列表，由 Manager 统一分发 |
+| `spec.skills` | []string | 否 | — | 分配给 Worker 的 skills，由 Manager 统一校验和分发 |
 | `spec.mcpServers` | []string | 否 | — | 内置 MCP Servers 列表，通过 Higress 网关授权 |
 | `spec.package` | string | 否 | — | 自定义包 URI：`file://`、`http(s)://`、`nacos://`，或上传后由 Controller 解析的 `packages/{name}.zip` |
 | `spec.expose` | []object | 否 | — | 通过 Higress 网关暴露的端口列表（见 [服务发布](#服务发布)） |
@@ -101,11 +101,17 @@ spec:
 
 两者可以同时使用——当同时配置时，内联字段会覆盖包中的对应文件。这允许你使用 package 作为基础模板，同时通过 YAML 定制特定部分。例如，导入一个共享的 Worker 包，但通过 `soul` 字段覆盖角色定义，赋予 Worker 独特的身份。
 
-### 内置 Skills 与自定义 Skills
+### Worker Skills
 
-`spec.skills` 指的是 AgentTeams 平台内置的能力，由 Manager 通过 `push-worker-skills.sh` 分发到 Worker 的 MinIO 空间。
+`spec.skills` 记录分配给 Worker 的 Skills。被引用的 Skill 可以来自 AgentTeams 的 Worker Skill 库，也可以是放在 `$AGENTTEAMS_WORKSPACE_DIR/worker-skills/<skill-name>/` 下的第三方 Skill。
 
-如果需要自定义 Skills，通过 `spec.package` 引入一个包含 `skills/` 目录的 ZIP 包。内置 skills 和自定义 skills 会合并推送，互不冲突。
+对于已有 Worker，推荐先将完整 Skill 目录放入 Manager 工作空间，再通过对话让 Manager 安装：
+
+> 请将 `~/worker-skills/alert-fusion/` 中的 `alert-fusion` Skill 安装给 Worker `amy-ai`。请验证上传结果，并确认 Worker 的 Skill 分配已经包含该 Skill。
+
+Manager 会先上传并验证 `SKILL.md`，再更新 `spec.skills`。QwenPaw Worker 会消费生成的运行时分配，将指定 Skill 同步到原生工作空间，然后自动刷新并启用。
+
+也可以通过 `spec.package` 引入一个包含 `skills/` 目录的 Worker 包。包内 Skills 与按名称分配的 Skills 会合并，互不冲突。
 
 ### 带自定义包的 Worker
 
@@ -303,7 +309,7 @@ spec:
 
 ## Manager
 
-**Manager** 资源描述 AgentTeams 的 Manager Agent：接收 Admin 指令并编排 Worker 与 Team。与其它资源同属 `agentteams.io/v1beta1`，由 `agentteams-controller` 调和（镜像、SOUL/AGENTS、skills、MCP 授权、可选 package、期望 `state` 等）。
+**Manager** 资源描述 AgentTeams 的 Manager Agent：接收 Admin 指令并编排 Worker 与 Team。与其它资源同属 `agentteams.io/v1beta1`，由 `agentteams-controller` 调和（镜像、SOUL/AGENTS、MCP 授权、可选 package、期望 `state` 等）。
 
 ### 基础配置
 
@@ -319,8 +325,6 @@ spec:
     # Manager — 以协调为主
   agents: |
     # 可选 AGENTS.md 覆盖
-  skills:
-    - worker-management
   mcpServers:
     - name: github
       url: https://gateway.example.com/mcp-servers/github/mcp
@@ -341,7 +345,6 @@ spec:
 | `spec.image` | string | 否 | — | 自定义 Manager 镜像；留空则用部署默认值 |
 | `spec.soul` | string | 否 | — | 自定义 SOUL.md |
 | `spec.agents` | string | 否 | — | 自定义 AGENTS.md |
-| `spec.skills` | []string | 否 | — | 启用的按需 skills |
 | `spec.mcpServers` | []string | 否 | — | 经网关授权的 MCP |
 | `spec.package` | string | 否 | — | 包 URI（`file://`、`http(s)://`、`nacos://`） |
 | `spec.state` | string | 否 | `Running` | 期望生命周期：`Running`、`Sleeping`、`Stopped` |
@@ -763,7 +766,7 @@ Reconciler 执行对应脚本（create-worker.sh / create-team.sh / create-human
 | Worker | 创建容器 + Matrix 账号 + MinIO 空间 | model 变更→重新生成配置；skills 变更→重新推送 | 停止容器 + 清理资源 |
 | Team | 校验并关联已有 Worker + 创建 Team Room | `workerMembers` 变化→更新成员关系与协作上下文 | 清理 Team Room 与协作上下文；保留 Worker CR 及运行时 |
 | Human | 注册 Matrix 账号 + 配置权限 + 发邮件 | permissionLevel 变化→重算 groupAllowFrom | 从所有 groupAllowFrom 移除→踢出 Room |
-| Manager | 部署/更新 Manager Agent | model/skills/package/state 等变更→调和 | 按后端实现回收 Manager 相关资源 |
+| Manager | 部署/更新 Manager Agent | model/package/state 等变更→调和 | 按后端实现回收 Manager 相关资源 |
 
 所有资源使用 Kubernetes finalizer 模式，确保删除前完成清理。
 

--- a/docs/zh-cn/declarative-resource-management.md
+++ b/docs/zh-cn/declarative-resource-management.md
@@ -111,6 +111,10 @@ spec:
 
 Manager 会先上传并验证 `SKILL.md`，再更新 `spec.skills`。QwenPaw Worker 会消费生成的运行时分配，将指定 Skill 同步到原生工作空间，然后自动刷新并启用。
 
+除了使用 CLI，也可以直接通过对话检查分配结果：
+
+> 请检查 Worker `amy-ai` 当前分配的 Skill，并确认其中是否包含 `alert-fusion`。
+
 也可以通过 `spec.package` 引入一个包含 `skills/` 目录的 Worker 包。包内 Skills 与按名称分配的 Skills 会合并，互不冲突。
 
 ### 带自定义包的 Worker

--- a/docs/zh-cn/faq.md
+++ b/docs/zh-cn/faq.md
@@ -236,7 +236,9 @@ agt delete human john
 
 ## 如何通过 Manager 为 Worker 安装第三方 Skill
 
-将完整 Skill 目录放在 Manager 工作空间的 `worker-skills/` 目录下，例如：
+可以将完整 Skill 目录放在 Manager 工作空间的 `worker-skills/` 目录下，也可以直接向 Manager 发送一个包含完整 Skill 根目录的 ZIP 附件。
+
+工作空间示例：
 
 ```text
 ~/agentteams-manager/worker-skills/alert-fusion/SKILL.md
@@ -245,6 +247,10 @@ agt delete human john
 然后告诉 Manager：
 
 > 请将 `~/worker-skills/alert-fusion/` 中的 `alert-fusion` Skill 安装给 Worker `amy-ai`。请验证上传结果，并确认 `amy-ai` 的 Skill 分配已经包含它。
+
+如果已经发送 ZIP 附件，也可以说：
+
+> 请将我刚发送的 ZIP 附件中的 Skill 安装给 Worker `amy-ai`。请安全解压并校验，然后完成分发并验证分配结果。
 
 Manager 会上传文件、验证远端 `SKILL.md`，然后更新 Worker 的 Skill 分配。QwenPaw Worker 会自动同步并启用新分配的 Skill。
 

--- a/docs/zh-cn/faq.md
+++ b/docs/zh-cn/faq.md
@@ -5,6 +5,7 @@
 - [如何查看当前 AgentTeams 版本](#如何查看当前-agentteams-版本)
 - [新架构说明（v1.1.0+）](#新架构说明v110)
 - [如何使用 agt CLI 管理资源](#如何使用-agt-cli-管理资源)
+- [如何通过 Manager 为 Worker 安装第三方 Skill](#如何通过-manager-为-worker-安装第三方-skill)
 - [如何为 Worker 配置 GitHub 凭据](#如何为-worker-配置-github-凭据)
 - [如何对接飞书/钉钉/企业微信/Discord/Telegram](#如何对接飞书钉钉企业微信discordtelegram)
 - [Windows 下执行安装脚本闪退](#windows-下执行安装脚本闪退)
@@ -230,6 +231,28 @@ agt delete human john
 > **提示：** Manager Agent 的大部分操作（创建 Worker、切换模型、分配任务）底层都调用了同一套 `agt` CLI。直接使用 CLI 适合调试、批量操作或自动化脚本场景。
 
 声明式 YAML 资源定义的完整文档请参阅 [声明式资源管理](declarative-resource-management.md)。
+
+---
+
+## 如何通过 Manager 为 Worker 安装第三方 Skill
+
+将完整 Skill 目录放在 Manager 工作空间的 `worker-skills/` 目录下，例如：
+
+```text
+~/agentteams-manager/worker-skills/alert-fusion/SKILL.md
+```
+
+然后告诉 Manager：
+
+> 请将 `~/worker-skills/alert-fusion/` 中的 `alert-fusion` Skill 安装给 Worker `amy-ai`。请验证上传结果，并确认 `amy-ai` 的 Skill 分配已经包含它。
+
+Manager 会上传文件、验证远端 `SKILL.md`，然后更新 Worker 的 Skill 分配。QwenPaw Worker 会自动同步并启用新分配的 Skill。可使用以下命令检查最终结果：
+
+```bash
+agt get workers amy-ai -o json | jq '.skills'
+```
+
+如果安装失败，请检查目录名是否与 `SKILL.md` 中的 `name` 一致，并确认文件位于 `worker-skills/<skill-name>/` 下。完整流程参见 [通过 Manager 为 Worker 安装 Skill](manager-guide.md#通过-manager-为-worker-安装-skill)。
 
 ---
 

--- a/docs/zh-cn/faq.md
+++ b/docs/zh-cn/faq.md
@@ -246,7 +246,13 @@ agt delete human john
 
 > 请将 `~/worker-skills/alert-fusion/` 中的 `alert-fusion` Skill 安装给 Worker `amy-ai`。请验证上传结果，并确认 `amy-ai` 的 Skill 分配已经包含它。
 
-Manager 会上传文件、验证远端 `SKILL.md`，然后更新 Worker 的 Skill 分配。QwenPaw Worker 会自动同步并启用新分配的 Skill。可使用以下命令检查最终结果：
+Manager 会上传文件、验证远端 `SKILL.md`，然后更新 Worker 的 Skill 分配。QwenPaw Worker 会自动同步并启用新分配的 Skill。
+
+可以通过自然语言对话检查分配结果：
+
+> 请列出 Worker `amy-ai` 当前分配的 Skill，并确认其中是否包含 `alert-fusion`。
+
+如果需要从运维侧检查或排障，可使用等价的 CLI 查询：
 
 ```bash
 agt get workers amy-ai -o json | jq '.skills'

--- a/docs/zh-cn/k8s-native-agent-orch.md
+++ b/docs/zh-cn/k8s-native-agent-orch.md
@@ -172,7 +172,6 @@ spec:
   runtime: openclaw                   # openclaw | copaw
   # soul: | …                         # 可选：覆盖 SOUL.md
   # agents: | …                       # 可选：覆盖 AGENTS.md
-  skills: [worker-management]         # 按需启用的 Manager skills
   mcpServers:
     - name: github
       url: https://gateway.example.com/mcp-servers/github/mcp

--- a/docs/zh-cn/manager-guide.md
+++ b/docs/zh-cn/manager-guide.md
@@ -71,13 +71,21 @@ Manager 通过安装时设置的环境变量进行配置。安装脚本会生成
 
 Manager 会依次校验 Skill 源文件、将完整目录上传到 Worker 的隔离存储、确认远端 `SKILL.md` 存在，然后才更新 Worker 的 Skill 分配。对于 QwenPaw Worker，运行时会拉取新的分配，将 Skill 复制到原生工作空间，刷新 Skill 列表并启用该 Skill，无需手动重启 QwenPaw。
 
-可在 Manager 或 controller 容器中检查分配结果：
+可以直接通过自然语言对话让 Manager 检查分配结果：
+
+> 请检查 Worker `amy-ai` 当前分配的 Skill，并确认其中是否包含 `alert-fusion`。
+
+如果需要验证的不只是分配记录，而是 Worker 运行时是否已经实际可用，可以继续询问：
+
+> 请让 Worker `amy-ai` 确认它能够发现并使用 `alert-fusion` Skill。
+
+如果需要从运维侧检查或排障，也可以在 Manager 或 controller 容器中执行等价查询：
 
 ```bash
 agt get workers amy-ai -o json | jq '.skills'
 ```
 
-也可以让 Manager 通知 `amy-ai`，由 Worker 确认能够读取并使用 `alert-fusion`。如果 Manager 提示找不到源文件，请确认 `SKILL.md` 位于 `worker-skills/<skill-name>/` 下，而不是直接放在 `worker-skills/` 根目录。
+如果 Manager 提示找不到源文件，请确认 `SKILL.md` 位于 `worker-skills/<skill-name>/` 下，而不是直接放在 `worker-skills/` 根目录。
 
 ### 管理 MCP Server
 

--- a/docs/zh-cn/manager-guide.md
+++ b/docs/zh-cn/manager-guide.md
@@ -52,16 +52,32 @@ Manager 通过安装时设置的环境变量进行配置。安装脚本会生成
 
 若本地仍暴露 MinIO 端口，可使用 MinIO 控制台；否则在 **`agentteams-controller`** 内使用 `mc`，或编辑宿主机工作区中的镜像文件。
 
-### 添加技能
+### 通过 Manager 为 Worker 安装 Skill
 
-仓库内置 **16** 个 Manager 技能，源码位于 `manager/agent/skills/`，同步到桶内路径 `agents/manager/skills/<name>/SKILL.md`：**channel-management**、**file-sync-management**、**git-delegation-management**、**agentteams-find-worker**、**human-management**、**matrix-server-management**、**mcp-server-management**、**mcporter**、**model-switch**、**project-management**、**service-publishing**、**task-coordination**、**task-management**、**team-management**、**worker-management**、**worker-model-switch**。
+要给已有 Worker 增加第三方 Skill，先将完整的 Skill 目录放入 Manager 工作空间的 Worker Skill 库。使用默认工作空间时，宿主机目录结构如下：
 
-将更多自包含的 `SKILL.md` 放到 `agents/manager/skills/<skill-name>/`。Manager 运行时会自动发现该目录下的技能。
+```text
+~/agentteams-manager/worker-skills/alert-fusion/
+├── SKILL.md
+├── scripts/       # 可选
+└── references/    # 可选
+```
 
-添加新技能的步骤：
-1. 创建目录：`agents/manager/skills/<your-skill-name>/`
-2. 编写 `SKILL.md`，包含完整的 API 参考和示例
-3. Manager Agent 会自动发现它（约 300ms）
+如果通过 `AGENTTEAMS_WORKSPACE_DIR` 配置了其他工作空间，请将 `~/agentteams-manager` 替换为实际目录。在 Manager 容器中，同一个 Skill 的路径为 `~/worker-skills/alert-fusion/`。目录名应与 `SKILL.md` 中的 `name` 保持一致。
+
+然后直接向 Manager 下达指令，例如：
+
+> 请为 Worker `amy-ai` 安装 `alert-fusion` Skill。Skill 文件位于 `~/worker-skills/alert-fusion/`。安装完成后请验证，并确认该 Skill 已加入 Worker 的分配列表。
+
+Manager 会依次校验 Skill 源文件、将完整目录上传到 Worker 的隔离存储、确认远端 `SKILL.md` 存在，然后才更新 Worker 的 Skill 分配。对于 QwenPaw Worker，运行时会拉取新的分配，将 Skill 复制到原生工作空间，刷新 Skill 列表并启用该 Skill，无需手动重启 QwenPaw。
+
+可在 Manager 或 controller 容器中检查分配结果：
+
+```bash
+agt get workers amy-ai -o json | jq '.skills'
+```
+
+也可以让 Manager 通知 `amy-ai`，由 Worker 确认能够读取并使用 `alert-fusion`。如果 Manager 提示找不到源文件，请确认 `SKILL.md` 位于 `worker-skills/<skill-name>/` 下，而不是直接放在 `worker-skills/` 根目录。
 
 ### 管理 MCP Server
 

--- a/docs/zh-cn/manager-guide.md
+++ b/docs/zh-cn/manager-guide.md
@@ -54,7 +54,11 @@ Manager 通过安装时设置的环境变量进行配置。安装脚本会生成
 
 ### 通过 Manager 为 Worker 安装 Skill
 
-要给已有 Worker 增加第三方 Skill，先将完整的 Skill 目录放入 Manager 工作空间的 Worker Skill 库。使用默认工作空间时，宿主机目录结构如下：
+有两种方式可以把 Skill 文件交给 Manager。
+
+#### 使用 Manager 工作空间
+
+将完整的 Skill 目录放入 Manager 工作空间的 Worker Skill 库。使用默认工作空间时，宿主机目录结构如下：
 
 ```text
 ~/agentteams-manager/worker-skills/alert-fusion/
@@ -68,6 +72,14 @@ Manager 通过安装时设置的环境变量进行配置。安装脚本会生成
 然后直接向 Manager 下达指令，例如：
 
 > 请为 Worker `amy-ai` 安装 `alert-fusion` Skill。Skill 文件位于 `~/worker-skills/alert-fusion/`。安装完成后请验证，并确认该 Skill 已加入 Worker 的分配列表。
+
+#### 直接向 Manager 发送 ZIP 附件
+
+将一个完整的 Skill 根目录打包为 ZIP。压缩包必须包含 `SKILL.md`，也可以包含 `scripts/` 和 `references/`。在 Manager 对话中把 ZIP 作为文件附件发送，然后继续发送指令，例如：
+
+> 请将我刚发送的 ZIP 附件中的 Skill 安装给 Worker `amy-ai`。请安全解压并校验 `SKILL.md`，将完整 Skill 放入 `~/worker-skills/`，完成分发后检查最终分配结果。
+
+内置 Matrix 对话支持文件附件。Manager 会下载附件，拒绝存在不安全路径或包含多个 Skill 根目录的压缩包，在临时目录中解压并校验 Skill 元数据，然后才将完整目录放入 Worker Skill 库并开始分发。如果 Skill 还包含脚本或参考资料，应发送完整 ZIP，而不是分别发送多个文件。
 
 Manager 会依次校验 Skill 源文件、将完整目录上传到 Worker 的隔离存储、确认远端 `SKILL.md` 存在，然后才更新 Worker 的 Skill 分配。对于 QwenPaw Worker，运行时会拉取新的分配，将 Skill 复制到原生工作空间，刷新 Skill 列表并启用该 Skill，无需手动重启 QwenPaw。
 

--- a/docs/zh-cn/worker-guide.md
+++ b/docs/zh-cn/worker-guide.md
@@ -72,7 +72,11 @@ Manager 会在回复中提供所有具体参数值。
 
 Manager 会先上传并校验文件，再更新 `Worker.spec.skills`，避免 Worker 收到一个缺少实际内容的 Skill 分配。QwenPaw Worker 随后会把已分配 Skill 同步到原生工作空间，并自动刷新、启用。
 
-可使用以下命令检查分配结果：
+可以直接询问 Manager 来检查分配结果：
+
+> 请列出 Worker `amy-ai` 当前分配的 Skill，并确认其中是否包含 `alert-fusion`。
+
+如果需要从运维侧检查或排障，可使用等价的 CLI 查询：
 
 ```bash
 agt get workers amy-ai -o json | jq '.skills'

--- a/docs/zh-cn/worker-guide.md
+++ b/docs/zh-cn/worker-guide.md
@@ -58,6 +58,28 @@ docker run -d --name agentteams-worker-alice \
 
 Manager 会在回复中提供所有具体参数值。
 
+## 通过 Manager 安装 Skill
+
+对于已有 Worker，推荐以 Manager 对话作为安装入口：
+
+1. 在 Manager 宿主机上，将完整的第三方 Skill 放到 `$AGENTTEAMS_WORKSPACE_DIR/worker-skills/<skill-name>/`。默认路径为 `~/agentteams-manager/worker-skills/<skill-name>/`。
+2. 确认目录中包含 `SKILL.md`，并且其中的 `name` 与 `<skill-name>` 一致。
+3. 让 Manager 为指定 Worker 安装该 Skill，并验证分配结果。
+
+例如：
+
+> 请将 `~/worker-skills/alert-fusion/` 中的 `alert-fusion` Skill 安装给 Worker `amy-ai`。请确认文件上传成功，并验证 Worker 的 Skill 分配已经更新。
+
+Manager 会先上传并校验文件，再更新 `Worker.spec.skills`，避免 Worker 收到一个缺少实际内容的 Skill 分配。QwenPaw Worker 随后会把已分配 Skill 同步到原生工作空间，并自动刷新、启用。
+
+可使用以下命令检查分配结果：
+
+```bash
+agt get workers amy-ai -o json | jq '.skills'
+```
+
+仅将文件复制到 Worker 存储并不等于完成安装。Skill 名称还必须出现在 `Worker.spec.skills` 中，受管运行时才能确定需要加载哪些 Skill。
+
 ## 故障排查
 
 ### Worker 无法启动

--- a/docs/zh-cn/worker-guide.md
+++ b/docs/zh-cn/worker-guide.md
@@ -60,15 +60,20 @@ Manager 会在回复中提供所有具体参数值。
 
 ## 通过 Manager 安装 Skill
 
-对于已有 Worker，推荐以 Manager 对话作为安装入口：
+对于已有 Worker，推荐以 Manager 对话作为安装入口。可以通过以下任一方式提供 Skill：
 
-1. 在 Manager 宿主机上，将完整的第三方 Skill 放到 `$AGENTTEAMS_WORKSPACE_DIR/worker-skills/<skill-name>/`。默认路径为 `~/agentteams-manager/worker-skills/<skill-name>/`。
-2. 确认目录中包含 `SKILL.md`，并且其中的 `name` 与 `<skill-name>` 一致。
-3. 让 Manager 为指定 Worker 安装该 Skill，并验证分配结果。
+1. 在 Manager 宿主机上，将完整的第三方 Skill 放到 `$AGENTTEAMS_WORKSPACE_DIR/worker-skills/<skill-name>/`。默认路径为 `~/agentteams-manager/worker-skills/<skill-name>/`；或者
+2. 直接向 Manager 发送 ZIP 附件，压缩包内包含一个完整的 Skill 根目录、`SKILL.md`，以及可选的 `scripts/`、`references/`。
+
+然后让 Manager 为指定 Worker 安装该 Skill，并验证分配结果。如果使用 ZIP 附件，应明确要求 Manager 在分发前安全解压并校验内容。
 
 例如：
 
 > 请将 `~/worker-skills/alert-fusion/` 中的 `alert-fusion` Skill 安装给 Worker `amy-ai`。请确认文件上传成功，并验证 Worker 的 Skill 分配已经更新。
+
+或者在发送 ZIP 附件后说：
+
+> 请将我刚发送的 ZIP 附件中的 Skill 安装给 Worker `amy-ai`。请安全解压和校验，分发完整 Skill，并验证 Worker 的 Skill 分配。
 
 Manager 会先上传并校验文件，再更新 `Worker.spec.skills`，避免 Worker 收到一个缺少实际内容的 Skill 分配。QwenPaw Worker 随后会把已分配 Skill 同步到原生工作空间，并自动刷新、启用。
 

--- a/manager/agent/skills/worker-management/references/skills-management.md
+++ b/manager/agent/skills/worker-management/references/skills-management.md
@@ -32,6 +32,20 @@ After pushing, the script notifies affected Workers via Matrix @mention to use `
      --worker <name> --add-skill <skill-name>
    ```
 
+### From a chat attachment
+
+When the admin sends a Worker Skill as a ZIP attachment, the attachment is available to you as a local file. Do not search the entire filesystem for it: use the local path in the incoming `FileContent`. If that path is unavailable, report that the attachment could not be read and ask the admin to resend it.
+
+Before assigning the Skill:
+
+1. Inspect the ZIP without extracting it. Reject absolute paths, `..` traversal, symlinks, or archives containing more than one Skill root.
+2. Extract into a temporary directory, never directly into `~/worker-skills/`.
+3. Locate `SKILL.md`, validate its `name`, `description`, and `assign_when` frontmatter, and require the Skill name to match `^[A-Za-z0-9][A-Za-z0-9._-]*$`.
+4. Copy the complete validated Skill root, including optional `scripts/` and `references/`, to `~/worker-skills/<skill-name>/`.
+5. Run `push-worker-skills.sh --worker <name> --add-skill <skill-name>`, then query the Worker and report the final assignment.
+
+Never install an attached archive into the Manager's own `~/skills/` directory.
+
 ## Key facts
 
 - `file-sync`, `task-progress`, `project-participation` are default skills — always included, cannot be removed

--- a/manager/agent/skills/worker-management/scripts/push-worker-skills.sh
+++ b/manager/agent/skills/worker-management/scripts/push-worker-skills.sh
@@ -7,6 +7,7 @@ WORKER_NAME=""
 SKILL_NAME=""
 ADD_SKILL=""
 REMOVE_SKILL=""
+NOTIFY=true
 
 if [ -f /opt/agentteams/scripts/lib/agentteams-env.sh ]; then
     # shellcheck disable=SC1091
@@ -41,6 +42,13 @@ mirror_skill() {
     fi
     if source=$(find_skill_source "${skill}"); then
         mc mirror "${source}/" "${destination}/" --overwrite
+        # Some mc releases can print an S3 authorization error yet still exit
+        # zero from `mirror`. Verify the contract file before changing the CR,
+        # otherwise the Manager would report success for a missing skill.
+        if ! mc stat "${destination}/SKILL.md" >/dev/null 2>&1; then
+            echo "Worker skill upload verification failed: ${destination}/SKILL.md" >&2
+            return 1
+        fi
         return
     fi
     # A Manager may have uploaded a custom skill immediately before updating
@@ -53,13 +61,43 @@ mirror_skill() {
     return 1
 }
 
+notify_worker() {
+    local worker="$1"
+    local room_id="$2"
+    local skills_list="$3"
+    local token="${AGENTTEAMS_MANAGER_MATRIX_TOKEN:-}"
+    local matrix_url="${AGENTTEAMS_MATRIX_URL:-}"
+    local matrix_domain="${AGENTTEAMS_MATRIX_DOMAIN:-}"
+    local worker_id message payload txn_id
+
+    if [ -z "${room_id}" ] || [ -z "${token}" ] || [ -z "${matrix_url}" ] || [ -z "${matrix_domain}" ]; then
+        echo "Worker skill files were pushed, but Matrix notification is unavailable for ${worker}" >&2
+        return 0
+    fi
+
+    worker_id="@${worker}:${matrix_domain}"
+    message="${worker_id} Your Manager updated these workspace skills: [${skills_list}]. Use your file-sync skill now to pull the latest files."
+    payload=$(jq -nc \
+        --arg body "${message}" \
+        --arg worker_id "${worker_id}" \
+        '{msgtype:"m.text", body:$body, "m.mentions":{user_ids:[$worker_id]}}')
+    txn_id="worker-skills-$(date +%s)-$$"
+
+    curl -fsS -X PUT \
+        "${matrix_url%/}/_matrix/client/v3/rooms/${room_id}/send/m.room.message/${txn_id}" \
+        -H "Authorization: Bearer ${token}" \
+        -H 'Content-Type: application/json' \
+        --data "${payload}" >/dev/null \
+        || echo "Worker skill files were pushed, but Matrix notification failed for ${worker}" >&2
+}
+
 while [ $# -gt 0 ]; do
     case "$1" in
         --worker) WORKER_NAME="$2"; shift 2 ;;
         --skill) SKILL_NAME="$2"; shift 2 ;;
         --add-skill) ADD_SKILL="$2"; shift 2 ;;
         --remove-skill) REMOVE_SKILL="$2"; shift 2 ;;
-        --no-notify) shift ;;
+        --no-notify) NOTIFY=false; shift ;;
         *) echo "Unknown option: $1" >&2; exit 2 ;;
     esac
 done
@@ -69,6 +107,16 @@ if [ -z "${WORKER_NAME}" ] && [ -z "${SKILL_NAME}" ]; then
     exit 2
 fi
 [ -z "${ADD_SKILL}" ] || [ -z "${REMOVE_SKILL}" ] || { echo "--add-skill and --remove-skill are mutually exclusive" >&2; exit 2; }
+
+# Controller reconciliation already knows the Worker and assigned Skill. This
+# internal form avoids calling the Controller API from inside its own reconcile
+# loop, which may run before the API bearer token is ready during startup.
+if [ -n "${WORKER_NAME}" ] && [ -n "${SKILL_NAME}" ] \
+    && [ -z "${ADD_SKILL}" ] && [ -z "${REMOVE_SKILL}" ] \
+    && [ "${NOTIFY}" = false ]; then
+    mirror_skill "${WORKER_NAME}" "${SKILL_NAME}"
+    exit 0
+fi
 
 workers_json=$(agt get workers -o json)
 if [ -n "${WORKER_NAME}" ]; then
@@ -91,11 +139,22 @@ for worker in ${targets}; do
         [ -z "${skill}" ] || mirror_skill "${worker}" "${skill}"
     done < <(echo "${desired}" | jq -r '.[]')
 
-    # Controller reconciliation passes only --worker/--no-notify. Files must
-    # still be mirrored, but rewriting the same CR here would recurse.
+    # Re-push mode mirrors current assignments without rewriting the same CR.
     if [ -z "${ADD_SKILL}" ] && [ -z "${REMOVE_SKILL}" ]; then
+        if [ "${NOTIFY}" = true ]; then
+            room_id=$(echo "${workers_json}" | jq -r --arg worker "${worker}" \
+                '.workers[] | select(.name == $worker) | .roomID // empty')
+            notify_skills="${SKILL_NAME:-$(echo "${desired}" | jq -r 'join(", ")')}"
+            notify_worker "${worker}" "${room_id}" "${notify_skills}"
+        fi
         continue
     fi
     csv=$(echo "${desired}" | jq -r 'join(",")')
     agt update worker --name "${worker}" --skills "${csv}"
+    if [ "${NOTIFY}" = true ]; then
+        room_id=$(echo "${workers_json}" | jq -r --arg worker "${worker}" \
+            '.workers[] | select(.name == $worker) | .roomID // empty')
+        notify_skills="${ADD_SKILL:-${REMOVE_SKILL:-${csv}}}"
+        notify_worker "${worker}" "${room_id}" "${notify_skills}"
+    fi
 done

--- a/manager/agent/skills/worker-management/scripts/push-worker-skills.sh
+++ b/manager/agent/skills/worker-management/scripts/push-worker-skills.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# push-worker-skills.sh - Reconcile Worker skills through Worker CR specs.
+# push-worker-skills.sh - Distribute Worker skills and reconcile Worker CR specs.
 
 set -euo pipefail
 
@@ -7,6 +7,51 @@ WORKER_NAME=""
 SKILL_NAME=""
 ADD_SKILL=""
 REMOVE_SKILL=""
+
+if [ -f /opt/agentteams/scripts/lib/agentteams-env.sh ]; then
+    # shellcheck disable=SC1091
+    source /opt/agentteams/scripts/lib/agentteams-env.sh
+fi
+AGENTTEAMS_STORAGE_PREFIX="${AGENTTEAMS_STORAGE_PREFIX:-agentteams/agentteams-storage}"
+
+find_skill_source() {
+    local skill="$1"
+    local candidate
+    for candidate in \
+        "${HOME}/worker-skills/${skill}" \
+        "/root/manager-workspace/worker-skills/${skill}" \
+        "/root/agentteams-fs/agents/manager/worker-skills/${skill}" \
+        "/opt/agentteams/agent/worker-skills/${skill}"
+    do
+        if [ -f "${candidate}/SKILL.md" ]; then
+            printf '%s\n' "${candidate}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+mirror_skill() {
+    local worker="$1"
+    local skill="$2"
+    local source
+    local destination="${AGENTTEAMS_STORAGE_PREFIX}/agents/${worker}/skills/${skill}"
+    if declare -F ensure_mc_credentials >/dev/null 2>&1; then
+        ensure_mc_credentials
+    fi
+    if source=$(find_skill_source "${skill}"); then
+        mc mirror "${source}/" "${destination}/" --overwrite
+        return
+    fi
+    # A Manager may have uploaded a custom skill immediately before updating
+    # the CR. Controller reconciliation can reuse that verified remote copy
+    # even when it cannot mount the Manager workspace (for example on K8s).
+    if mc stat "${destination}/SKILL.md" >/dev/null 2>&1; then
+        return
+    fi
+    echo "Worker skill not found: ${HOME}/worker-skills/${skill}/SKILL.md (or built-in /opt/agentteams/agent/worker-skills/${skill}/SKILL.md)" >&2
+    return 1
+}
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -40,6 +85,16 @@ for worker in ${targets}; do
         desired=$(echo "${current}" | jq --arg skill "${REMOVE_SKILL}" 'map(select(. != $skill))')
     else
         desired="${current}"
+    fi
+
+    while IFS= read -r skill; do
+        [ -z "${skill}" ] || mirror_skill "${worker}" "${skill}"
+    done < <(echo "${desired}" | jq -r '.[]')
+
+    # Controller reconciliation passes only --worker/--no-notify. Files must
+    # still be mirrored, but rewriting the same CR here would recurse.
+    if [ -z "${ADD_SKILL}" ] && [ -z "${REMOVE_SKILL}" ]; then
+        continue
     fi
     csv=$(echo "${desired}" | jq -r 'join(",")')
     agt update worker --name "${worker}" --skills "${csv}"

--- a/manager/scripts/init/qwenpaw_manager_skill_sync.py
+++ b/manager/scripts/init/qwenpaw_manager_skill_sync.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Mirror Manager workspace skills into QwenPaw and refresh them at runtime."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+SKILL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+class ManagerSkillSync:
+    def __init__(
+        self,
+        *,
+        source_dir: Path,
+        workspace_dir: Path,
+        api_url: str,
+        state_file: Path,
+        request_timeout: float = 5.0,
+    ) -> None:
+        self.source_dir = source_dir
+        self.workspace_dir = workspace_dir
+        self.skills_dir = workspace_dir / "skills"
+        self.active_skills_dir = workspace_dir / "active_skills"
+        self.api_url = api_url.rstrip("/")
+        self.state_file = state_file
+        self.request_timeout = request_timeout
+
+    def _load_state(self) -> dict[str, str]:
+        try:
+            payload = json.loads(self.state_file.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return {}
+        skills = payload.get("skills")
+        if not isinstance(skills, dict):
+            return {}
+        return {
+            name: digest
+            for name, digest in skills.items()
+            if isinstance(name, str)
+            and SKILL_NAME_PATTERN.fullmatch(name)
+            and isinstance(digest, str)
+        }
+
+    def _save_state(self, skills: dict[str, str]) -> None:
+        self.state_file.parent.mkdir(parents=True, exist_ok=True)
+        temp_file = self.state_file.with_suffix(".tmp")
+        temp_file.write_text(
+            json.dumps({"skills": skills}, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(temp_file, self.state_file)
+
+    def _skill_digest(self, skill_dir: Path) -> str:
+        digest = hashlib.sha256()
+        for path in sorted(item for item in skill_dir.rglob("*") if item.is_file()):
+            relative = path.relative_to(skill_dir).as_posix().encode()
+            digest.update(len(relative).to_bytes(8, "big"))
+            digest.update(relative)
+            with path.open("rb") as handle:
+                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                    digest.update(chunk)
+        return digest.hexdigest()
+
+    def _scan_source(self) -> dict[str, tuple[Path, str]]:
+        result: dict[str, tuple[Path, str]] = {}
+        for skill_dir in sorted(self.source_dir.iterdir()):
+            if not skill_dir.is_dir():
+                continue
+            name = skill_dir.name
+            if not SKILL_NAME_PATTERN.fullmatch(name):
+                continue
+            if not (skill_dir / "SKILL.md").is_file():
+                continue
+            result[name] = (skill_dir, self._skill_digest(skill_dir))
+        return result
+
+    def _replace_skill_dir(self, source: Path, destination: Path) -> None:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        stage_root = Path(
+            tempfile.mkdtemp(prefix=f".{destination.name}.agentteams-", dir=destination.parent)
+        )
+        staged = stage_root / destination.name
+        backup = stage_root / "previous"
+        try:
+            shutil.copytree(source, staged)
+            if destination.exists():
+                os.replace(destination, backup)
+            try:
+                os.replace(staged, destination)
+            except Exception:
+                if backup.exists() and not destination.exists():
+                    os.replace(backup, destination)
+                raise
+        finally:
+            shutil.rmtree(backup, ignore_errors=True)
+            shutil.rmtree(stage_root, ignore_errors=True)
+
+    def _post_json(self, path: str, payload: object) -> Any:
+        body = json.dumps(payload).encode()
+        request = Request(
+            f"{self.api_url}{path}",
+            data=body,
+            headers={"content-type": "application/json"},
+            method="POST",
+        )
+        with urlopen(request, timeout=self.request_timeout) as response:
+            response_body = response.read()
+        if not response_body:
+            return None
+        return json.loads(response_body)
+
+    def _refresh_and_enable(self, changed: list[str]) -> None:
+        self._post_json("/api/skills/refresh", {})
+        if not changed:
+            return
+        result = self._post_json("/api/skills/batch-enable", changed)
+        if isinstance(result, dict) and isinstance(result.get("results"), dict):
+            results = result["results"]
+            failed = [
+                name
+                for name in changed
+                if not isinstance(results.get(name), dict)
+                or not results[name].get("success")
+            ]
+        elif isinstance(result, list):
+            # Keep compatibility with earlier CoPaw API responses.
+            failed = [
+                str(item.get("name") or "unknown")
+                for item in result
+                if not isinstance(item, dict) or not item.get("success")
+            ]
+        else:
+            raise RuntimeError("QwenPaw skill enable returned an invalid response")
+        if failed:
+            raise RuntimeError(f"QwenPaw skill enable failed: {', '.join(failed)}")
+
+    def sync_once(self) -> bool:
+        if not self.source_dir.is_dir():
+            print(
+                f"[manager-skill-sync] source directory is missing: {self.source_dir}",
+                file=sys.stderr,
+            )
+            return False
+
+        try:
+            previous = self._load_state()
+            current = self._scan_source()
+            changed = sorted(
+                name
+                for name, (_, digest) in current.items()
+                if previous.get(name) != digest
+            )
+            removed = sorted(set(previous) - set(current))
+            if not changed and not removed:
+                return True
+
+            for name in changed:
+                self._replace_skill_dir(current[name][0], self.skills_dir / name)
+            for name in removed:
+                shutil.rmtree(self.skills_dir / name, ignore_errors=True)
+                shutil.rmtree(self.active_skills_dir / name, ignore_errors=True)
+            self._refresh_and_enable(changed)
+            self._save_state({name: digest for name, (_, digest) in current.items()})
+        except (HTTPError, URLError, OSError, RuntimeError, ValueError) as exc:
+            print(f"[manager-skill-sync] sync failed: {exc}", file=sys.stderr)
+            return False
+
+        if changed:
+            print(
+                f"[manager-skill-sync] refreshed and enabled: {', '.join(changed)}",
+                file=sys.stderr,
+            )
+        if removed:
+            print(f"[manager-skill-sync] removed: {', '.join(removed)}", file=sys.stderr)
+        return True
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source-dir", type=Path, required=True)
+    parser.add_argument("--workspace-dir", type=Path, required=True)
+    parser.add_argument("--api-url", default="http://127.0.0.1:18799")
+    parser.add_argument("--state-file", type=Path, required=True)
+    parser.add_argument("--interval", type=float, default=1.0)
+    parser.add_argument("--once", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    sync = ManagerSkillSync(
+        source_dir=args.source_dir,
+        workspace_dir=args.workspace_dir,
+        api_url=args.api_url,
+        state_file=args.state_file,
+    )
+    if args.once:
+        return 0 if sync.sync_once() else 1
+    while True:
+        sync.sync_once()
+        time.sleep(max(args.interval, 0.1))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/manager/scripts/init/start-qwenpaw-manager.sh
+++ b/manager/scripts/init/start-qwenpaw-manager.sh
@@ -328,5 +328,17 @@ fi
 
 log "Starting QwenPaw 2.0 Manager (app mode)..."
 
+# Keep canonical Manager skills under $HOME/skills synchronized with the
+# QwenPaw native workspace after startup. QwenPaw does not watch the OpenClaw
+# layout itself, so merely adding a SKILL.md there would otherwise require a
+# Manager restart. The sync process waits for the API, refreshes the scanner,
+# and enables newly added or updated skills.
+python3 /opt/agentteams/scripts/init/qwenpaw_manager_skill_sync.py \
+    --source-dir "${OPENCLAW_WORKSPACE}/skills" \
+    --workspace-dir "${WORKSPACE_DIR}" \
+    --state-file "${QWENPAW_WORKING_DIR}/agentteams-manager-skills.json" \
+    --interval "${AGENTTEAMS_QWENPAW_SKILL_SYNC_INTERVAL_SECONDS:-1}" &
+log "QwenPaw Manager skill watcher started (PID: $!)"
+
 # run_copaw_app.py starts qwenpaw app (tools registered via agentteams-manager-tools plugin)
 exec python3 -m copaw_worker.run_copaw_app app --host 0.0.0.0 --port 18799

--- a/manager/scripts/init/start-qwenpaw-manager.sh
+++ b/manager/scripts/init/start-qwenpaw-manager.sh
@@ -87,6 +87,9 @@ log "Config bridged from openclaw.json"
 # ============================================================
 WORKSPACE_DIR="${QWENPAW_WORKING_DIR}/workspaces/default"
 mkdir -p "${WORKSPACE_DIR}"
+# QwenPaw's Matrix channel writes incoming attachments directly under media/
+# and currently assumes the directory already exists.
+mkdir -p "${WORKSPACE_DIR}/media"
 
 log "Syncing prompt files (cp -u: update only if source is newer)..."
 for _f in AGENTS.md SOUL.md HEARTBEAT.md TOOLS.md; do

--- a/manager/tests/test-push-worker-skills.sh
+++ b/manager/tests/test-push-worker-skills.sh
@@ -84,12 +84,19 @@ cat > "${CASE_DIR}/bin/mc" <<'EOF'
 set -euo pipefail
 printf 'mc %s\n' "$*" >> "${TEST_EVENTS}"
 if [ "${1:-}" = stat ]; then
-    [ "${TEST_MC_STAT_SUCCESS:-0}" = 1 ]
-    exit
+    if [ "${TEST_MC_STAT_SUCCESS:-0}" = 1 ] || grep -q '^mc mirror ' "${TEST_EVENTS}"; then
+        exit 0
+    fi
+    exit 1
 fi
 exit 0
 EOF
-    chmod +x "${CASE_DIR}/bin/agt" "${CASE_DIR}/bin/mc"
+cat > "${CASE_DIR}/bin/curl" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+printf 'curl %s\n' "$*" >> "${TEST_EVENTS}"
+EOF
+    chmod +x "${CASE_DIR}/bin/agt" "${CASE_DIR}/bin/mc" "${CASE_DIR}/bin/curl"
 }
 
 run_script() {
@@ -99,6 +106,9 @@ run_script() {
     TEST_STATE="${STATE}" \
     TEST_MC_STAT_SUCCESS="${MC_STAT_SUCCESS:-0}" \
     AGENTTEAMS_STORAGE_PREFIX="test/agentteams-storage" \
+    AGENTTEAMS_MANAGER_MATRIX_TOKEN="manager-token" \
+    AGENTTEAMS_MATRIX_URL="http://matrix.example.com" \
+    AGENTTEAMS_MATRIX_DOMAIN="example.com" \
     bash "${SCRIPT}" "$@"
 }
 
@@ -112,8 +122,14 @@ fi
 assert_contains "source is mirrored into amy-ai storage" \
     "mc mirror ${CASE_DIR}/home/worker-skills/competition-skill/ test/agentteams-storage/agents/amy-ai/skills/competition-skill/ --overwrite" \
     "${EVENTS}"
+assert_contains "uploaded SKILL.md is verified before updating the CR" \
+    "mc stat test/agentteams-storage/agents/amy-ai/skills/competition-skill/SKILL.md" \
+    "${EVENTS}"
 assert_contains "Worker.spec.skills is updated" \
     "agt update worker --name amy-ai --skills competition-skill" \
+    "${EVENTS}"
+assert_contains "worker is notified to pull the installed skill" \
+    "http://matrix.example.com/_matrix/client/v3/rooms/!amy:example.com/send/m.room.message/" \
     "${EVENTS}"
 mirror_line=$(grep -n '^mc mirror ' "${EVENTS}" | head -1 | cut -d: -f1)
 update_line=$(grep -n '^agt update worker ' "${EVENTS}" | head -1 | cut -d: -f1)
@@ -124,12 +140,12 @@ else
         "mirror line before update line" "$(cat "${EVENTS}")"
 fi
 
-echo "=== TC2: reconcile mode pushes current skills without recursively updating the CR ==="
+echo "=== TC2: reconcile mode pushes one assigned skill without calling the Controller API ==="
 setup_case "${TMPDIR_ROOT}/reconcile"
 cat > "${STATE}" <<'EOF'
 {"workers":[{"name":"amy-ai","runtime":"openclaw","skills":["competition-skill"],"roomID":"!amy:example.com"}],"total":1}
 EOF
-if run_script --worker amy-ai --no-notify; then
+if run_script --worker amy-ai --skill competition-skill --no-notify; then
     pass "reconcile push exits successfully"
 else
     fail "reconcile push exits successfully" "exit 0" "non-zero"
@@ -139,6 +155,10 @@ assert_contains "reconcile mirrors the assigned skill" \
     "${EVENTS}"
 assert_not_contains "reconcile does not recursively update Worker.spec.skills" \
     "agt update worker" "${EVENTS}"
+assert_not_contains "reconcile does not call the Controller API" \
+    "agt get workers" "${EVENTS}"
+assert_not_contains "reconcile --no-notify does not send Matrix messages" \
+    "curl " "${EVENTS}"
 
 echo "=== TC3: Manager-only skills are not silently exposed to Workers ==="
 setup_case "${TMPDIR_ROOT}/manager-only"
@@ -166,7 +186,7 @@ cat > "${STATE}" <<'EOF'
 {"workers":[{"name":"amy-ai","runtime":"qwenpaw","skills":["competition-skill"],"roomID":"!amy:example.com"}],"total":1}
 EOF
 MC_STAT_SUCCESS=1
-if run_script --worker amy-ai --no-notify; then
+if run_script --worker amy-ai --skill competition-skill --no-notify; then
     pass "reconcile reuses an existing remote custom skill"
 else
     fail "reconcile reuses an existing remote custom skill" "exit 0" "non-zero"

--- a/manager/tests/test-push-worker-skills.sh
+++ b/manager/tests/test-push-worker-skills.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# Regression tests for Manager-controlled Worker skill distribution.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+TMPDIR_ROOT=$(mktemp -d)
+trap 'rm -rf "${TMPDIR_ROOT}"' EXIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SCRIPT="${PROJECT_ROOT}/manager/agent/skills/worker-management/scripts/push-worker-skills.sh"
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; echo "       expected: $2"; echo "       got:      $3"; FAIL=$((FAIL + 1)); }
+
+assert_contains() {
+    local desc="$1" needle="$2" file="$3"
+    if grep -qF -- "${needle}" "${file}"; then
+        pass "${desc}"
+    else
+        fail "${desc}" "contains '${needle}'" "$(cat "${file}" 2>/dev/null || true)"
+    fi
+}
+
+assert_not_contains() {
+    local desc="$1" needle="$2" file="$3"
+    if ! grep -qF -- "${needle}" "${file}"; then
+        pass "${desc}"
+    else
+        fail "${desc}" "does not contain '${needle}'" "$(cat "${file}" 2>/dev/null || true)"
+    fi
+}
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "${expected}" = "${actual}" ]; then
+        pass "${desc}"
+    else
+        fail "${desc}" "${expected}" "${actual}"
+    fi
+}
+
+setup_case() {
+    CASE_DIR="$1"
+    mkdir -p "${CASE_DIR}/bin" "${CASE_DIR}/home/worker-skills/competition-skill"
+    EVENTS="${CASE_DIR}/events.log"
+    STATE="${CASE_DIR}/state.json"
+    : > "${EVENTS}"
+
+    cat > "${CASE_DIR}/home/worker-skills/competition-skill/SKILL.md" <<'EOF'
+---
+name: competition-skill
+description: Competition skill used by the regression test.
+assign_when: Use for competition tasks.
+---
+EOF
+
+    cat > "${STATE}" <<'EOF'
+{"workers":[{"name":"amy-ai","runtime":"openclaw","skills":[],"roomID":"!amy:example.com"}],"total":1}
+EOF
+
+    cat > "${CASE_DIR}/bin/agt" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+printf 'agt %s\n' "$*" >> "${TEST_EVENTS}"
+if [ "${1:-}" = get ] && [ "${2:-}" = workers ]; then
+    if [ "${3:-}" = -o ]; then
+        cat "${TEST_STATE}"
+    else
+        jq --arg worker "${3:-}" '.workers[] | select(.name == $worker)' "${TEST_STATE}"
+    fi
+    exit 0
+fi
+if [ "${1:-}" = update ] && [ "${2:-}" = worker ]; then
+    exit 0
+fi
+exit 2
+EOF
+
+cat > "${CASE_DIR}/bin/mc" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+printf 'mc %s\n' "$*" >> "${TEST_EVENTS}"
+if [ "${1:-}" = stat ]; then
+    [ "${TEST_MC_STAT_SUCCESS:-0}" = 1 ]
+    exit
+fi
+exit 0
+EOF
+    chmod +x "${CASE_DIR}/bin/agt" "${CASE_DIR}/bin/mc"
+}
+
+run_script() {
+    HOME="${CASE_DIR}/home" \
+    PATH="${CASE_DIR}/bin:/usr/bin:/bin" \
+    TEST_EVENTS="${EVENTS}" \
+    TEST_STATE="${STATE}" \
+    TEST_MC_STAT_SUCCESS="${MC_STAT_SUCCESS:-0}" \
+    AGENTTEAMS_STORAGE_PREFIX="test/agentteams-storage" \
+    bash "${SCRIPT}" "$@"
+}
+
+echo "=== TC1: add-skill distributes files before updating Worker.spec.skills ==="
+setup_case "${TMPDIR_ROOT}/add"
+if run_script --worker amy-ai --add-skill competition-skill; then
+    pass "add-skill exits successfully"
+else
+    fail "add-skill exits successfully" "exit 0" "non-zero"
+fi
+assert_contains "source is mirrored into amy-ai storage" \
+    "mc mirror ${CASE_DIR}/home/worker-skills/competition-skill/ test/agentteams-storage/agents/amy-ai/skills/competition-skill/ --overwrite" \
+    "${EVENTS}"
+assert_contains "Worker.spec.skills is updated" \
+    "agt update worker --name amy-ai --skills competition-skill" \
+    "${EVENTS}"
+mirror_line=$(grep -n '^mc mirror ' "${EVENTS}" | head -1 | cut -d: -f1)
+update_line=$(grep -n '^agt update worker ' "${EVENTS}" | head -1 | cut -d: -f1)
+if [ -n "${mirror_line}" ] && [ -n "${update_line}" ] && [ "${mirror_line}" -lt "${update_line}" ]; then
+    pass "files are distributed before the CR update can trigger reconciliation"
+else
+    fail "files are distributed before the CR update can trigger reconciliation" \
+        "mirror line before update line" "$(cat "${EVENTS}")"
+fi
+
+echo "=== TC2: reconcile mode pushes current skills without recursively updating the CR ==="
+setup_case "${TMPDIR_ROOT}/reconcile"
+cat > "${STATE}" <<'EOF'
+{"workers":[{"name":"amy-ai","runtime":"openclaw","skills":["competition-skill"],"roomID":"!amy:example.com"}],"total":1}
+EOF
+if run_script --worker amy-ai --no-notify; then
+    pass "reconcile push exits successfully"
+else
+    fail "reconcile push exits successfully" "exit 0" "non-zero"
+fi
+assert_contains "reconcile mirrors the assigned skill" \
+    "mc mirror ${CASE_DIR}/home/worker-skills/competition-skill/ test/agentteams-storage/agents/amy-ai/skills/competition-skill/ --overwrite" \
+    "${EVENTS}"
+assert_not_contains "reconcile does not recursively update Worker.spec.skills" \
+    "agt update worker" "${EVENTS}"
+
+echo "=== TC3: Manager-only skills are not silently exposed to Workers ==="
+setup_case "${TMPDIR_ROOT}/manager-only"
+mkdir -p "${CASE_DIR}/home/skills/manager-only"
+cat > "${CASE_DIR}/home/skills/manager-only/SKILL.md" <<'EOF'
+---
+name: manager-only
+description: Must remain private to the Manager.
+---
+EOF
+if run_script --worker amy-ai --add-skill manager-only >"${CASE_DIR}/output.log" 2>&1; then
+    fail "Manager-only source is rejected" "non-zero" "exit 0"
+else
+    pass "Manager-only source is rejected"
+fi
+assert_contains "error points to the Worker skill directory" \
+    "worker-skills/manager-only/SKILL.md" "${CASE_DIR}/output.log"
+assert_not_contains "failed validation does not update Worker.spec.skills" \
+    "agt update worker" "${EVENTS}"
+
+echo "=== TC4: reconcile accepts a custom skill already uploaded by Manager ==="
+setup_case "${TMPDIR_ROOT}/remote-existing"
+rm -rf "${CASE_DIR}/home/worker-skills/competition-skill"
+cat > "${STATE}" <<'EOF'
+{"workers":[{"name":"amy-ai","runtime":"qwenpaw","skills":["competition-skill"],"roomID":"!amy:example.com"}],"total":1}
+EOF
+MC_STAT_SUCCESS=1
+if run_script --worker amy-ai --no-notify; then
+    pass "reconcile reuses an existing remote custom skill"
+else
+    fail "reconcile reuses an existing remote custom skill" "exit 0" "non-zero"
+fi
+unset MC_STAT_SUCCESS
+assert_contains "reconcile verifies the remote SKILL.md" \
+    "mc stat test/agentteams-storage/agents/amy-ai/skills/competition-skill/SKILL.md" \
+    "${EVENTS}"
+assert_not_contains "remote reuse does not recursively update Worker.spec.skills" \
+    "agt update worker" "${EVENTS}"
+
+echo
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ]

--- a/manager/tests/test_qwenpaw_manager_skill_sync.py
+++ b/manager/tests/test_qwenpaw_manager_skill_sync.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Regression tests for QwenPaw Manager workspace skill hot loading."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from urllib.error import URLError
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = (
+    PROJECT_ROOT
+    / "manager"
+    / "scripts"
+    / "init"
+    / "qwenpaw_manager_skill_sync.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("qwenpaw_manager_skill_sync", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load {MODULE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class QwenPawManagerSkillSyncTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.module = load_module()
+
+    def setUp(self) -> None:
+        self.requests: list[tuple[str, object]] = []
+        self.fail_refresh = False
+        self.tempdir = tempfile.TemporaryDirectory()
+        root = Path(self.tempdir.name)
+        self.source = root / "manager-workspace" / "skills"
+        self.workspace = root / ".qwenpaw" / "workspaces" / "default"
+        self.state_file = root / ".qwenpaw" / "agentteams-manager-skills.json"
+        self.source.mkdir(parents=True)
+        self.workspace.mkdir(parents=True)
+        self.sync = self.module.ManagerSkillSync(
+            source_dir=self.source,
+            workspace_dir=self.workspace,
+            api_url="http://qwenpaw.test",
+            state_file=self.state_file,
+        )
+        self.sync._post_json = self.post_json
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def write_skill(self, name: str, body: str = "first") -> None:
+        skill_dir = self.source / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: test\n---\n\n{body}\n",
+            encoding="utf-8",
+        )
+
+    def post_json(self, path: str, payload: object) -> object:
+        self.requests.append((path, payload))
+        if path == "/api/skills/refresh" and self.fail_refresh:
+            raise URLError("refresh unavailable")
+        if path == "/api/skills/batch-enable":
+            return {
+                "results": {
+                    name: {
+                        "success": True,
+                        "updated_workspaces": ["default"],
+                        "failed": [],
+                        "reason": None,
+                    }
+                    for name in payload
+                }
+            }
+        return {}
+
+    def test_new_skill_is_copied_refreshed_and_enabled(self) -> None:
+        self.write_skill("alert-fusion")
+
+        self.assertTrue(self.sync.sync_once())
+
+        copied = self.workspace / "skills" / "alert-fusion" / "SKILL.md"
+        self.assertTrue(copied.is_file())
+        self.assertEqual(
+            self.requests,
+            [
+                ("/api/skills/refresh", {}),
+                ("/api/skills/batch-enable", ["alert-fusion"]),
+            ],
+        )
+        self.assertEqual(
+            json.loads(self.state_file.read_text(encoding="utf-8"))["skills"].keys(),
+            {"alert-fusion"},
+        )
+
+    def test_content_update_triggers_another_refresh(self) -> None:
+        self.write_skill("alert-fusion")
+        self.assertTrue(self.sync.sync_once())
+        self.requests = []
+
+        self.write_skill("alert-fusion", body="updated")
+        self.assertTrue(self.sync.sync_once())
+
+        self.assertIn(
+            "updated",
+            (self.workspace / "skills" / "alert-fusion" / "SKILL.md").read_text(
+                encoding="utf-8"
+            ),
+        )
+        self.assertEqual(
+            self.requests,
+            [
+                ("/api/skills/refresh", {}),
+                ("/api/skills/batch-enable", ["alert-fusion"]),
+            ],
+        )
+
+    def test_removal_only_deletes_previously_managed_skills(self) -> None:
+        self.write_skill("alert-fusion")
+        unmanaged = self.workspace / "skills" / "qwenpaw-native"
+        unmanaged.mkdir(parents=True)
+        (unmanaged / "SKILL.md").write_text("native", encoding="utf-8")
+        self.assertTrue(self.sync.sync_once())
+        active_copy = self.workspace / "active_skills" / "alert-fusion"
+        active_copy.mkdir(parents=True)
+        (active_copy / "SKILL.md").write_text("startup copy", encoding="utf-8")
+        self.requests = []
+
+        skill_dir = self.source / "alert-fusion"
+        (skill_dir / "SKILL.md").unlink()
+        skill_dir.rmdir()
+        self.assertTrue(self.sync.sync_once())
+
+        self.assertFalse((self.workspace / "skills" / "alert-fusion").exists())
+        self.assertFalse(active_copy.exists())
+        self.assertTrue(unmanaged.is_dir())
+        self.assertEqual(self.requests, [("/api/skills/refresh", {})])
+
+    def test_failed_refresh_does_not_commit_state(self) -> None:
+        self.write_skill("alert-fusion")
+        self.fail_refresh = True
+
+        self.assertFalse(self.sync.sync_once())
+        self.assertFalse(self.state_file.exists())
+
+        self.fail_refresh = False
+        self.requests = []
+        self.assertTrue(self.sync.sync_once())
+        self.assertTrue(self.state_file.exists())
+        self.assertEqual(
+            self.requests,
+            [
+                ("/api/skills/refresh", {}),
+                ("/api/skills/batch-enable", ["alert-fusion"]),
+            ],
+        )
+
+    def test_directory_without_skill_md_is_ignored(self) -> None:
+        invalid = self.source / "not-a-skill"
+        invalid.mkdir()
+        (invalid / "README.md").write_text("ignored", encoding="utf-8")
+
+        self.assertTrue(self.sync.sync_once())
+
+        self.assertEqual(self.requests, [])
+        self.assertFalse((self.workspace / "skills" / "not-a-skill").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qwenpaw/src/qwenpaw_worker/update.py
+++ b/qwenpaw/src/qwenpaw_worker/update.py
@@ -369,6 +369,10 @@ class MemberRuntimeConfig:
         return _section(self.desired, "channels")
 
     @property
+    def skills(self) -> List[str]:
+        return _string_list(self.desired.get("skills"))
+
+    @property
     def dingtalk_channel(self) -> Optional[Dict[str, Any]]:
         value = self.channels.get("dingtalk")
         return value if isinstance(value, dict) else None
@@ -378,7 +382,7 @@ class MemberRuntimeConfig:
         return _section(self.desired, "channelPolicy")
 
     @property
-    def desired_identity(self) -> Tuple[str, str, str, str, str, str, str, str, str]:
+    def desired_identity(self) -> Tuple[str, ...]:
         return (
             *self.agent_package_identity,
             _stable_json(self.inline_config),
@@ -386,6 +390,7 @@ class MemberRuntimeConfig:
             _stable_json(self.mcp_servers),
             _stable_json(self.channels),
             _stable_json(self.channel_policy),
+            _stable_json(self.skills),
         )
 
     @property
@@ -1271,6 +1276,7 @@ class RuntimeUpdater:
         team_context_renderer: Optional[Callable[[MemberRuntimeConfig], str]] = None,
         api_client: Optional[QwenPawApiClient] = None,
         runtime_reconcile: Optional[Callable[[MemberRuntimeConfig], None]] = None,
+        skill_sync: Optional[Callable[[List[str]], None]] = None,
     ) -> None:
         self.config = config
         self.adapter_apply = adapter_apply
@@ -1278,6 +1284,7 @@ class RuntimeUpdater:
         self.team_context_renderer = team_context_renderer
         self.api_client = api_client
         self.runtime_reconcile = runtime_reconcile
+        self.skill_sync = skill_sync
         self.package_manager = package_manager or AgentPackageManager(
             config.qwenpaw_working_dir / "agent-packages",
             workspace_dir=config.default_workspace_dir,
@@ -1348,6 +1355,7 @@ class RuntimeUpdater:
         applied_package = self.package_manager.apply(config)
         self._apply_package_mcp_servers(applied_package)
         self._apply_package_skills(applied_package)
+        self._apply_managed_skills(config)
         self._apply_inline_config(config)
 
         adapter_applied = False
@@ -1625,6 +1633,24 @@ class RuntimeUpdater:
         skill_names = package_skills(package_dir) if callable(package_skills) else []
         if skill_names:
             self.api_client.refresh_and_enable_skills(skill_names)
+
+    def _apply_managed_skills(self, config: MemberRuntimeConfig) -> None:
+        skill_names = config.skills
+        if not skill_names:
+            return
+        if self.skill_sync is None:
+            raise RuntimeError("AgentTeams skill sync is required for assigned QwenPaw skills")
+        if self.api_client is None:
+            raise RuntimeError("QwenPaw API client is required for assigned skills")
+        self.skill_sync(skill_names)
+        missing = [
+            name
+            for name in skill_names
+            if not (self.config.default_workspace_dir / "skills" / name / "SKILL.md").is_file()
+        ]
+        if missing:
+            raise RuntimeError(f"assigned skill files are missing: {', '.join(missing)}")
+        self.api_client.refresh_and_enable_skills(skill_names)
 
     def _apply_channel_policy(self, config: MemberRuntimeConfig) -> None:
         group_allow, dm_allow, group_deny, dm_deny = self._matrix_policy_ids(config)

--- a/qwenpaw/src/qwenpaw_worker/worker.py
+++ b/qwenpaw/src/qwenpaw_worker/worker.py
@@ -122,7 +122,6 @@ class Worker:
             remote_prefix=self.config.storage_prefix,
             shared_prefix=self.config.shared_prefix,
         )
-
         try:
             stage_started = self._log_worker_stage_begin("mirror_all")
             self.sync.mirror_all()
@@ -150,6 +149,7 @@ class Worker:
         self.config.default_workspace_dir.mkdir(parents=True, exist_ok=True)
         self.heartbeat.persist()
         self.updater.runtime_config_pull = lambda: self.sync.pull_runtime_config(self.config.runtime_config_path)
+        self.updater.skill_sync = self._sync_managed_skills
 
         try:
             stage_started = self._log_worker_stage_begin("load_runtime_config", path=self.config.runtime_config_path)
@@ -570,6 +570,17 @@ class Worker:
         self._link_workspace_shared()
         self._configure_builtin_plugin_mcp_clients()
         self._configure_builtin_plugin_mcp_policies()
+
+    def _sync_managed_skills(self, skill_names: list[str]) -> None:
+        if self.sync is None:
+            raise RuntimeError("file sync is not initialized")
+        for name in skill_names:
+            if not name or name in {".", ".."} or "/" in name or "\\" in name:
+                raise ValueError(f"invalid assigned skill name: {name!r}")
+            self.sync.mirror_prefix(
+                f"{self.sync.remote_prefix}/skills/{name}",
+                self.config.default_workspace_dir / "skills" / name,
+            )
 
     def _runtime_shared_prefix(self, runtime_config) -> str:
         storage = getattr(runtime_config, "storage", {}) or {}

--- a/qwenpaw/src/qwenpaw_worker/worker.py
+++ b/qwenpaw/src/qwenpaw_worker/worker.py
@@ -122,6 +122,7 @@ class Worker:
             remote_prefix=self.config.storage_prefix,
             shared_prefix=self.config.shared_prefix,
         )
+
         try:
             stage_started = self._log_worker_stage_begin("mirror_all")
             self.sync.mirror_all()

--- a/qwenpaw/tests/test_update.py
+++ b/qwenpaw/tests/test_update.py
@@ -101,6 +101,38 @@ def _runtime_updater(*args, **kwargs):
     return RuntimeUpdater(*args, **kwargs)
 
 
+def test_runtime_updater_syncs_and_enables_assigned_skills(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    synced = []
+
+    def sync_skills(skill_names):
+        synced.extend(skill_names)
+        for name in skill_names:
+            skill_dir = config.default_workspace_dir / "skills" / name
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            (skill_dir / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+
+    updater = _runtime_updater(
+        config=config,
+        package_manager=_NoopPackageManager(),
+        skill_sync=sync_skills,
+    )
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {"skills": ["competition-skill"]},
+            },
+        ),
+    )
+
+    assert synced == ["competition-skill"]
+    assert (config.default_workspace_dir / "skills" / "competition-skill" / "SKILL.md").is_file()
+    assert updater.api_client.enabled_skills == ["competition-skill"]
+
+
 def test_runtime_updater_reconciles_model_mcp_matrix_channel_and_acl_via_api(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/qwenpaw/tests/test_worker_lifecycle.py
+++ b/qwenpaw/tests/test_worker_lifecycle.py
@@ -155,6 +155,23 @@ def test_link_workspace_shared_points_to_canonical_shared(tmp_path: Path) -> Non
     assert (config.shared_dir / "tasks" / "task-1" / "workspace" / "note.txt").read_text(encoding="utf-8") == "ready\n"
 
 
+def test_sync_managed_skills_targets_native_qwenpaw_workspace(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    worker = Worker(config)
+    mirrored: list[tuple[str, Path]] = []
+    worker.sync = types.SimpleNamespace(
+        remote_prefix="agents/worker-a",
+        mirror_prefix=lambda prefix, local_dir: mirrored.append((prefix, local_dir)),
+    )
+
+    worker._sync_managed_skills(["competition-skill"])
+
+    assert mirrored == [(
+        "agents/worker-a/skills/competition-skill",
+        config.default_workspace_dir / "skills" / "competition-skill",
+    )]
+
+
 def test_runtime_storage_change_relinks_shared_and_refreshes_builtin_mcp(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/shared/lib/oss-credentials.sh
+++ b/shared/lib/oss-credentials.sh
@@ -153,6 +153,14 @@ EOF
 # --------------------------------------------------------------------------
 
 ensure_mc_credentials() {
+    # MinIO (the default provider) uses the static alias configured by the
+    # container entrypoint. Do not mistake the controller URL and bearer token
+    # (which are also present in local/K8s deployments) for proof that STS is
+    # available. Cloud deployments must opt into STS explicitly with "oss".
+    if [ "${AGENTTEAMS_STORAGE_PROVIDER:-minio}" != "oss" ]; then
+        return 0
+    fi
+
     # Cloud mode: Controller URL + any resolvable bearer token → controller-mediated STS
     if _oss_has_controller_url; then
         local bearer

--- a/shared/tests/test-oss-credentials.sh
+++ b/shared/tests/test-oss-credentials.sh
@@ -86,11 +86,55 @@ run_refresh() {
     cat "${curl_log}"
 }
 
+run_ensure() {
+    local case_name="$1"
+    local storage_provider="$2"
+    local mockbin="${TMPDIR_ROOT}/${case_name}-bin"
+    local curl_log="${TMPDIR_ROOT}/${case_name}-curl.log"
+    create_mock_tools "${mockbin}"
+    : > "${curl_log}"
+
+    (
+        . "${PROJECT_ROOT}/shared/lib/oss-credentials.sh"
+        _OSS_CRED_FILE="${TMPDIR_ROOT}/${case_name}-mc.env"
+        export PATH="${mockbin}:${PATH}"
+        export TEST_CURL_LOG="${curl_log}"
+        export AGENTTEAMS_STORAGE_PROVIDER="${storage_provider}"
+        export AGENTTEAMS_CONTROLLER_URL="http://controller:8090"
+        export AGENTTEAMS_AUTH_TOKEN="controller-token"
+        ensure_mc_credentials >/dev/null
+    )
+
+    cat "${curl_log}"
+}
+
 echo ""
 echo "=== oss credentials STS controller request ==="
 
 request="$(run_refresh sts-request)"
 assert_not_contains "cluster header should not be sent" "X-AgentTeams-Cluster-ID:" "${request}"
 assert_contains "bearer token should be sent" "Authorization: Bearer controller-token" "${request}"
+
+echo ""
+echo "=== storage provider selects static MinIO or controller STS ==="
+
+request="$(run_ensure minio-provider minio)"
+if [ -z "${request}" ]; then
+    pass "MinIO storage does not request controller STS"
+else
+    echo "  FAIL: MinIO storage unexpectedly requested controller STS: ${request}" >&2
+    exit 1
+fi
+
+request="$(run_ensure default-provider "")"
+if [ -z "${request}" ]; then
+    pass "default storage does not request controller STS"
+else
+    echo "  FAIL: default storage unexpectedly requested controller STS: ${request}" >&2
+    exit 1
+fi
+
+request="$(run_ensure oss-provider oss)"
+assert_contains "OSS storage requests controller STS" "/api/v1/credentials/sts" "${request}"
 
 echo "All oss-credentials tests passed"

--- a/tests/test-27-qwenpaw-manager-startup.sh
+++ b/tests/test-27-qwenpaw-manager-startup.sh
@@ -9,6 +9,13 @@ source "${SCRIPT_DIR}/lib/test-helpers.sh"
 test_setup "27-qwenpaw-manager-startup"
 
 _AGENT_CTR="${TEST_AGENT_CONTAINER:-${TEST_CONTROLLER_CONTAINER:-agentteams-controller}}"
+_HOT_SKILL="test-manager-hot-skill-$$"
+
+_cleanup_hot_skill() {
+    docker exec "${_AGENT_CTR}" rm -rf \
+        "/root/manager-workspace/skills/${_HOT_SKILL}" 2>/dev/null || true
+}
+trap _cleanup_hot_skill EXIT
 
 # Guard: skip if Manager is not QwenPaw (e.g., openclaw shard)
 _MANAGER_RUNTIME=$(docker exec "${_AGENT_CTR}" printenv AGENTTEAMS_MANAGER_RUNTIME 2>/dev/null || echo "openclaw")
@@ -100,6 +107,81 @@ if docker exec "${_AGENT_CTR}" curl -sf http://127.0.0.1:18799/ >/dev/null 2>&1;
     log_pass "QwenPaw health endpoint responding on :18799"
 else
     log_fail "QwenPaw health endpoint responding on :18799"
+fi
+
+# ---- Manager workspace skill hot loading ----
+log_section "Manager Skill Hot Loading"
+
+docker exec "${_AGENT_CTR}" mkdir -p \
+    "/root/manager-workspace/skills/${_HOT_SKILL}"
+docker exec "${_AGENT_CTR}" bash -c \
+    "printf '%s\n' '---' 'name: ${_HOT_SKILL}' 'description: QwenPaw Manager hot loading regression skill.' '---' '' '# Hot Loading Regression' > '/root/manager-workspace/skills/${_HOT_SKILL}/SKILL.md'"
+
+_skill_loaded=false
+_deadline=$(( $(date +%s) + 30 ))
+while [ "$(date +%s)" -lt "${_deadline}" ]; do
+    if docker exec "${_AGENT_CTR}" curl -fsS http://127.0.0.1:18799/api/skills 2>/dev/null \
+        | jq -e --arg name "${_HOT_SKILL}" '.[] | select(.name == $name and .enabled == true)' \
+            >/dev/null 2>&1; then
+        _skill_loaded=true
+        break
+    fi
+    sleep 1
+done
+
+if [ "${_skill_loaded}" = "true" ]; then
+    log_pass "QwenPaw Manager discovers and enables a workspace skill without restart"
+else
+    log_fail "QwenPaw Manager did not hot-load workspace skill ${_HOT_SKILL}"
+fi
+
+# Update the canonical workspace copy and verify QwenPaw sees the new content.
+docker exec "${_AGENT_CTR}" bash -c \
+    "printf '%s\n' '---' 'name: ${_HOT_SKILL}' 'description: QwenPaw Manager updated hot loading regression skill.' '---' '' '# Hot Loading Regression Updated' > '/root/manager-workspace/skills/${_HOT_SKILL}/SKILL.md'"
+
+_skill_updated=false
+_deadline=$(( $(date +%s) + 30 ))
+while [ "$(date +%s)" -lt "${_deadline}" ]; do
+    if docker exec "${_AGENT_CTR}" curl -fsS http://127.0.0.1:18799/api/skills 2>/dev/null \
+        | jq -e --arg name "${_HOT_SKILL}" \
+            '.[] | select(.name == $name and (.content | contains("# Hot Loading Regression Updated")))' \
+            >/dev/null 2>&1; then
+        _skill_updated=true
+        break
+    fi
+    sleep 1
+done
+
+if [ "${_skill_updated}" = "true" ]; then
+    log_pass "QwenPaw Manager hot-reloads updated workspace skill content"
+else
+    log_fail "QwenPaw Manager did not hot-reload updated skill ${_HOT_SKILL}"
+fi
+
+_cleanup_hot_skill
+
+_skill_removed=false
+_deadline=$(( $(date +%s) + 30 ))
+while [ "$(date +%s)" -lt "${_deadline}" ]; do
+    if docker exec "${_AGENT_CTR}" curl -fsS http://127.0.0.1:18799/api/skills 2>/dev/null \
+        | jq -e --arg name "${_HOT_SKILL}" 'all(.name != $name)' >/dev/null 2>&1; then
+        _skill_removed=true
+        break
+    fi
+    sleep 1
+done
+
+if [ "${_skill_removed}" = "true" ]; then
+    log_pass "QwenPaw Manager removes a deleted workspace skill without restart"
+else
+    log_fail "QwenPaw Manager still lists deleted skill ${_HOT_SKILL}"
+fi
+
+if docker exec "${_AGENT_CTR}" test ! -e \
+    "${_qwenpaw_wd}/workspaces/default/active_skills/${_HOT_SKILL}"; then
+    log_pass "QwenPaw Manager removes the deleted skill's active startup copy"
+else
+    log_fail "QwenPaw Manager left an active startup copy for ${_HOT_SKILL}"
 fi
 
 test_teardown "27-qwenpaw-manager-startup"

--- a/tests/test-27-qwenpaw-manager-startup.sh
+++ b/tests/test-27-qwenpaw-manager-startup.sh
@@ -52,6 +52,12 @@ else
     log_fail "agent.json exists in .qwenpaw workspace"
 fi
 
+if docker exec "${_AGENT_CTR}" test -d "${_qwenpaw_wd}/workspaces/default/media" 2>/dev/null; then
+    log_pass "QwenPaw Manager media directory exists for incoming attachments"
+else
+    log_fail "QwenPaw Manager media directory exists for incoming attachments"
+fi
+
 if docker exec "${_AGENT_CTR}" test -f "${_qwenpaw_wd}/workspaces/default/SOUL.md" 2>/dev/null || \
    docker exec "${_AGENT_CTR}" test -f "/root/manager-workspace/SOUL.md" 2>/dev/null; then
     log_pass "SOUL.md accessible"


### PR DESCRIPTION
## Summary

- hot-sync workspace skills into the native QwenPaw Manager workspace and refresh/enable changes without restarting the Manager
- validate and upload Manager-hosted Worker skills before updating Worker assignments, then notify Workers to pull them
- reconcile assigned skills without recursive CR updates and restore Manager access to Worker storage after Controller restarts
- sync assigned skills into the native QwenPaw Worker workspace and enable them at runtime
- cover Manager sync, Worker distribution, storage credentials, reconciliation, and QwenPaw lifecycle behavior with regression tests

## Testing

- `python3 manager/tests/test_qwenpaw_manager_skill_sync.py` (5 passed)
- `bash manager/tests/test-push-worker-skills.sh` (17 passed)
- `git diff --check origin/main...HEAD`

Not rerun in the current host environment because the required toolchain is unavailable:

- `python3 -m pytest qwenpaw/tests/test_update.py qwenpaw/tests/test_worker_lifecycle.py -q` (`pytest` is not installed)
- `go test ./internal/... ./cmd/...` (`go` is not installed)
