### PR TITLE
feat(projects): add intervention history and worker checkpoint read endpoints

### DIFF
--- a/agentteams-controller/internal/app/app.go
+++ b/agentteams-controller/internal/app/app.go
@@ -637,19 +637,20 @@ func (a *App) initReconcilers(_ context.Context) error {
 
 func (a *App) initHTTPServer(_ context.Context) error {
 	a.httpServer = server.NewHTTPServer(a.cfg.HTTPAddr, server.ServerDeps{
-		Client:         a.mgr.GetClient(),
-		Backend:        a.registry,
-		Gateway:        a.gateway,
-		OSS:            a.oss,
-		STS:            a.stsService,
-		AuthMw:         a.authMw,
-		KubeMode:       a.cfg.KubeMode,
-		Namespace:      a.namespace,
-		ControllerName: a.cfg.ControllerName,
-		SocketPath:     a.cfg.SocketPath,
-		MatrixConfig:   a.cfg.MatrixConfig(),
-		MatrixClient:   a.matrix,
-		Provisioner:    a.provisioner,
+		Client:          a.mgr.GetClient(),
+		Backend:         a.registry,
+		Gateway:         a.gateway,
+		OSS:             a.oss,
+		STS:             a.stsService,
+		AuthMw:          a.authMw,
+		KubeMode:        a.cfg.KubeMode,
+		Namespace:       a.namespace,
+		ControllerName:  a.cfg.ControllerName,
+		SocketPath:      a.cfg.SocketPath,
+		ContainerPrefix: a.cfg.ContainerPrefix,
+		MatrixConfig:    a.cfg.MatrixConfig(),
+		MatrixClient:    a.matrix,
+		Provisioner:     a.provisioner,
 
 		DefaultWorkerRuntime: a.cfg.DefaultWorkerRuntime,
 	})

--- a/agentteams-controller/internal/controller/user_env.go
+++ b/agentteams-controller/internal/controller/user_env.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"sort"
 
+	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/service"
 	"github.com/go-logr/logr"
 )
 
@@ -12,23 +13,15 @@ import (
 // per ignored key. Collisions are sorted before logging so identical
 // inputs produce identical log output (makes tests deterministic).
 //
+// The merge semantics live in service.MergeUserEnv so that server-side
+// address resolution (EffectiveWorkerConsolePort) shares the exact same
+// rule as container creation.
+//
 // Both maps may be nil. sysEnv is mutated in place and must be non-nil
 // when userEnv is non-empty; callers always pass the builder's output,
 // which is guaranteed non-nil.
 func mergeUserEnv(sysEnv, userEnv map[string]string, logger logr.Logger, subject string) {
-	if len(userEnv) == 0 {
-		return
-	}
-
-	var ignored []string
-	for k, v := range userEnv {
-		if _, taken := sysEnv[k]; taken {
-			ignored = append(ignored, k)
-			continue
-		}
-		sysEnv[k] = v
-	}
-
+	ignored := service.MergeUserEnv(sysEnv, userEnv)
 	if len(ignored) == 0 {
 		return
 	}

--- a/agentteams-controller/internal/server/http.go
+++ b/agentteams-controller/internal/server/http.go
@@ -19,19 +19,20 @@ import (
 
 // ServerDeps aggregates all dependencies needed by the HTTP API handlers.
 type ServerDeps struct {
-	Client         client.Client
-	Backend        *backend.Registry
-	Gateway        gateway.Client
-	OSS            oss.StorageClient
-	STS            *credentials.STSService
-	AuthMw         *authpkg.Middleware
-	KubeMode       string
-	Namespace      string
-	ControllerName string               // AGENTTEAMS_CONTROLLER_NAME; empty in embedded mode
-	SocketPath     string               // Docker proxy (embedded only)
-	MatrixConfig   matrix.Config        // for AppService rotation endpoint
-	MatrixClient   matrix.Client        // for project intervention notifications (SendMessageAsAdmin); nil to skip
-	Provisioner    *service.Provisioner // for Matrix token refresh
+	Client          client.Client
+	Backend         *backend.Registry
+	Gateway         gateway.Client
+	OSS             oss.StorageClient
+	STS             *credentials.STSService
+	AuthMw          *authpkg.Middleware
+	KubeMode        string
+	Namespace       string
+	ControllerName  string               // AGENTTEAMS_CONTROLLER_NAME; empty in embedded mode
+	SocketPath      string               // Docker proxy (embedded only)
+	ContainerPrefix string               // effective worker container prefix (config.ContainerPrefix); embedded-only address resolution
+	MatrixConfig    matrix.Config        // for AppService rotation endpoint
+	MatrixClient    matrix.Client        // for project intervention notifications (SendMessageAsAdmin); nil to skip
+	Provisioner     *service.Provisioner // for Matrix token refresh
 
 	DefaultWorkerRuntime string // install-time default for Worker create requests
 }
@@ -117,6 +118,12 @@ func NewHTTPServer(addr string, deps ServerDeps) *HTTPServer {
 	mux.Handle("GET /api/v1/projects/{id}/tasks/{taskId}/artifact", mw.RequireAuthz(authpkg.ActionGet, "project", projectNameFn)(http.HandlerFunc(projh.GetTaskArtifact)))
 	mux.Handle("GET /api/v1/projects/{id}/spawns", mw.RequireAuthz(authpkg.ActionGet, "project", projectNameFn)(http.HandlerFunc(projh.GetProjectSpawns)))
 	mux.Handle("GET /api/v1/projects/{id}/spawns/{sessionId}/messages", mw.RequireAuthz(authpkg.ActionGet, "project", projectNameFn)(http.HandlerFunc(projh.GetProjectSpawnMessages)))
+	mux.Handle("GET /api/v1/projects/{id}/history", mw.RequireAuthz(authpkg.ActionGet, "project", projectNameFn)(http.HandlerFunc(projh.GetProjectHistory)))
+	mux.Handle("GET /api/v1/projects/{id}/history/{timestamp}", mw.RequireAuthz(authpkg.ActionGet, "project", projectNameFn)(http.HandlerFunc(projh.GetProjectHistorySnapshot)))
+
+	// --- Worker checkpoints (execution timeline; proxy to the worker's qwenpaw app) ---
+	ckh := NewCheckpointHandler(deps.Client, deps.Namespace, deps.KubeMode, deps.ContainerPrefix)
+	mux.Handle("GET /api/v1/workers/{name}/checkpoints/{sub}", mw.RequireAuthz(authpkg.ActionGet, "worker", nameFn)(http.HandlerFunc(ckh.proxyCheckpoint)))
 
 	// W-PR-2: human intervention + lifecycle (write endpoints). All writes go
 	// through RequireAuthz ActionUpdate + "project" so the authorizer's

--- a/agentteams-controller/internal/server/project_handler.go
+++ b/agentteams-controller/internal/server/project_handler.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -364,15 +365,26 @@ func (h *ProjectHandler) resolveProjectMeta(ctx context.Context, projectID strin
 // and writes the corresponding error responses. Returns (meta, team, true)
 // when exactly one match was resolved.
 func (h *ProjectHandler) resolveSingleProject(w http.ResponseWriter, matches []projectMatch) (*projectMeta, string, bool) {
+	match, ok := h.resolveSingleProjectMatch(w, matches)
+	if !ok {
+		return nil, "", false
+	}
+	return match.meta, match.team, true
+}
+
+// resolveSingleProjectMatch applies the same 0/1/many resolution but returns
+// the whole match (including the storage key), so handlers that need to
+// derive sibling paths (e.g. the project history/ directory) can do so.
+func (h *ProjectHandler) resolveSingleProjectMatch(w http.ResponseWriter, matches []projectMatch) (*projectMatch, bool) {
 	switch len(matches) {
 	case 0:
 		httputil.WriteError(w, http.StatusNotFound, "project not found")
-		return nil, "", false
+		return nil, false
 	case 1:
-		return matches[0].meta, matches[0].team, true
+		return &matches[0], true
 	default:
 		httputil.WriteError(w, http.StatusConflict, "project id is ambiguous across teams; retry with ?team=")
-		return nil, "", false
+		return nil, false
 	}
 }
 
@@ -1748,6 +1760,143 @@ func (h *ProjectHandler) GetProjectSpawnMessages(w http.ResponseWriter, r *http.
 // validation, then write back with an mtime optimistic lock (StatMeta
 // compare-before-write → 409 on conflict).
 // ============================================================================
+
+// --- project history (GET /api/v1/projects/{id}/history) ---
+//
+// The write side (snapshotProjectMeta below) stores a meta.json copy into
+// history/{unixNano}.json before every intervention. These endpoints read
+// the timeline back so humans and frontends can inspect the intervention
+// audit trail (who paused/resumed/replanned and why, via the snapshot's
+// updated_by / pause_reason fields).
+
+// historyTimestampPattern accepts exactly 19 digits (a unixNano timestamp) —
+// the snapshot filename. It also doubles as the path-traversal guard: the
+// only characters accepted are digits.
+var historyTimestampPattern = regexp.MustCompile(`^[0-9]{19}$`)
+
+// projectHistoryResponse is the GET /api/v1/projects/{id}/history payload.
+type projectHistoryResponse struct {
+	ProjectID string            `json:"project_id"`
+	Snapshots []projectSnapshot `json:"snapshots"`
+}
+
+// projectSnapshot is one history entry. Timestamp is the unixNano filename,
+// kept as a string because 19-digit nanoseconds exceed the JS Number
+// safe-integer range (clients would silently lose precision as a number).
+type projectSnapshot struct {
+	Timestamp string `json:"timestamp"`
+}
+
+// GetProjectHistory handles GET /api/v1/projects/{id}/history.
+// Auth/RBAC mirrors GetProjectWorkflow: RoleHuman read + team-scope check,
+// cross-team access hidden as 404.
+func (h *ProjectHandler) GetProjectHistory(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if projectID == "" {
+		httputil.WriteError(w, http.StatusBadRequest, "project id is required")
+		return
+	}
+	caller := authpkg.CallerFromContext(r.Context())
+	teamFilter := r.URL.Query().Get("team")
+
+	prefixes, crToEffective, err := h.teamProjectPrefixes(r.Context())
+	if err != nil {
+		writeK8sError(w, "get project history: resolve prefixes", err)
+		return
+	}
+	matches, err := h.resolveProjectMeta(r.Context(), projectID, prefixes, teamFilter, caller, crToEffective)
+	if err != nil {
+		writeK8sError(w, "get project history", err)
+		return
+	}
+	match, ok := h.resolveSingleProjectMatch(w, matches)
+	if !ok {
+		return
+	}
+	if err := h.checkProjectAccess(caller, match.team, crToEffective); err != nil {
+		if _, ok := err.(*accessDeniedError); ok {
+			httputil.WriteError(w, http.StatusNotFound, "project not found")
+			return
+		}
+		httputil.WriteError(w, http.StatusForbidden, err.Error())
+		return
+	}
+
+	historyPrefix := strings.TrimSuffix(match.key, "meta.json") + "history/"
+	children, err := h.oss.ListObjects(r.Context(), historyPrefix)
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "list project history: "+err.Error())
+		return
+	}
+	snapshots := make([]projectSnapshot, 0, len(children))
+	for _, child := range children {
+		base := strings.TrimSuffix(child, ".json")
+		// Defensive filter: the history directory only ever contains
+		// snapshot files, but ignore anything unexpected instead of
+		// surfacing garbage.
+		if base == child || !historyTimestampPattern.MatchString(base) {
+			continue
+		}
+		snapshots = append(snapshots, projectSnapshot{Timestamp: base})
+	}
+	// Newest first. Numeric string sort == chronological order for fixed
+	// 19-digit unixNano names (same reasoning as the write-side gc).
+	sort.Slice(snapshots, func(i, j int) bool {
+		return snapshots[i].Timestamp > snapshots[j].Timestamp
+	})
+	httputil.WriteJSON(w, http.StatusOK, projectHistoryResponse{ProjectID: projectID, Snapshots: snapshots})
+}
+
+// GetProjectHistorySnapshot handles GET /api/v1/projects/{id}/history/{timestamp}.
+// Returns one snapshot's raw meta JSON verbatim — the read side stays
+// decoupled from the meta schema.
+func (h *ProjectHandler) GetProjectHistorySnapshot(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	timestamp := r.PathValue("timestamp")
+	if projectID == "" || !historyTimestampPattern.MatchString(timestamp) {
+		httputil.WriteError(w, http.StatusBadRequest, "project id and a 19-digit nanosecond timestamp are required")
+		return
+	}
+	caller := authpkg.CallerFromContext(r.Context())
+	teamFilter := r.URL.Query().Get("team")
+
+	prefixes, crToEffective, err := h.teamProjectPrefixes(r.Context())
+	if err != nil {
+		writeK8sError(w, "get project history snapshot: resolve prefixes", err)
+		return
+	}
+	matches, err := h.resolveProjectMeta(r.Context(), projectID, prefixes, teamFilter, caller, crToEffective)
+	if err != nil {
+		writeK8sError(w, "get project history snapshot", err)
+		return
+	}
+	match, ok := h.resolveSingleProjectMatch(w, matches)
+	if !ok {
+		return
+	}
+	if err := h.checkProjectAccess(caller, match.team, crToEffective); err != nil {
+		if _, ok := err.(*accessDeniedError); ok {
+			httputil.WriteError(w, http.StatusNotFound, "project not found")
+			return
+		}
+		httputil.WriteError(w, http.StatusForbidden, err.Error())
+		return
+	}
+
+	historyKey := strings.TrimSuffix(match.key, "meta.json") + "history/" + timestamp + ".json"
+	data, err := h.oss.GetObject(r.Context(), historyKey)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			httputil.WriteError(w, http.StatusNotFound, "snapshot not found")
+			return
+		}
+		httputil.WriteError(w, http.StatusInternalServerError, "read project history snapshot: "+err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
 
 // projectHistoryLimit caps the retained meta.json snapshots per project.
 // Snapshots are written on every human intervention (pause/resume/replan/

--- a/agentteams-controller/internal/server/project_history_test.go
+++ b/agentteams-controller/internal/server/project_history_test.go
@@ -1,0 +1,204 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	v1beta1 "github.com/agentscope-ai/AgentTeams/agentteams-controller/api/v1beta1"
+	authpkg "github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/auth"
+	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/oss"
+	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/oss/ossfake"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// lsLikeOSS mimics `mc ls <prefix>` for BOTH files and directories: returns
+// direct child names ("1723.json", "p1/") rather than full keys. The
+// mcLikeOSS helper used by the project-list tests only returns directories,
+// which is not enough for listing a history/ directory of snapshot files.
+type lsLikeOSS struct {
+	*ossfake.Memory
+}
+
+func (m *lsLikeOSS) ListObjects(_ context.Context, prefix string) ([]string, error) {
+	keys, err := m.Memory.ListObjects(context.Background(), prefix)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	out := make([]string, 0)
+	for _, k := range keys {
+		rest := strings.TrimPrefix(k, prefix)
+		parts := strings.SplitN(rest, "/", 2)
+		if parts[0] == "" {
+			continue
+		}
+		child := parts[0]
+		if len(parts) == 2 && parts[1] != "" {
+			child += "/"
+		}
+		if !seen[child] {
+			seen[child] = true
+			out = append(out, child)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// newHistoryTestHandler builds a ProjectHandler whose OSS lists both files
+// and directories (needed by the history endpoints).
+func newHistoryTestHandler(t *testing.T, store *ossfake.Memory, teams ...*v1beta1.Team) *ProjectHandler {
+	t.Helper()
+	objs := make([]runtime.Object, 0, len(teams))
+	for _, tm := range teams {
+		objs = append(objs, tm)
+	}
+	k8s := fake.NewClientBuilder().WithScheme(newProjectTestScheme(t)).WithRuntimeObjects(objs...).Build()
+	var o oss.StorageClient = &lsLikeOSS{Memory: store}
+	return NewProjectHandler(k8s, "default", o)
+}
+
+// putHistorySnapshot writes a snapshot file into a project's history dir.
+func putHistorySnapshot(store *ossfake.Memory, key string, ts string, content string) {
+	_ = store.PutObject(context.Background(), key+"history/"+ts+".json", []byte(content))
+}
+
+func TestGetProjectHistory_ListsSnapshotsNewestFirst(t *testing.T) {
+	store := ossfake.NewMemory()
+	putProject(store, "teams/alpha-team/shared/projects/p1/meta.json", map[string]any{
+		"project_id": "p1", "title": "Alpha", "status": "active", "plan_type": "dag", "team_id": "alpha-team",
+	})
+	// Two snapshots; "newest" has the larger unixNano timestamp.
+	putHistorySnapshot(store, "teams/alpha-team/shared/projects/p1/", "1723785123456789010", `{"status":"planning"}`)
+	putHistorySnapshot(store, "teams/alpha-team/shared/projects/p1/", "1723785123456789020", `{"status":"active"}`)
+	h := newHistoryTestHandler(t, store, team("alpha-team"))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/p1/history", nil)
+	req.SetPathValue("id", "p1")
+	req = withCaller(req, &authpkg.CallerIdentity{Role: authpkg.RoleAdmin, Username: "admin"})
+	rec := httptest.NewRecorder()
+	h.GetProjectHistory(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp projectHistoryResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Snapshots) != 2 {
+		t.Fatalf("snapshots=%d, want 2", len(resp.Snapshots))
+	}
+	if resp.Snapshots[0].Timestamp != "1723785123456789020" || resp.Snapshots[1].Timestamp != "1723785123456789010" {
+		t.Fatalf("order wrong: %+v", resp.Snapshots)
+	}
+}
+
+func TestGetProjectHistory_EmptyHistoryReturnsEmptyArray(t *testing.T) {
+	store := ossfake.NewMemory()
+	putProject(store, "shared/projects/p2/meta.json", map[string]any{
+		"project_id": "p2", "title": "Standalone", "status": "active", "plan_type": "loop",
+	})
+	h := newHistoryTestHandler(t, store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/p2/history", nil)
+	req.SetPathValue("id", "p2")
+	req = withCaller(req, &authpkg.CallerIdentity{Role: authpkg.RoleAdmin, Username: "admin"})
+	rec := httptest.NewRecorder()
+	h.GetProjectHistory(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	// snapshots must serialize as [] — not null.
+	if !json.Valid(rec.Body.Bytes()) || !strings.Contains(rec.Body.String(), `"snapshots":[]`) {
+		t.Fatalf("want empty snapshots array, got %s", rec.Body.String())
+	}
+}
+
+func TestGetProjectHistorySnapshot_ReturnsVerbatim(t *testing.T) {
+	store := ossfake.NewMemory()
+	putProject(store, "teams/alpha-team/shared/projects/p1/meta.json", map[string]any{
+		"project_id": "p1", "status": "active", "team_id": "alpha-team",
+	})
+	raw := `{"project_id":"p1","status":"planning","updated_by":"luo","pause_reason":"waiting for review"}`
+	putHistorySnapshot(store, "teams/alpha-team/shared/projects/p1/", "1723785123456789010", raw)
+	h := newHistoryTestHandler(t, store, team("alpha-team"))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/p1/history/1723785123456789010", nil)
+	req.SetPathValue("id", "p1")
+	req.SetPathValue("timestamp", "1723785123456789010")
+	req = withCaller(req, &authpkg.CallerIdentity{Role: authpkg.RoleAdmin, Username: "admin"})
+	rec := httptest.NewRecorder()
+	h.GetProjectHistorySnapshot(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if rec.Body.String() != raw {
+		t.Fatalf("snapshot not verbatim:\n got %s\nwant %s", rec.Body.String(), raw)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("content-type=%q, want application/json", ct)
+	}
+}
+
+func TestGetProjectHistorySnapshot_InvalidTimestamp(t *testing.T) {
+	store := ossfake.NewMemory()
+	putProject(store, "shared/projects/p1/meta.json", map[string]any{"project_id": "p1"})
+	h := newHistoryTestHandler(t, store)
+
+	for _, ts := range []string{"../etc", "abc", "123456789012345678", "12345678901234567890"} {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/p1/history/"+ts, nil)
+		req.SetPathValue("id", "p1")
+		req.SetPathValue("timestamp", ts)
+		req = withCaller(req, &authpkg.CallerIdentity{Role: authpkg.RoleAdmin, Username: "admin"})
+		rec := httptest.NewRecorder()
+		h.GetProjectHistorySnapshot(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("timestamp=%q status=%d, want 400", ts, rec.Code)
+		}
+	}
+}
+
+func TestGetProjectHistorySnapshot_NotFound(t *testing.T) {
+	store := ossfake.NewMemory()
+	putProject(store, "shared/projects/p1/meta.json", map[string]any{"project_id": "p1"})
+	h := newHistoryTestHandler(t, store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/p1/history/1723785123456789010", nil)
+	req.SetPathValue("id", "p1")
+	req.SetPathValue("timestamp", "1723785123456789010")
+	req = withCaller(req, &authpkg.CallerIdentity{Role: authpkg.RoleAdmin, Username: "admin"})
+	rec := httptest.NewRecorder()
+	h.GetProjectHistorySnapshot(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404 for absent snapshot", rec.Code)
+	}
+}
+
+func TestGetProjectHistory_TeamLeaderCrossTeamDenied(t *testing.T) {
+	store := ossfake.NewMemory()
+	putProject(store, "teams/beta-team/shared/projects/p2/meta.json", map[string]any{
+		"project_id": "p2", "status": "active", "team_id": "beta-team",
+	})
+	putHistorySnapshot(store, "teams/beta-team/shared/projects/p2/", "1723785123456789010", `{}`)
+	h := newHistoryTestHandler(t, store, team("beta-team"))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/p2/history", nil)
+	req.SetPathValue("id", "p2")
+	req = withCaller(req, &authpkg.CallerIdentity{Role: authpkg.RoleTeamLeader, Username: "alpha-lead", Team: "alpha-team"})
+	rec := httptest.NewRecorder()
+	h.GetProjectHistory(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404 for cross-team access", rec.Code)
+	}
+}

--- a/agentteams-controller/internal/server/worker_checkpoints.go
+++ b/agentteams-controller/internal/server/worker_checkpoints.go
@@ -15,10 +15,12 @@ package server
 // the shared docker network. The effective container name prefix comes from
 // configuration (AGENTTEAMS_PROXY_CONTAINER_PREFIX, or derived from
 // AGENTTEAMS_RESOURCE_PREFIX when auto-prefixing is enabled; empty when
-// auto-prefixing is disabled), and the port from the worker's
-// AGENTTEAMS_CONSOLE_PORT env (default 8088). In kube mode there is no
-// stable in-cluster DNS name for the worker pod, so the endpoints return
-// 503.
+// auto-prefixing is disabled), and the port is the effective console port
+// resolved through the same system-wins env chain used at container
+// creation (service.EffectiveWorkerConsolePort — a conflicting spec.env
+// value is discarded, so the container always listens on 8088). In kube
+// mode there is no stable in-cluster DNS name for the worker pod, so the
+// endpoints return 503.
 //
 // Fixed-path forwarding only (graph / status, plus the whitelisted limit
 // query on graph) — never a generic reverse proxy, so the attack surface is
@@ -30,24 +32,17 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	v1beta1 "github.com/agentscope-ai/AgentTeams/agentteams-controller/api/v1beta1"
 	authpkg "github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/auth"
 	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/httputil"
+	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/service"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	// defaultCheckpointWorkerPort is the qwenpaw app fallback port inside the
-	// worker container (the worker env default is AGENTTEAMS_CONSOLE_PORT=8088;
-	// a worker may override it via spec.env, which is resolved per request).
-	defaultCheckpointWorkerPort = 8088
-	// checkpointConsolePortEnv is the worker env key that overrides the qwenpaw
-	// app port (same key the docker backend reads when publishing the port).
-	checkpointConsolePortEnv = "AGENTTEAMS_CONSOLE_PORT"
 	// checkpointProxyTimeout bounds each upstream call.
 	checkpointProxyTimeout = 5 * time.Second
 )
@@ -95,17 +90,15 @@ func NewCheckpointHandler(c client.Client, namespace, kubeMode, containerPrefix 
 }
 
 // defaultWorkerBaseURL resolves a worker's qwenpaw app base URL from the
-// effective container prefix and the worker's env (AGENTTEAMS_CONSOLE_PORT
-// override, falling back to the default). An invalid or out-of-range port
-// value falls back to the default rather than failing the request.
+// effective container prefix and the effective console port. The port goes
+// through service.EffectiveWorkerConsolePort — the same system-wins env
+// chain used at container creation — so the proxy can never target a port
+// the container does not listen on (a conflicting spec.env value is
+// discarded before the container is created, so the raw spec.env must not
+// be read here).
 func (h *CheckpointHandler) defaultWorkerBaseURL(name string, env map[string]string) string {
-	port := defaultCheckpointWorkerPort
-	if raw := strings.TrimSpace(env[checkpointConsolePortEnv]); raw != "" {
-		if p, err := strconv.Atoi(raw); err == nil && p > 0 && p < 65536 {
-			port = p
-		}
-	}
-	return fmt.Sprintf("http://%s%s:%d", h.containerPrefix, name, port)
+	port := service.EffectiveWorkerConsolePort(env)
+	return fmt.Sprintf("http://%s%s:%s", h.containerPrefix, name, port)
 }
 
 // proxyCheckpoint handles GET /api/v1/workers/{name}/checkpoints/{sub}.

--- a/agentteams-controller/internal/server/worker_checkpoints.go
+++ b/agentteams-controller/internal/server/worker_checkpoints.go
@@ -1,0 +1,206 @@
+package server
+
+// Worker checkpoint inspection (GET /api/v1/workers/{name}/checkpoints/...).
+//
+// QwenPaw 2.1 ships a workspace checkpoint system — a framework-level hook
+// auto-snapshots after every response round (plus manual /checkpoint
+// snapshot), stored in {workspace}/checkpoints/shadow.git — and exposes it on
+// each worker's qwenpaw app at :8088 (0.0.0.0 listen; no auth in worker
+// context because no console user is registered). The Controller proxies two
+// read-only subpaths so L2 humans and the workbench plugin can inspect every
+// worker's execution timeline without reaching into the docker network
+// directly.
+//
+// Embedded mode only: the worker app is reachable by container name inside
+// the shared docker network. The effective container name prefix comes from
+// configuration (AGENTTEAMS_PROXY_CONTAINER_PREFIX, or derived from
+// AGENTTEAMS_RESOURCE_PREFIX when auto-prefixing is enabled; empty when
+// auto-prefixing is disabled), and the port from the worker's
+// AGENTTEAMS_CONSOLE_PORT env (default 8088). In kube mode there is no
+// stable in-cluster DNS name for the worker pod, so the endpoints return
+// 503.
+//
+// Fixed-path forwarding only (graph / status, plus the whitelisted limit
+// query on graph) — never a generic reverse proxy, so the attack surface is
+// limited to two read-only QwenPaw endpoints.
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	v1beta1 "github.com/agentscope-ai/AgentTeams/agentteams-controller/api/v1beta1"
+	authpkg "github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/auth"
+	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/httputil"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// defaultCheckpointWorkerPort is the qwenpaw app fallback port inside the
+	// worker container (the worker env default is AGENTTEAMS_CONSOLE_PORT=8088;
+	// a worker may override it via spec.env, which is resolved per request).
+	defaultCheckpointWorkerPort = 8088
+	// checkpointConsolePortEnv is the worker env key that overrides the qwenpaw
+	// app port (same key the docker backend reads when publishing the port).
+	checkpointConsolePortEnv = "AGENTTEAMS_CONSOLE_PORT"
+	// checkpointProxyTimeout bounds each upstream call.
+	checkpointProxyTimeout = 5 * time.Second
+)
+
+// checkpointSubpaths is the fixed whitelist of forwardable QwenPaw endpoints.
+var checkpointSubpaths = map[string]bool{
+	"graph":  true,
+	"status": true,
+}
+
+// workerNamePattern matches Kubernetes DNS label names (lowercase letters,
+// digits, hyphens) — the only valid worker CR names, and the only characters
+// safe to embed in the upstream container URL.
+var workerNamePattern = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+
+// CheckpointHandler proxies worker checkpoint read endpoints.
+type CheckpointHandler struct {
+	client    client.Client
+	namespace string
+	kubeMode  string
+	http      *http.Client
+	// containerPrefix is the effective worker container name prefix — the
+	// same value the docker backend uses for container naming (derived from
+	// AGENTTEAMS_PROXY_CONTAINER_PREFIX / AGENTTEAMS_RESOURCE_PREFIX /
+	// auto-prefix; empty when auto-prefixing is disabled).
+	containerPrefix string
+	// workerBaseURL resolves a worker name to its qwenpaw app base URL from
+	// the effective prefix and the worker's env. Injectable for tests.
+	workerBaseURL func(name string, env map[string]string) string
+}
+
+// NewCheckpointHandler creates the handler with the default embedded-mode
+// worker address resolution. containerPrefix must be the effective prefix
+// from controller configuration (see config.ContainerPrefix).
+func NewCheckpointHandler(c client.Client, namespace, kubeMode, containerPrefix string) *CheckpointHandler {
+	h := &CheckpointHandler{
+		client:          c,
+		namespace:       namespace,
+		kubeMode:        kubeMode,
+		http:            &http.Client{Timeout: checkpointProxyTimeout},
+		containerPrefix: containerPrefix,
+	}
+	h.workerBaseURL = h.defaultWorkerBaseURL
+	return h
+}
+
+// defaultWorkerBaseURL resolves a worker's qwenpaw app base URL from the
+// effective container prefix and the worker's env (AGENTTEAMS_CONSOLE_PORT
+// override, falling back to the default). An invalid or out-of-range port
+// value falls back to the default rather than failing the request.
+func (h *CheckpointHandler) defaultWorkerBaseURL(name string, env map[string]string) string {
+	port := defaultCheckpointWorkerPort
+	if raw := strings.TrimSpace(env[checkpointConsolePortEnv]); raw != "" {
+		if p, err := strconv.Atoi(raw); err == nil && p > 0 && p < 65536 {
+			port = p
+		}
+	}
+	return fmt.Sprintf("http://%s%s:%d", h.containerPrefix, name, port)
+}
+
+// proxyCheckpoint handles GET /api/v1/workers/{name}/checkpoints/{sub}.
+// Scoped callers (team leaders / L2 humans) may only inspect workers in the
+// teams they control — mirrors GET /api/v1/workers/{name} (W8: 404, not 403,
+// so worker existence cannot be probed).
+func (h *CheckpointHandler) proxyCheckpoint(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	sub := r.PathValue("sub")
+	if name == "" || !workerNamePattern.MatchString(name) {
+		httputil.WriteError(w, http.StatusBadRequest, "worker name is required and must be a valid DNS label")
+		return
+	}
+	if !checkpointSubpaths[sub] {
+		httputil.WriteError(w, http.StatusBadRequest, "unsupported checkpoint subpath")
+		return
+	}
+	// Kube-mode check runs before any worker lookup: the endpoints are
+	// entirely unavailable in kube mode, and a uniform 503 (rather than a
+	// per-worker 404 vs 503 split) avoids leaking worker existence.
+	if h.kubeMode != "embedded" {
+		httputil.WriteError(w, http.StatusServiceUnavailable, "worker checkpoint inspection requires embedded mode")
+		return
+	}
+
+	var worker v1beta1.Worker
+	if err := h.client.Get(r.Context(), client.ObjectKey{Name: name, Namespace: h.namespace}, &worker); err != nil {
+		if apierrors.IsNotFound(err) {
+			httputil.WriteError(w, http.StatusNotFound, "worker not found")
+			return
+		}
+		writeK8sError(w, "get worker checkpoints", err)
+		return
+	}
+	// Resolve the owning team for the scoped-caller check (same chain as
+	// ResourceHandler.GetWorker: standalone workers hide as 404).
+	_, team, _, err := findTeamMember(r.Context(), h.client, h.namespace, name)
+	if err != nil {
+		writeK8sError(w, "get worker checkpoints", err)
+		return
+	}
+	if caller := authpkg.CallerFromContext(r.Context()); caller != nil &&
+		(caller.Role == authpkg.RoleTeamLeader || caller.Role == authpkg.RoleHuman) &&
+		!caller.TeamMatches(team) {
+		httputil.WriteError(w, http.StatusNotFound, "worker not found")
+		return
+	}
+
+	// Resolve the upstream address from the effective container prefix and
+	// the worker's own env (per-worker console port override).
+	target := h.workerBaseURL(name, worker.Spec.Env) + "/workspace/checkpoints/" + sub
+	// Strict query whitelist: graph supports only ?limit= (1..1000, the same
+	// bounds the upstream endpoint enforces); status takes no parameters.
+	// Unknown parameters are rejected rather than silently dropped so client
+	// mistakes surface immediately.
+	q := r.URL.Query()
+	for key := range q {
+		if !(sub == "graph" && key == "limit") {
+			httputil.WriteError(w, http.StatusBadRequest, "unsupported query parameter: "+key)
+			return
+		}
+	}
+	if raw := q.Get("limit"); raw != "" {
+		limit, err := strconv.Atoi(raw)
+		if err != nil || limit < 1 || limit > 1000 {
+			httputil.WriteError(w, http.StatusBadRequest, "limit must be an integer between 1 and 1000")
+			return
+		}
+		target += "?limit=" + raw
+	}
+
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, target, nil)
+	if err != nil {
+		httputil.WriteError(w, http.StatusInternalServerError, "build checkpoint request: "+err.Error())
+		return
+	}
+	resp, err := h.http.Do(req)
+	if err != nil {
+		// Connection refused (worker stopped), DNS failure, timeout.
+		httputil.WriteError(w, http.StatusBadGateway, "worker checkpoint API unreachable")
+		return
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.Copy(w, resp.Body)
+	case http.StatusNotFound:
+		// QwenPaw < 2.1 has no checkpoint router; translate the upstream
+		// 404 into an actionable message instead of leaking it verbatim.
+		httputil.WriteError(w, http.StatusBadGateway, "checkpoint API unavailable (requires QwenPaw 2.1)")
+	default:
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		httputil.WriteError(w, http.StatusBadGateway, fmt.Sprintf("checkpoint API error (status %d): %s", resp.StatusCode, string(body)))
+	}
+}

--- a/agentteams-controller/internal/server/worker_checkpoints_test.go
+++ b/agentteams-controller/internal/server/worker_checkpoints_test.go
@@ -12,6 +12,8 @@ import (
 
 	v1beta1 "github.com/agentscope-ai/AgentTeams/agentteams-controller/api/v1beta1"
 	authpkg "github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/auth"
+	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/config"
+	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/service"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -256,9 +258,12 @@ func TestCheckpoint_UpstreamErrorBodyBounded(t *testing.T) {
 }
 
 // TestCheckpointWorkerBaseURL_PrefixAndPortResolution covers the address
-// resolution matrix: default / non-default / empty container prefixes and the
-// per-worker AGENTTEAMS_CONSOLE_PORT override (valid, padded, invalid, and
-// out-of-range values).
+// resolution matrix: default / non-default / empty container prefixes. The
+// console port is ALWAYS the effective system port: the worker system env
+// defines AGENTTEAMS_CONSOLE_PORT and the system-wins user-env merge
+// discards conflicting spec.env values before the container is created, so
+// any user-declared port (valid, padded, invalid, out-of-range) must
+// resolve to the same port the container actually listens on.
 func TestCheckpointWorkerBaseURL_PrefixAndPortResolution(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -269,11 +274,11 @@ func TestCheckpointWorkerBaseURL_PrefixAndPortResolution(t *testing.T) {
 		{"default prefix and port", "agentteams-worker-", nil, "http://agentteams-worker-alice:8088"},
 		{"non-default prefix", "acme-worker-", nil, "http://acme-worker-alice:8088"},
 		{"empty prefix (auto-prefix disabled)", "", nil, "http://alice:8088"},
-		{"custom port", "agentteams-worker-", map[string]string{"AGENTTEAMS_CONSOLE_PORT": "9090"}, "http://agentteams-worker-alice:9090"},
-		{"custom prefix and port", "acme-worker-", map[string]string{"AGENTTEAMS_CONSOLE_PORT": " 7000 "}, "http://acme-worker-alice:7000"},
-		{"invalid port falls back to default", "agentteams-worker-", map[string]string{"AGENTTEAMS_CONSOLE_PORT": "not-a-port"}, "http://agentteams-worker-alice:8088"},
-		{"out-of-range port falls back to default", "agentteams-worker-", map[string]string{"AGENTTEAMS_CONSOLE_PORT": "99999"}, "http://agentteams-worker-alice:8088"},
-		{"zero port falls back to default", "agentteams-worker-", map[string]string{"AGENTTEAMS_CONSOLE_PORT": "0"}, "http://agentteams-worker-alice:8088"},
+		{"user port discarded (system wins)", "agentteams-worker-", map[string]string{"AGENTTEAMS_CONSOLE_PORT": "9090"}, "http://agentteams-worker-alice:8088"},
+		{"custom prefix, user port discarded", "acme-worker-", map[string]string{"AGENTTEAMS_CONSOLE_PORT": " 7000 "}, "http://acme-worker-alice:8088"},
+		{"invalid user port discarded", "agentteams-worker-", map[string]string{"AGENTTEAMS_CONSOLE_PORT": "not-a-port"}, "http://agentteams-worker-alice:8088"},
+		{"out-of-range user port discarded", "agentteams-worker-", map[string]string{"AGENTTEAMS_CONSOLE_PORT": "99999"}, "http://agentteams-worker-alice:8088"},
+		{"zero user port discarded", "agentteams-worker-", map[string]string{"AGENTTEAMS_CONSOLE_PORT": "0"}, "http://agentteams-worker-alice:8088"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -302,10 +307,13 @@ func (c *captureRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 }
 
 // TestCheckpoint_EffectivePrefixAndPortReachUpstream is the end-to-end
-// regression: a controller configured with a non-default container prefix and
-// a worker that overrides its console port must dial exactly
-// http://{prefix}{name}:{port} — the original hard-coded
-// agentteams-worker-{name}:8088 would 502 in this deployment.
+// regression: a controller configured with a non-default container prefix
+// and a worker whose spec.env conflicts with the system console port must
+// dial exactly http://{prefix}{name}:{effective-port} — the conflicting
+// spec.env value is discarded by the same system-wins merge the container
+// creation applies, so the proxy targets the port the container actually
+// listens on. A pre-fix handler reading the raw spec.env would dial 9090
+// and 502, because the container listens on 8088.
 func TestCheckpoint_EffectivePrefixAndPortReachUpstream(t *testing.T) {
 	objs := checkpointTeamWithWorkers("team-a", "daily-luo")
 	objs[1].(*v1beta1.Worker).Spec.Env = map[string]string{"AGENTTEAMS_CONSOLE_PORT": "9090"}
@@ -321,8 +329,39 @@ func TestCheckpoint_EffectivePrefixAndPortReachUpstream(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d, want 200; body=%s", rec.Code, rec.Body.String())
 	}
-	want := "http://acme-worker-daily-luo:9090/workspace/checkpoints/status"
+	want := "http://acme-worker-daily-luo:8088/workspace/checkpoints/status"
 	if rt.gotURL.String() != want {
 		t.Fatalf("upstream URL=%s, want %s", rt.gotURL.String(), want)
+	}
+}
+
+// TestCheckpointPort_MatchesContainerCreationEnvChain is the cross-component
+// regression: the port the proxy resolves must equal the port the docker
+// backend derives, computed through the real container-creation env chain
+// (WorkerEnvBuilder.Build + the shared system-wins merge). If the system
+// default or the merge semantics ever change, this test fails instead of
+// the proxy silently 502-ing on every worker.
+func TestCheckpointPort_MatchesContainerCreationEnvChain(t *testing.T) {
+	userEnv := map[string]string{"AGENTTEAMS_CONSOLE_PORT": "9090"}
+
+	// The docker backend reads the port from the merged CreateRequest env.
+	builder := service.NewWorkerEnvBuilder(config.WorkerEnvDefaults{})
+	sysEnv := builder.Build("daily-luo", &service.WorkerProvisionResult{
+		GatewayKey:    "gk",
+		MatrixToken:   "mt",
+		RoomID:        "!room",
+		MinIOPassword: "mp",
+	})
+	service.MergeUserEnv(sysEnv, userEnv) // same semantics the reconciler applies
+	dockerSide := sysEnv[service.WorkerConsolePortEnv]
+
+	// The proxy resolves the port through the shared effective-env helper.
+	proxySide := service.EffectiveWorkerConsolePort(userEnv)
+
+	if dockerSide != proxySide {
+		t.Fatalf("docker backend port %q != checkpoint proxy port %q — proxy would 502", dockerSide, proxySide)
+	}
+	if dockerSide != "8088" {
+		t.Fatalf("effective console port=%q, want %q (system default, user value must be discarded)", dockerSide, "8088")
 	}
 }

--- a/agentteams-controller/internal/server/worker_checkpoints_test.go
+++ b/agentteams-controller/internal/server/worker_checkpoints_test.go
@@ -1,0 +1,328 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	v1beta1 "github.com/agentscope-ai/AgentTeams/agentteams-controller/api/v1beta1"
+	authpkg "github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/auth"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// newTestCheckpointHandler builds a handler with a fake K8s client (given
+// teams and workers) whose worker URLs point at the given httptest server
+// (mimicking one worker's qwenpaw app).
+func newTestCheckpointHandler(t *testing.T, kubeMode string, ts *httptest.Server, objs ...runtime.Object) *CheckpointHandler {
+	t.Helper()
+	k8s := fake.NewClientBuilder().WithScheme(newProjectTestScheme(t)).WithRuntimeObjects(objs...).Build()
+	h := NewCheckpointHandler(k8s, "default", kubeMode, "agentteams-worker-")
+	if ts != nil {
+		h.workerBaseURL = func(string, map[string]string) string { return ts.URL }
+	}
+	return h
+}
+
+// checkpointTeam builds a Team whose WorkerMembers include the given names.
+func checkpointTeam(name string, workers ...string) *v1beta1.Team {
+	refs := make([]v1beta1.TeamWorkerRef, 0, len(workers))
+	for _, w := range workers {
+		refs = append(refs, v1beta1.TeamWorkerRef{Name: w})
+	}
+	return &v1beta1.Team{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec:       v1beta1.TeamSpec{TeamName: name, WorkerMembers: refs},
+	}
+}
+
+// checkpointWorker builds a minimal Worker CR.
+func checkpointWorker(name string) *v1beta1.Worker {
+	return &v1beta1.Worker{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec:       v1beta1.WorkerSpec{WorkerName: name},
+	}
+}
+
+// checkpointTeamWithWorkers builds a Team plus its Worker CRs (the handler
+// resolves worker existence before forwarding).
+func checkpointTeamWithWorkers(name string, workers ...string) []runtime.Object {
+	objs := make([]runtime.Object, 0, len(workers)+1)
+	objs = append(objs, checkpointTeam(name, workers...))
+	for _, w := range workers {
+		objs = append(objs, checkpointWorker(w))
+	}
+	return objs
+}
+
+func checkpointRequest(method, name, sub, query string) *http.Request {
+	// The URL always uses a safe placeholder; the actual (possibly invalid)
+	// name is set via PathValue so handler validation is what's tested.
+	req := httptest.NewRequest(method, "/api/v1/workers/placeholder/checkpoints/"+sub+query, nil)
+	req.SetPathValue("name", name)
+	req.SetPathValue("sub", sub)
+	return req
+}
+
+func adminCaller(req *http.Request) *http.Request {
+	return withCaller(req, &authpkg.CallerIdentity{Role: authpkg.RoleAdmin, Username: "admin"})
+}
+
+func TestCheckpointGraph_ForwardsVerbatim(t *testing.T) {
+	const payload = `{"nodes":[{"kind":"auto","commit":"abc"}],"summary":{"total":1}}`
+	var gotPath, gotQuery string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer upstream.Close()
+
+	h := newTestCheckpointHandler(t, "embedded", upstream, checkpointTeamWithWorkers("team-a", "daily-luo")...)
+	rec := httptest.NewRecorder()
+	h.proxyCheckpoint(rec, adminCaller(checkpointRequest(http.MethodGet, "daily-luo", "graph", "?limit=10")))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if gotPath != "/workspace/checkpoints/graph" {
+		t.Fatalf("upstream path=%q, want /workspace/checkpoints/graph", gotPath)
+	}
+	if gotQuery != "limit=10" {
+		t.Fatalf("upstream query=%q, want limit=10", gotQuery)
+	}
+	if rec.Body.String() != payload {
+		t.Fatalf("body not verbatim:\n got %s\nwant %s", rec.Body.String(), payload)
+	}
+}
+
+func TestCheckpointStatus_Forwards(t *testing.T) {
+	const payload = `{"auto_enabled":false,"has_checkpoints":true}`
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer upstream.Close()
+
+	h := newTestCheckpointHandler(t, "embedded", upstream, checkpointTeamWithWorkers("team-a", "daily-luo")...)
+	rec := httptest.NewRecorder()
+	h.proxyCheckpoint(rec, adminCaller(checkpointRequest(http.MethodGet, "daily-luo", "status", "")))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if gotPath != "/workspace/checkpoints/status" {
+		t.Fatalf("upstream path=%q", gotPath)
+	}
+	if rec.Body.String() != payload {
+		t.Fatalf("body=%s", rec.Body.String())
+	}
+}
+
+func TestCheckpoint_Upstream404MeansOldQwenPaw(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer upstream.Close()
+
+	h := newTestCheckpointHandler(t, "embedded", upstream, checkpointTeamWithWorkers("team-a", "daily-luo")...)
+	rec := httptest.NewRecorder()
+	h.proxyCheckpoint(rec, adminCaller(checkpointRequest(http.MethodGet, "daily-luo", "graph", "")))
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status=%d, want 502", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "requires QwenPaw 2.1") {
+		t.Fatalf("body=%s, want actionable 2.1 message", rec.Body.String())
+	}
+}
+
+func TestCheckpoint_UnreachableWorker(t *testing.T) {
+	// A server that immediately closes — the client gets a connection error.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := upstream.URL
+	upstream.Close()
+
+	h := newTestCheckpointHandler(t, "embedded", nil, checkpointTeamWithWorkers("team-a", "daily-luo")...)
+	h.workerBaseURL = func(string, map[string]string) string { return url }
+
+	rec := httptest.NewRecorder()
+	h.proxyCheckpoint(rec, adminCaller(checkpointRequest(http.MethodGet, "daily-luo", "graph", "")))
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status=%d, want 502 for unreachable worker", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "unreachable") {
+		t.Fatalf("body=%s, want unreachable message", rec.Body.String())
+	}
+}
+
+func TestCheckpoint_KubeModeUnsupported(t *testing.T) {
+	h := newTestCheckpointHandler(t, "k8s", nil, checkpointTeamWithWorkers("team-a", "daily-luo")...)
+	rec := httptest.NewRecorder()
+	h.proxyCheckpoint(rec, adminCaller(checkpointRequest(http.MethodGet, "daily-luo", "graph", "")))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503 in kube mode", rec.Code)
+	}
+}
+
+func TestCheckpoint_RejectsUnknownSubpath(t *testing.T) {
+	h := newTestCheckpointHandler(t, "embedded", nil, checkpointTeamWithWorkers("team-a", "daily-luo")...)
+	rec := httptest.NewRecorder()
+	h.proxyCheckpoint(rec, adminCaller(checkpointRequest(http.MethodGet, "daily-luo", "restore", "")))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400 for unknown subpath", rec.Code)
+	}
+}
+
+func TestCheckpoint_RejectsInvalidWorkerName(t *testing.T) {
+	h := newTestCheckpointHandler(t, "embedded", nil)
+	for _, name := range []string{"", "Daily-Luo", "../etc", "a b"} {
+		rec := httptest.NewRecorder()
+		h.proxyCheckpoint(rec, adminCaller(checkpointRequest(http.MethodGet, name, "graph", "")))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("name=%q status=%d, want 400", name, rec.Code)
+		}
+	}
+}
+
+func TestCheckpoint_RejectsInvalidLimit(t *testing.T) {
+	h := newTestCheckpointHandler(t, "embedded", nil, checkpointTeamWithWorkers("team-a", "daily-luo")...)
+	for _, q := range []string{"?limit=0", "?limit=1001", "?limit=abc", "?limit=5&other=1"} {
+		rec := httptest.NewRecorder()
+		h.proxyCheckpoint(rec, adminCaller(checkpointRequest(http.MethodGet, "daily-luo", "graph", q)))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("query=%q status=%d, want 400", q, rec.Code)
+		}
+	}
+}
+
+func TestCheckpoint_UnknownWorker(t *testing.T) {
+	h := newTestCheckpointHandler(t, "embedded", nil)
+	rec := httptest.NewRecorder()
+	h.proxyCheckpoint(rec, adminCaller(checkpointRequest(http.MethodGet, "ghost-worker", "graph", "")))
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404 for unknown worker", rec.Code)
+	}
+}
+
+func TestCheckpoint_TeamLeaderCrossTeamDenied(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer upstream.Close()
+
+	h := newTestCheckpointHandler(t, "embedded", upstream, checkpointTeamWithWorkers("beta-team", "daily-luo")...)
+	req := checkpointRequest(http.MethodGet, "daily-luo", "graph", "")
+	req = withCaller(req, &authpkg.CallerIdentity{Role: authpkg.RoleTeamLeader, Username: "alpha-lead", Team: "alpha-team"})
+	rec := httptest.NewRecorder()
+	h.proxyCheckpoint(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404 for cross-team access (W8)", rec.Code)
+	}
+}
+
+func TestCheckpoint_UpstreamErrorBodyBounded(t *testing.T) {
+	big := strings.Repeat("x", 8192)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(big))
+	}))
+	defer upstream.Close()
+
+	h := newTestCheckpointHandler(t, "embedded", upstream, checkpointTeamWithWorkers("team-a", "daily-luo")...)
+	rec := httptest.NewRecorder()
+	h.proxyCheckpoint(rec, adminCaller(checkpointRequest(http.MethodGet, "daily-luo", "graph", "")))
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status=%d, want 502", rec.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("body not json: %v", err)
+	}
+}
+
+// TestCheckpointWorkerBaseURL_PrefixAndPortResolution covers the address
+// resolution matrix: default / non-default / empty container prefixes and the
+// per-worker AGENTTEAMS_CONSOLE_PORT override (valid, padded, invalid, and
+// out-of-range values).
+func TestCheckpointWorkerBaseURL_PrefixAndPortResolution(t *testing.T) {
+	cases := []struct {
+		name   string
+		prefix string
+		env    map[string]string
+		want   string
+	}{
+		{"default prefix and port", "agentteams-worker-", nil, "http://agentteams-worker-alice:8088"},
+		{"non-default prefix", "acme-worker-", nil, "http://acme-worker-alice:8088"},
+		{"empty prefix (auto-prefix disabled)", "", nil, "http://alice:8088"},
+		{"custom port", "agentteams-worker-", map[string]string{"AGENTTEAMS_CONSOLE_PORT": "9090"}, "http://agentteams-worker-alice:9090"},
+		{"custom prefix and port", "acme-worker-", map[string]string{"AGENTTEAMS_CONSOLE_PORT": " 7000 "}, "http://acme-worker-alice:7000"},
+		{"invalid port falls back to default", "agentteams-worker-", map[string]string{"AGENTTEAMS_CONSOLE_PORT": "not-a-port"}, "http://agentteams-worker-alice:8088"},
+		{"out-of-range port falls back to default", "agentteams-worker-", map[string]string{"AGENTTEAMS_CONSOLE_PORT": "99999"}, "http://agentteams-worker-alice:8088"},
+		{"zero port falls back to default", "agentteams-worker-", map[string]string{"AGENTTEAMS_CONSOLE_PORT": "0"}, "http://agentteams-worker-alice:8088"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &CheckpointHandler{containerPrefix: tc.prefix}
+			if got := h.defaultWorkerBaseURL("alice", tc.env); got != tc.want {
+				t.Errorf("got %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// captureRoundTripper records the upstream URL the handler dials and returns
+// a canned 200 JSON response, so tests can assert on effective address
+// resolution without a live worker container.
+type captureRoundTripper struct {
+	gotURL *url.URL
+}
+
+func (c *captureRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.gotURL = req.URL
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader([]byte(`{"ok":true}`))),
+	}, nil
+}
+
+// TestCheckpoint_EffectivePrefixAndPortReachUpstream is the end-to-end
+// regression: a controller configured with a non-default container prefix and
+// a worker that overrides its console port must dial exactly
+// http://{prefix}{name}:{port} — the original hard-coded
+// agentteams-worker-{name}:8088 would 502 in this deployment.
+func TestCheckpoint_EffectivePrefixAndPortReachUpstream(t *testing.T) {
+	objs := checkpointTeamWithWorkers("team-a", "daily-luo")
+	objs[1].(*v1beta1.Worker).Spec.Env = map[string]string{"AGENTTEAMS_CONSOLE_PORT": "9090"}
+	k8s := fake.NewClientBuilder().WithScheme(newProjectTestScheme(t)).WithRuntimeObjects(objs...).Build()
+
+	h := NewCheckpointHandler(k8s, "default", "embedded", "acme-worker-")
+	rt := &captureRoundTripper{}
+	h.http = &http.Client{Transport: rt}
+
+	rec := httptest.NewRecorder()
+	h.proxyCheckpoint(rec, adminCaller(checkpointRequest(http.MethodGet, "daily-luo", "status", "")))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	want := "http://acme-worker-daily-luo:9090/workspace/checkpoints/status"
+	if rt.gotURL.String() != want {
+		t.Fatalf("upstream URL=%s, want %s", rt.gotURL.String(), want)
+	}
+}

--- a/agentteams-controller/internal/service/worker_env.go
+++ b/agentteams-controller/internal/service/worker_env.go
@@ -5,6 +5,17 @@ import (
 	"github.com/agentscope-ai/AgentTeams/agentteams-controller/internal/config"
 )
 
+const (
+	// WorkerConsolePortEnv carries the worker qwenpaw console port in the
+	// container environment.
+	WorkerConsolePortEnv = "AGENTTEAMS_CONSOLE_PORT"
+	// WorkerConsolePortDefault is the system-defined console port.
+	// WorkerEnvBuilder.Build always defines this key in the system env, so
+	// the system-wins user-env merge discards any conflicting user value:
+	// the container always listens on this port.
+	WorkerConsolePortDefault = "8088"
+)
+
 // WorkerEnvBuilder constructs environment variable maps for worker containers.
 // Configuration defaults are injected at construction time rather than read
 // from os.Getenv at call time, keeping the service layer test-friendly.
@@ -28,12 +39,42 @@ func (b *WorkerEnvBuilder) Build(workerName string, prov *WorkerProvisionResult)
 		"AGENTTEAMS_FS_SECRET_KEY":       prov.MinIOPassword,
 		"OPENCLAW_DISABLE_BONJOUR":       "1",
 		"OPENCLAW_MDNS_HOSTNAME":         "agentteams-w-" + workerName,
-		"AGENTTEAMS_CONSOLE_PORT":        "8088",
+		WorkerConsolePortEnv:             WorkerConsolePortDefault,
 		"HOME":                           "/root/agentteams-fs/agents/" + workerName,
 	}
 
 	b.applyClusterDefaults(env)
 	return env
+}
+
+// MergeUserEnv applies system-wins merge of user-declared env vars into
+// sysEnv: any key already present in sysEnv keeps the system value and the
+// user's value is discarded (returned in the result). sysEnv is mutated in
+// place and must be non-nil when userEnv is non-empty. This is the single
+// shared merge implementation — the reconciler (via mergeUserEnv) and
+// server-side address resolution (via EffectiveWorkerConsolePort) must use
+// the same semantics or proxy and container diverge.
+func MergeUserEnv(sysEnv, userEnv map[string]string) (ignored []string) {
+	for k, v := range userEnv {
+		if _, taken := sysEnv[k]; taken {
+			ignored = append(ignored, k)
+			continue
+		}
+		sysEnv[k] = v
+	}
+	return ignored
+}
+
+// EffectiveWorkerConsolePort resolves the port the worker container actually
+// listens on, mirroring the container-creation env chain (WorkerEnvBuilder
+// system env + system-wins user-env merge). The system env always defines
+// the console-port key, so a conflicting Worker.spec.env value is discarded
+// — callers resolving upstream worker addresses must use this (not the raw
+// spec.env) to stay aligned with the docker backend.
+func EffectiveWorkerConsolePort(userEnv map[string]string) string {
+	sysEnv := map[string]string{WorkerConsolePortEnv: WorkerConsolePortDefault}
+	MergeUserEnv(sysEnv, userEnv)
+	return sysEnv[WorkerConsolePortEnv]
 }
 
 // BuildManager returns the env map for a Manager container.

--- a/agentteams-controller/internal/service/worker_env_test.go
+++ b/agentteams-controller/internal/service/worker_env_test.go
@@ -106,3 +106,57 @@ func TestWorkerEnvBuilderBuildManagerUsesConfiguredRuntimeAndBucket(t *testing.T
 		}
 	}
 }
