### PR TITLE
docs: prepare v1.2.2 changelog

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -38,7 +38,9 @@ Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `o
 
 - `c15ba378` fix(controller): join Team members to Team Room (#1149)
 - `c2d84b09` fix(skills): complete manager and worker skill loading (#1153)
+- `90f861c0` test(skills): verify Manager-to-Worker distribution (#1156)
 
 **Also in this window / 同期其他变更**
 
 - Archive the v1.2.1 changelog before collecting the v1.2.2 release window. ([#1146](https://github.com/agentscope-ai/AgentTeams/pull/1146))
+- Add integration coverage for Manager-to-Worker Skill distribution through `Worker.spec.skills`, Worker storage, and the QwenPaw Skill API. ([#1156](https://github.com/agentscope-ai/AgentTeams/pull/1156))

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -1,21 +1,44 @@
 # Changelog (Unreleased)
 
+Target release: `v1.2.2`
+
+Comparison baseline: `v1.2.1`
+
 Record image-affecting changes to `manager/`, `worker/`, `copaw/`, `hermes/`, `openclaw-base/`, and `agentteams-controller/` here before the next release.
 
 ---
 
+**What's New**
+
+- **Manager-to-Worker custom Skill delivery**: A Manager can validate, upload, and assign a custom Worker Skill before updating `Worker.spec.skills`; QwenPaw Workers synchronize the assigned Skill into their native workspace and refresh plus enable it without a restart. ([c2d84b09](https://github.com/agentscope-ai/AgentTeams/commit/c2d84b09d3547b258decbb1d24b245c10a98c088), [#1153](https://github.com/agentscope-ai/AgentTeams/pull/1153))
+
 **Bug Fixes**
 
-- **Worker custom skill loading**: Validate and upload Manager-hosted Worker skill files before updating assignments, grant Managers access to Worker storage prefixes, avoid recursive CR updates during reconciliation, keep local/default MinIO paths off unavailable STS, restore Manager MinIO access after Controller restarts, verify uploaded `SKILL.md` files, restore Worker file-sync notifications, and sync plus enable assigned skills in the native QwenPaw workspace.
-- **QwenPaw Manager custom skill hot loading**: Continuously mirror workspace skills into the native QwenPaw workspace, then refresh and enable additions or updates without restarting the Manager.
-- **QwenPaw Manager Skill attachments**: Initialize the Matrix attachment directory at startup so an admin can send a complete Worker Skill ZIP to the Manager for validation and distribution.
-- **Team Room membership convergence**: Explicitly join Team Leaders and Workers with their own Matrix tokens after invitation, so pending invites cannot leave a Team Active while Hermes members remain unreachable. ([41f6e517](https://github.com/agentscope-ai/AgentTeams/commit/41f6e5175a6fb8bf1c7ee19632d3d2fac6f66f26), [#1142](https://github.com/agentscope-ai/AgentTeams/issues/1142))
+- **Worker custom Skill loading safeguards**: Grant Managers access to Worker storage prefixes, avoid recursive CR updates during reconciliation, keep local/default MinIO paths off unavailable STS, restore Manager MinIO access after Controller restarts, verify uploaded `SKILL.md` files, and restore Worker file-sync notifications. ([c2d84b09](https://github.com/agentscope-ai/AgentTeams/commit/c2d84b09d3547b258decbb1d24b245c10a98c088), [#1153](https://github.com/agentscope-ai/AgentTeams/pull/1153))
+- **QwenPaw Manager custom Skill hot loading**: Continuously mirror workspace Skills into the native QwenPaw workspace, then refresh and enable additions or updates without restarting the Manager. ([c2d84b09](https://github.com/agentscope-ai/AgentTeams/commit/c2d84b09d3547b258decbb1d24b245c10a98c088), [#1153](https://github.com/agentscope-ai/AgentTeams/pull/1153))
+- **QwenPaw Manager Skill attachments**: Initialize the Matrix attachment directory at startup so an admin can send a complete Worker Skill ZIP to the Manager for validation and distribution. ([c2d84b09](https://github.com/agentscope-ai/AgentTeams/commit/c2d84b09d3547b258decbb1d24b245c10a98c088), [#1153](https://github.com/agentscope-ai/AgentTeams/pull/1153))
+- **Team Room membership convergence**: Explicitly join Team Leaders and Workers with their own Matrix tokens after invitation, so pending invites cannot leave a Team Active while Hermes members remain unreachable. ([c15ba378](https://github.com/agentscope-ai/AgentTeams/commit/c15ba378f9b868778e252bc689e7ea3f5f23a695), [#1142](https://github.com/agentscope-ai/AgentTeams/issues/1142), [#1149](https://github.com/agentscope-ai/AgentTeams/pull/1149))
 
 ---
 
+**新增功能**
+
+- **Manager 向 Worker 下发自定义 Skill**：Manager 可在更新 `Worker.spec.skills` 前校验、上传并分配自定义 Worker Skill；QwenPaw Worker 会将已分配 Skill 同步到原生 workspace，并在无需重启的情况下刷新和启用。([c2d84b09](https://github.com/agentscope-ai/AgentTeams/commit/c2d84b09d3547b258decbb1d24b245c10a98c088), [#1153](https://github.com/agentscope-ai/AgentTeams/pull/1153))
+
 **Bug 修复**
 
-- **Worker 自定义 Skill 加载**：更新分配前校验并上传 Manager 托管的 Worker Skill 文件，授予 Manager 对 Worker 存储前缀的访问权限，避免调和期间递归更新 CR，避免本地或默认 MinIO 路径误请求不可用的 STS，Controller 重启后恢复 Manager 的 MinIO 访问并校验已上传的 `SKILL.md`，恢复 Worker 的 file-sync 通知，并在 QwenPaw 原生 workspace 中同步、启用已分配 Skill。
-- **QwenPaw Manager 自定义 Skill 热加载**：持续将 workspace Skill 投影到 QwenPaw 原生 workspace，并自动刷新、启用新增或更新的 Skill，无需重启 Manager。
-- **QwenPaw Manager Skill 附件**：启动时创建 Matrix 附件目录，使管理员可以将完整的 Worker Skill ZIP 发送给 Manager，由其校验并分发。
-- **Team Room 成员收敛**：邀请 Team Leader 和 Worker 后，使用各自的 Matrix token 显式加入 Team Room，避免 Team 已处于 Active 状态时 Hermes 成员仍停留在 invite、无法接收消息。([41f6e517](https://github.com/agentscope-ai/AgentTeams/commit/41f6e5175a6fb8bf1c7ee19632d3d2fac6f66f26), [#1142](https://github.com/agentscope-ai/AgentTeams/issues/1142))
+- **Worker 自定义 Skill 加载保护**：授予 Manager 对 Worker 存储前缀的访问权限，避免调和期间递归更新 CR，避免本地或默认 MinIO 路径误请求不可用的 STS，Controller 重启后恢复 Manager 的 MinIO 访问并校验已上传的 `SKILL.md`，同时恢复 Worker 的 file-sync 通知。([c2d84b09](https://github.com/agentscope-ai/AgentTeams/commit/c2d84b09d3547b258decbb1d24b245c10a98c088), [#1153](https://github.com/agentscope-ai/AgentTeams/pull/1153))
+- **QwenPaw Manager 自定义 Skill 热加载**：持续将 workspace Skill 投影到 QwenPaw 原生 workspace，并自动刷新、启用新增或更新的 Skill，无需重启 Manager。([c2d84b09](https://github.com/agentscope-ai/AgentTeams/commit/c2d84b09d3547b258decbb1d24b245c10a98c088), [#1153](https://github.com/agentscope-ai/AgentTeams/pull/1153))
+- **QwenPaw Manager Skill 附件**：启动时创建 Matrix 附件目录，使管理员可以将完整的 Worker Skill ZIP 发送给 Manager，由其校验并分发。([c2d84b09](https://github.com/agentscope-ai/AgentTeams/commit/c2d84b09d3547b258decbb1d24b245c10a98c088), [#1153](https://github.com/agentscope-ai/AgentTeams/pull/1153))
+- **Team Room 成员收敛**：邀请 Team Leader 和 Worker 后，使用各自的 Matrix token 显式加入 Team Room，避免 Team 已处于 Active 状态时 Hermes 成员仍停留在 invite、无法接收消息。([c15ba378](https://github.com/agentscope-ai/AgentTeams/commit/c15ba378f9b868778e252bc689e7ea3f5f23a695), [#1142](https://github.com/agentscope-ai/AgentTeams/issues/1142), [#1149](https://github.com/agentscope-ai/AgentTeams/pull/1149))
+
+---
+
+**Change list / 变更列表**
+
+- `c15ba378` fix(controller): join Team members to Team Room (#1149)
+- `c2d84b09` fix(skills): complete manager and worker skill loading (#1153)
+
+**Also in this window / 同期其他变更**
+
+- Archive the v1.2.1 changelog before collecting the v1.2.2 release window. ([#1146](https://github.com/agentscope-ai/AgentTeams/pull/1146))

--- a/install/agentteams-install.sh
+++ b/install/agentteams-install.sh
@@ -59,7 +59,7 @@
 set -e
 
 AGENTTEAMS_VERSION="${AGENTTEAMS_VERSION:-}"
-AGENTTEAMS_KNOWN_STABLE_VERSION="v1.2.1"   # fallback if GitHub API is unreachable
+AGENTTEAMS_KNOWN_STABLE_VERSION="v1.2.2"   # fallback if GitHub API is unreachable
 
 _normalize_version() {
     local version="$1"


### PR DESCRIPTION
## Summary
- organize the v1.2.2 release notes for the v1.2.1..main window
- document Manager-to-Worker custom Skill delivery and Team Room membership convergence
- bump the installer stable fallback to v1.2.2

## Release gates
- Manager→QwenPaw Worker Skill E2E passed in PR #1156
- full integration matrix passed after one isolated QwenPaw TeamHarness LLM bootstrap rerun
- QwenPaw Worker remains included in the tag build and installer pull paths

## Validation
- release body extraction checked with awk
- installer fallback checked with rg
- git diff --check