### PR TITLE
fix(install): generate and pass Matrix AppService tokens in Windows installer

### DIFF
--- a/install/agentteams-install.ps1
+++ b/install/agentteams-install.ps1
@@ -1035,6 +1035,9 @@ AGENTTEAMS_MINIO_PASSWORD=$($Config.MINIO_PASSWORD)
 # Internal
 AGENTTEAMS_MANAGER_PASSWORD=$($Config.MANAGER_PASSWORD)
 AGENTTEAMS_REGISTRATION_TOKEN=$($Config.REGISTRATION_TOKEN)
+AGENTTEAMS_MATRIX_APPSERVICE_ENABLED=true
+AGENTTEAMS_MATRIX_APPSERVICE_AS_TOKEN=$($Config.APPSERVICE_AS_TOKEN)
+AGENTTEAMS_MATRIX_APPSERVICE_HS_TOKEN=$($Config.APPSERVICE_HS_TOKEN)
 
 # GitHub (optional)
 AGENTTEAMS_GITHUB_TOKEN=$($Config.GITHUB_TOKEN)
@@ -2668,6 +2671,11 @@ function Install-Manager {
     $config.MINIO_USER = if ($env:AGENTTEAMS_MINIO_USER) { $env:AGENTTEAMS_MINIO_USER } else { $config.ADMIN_USER }
     $config.MINIO_PASSWORD = if ($env:AGENTTEAMS_MINIO_PASSWORD) { $env:AGENTTEAMS_MINIO_PASSWORD } else { $config.ADMIN_PASSWORD }
     $config.MANAGER_GATEWAY_KEY = if ($env:AGENTTEAMS_MANAGER_GATEWAY_KEY) { $env:AGENTTEAMS_MANAGER_GATEWAY_KEY } else { New-RandomKey }
+    # Matrix AppService tokens - generate once during install if not provided.
+    # Required by the controller (>= v1.2) when AppService mode is enabled (the default).
+    # Mirrors the "Matrix AppService tokens" block in agentteams-install.sh.
+    $config.APPSERVICE_AS_TOKEN = if ($env:AGENTTEAMS_MATRIX_APPSERVICE_AS_TOKEN) { $env:AGENTTEAMS_MATRIX_APPSERVICE_AS_TOKEN } else { Get-AgentTeamsRandomHex 32 }
+    $config.APPSERVICE_HS_TOKEN = if ($env:AGENTTEAMS_MATRIX_APPSERVICE_HS_TOKEN) { $env:AGENTTEAMS_MATRIX_APPSERVICE_HS_TOKEN } else { Get-AgentTeamsRandomHex 32 }
 
     # Store additional config
     $config.LANGUAGE = $script:AGENTTEAMS_LANGUAGE
@@ -3070,6 +3078,16 @@ function Install-Manager {
             "-e", "AGENTTEAMS_HOST_SHARE_DIR=$($config.HOST_SHARE_DIR)",
             "-e", "AGENTTEAMS_MANAGER_ENABLED=true",
             "-e", "AGENTTEAMS_PORT_MANAGER_CONSOLE=$($config.PORT_MANAGER_CONSOLE)"
+        )
+
+        # Matrix AppService tokens - required by the embedded controller when
+        # AppService mode is enabled (parity with the bash installer). The
+        # controller env is built from this explicit list, so persisting the
+        # tokens to the env file alone is not enough.
+        $ctrlArgs += @(
+            "-e", "AGENTTEAMS_MATRIX_APPSERVICE_ENABLED=true",
+            "-e", "AGENTTEAMS_MATRIX_APPSERVICE_AS_TOKEN=$($config.APPSERVICE_AS_TOKEN)",
+            "-e", "AGENTTEAMS_MATRIX_APPSERVICE_HS_TOKEN=$($config.APPSERVICE_HS_TOKEN)"
         )
 
         if ($script:AGENTTEAMS_TIMEZONE) {


### PR DESCRIPTION
> **中文摘要**:Windows 安装脚本(PowerShell 版)缺失 Matrix AppService 令牌的生成与传递逻辑,导致 controller v1.2+ 在 Windows 上全新安装必然崩溃(controller 反复 panic,Manager 容器无法创建)。bash 版安装脚本已有完整处理,本 PR 将其对齐到 PowerShell 版:① 密钥生成阶段产出 AS/HS 令牌(尊重预设环境变量);② 写入生成的 env 文件;③ 加入控制器容器的环境变量清单(该清单为显式 `-e` 列表,仅改 env 文件不生效)。已在 Windows 11 + Docker Desktop 4.85 + v1.2.2 镜像实测:修复前必现崩溃,修复后安装、onboarding 与 Worker 创建端到端可用。

## Problem

The Windows installer (`install/agentteams-install.ps1`) does not generate the Matrix AppService tokens, while the controller (>= v1.2) requires them when AppService mode is enabled (the default). As a result, **a fresh install on Windows always fails**: the embedded controller crash-loops with

```
panic: AGENTTEAMS_MATRIX_APPSERVICE_AS_TOKEN is required when AppService mode is enabled; run install script or set env var
```

and the Manager Agent container is never created (`Manager Agent container not created after 300s`).

The bash installer handles this correctly (see the "Matrix AppService tokens" block in `agentteams-install.sh`): it generates `AS_TOKEN` / `HS_TOKEN` via `openssl rand -hex 32`, persists them to the env file, and exports them so the controller container receives them. The PowerShell port is missing **both** halves:

1. Token generation + persistence to `agentteams-manager.env`
2. Passing the tokens to the controller container — the ps1 builds the controller's environment as an explicit `-e` list (`$ctrlArgs`), so even a hand-edited env file is not picked up

## Fix

Mirrors the bash installer behavior:

- Generate `APPSERVICE_AS_TOKEN` / `APPSERVICE_HS_TOKEN` (random 32-byte hex) during secret generation, honoring pre-set `AGENTTEAMS_MATRIX_APPSERVICE_{AS,HS}_TOKEN` env vars
- Write `AGENTTEAMS_MATRIX_APPSERVICE_ENABLED/AS_TOKEN/HS_TOKEN` to the env file template
- Append the three variables to `$ctrlArgs` so the embedded controller container receives them

## Tested

Windows 11 Home (26200), Docker Desktop 4.85, PowerShell 7.5, AgentTeams v1.2.2 images from the cn-hangzhou registry:

- Before: fresh install fails, controller crash-loops with the panic above
- After: fresh install completes; Manager container is created; onboarding conversation and worker creation via Element Web work end-to-end