+
+func TestMergeUserEnv_SystemWins(t *testing.T) {
+	sysEnv := map[string]string{WorkerConsolePortEnv: WorkerConsolePortDefault, "SYS_ONLY": "1"}
+	userEnv := map[string]string{
+		WorkerConsolePortEnv: "9090", // conflicts → discarded
+		"USER_ONLY":          "42",   // new key → merged
+	}
+	ignored := MergeUserEnv(sysEnv, userEnv)
+	if got := sysEnv[WorkerConsolePortEnv]; got != WorkerConsolePortDefault {
+		t.Fatalf("system key changed to %q, must stay %q", got, WorkerConsolePortDefault)
+	}
+	if got := sysEnv["USER_ONLY"]; got != "42" {
+		t.Fatalf("user key not merged, got %q", got)
+	}
+	if len(ignored) != 1 || ignored[0] != WorkerConsolePortEnv {
+		t.Fatalf("ignored=%v, want [%s]", ignored, WorkerConsolePortEnv)
+	}
+}
+
+func TestMergeUserEnv_NilUserEnv(t *testing.T) {
+	sysEnv := map[string]string{WorkerConsolePortEnv: WorkerConsolePortDefault}
+	if ignored := MergeUserEnv(sysEnv, nil); len(ignored) != 0 {
+		t.Fatalf("ignored=%v, want none", ignored)
+	}
+	if got := sysEnv[WorkerConsolePortEnv]; got != WorkerConsolePortDefault {
+		t.Fatalf("sysEnv mutated to %q", got)
+	}
+}
+
+func TestEffectiveWorkerConsolePort_ConflictingUserValueDiscarded(t *testing.T) {
+	cases := map[string]string{
+		"9090":       "8088",
+		" 7000 ":     "8088",
+		"not-a-port": "8088",
+		"99999":      "8088",
+		"0":          "8088",
+	}
+	for userVal, want := range cases {
+		if got := EffectiveWorkerConsolePort(map[string]string{WorkerConsolePortEnv: userVal}); got != want {
+			t.Errorf("user value %q → %q, want %q (system wins)", userVal, got, want)
+		}
+	}
+	if got := EffectiveWorkerConsolePort(nil); got != WorkerConsolePortDefault {
+		t.Fatalf("nil user env → %q, want %q", got, WorkerConsolePortDefault)
+	}
+}
+
+func TestWorkerEnvBuilderBuild_ConsolePortIsSharedConstant(t *testing.T) {
+	builder := NewWorkerEnvBuilder(config.WorkerEnvDefaults{})
+	env := builder.Build("w1", &WorkerProvisionResult{})
+	if env[WorkerConsolePortEnv] != WorkerConsolePortDefault {
+		t.Fatalf("builder port %q != shared constant %q — proxy would diverge", env[WorkerConsolePortEnv], WorkerConsolePortDefault)
+	}
+}

