### PR TITLE
fix(controller): preserve worker rooms for admin leave

### DIFF
--- a/agentteams-controller/internal/controller/member_reconcile.go
+++ b/agentteams-controller/internal/controller/member_reconcile.go
@@ -1957,12 +1957,6 @@ func ReconcileMemberDelete(ctx context.Context, d MemberDeps, m MemberContext) e
 	if err := d.Provisioner.LeaveAllWorkerRooms(ctx, m.RuntimeName); err != nil {
 		logger.Error(err, "member leave-all-rooms failed (non-fatal)", "name", m.Name, "runtimeName", m.RuntimeName)
 	}
-	if m.ExistingRoomID != "" {
-		if err := d.Provisioner.DeleteWorkerRoom(ctx, m.ExistingRoomID); err != nil {
-			logger.Error(err, "member room delete command failed (non-fatal)",
-				"name", m.Name, "runtimeName", m.RuntimeName, "roomID", m.ExistingRoomID)
-		}
-	}
 
 	if err := d.Provisioner.DeprovisionWorker(ctx, service.WorkerDeprovisionRequest{
 		Name:         m.RuntimeName,

--- a/agentteams-controller/internal/controller/member_reconcile_test.go
+++ b/agentteams-controller/internal/controller/member_reconcile_test.go
@@ -120,6 +120,28 @@ func TestReconcileMemberInfraPreservesTeamStorageAccess(t *testing.T) {
 	}
 }
 
+func TestReconcileMemberDeletePreservesRoomForAdminLeave(t *testing.T) {
+	prov := mocks.NewMockProvisioner()
+
+	if err := ReconcileMemberDelete(context.Background(), MemberDeps{
+		Provisioner: prov,
+		Deployer:    mocks.NewMockDeployer(),
+	}, MemberContext{
+		Name:           "worker-cr",
+		RuntimeName:    "worker-runtime",
+		ExistingRoomID: "!worker-dm:matrix.local",
+	}); err != nil {
+		t.Fatalf("ReconcileMemberDelete: %v", err)
+	}
+
+	if got := prov.Calls.LeaveAllWorkerRooms; len(got) != 1 || got[0] != "worker-runtime" {
+		t.Fatalf("LeaveAllWorkerRooms calls=%v, want [worker-runtime]", got)
+	}
+	if got := prov.Calls.DeleteWorkerRoom; len(got) != 0 {
+		t.Fatalf("DeleteWorkerRoom calls=%v, want none so the admin can leave normally", got)
+	}
+}
+
 func TestResolveBackendForMember_NoBackendAvailable(t *testing.T) {
 	// An empty registry surfaces an error so callers can decide whether
 	// to skip container management or fail loudly.


### PR DESCRIPTION
## Summary

- stop hard-deleting a Worker's Matrix DM room during Worker cleanup
- keep the normal Worker leave flow so the administrator can leave the preserved room through Element
- add a regression test that prevents `DeleteWorkerRoom` from being called during member deletion

## Root cause

The Worker deletion reconciler sent `!admin rooms delete-room` immediately after the Worker left its rooms. Tuwunel removed the room before Element received a normal administrator membership leave event, leaving the room stuck in Element's local room list and causing later `/forget` requests to fail.

## Validation

- `go test ./internal/controller -run '^TestReconcileMemberDeletePreservesRoomForAdminLeave$' -count=1`
- `go test ./internal/controller ./internal/service ./internal/matrix`
- `go test ./...` (from `agentteams-controller`)
- `git diff --check`

Fixes #1138