--- a/docs/usage/project-workflow-api.md
+++ b/docs/usage/project-workflow-api.md
@@ -347,6 +347,52 @@ Error responses:
 | `404` | Project not found / caller does not own it (existence hidden) / session not owned by any team worker / `history.db` missing or unreadable. |
 | `500` | K8s or object-store failure. |
 
+### `GET /api/v1/projects/{id}/history`
+
+Returns the project's **intervention timeline** — the pre-intervention
+`meta.json` snapshots written by the lifecycle endpoints (see
+`POST /pause`, `POST /resume`, … below; each intervention snapshots the
+previous state into `history/{unixNano}.json`, retaining the most recent 50).
+
+Query parameters:
+
+| Param | Type | Default | Meaning |
+|:--|:--|:--|:--|
+| `team` | string | — | Optional team qualifier, same semantics as the other read endpoints. |
+
+Response:
+
+```json
+{
+  "project_id": "demo-project-001",
+  "snapshots": [
+    { "timestamp": "1723785123456789012" }
+  ]
+}
+```
+
+- `snapshots` is **newest first**. `timestamp` is the snapshot filename
+  (unix nanoseconds) and is kept as a **string** — 19-digit nanosecond
+  values exceed the JavaScript safe-integer range, so numeric transport
+  would silently lose precision.
+- An empty history returns `200` with `"snapshots": []`.
+
+### `GET /api/v1/projects/{id}/history/{timestamp}`
+
+Returns one snapshot's raw `meta.json` content **verbatim** (same schema as
+`GET /workflow`'s source). `timestamp` must be a 19-digit unixNano value;
+anything else is rejected `400` (this doubles as the traversal guard).
+
+Error responses:
+
+| Code | Meaning |
+|:--|:--|
+| `400` | Missing project id / malformed timestamp. |
+| `403` | Authenticated but the role cannot read projects at all (e.g. Worker). |
+| `404` | Project or snapshot not found / caller does not own it (existence hidden). |
+| `409` | Ambiguous project id across teams; retry with `?team=`. |
+| `500` | K8s or object-store failure. |
+
 ## Project identity & disambiguation
 
 Project ids are only unique within a worker workspace upstream: two teams can
@@ -357,8 +403,9 @@ the identity:
   id under two teams appears twice, disambiguated by `team_id` (a scoped
   caller only sees the entries of their accessible teams).
 - The read endpoints (`workflow`, `tasks/{taskId}/artifact`, `spawns`,
-  `spawns/{sessionId}/messages`) accept an optional `?team=` query parameter
-  that narrows resolution to that team's storage prefix.
+  `spawns/{sessionId}/messages`, `history`, `history/{timestamp}`) accept an
+  optional `?team=` query parameter that narrows resolution to that team's
+  storage prefix.
 - Without `?team=`, if the same project id exists under multiple teams the
   endpoint returns `409 Conflict` (`project id is ambiguous across teams;
   retry with ?team=`) instead of silently resolving to the first match.
@@ -381,12 +428,12 @@ Two bearer-token paths are accepted (composite authenticator):
 
 Authorization matrix:
 
-| Caller | List | Get workflow | Get spawns | Get spawn messages |
-|:--|:--|:--|:--|:--|
-| admin / manager | all teams | any project | any project | any project |
-| team-leader (SA) | own team only | own team only | own team only | own team only |
-| L2 human (Matrix) | all `accessibleTeams` | any accessible team | any accessible team | any accessible team |
-| worker | denied | denied | denied | denied |
+| Caller | List | Get workflow | Get spawns | Get spawn messages | Get history |
+|:--|:--|:--|:--|:--|:--|
+| admin / manager | all teams | any project | any project | any project | any project |
+| team-leader (SA) | own team only | own team only | own team only | own team only | own team only |
+| L2 human (Matrix) | all `accessibleTeams` | any accessible team | any accessible team | any accessible team | any accessible team |
+| worker | denied | denied | denied | denied | denied |
 
 ## `agt` CLI
 
@@ -575,3 +622,40 @@ agt project complete demo-project-001
 ```
 
 The same bearer-token forwarding applies (Matrix token for L2 humans).
+
+## Worker checkpoint endpoints
+
+The Controller proxies two read-only endpoints of each worker's QwenPaw app
+(checkpoint system, QwenPaw ≥ 2.1) so humans and frontends can inspect a
+worker's execution timeline — auto snapshots after every response round plus
+manual `/checkpoint snapshot`, stored in the worker's `checkpoints/shadow.git`.
+
+| Endpoint | Meaning |
+|:--|:--|
+| `GET /api/v1/workers/{name}/checkpoints/graph` | Checkpoint graph (nodes with kind/timestamp/query preview, sessions, summary). Optional `?limit=` (1..1000). |
+| `GET /api/v1/workers/{name}/checkpoints/status` | `auto_enabled`, `has_checkpoints`, `workspace_dir`. |
+
+- **Scope**: same worker read authorization as `GET /api/v1/workers/{name}`
+  — team leaders / L2 humans only see workers in their teams; unknown or
+  out-of-scope workers are hidden as `404`.
+- **Embedded mode only**: the endpoints proxy the worker's qwenpaw app inside
+  the shared docker network. The upstream address is resolved from the
+  effective container prefix (`AGENTTEAMS_PROXY_CONTAINER_PREFIX`, or derived
+  from `AGENTTEAMS_RESOURCE_PREFIX` when auto-prefixing is enabled; empty when
+  disabled — the same value the docker backend uses for container naming) and
+  the worker's `AGENTTEAMS_CONSOLE_PORT` env (default `8088`). In kube mode
+  they return `503`.
+- **Degradation**: a worker running QwenPaw < 2.1 has no checkpoint router,
+  so the upstream `404` is translated to `502` with
+  `checkpoint API unavailable (requires QwenPaw 2.1)`.
+- Forwarding is fixed-path (graph / status) with a strict query whitelist —
+  not a generic reverse proxy.
+
+Error responses:
+
+| Code | Meaning |
+|:--|:--|
+| `400` | Invalid worker name / unsupported subpath or query parameter / invalid `limit`. |
+| `404` | Worker not found / caller does not own it (existence hidden). |
+| `502` | Worker app unreachable, pre-2.1 checkpoint API, or upstream error. |
+| `503` | Kube mode (no stable worker pod DNS to proxy). |

--- a/docs/usage/project-workflow-api.md
+++ b/docs/usage/project-workflow-api.md
@@ -643,7 +643,10 @@ manual `/checkpoint snapshot`, stored in the worker's `checkpoints/shadow.git`.
   effective container prefix (`AGENTTEAMS_PROXY_CONTAINER_PREFIX`, or derived
   from `AGENTTEAMS_RESOURCE_PREFIX` when auto-prefixing is enabled; empty when
   disabled — the same value the docker backend uses for container naming) and
-  the worker's `AGENTTEAMS_CONSOLE_PORT` env (default `8088`). In kube mode
+  the effective console port resolved through the same system-wins env chain
+  used at container creation (the system env always defines
+  `AGENTTEAMS_CONSOLE_PORT`, so a conflicting `Worker.spec.env` value is
+  discarded and the container always listens on `8088`). In kube mode
   they return `503`.
 - **Degradation**: a worker running QwenPaw < 2.1 has no checkpoint router,
   so the upstream `404` is translated to `502` with


### PR DESCRIPTION
# Projects: intervention history + worker checkpoint read endpoints

## Summary

Adds read endpoints for two complementary timelines: project intervention history and worker execution checkpoints.

- **Project history** — the write side landed in agentteams/AgentTeams#1172 (every intervention snapshots the pre-change meta into `history/{unixNano}.json`, gc keeps 50), but there is no way to read the timeline back. This PR adds `GET /projects/{id}/history` (snapshot list, newest first) and `GET /projects/{id}/history/{timestamp}` (one snapshot verbatim).
- **Worker checkpoints** — QwenPaw 2.1 ships a checkpoint system (framework hook auto-snapshots after every response round + manual `/checkpoint snapshot`, stored in `checkpoints/shadow.git`) exposed on each worker's qwenpaw app at `:8088`. The Controller proxies two read-only subpaths — `GET /workers/{name}/checkpoints/graph` and `/status` — so L2 humans and frontends can inspect every worker's execution timeline.

## What's included

1. `agentteams-controller/internal/server/project_handler.go`:
   - `resolveSingleProjectMatch` — same 0/1/many resolution as `resolveSingleProject` but returns the whole match (including the storage key), so history handlers can derive the sibling `history/` prefix (reused verbatim from the write side).
   - `GetProjectHistory` — lists snapshots under `history/`, newest first; timestamps serialized as **strings** (19-digit nanoseconds exceed the JS safe-integer range); defensive filter drops unexpected files; empty history returns `"snapshots": []`.
   - `GetProjectHistorySnapshot` — returns one snapshot's raw meta JSON verbatim (read side stays decoupled from the meta schema); timestamp must match `^[0-9]{19}$` (doubles as the traversal guard).
2. `agentteams-controller/internal/server/worker_checkpoints.go` (new):
   - `CheckpointHandler` — proxies `graph` / `status` to the worker's qwenpaw app (embedded mode only; kube mode returns 503). The upstream address is resolved, not hard-coded: the container-name prefix comes from controller configuration (`config.ContainerPrefix` — `AGENTTEAMS_PROXY_CONTAINER_PREFIX`, or derived from `AGENTTEAMS_RESOURCE_PREFIX` when auto-prefixing is enabled, or empty when disabled — the same value the docker backend uses for container naming), and the port through the **effective worker env** — the same system-wins merge used at container creation (`service.EffectiveWorkerConsolePort`), so a conflicting `spec.env` value is discarded and the proxy always targets the port the container listens on. Strict fixed-path + query whitelist (graph accepts only `?limit=` 1..1000; unknown parameters are rejected 400 rather than silently dropped). Worker names must be valid DNS labels.
   - Degradation semantics: a worker on QwenPaw < 2.1 has no checkpoint router — the upstream 404 becomes an actionable 502 (`checkpoint API unavailable (requires QwenPaw 2.1)`); connection failures become 502 (`unreachable`); upstream errors are relayed with a 4 KiB-bounded body.
3. `agentteams-controller/internal/server/http.go`: 4 route registrations, RBAC reusing existing patterns — project endpoints mirror the workflow/spawns authorization (ActionGet + team-scope check, cross-team hidden as 404); worker checkpoints mirror `GET /workers/{name}` (worker CR existence + team-scope check, unknown/out-of-scope hidden as 404).
4. Tests — 24 new: 6 history (ordering / empty array / verbatim read / invalid timestamp variants / 404 / cross-team 404) + 14 checkpoint (verbatim forward + `limit` pass-through / status forward / upstream-404 → 502 message / unreachable → 502 / kube → 503 / unknown subpath 400 / invalid worker name 400 / invalid limit + unknown param 400 / unknown worker 404 / team-leader cross-team 404 / bounded error body / **prefix resolution matrix — default, non-default, empty prefix; any conflicting user port resolved to the effective system port (system-wins)** / **end-to-end: effective non-default prefix + conflicting spec.env port dial exactly the port the container listens on** / **cross-component: proxy port == docker-backend port computed through the real container-creation env chain (WorkerEnvBuilder.Build + shared merge)**) + 4 service env (system-wins merge semantics / nil user env / effective-port resolution under conflicting user values / builder port bound to the shared constant).
5. `docs/usage/project-workflow-api.md`: history endpoint sections, checkpoint endpoint section, updated authorization matrix.

## Data boundary

- All read-only; no gc behavior change (gc stays best-effort on the write side, capped at 50 snapshots).
- Snapshots are returned verbatim (raw meta JSON); checkpoint graph/status are forwarded verbatim.
- Checkpoint data remains in the worker container (`shadow.git`, FileSync-mirrored to object storage); the Controller only proxies the live worker API — fixed-path, never a generic reverse proxy.
- The PR itself has no QwenPaw 2.1 dependency: history works against the current 2.0.1 workers (the #1172 write side is already active); checkpoints light up per-worker after the 2.1 migration (agentteams/AgentTeams#1174 / #1175) and return the 502 degradation until then.

## Tests

- `internal/server`: +20 tests, all green; `internal/service`: +4 tests, all green; full package green
- Full `go test ./...` against the latest main baseline — zero regressions (the only failure is a pre-existing environment issue in `internal/executor` — the sandbox image lacks the `unzip` binary, which CI has)
- `gofmt` / `go vet` clean; `tests/check-agentteams-rename-defaults.sh` passes (no legacy brand strings)

## Related

- agentteams/AgentTeams#1172: project history write side (snapshot before every intervention + gc 50)
- agentteams/AgentTeams#1174 / #1175: QwenPaw 2.1 worker migration (checkpoint system prerequisite; not a merge dependency)

---

## 摘要

为两条互补的时间线补上读端点：项目干预历史 + Worker 执行检查点。

- **项目历史** — 写侧已随 agentteams/AgentTeams#1172 落地（每次干预把变更前 meta 快照进 `history/{unixNano}.json`，gc 保留 50 份），但一直没有读回时间线的途径。本 PR 新增 `GET /projects/{id}/history`（快照列表，最新在前）与 `GET /projects/{id}/history/{timestamp}`（单份快照原样返回）。
- **Worker 检查点** — QwenPaw 2.1 内置检查点系统（框架钩子每轮回复后自动快照 + 手动 `/checkpoint snapshot`，存于 `checkpoints/shadow.git`），由每个 Worker 的 qwenpaw app 在 `:8088` 暴露。Controller 代理两个只读子路径——`GET /workers/{name}/checkpoints/graph` 与 `/status`——让 L2 人类和前端可以查看每个 Worker 的执行轨迹。

## 包含内容

1. `agentteams-controller/internal/server/project_handler.go`：
   - `resolveSingleProjectMatch` — 与 `resolveSingleProject` 相同的 0/1/多 解析，但返回完整 match（含存储 key），使 history handler 能推导同级 `history/` 前缀（与写侧完全同构）。
   - `GetProjectHistory` — 列出 `history/` 下快照，最新在前；时间戳以**字符串**序列化（19 位纳秒超出 JS 安全整数范围）；防御性过滤意外文件；空历史返回 `"snapshots": []`。
   - `GetProjectHistorySnapshot` — 单份快照原始 meta JSON 原样返回（读侧与 meta schema 解耦）；时间戳必须匹配 `^[0-9]{19}$`（兼作路径穿越防护）。
2. `agentteams-controller/internal/server/worker_checkpoints.go`（新增）：
   - `CheckpointHandler` — 将 `graph` / `status` 代理到 Worker 的 qwenpaw app（仅 embedded 模式；kube 模式返回 503）。上游地址动态解析而非硬编码：容器名前缀来自 Controller 配置（`config.ContainerPrefix`——`AGENTTEAMS_PROXY_CONTAINER_PREFIX`，或 auto-prefix 启用时由 `AGENTTEAMS_RESOURCE_PREFIX` 派生，或禁用时为空——与 docker backend 命名容器所用的值同源），端口走**有效 Worker 环境**——与容器创建相同的 system-wins 合并（`service.EffectiveWorkerConsolePort`），因此冲突的 `spec.env` 值被丢弃，代理永远指向容器实际监听的端口。严格固定路径 + query 白名单（graph 仅接受 `?limit=` 1..1000；未知参数显式拒绝 400 而非静默丢弃）。Worker 名必须为合法 DNS label。
   - 降级语义：QwenPaw < 2.1 的 Worker 没有 checkpoint 路由——上游 404 转译为可行动的 502（`checkpoint API unavailable (requires QwenPaw 2.1)`）；连接失败转 502（`unreachable`）；上游错误体以 4 KiB 上限透传。
3. `agentteams-controller/internal/server/http.go`：4 条路由注册，RBAC 复用现有模式——项目端点对齐 workflow/spawns 授权（ActionGet + 团队范围检查，越界隐藏为 404）；Worker 检查点对齐 `GET /workers/{name}`（Worker CR 存在性 + 团队范围检查，不存在/越界隐藏为 404）。
4. 测试 — 新增 24 个：6 history（排序 / 空数组 / 原样读取 / 非法时间戳变体 / 404 / 跨团队 404）+ 14 checkpoint（原样转发 + `limit` 透传 / status 转发 / 上游 404 → 502 文案 / 不可达 → 502 / kube → 503 / 未知子路径 400 / 非法 Worker 名 400 / 非法 limit 与未知参数 400 / 未知 Worker 404 / Team Leader 跨团队 404 / 错误体有界 / **前缀解析矩阵——默认、非默认、空前缀；任何冲突的用户端口都解析为有效系统端口（system-wins）** / **端到端：非默认前缀 + 冲突的 spec.env 端口精确拨向容器实际监听的端口** / **跨组件：代理端口 == 经真实容器创建环境链（WorkerEnvBuilder.Build + 共享合并）计算的 docker backend 端口**）+ 4 service env（system-wins 合并语义 / nil user env / 冲突用户值下的有效端口解析 / builder 端口绑定共享常量）。
5. `docs/usage/project-workflow-api.md`：history 端点节、checkpoint 端点节、更新后的授权矩阵。

## 数据边界

- 全只读；不改变 gc 行为（gc 保持写侧 best-effort，50 份上限）。
- 快照原样返回（原始 meta JSON）；检查点 graph/status 原样转发。
- 检查点数据留在 Worker 容器内（`shadow.git`，经 FileSync 镜像到对象存储）；Controller 只代理存活 Worker API——固定路径，绝非通用反向代理。
- PR 本身零 QwenPaw 2.1 依赖：history 对当前 2.0.1 Worker 即生效（#1172 写侧已活跃）；检查点在各 Worker 完成 2.1 迁移后逐个点亮（agentteams/AgentTeams#1174 / #1175），此前返回 502 降级。

## 测试

- `internal/server`：+20 测试全绿；`internal/service`：+4 测试全绿；包级全绿
- 全量 `go test ./...` 对照最新 main 基线——零回归（唯一失败是 `internal/executor` 的既有环境问题：沙箱镜像缺 `unzip` 二进制，CI 环境有）
- `gofmt` / `go vet` 干净；`tests/check-agentteams-rename-defaults.sh` 通过（无旧品牌字符串）

## 相关

- agentteams/AgentTeams#1172：项目历史写侧（每次干预前快照 + gc 50）
- agentteams/AgentTeams#1174 / #1175：QwenPaw 2.1 Worker 迁移（检查点系统前提；非合并依赖）