### PR TITLE
fix(qwenpaw): avoid unrelated runtime component reloads

### DIFF
--- a/qwenpaw/src/qwenpaw_worker/update.py
+++ b/qwenpaw/src/qwenpaw_worker/update.py
@@ -1290,6 +1290,15 @@ class RuntimeUpdater:
             workspace_dir=config.default_workspace_dir,
         )
         self.current_config: Optional[MemberRuntimeConfig] = None
+        self._applied_model_identity: Optional[str] = None
+        self._applied_direct_mcp_identity: Optional[str] = None
+        self._applied_matrix_channel_identity: Optional[str] = None
+        self._applied_dingtalk_channel_identity: Optional[str] = None
+        self._applied_channel_policy_identity: Optional[str] = None
+        self._applied_package_mcp_identity: Optional[Tuple[str, str, str, str]] = None
+        self._applied_package_skills_identity: Optional[Tuple[str, str, str, str]] = None
+        self._applied_managed_skills_identity: Optional[str] = None
+        self._applied_inline_config_identity: Optional[str] = None
 
     def load(self) -> MemberRuntimeConfig:
         if self.runtime_config_pull is not None:
@@ -1325,10 +1334,45 @@ class RuntimeUpdater:
             and self.adapter_apply is not None
             and not self._adapter_neutral_change(config)
         )
+        model_identity = self._component_identity(self._model_desired_state(config))
+        model_should_apply = force or model_identity != self._applied_model_identity
+        direct_mcp_identity = self._direct_mcp_identity(config)
+        direct_mcp_should_apply = (
+            force or direct_mcp_identity != self._applied_direct_mcp_identity
+        )
+        matrix_channel_identity = self._component_identity(self._matrix_channel_payload(config))
+        matrix_channel_should_apply = (
+            force or matrix_channel_identity != self._applied_matrix_channel_identity
+        )
+        dingtalk_channel_identity = self._component_identity(config.dingtalk_channel)
+        dingtalk_channel_should_apply = (
+            force or dingtalk_channel_identity != self._applied_dingtalk_channel_identity
+        )
+        channel_policy_identity = self._channel_policy_identity(config)
+        channel_policy_should_apply = (
+            force or channel_policy_identity != self._applied_channel_policy_identity
+        )
+        package_mcp_identity = config.agent_package_identity
+        package_mcp_should_apply = (
+            force or package_mcp_identity != self._applied_package_mcp_identity
+        )
+        package_skills_should_apply = (
+            force or package_mcp_identity != self._applied_package_skills_identity
+        )
+        managed_skills_identity = self._component_identity(config.skills)
+        managed_skills_should_apply = (
+            force or managed_skills_identity != self._applied_managed_skills_identity
+        )
+        inline_config_identity = self._component_identity(config.inline_config)
+        inline_config_should_apply = (
+            force or inline_config_identity != self._applied_inline_config_identity
+        )
         logger.info(
             "runtime config apply begin component=update worker=%s generation=%s team=%s member=%s role=%s "
             "force=%s reapply_adapter=%s adapter_applied=%s mcp_server_count=%s channel_names=%s "
-            "credential_binding_count=%s duration_ms=%s",
+            "credential_binding_count=%s model_reconcile=%s direct_mcp_reconcile=%s "
+            "matrix_channel_reconcile=%s dingtalk_channel_reconcile=%s channel_policy_reconcile=%s "
+            "package_mcp_reconcile=%s duration_ms=%s",
             self.config.worker_name,
             config.generation,
             config.team_name,
@@ -1340,23 +1384,47 @@ class RuntimeUpdater:
             _count_collection(config.mcp_servers),
             _named_keys(config.channels),
             len(config.credential_bindings),
+            model_should_apply,
+            direct_mcp_should_apply,
+            matrix_channel_should_apply,
+            dingtalk_channel_should_apply,
+            channel_policy_should_apply,
+            package_mcp_should_apply,
             _duration_ms(started_at),
         )
         self._apply_member_identity(config)
         if self.runtime_reconcile is not None:
             self.runtime_reconcile(config)
-        self._apply_model(config)
-        self._apply_mcp_servers(config)
-        self._apply_matrix_channel(config)
-        self._apply_dingtalk_channel(config)
-        self._apply_channel_policy(config)
+        if model_should_apply:
+            self._apply_model(config)
+            self._applied_model_identity = model_identity
+        if direct_mcp_should_apply:
+            self._apply_mcp_servers(config)
+            self._applied_direct_mcp_identity = direct_mcp_identity
+        if matrix_channel_should_apply:
+            self._apply_matrix_channel(config)
+            self._applied_matrix_channel_identity = matrix_channel_identity
+        if dingtalk_channel_should_apply:
+            self._apply_dingtalk_channel(config)
+            self._applied_dingtalk_channel_identity = dingtalk_channel_identity
+        if channel_policy_should_apply:
+            self._apply_channel_policy(config)
+            self._applied_channel_policy_identity = channel_policy_identity
         self._apply_team_context_prompt(config)
 
         applied_package = self.package_manager.apply(config)
-        self._apply_package_mcp_servers(applied_package)
-        self._apply_package_skills(applied_package)
-        self._apply_managed_skills(config)
-        self._apply_inline_config(config)
+        if package_mcp_should_apply:
+            self._apply_package_mcp_servers(applied_package)
+            self._applied_package_mcp_identity = package_mcp_identity
+        if package_skills_should_apply:
+            self._apply_package_skills(applied_package)
+            self._applied_package_skills_identity = package_mcp_identity
+        if managed_skills_should_apply:
+            self._apply_managed_skills(config)
+            self._applied_managed_skills_identity = managed_skills_identity
+        if inline_config_should_apply:
+            self._apply_inline_config(config)
+            self._applied_inline_config_identity = inline_config_identity
 
         adapter_applied = False
         if adapter_should_apply:
@@ -1379,6 +1447,25 @@ class RuntimeUpdater:
             _duration_ms(started_at),
         )
         return ApplyResult(runtime_config=config, changed=True, agent_package_dir=applied_package)
+
+    def _direct_mcp_identity(self, config: MemberRuntimeConfig) -> str:
+        return self._component_identity(self._mcporter_servers(config))
+
+    def _component_identity(self, value: Any) -> str:
+        payload = _stable_json(value).encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()
+
+    def _channel_policy_identity(self, config: MemberRuntimeConfig) -> str:
+        group_allow, dm_allow, group_deny, dm_deny = self._matrix_policy_ids(config)
+        return self._component_identity(
+            {
+                "groupAllow": sorted(set(group_allow)),
+                "dmAllow": sorted(set(dm_allow)),
+                "groupDeny": sorted(set(group_deny)),
+                "dmDeny": sorted(set(dm_deny)),
+                "self": _string(config.member.get("matrixUserId")),
+            }
+        )
 
     def _apply_inline_config(self, config: MemberRuntimeConfig) -> None:
         prompt_files = {
@@ -1514,15 +1601,26 @@ class RuntimeUpdater:
             os.environ["AGENTTEAMS_WORKER_ROLE"] = role
 
     def _apply_model(self, config: MemberRuntimeConfig) -> None:
-        model = config.model
-        if not model:
-            return
-        provider_id = _string(model.get("providerId") or model.get("provider_id") or model.get("provider"))
-        model_name = _string(model.get("model") or model.get("name"))
-        if not provider_id or not model_name:
+        desired = self._model_desired_state(config)
+        if desired is None:
             return
         if self.api_client is None:
             raise RuntimeError("QwenPaw API client is required for model configuration")
+        self.api_client.configure_active_model(
+            desired["provider_id"],
+            desired["model"],
+            base_url=desired["base_url"],
+            api_key=desired["api_key"],
+            provider_name=desired["provider_name"],
+            chat_model=desired["chat_model"],
+        )
+
+    def _model_desired_state(self, config: MemberRuntimeConfig) -> Optional[Dict[str, str]]:
+        model = config.model
+        provider_id = _string(model.get("providerId") or model.get("provider_id") or model.get("provider"))
+        model_name = _string(model.get("model") or model.get("name"))
+        if not provider_id or not model_name:
+            return None
         base_url = _string(
             model.get("baseUrl")
             or model.get("base_url")
@@ -1540,14 +1638,18 @@ class RuntimeUpdater:
         )
         if not api_key and api_key_env:
             api_key = _string(os.getenv(api_key_env))
-        self.api_client.configure_active_model(
-            provider_id,
-            model_name,
-            base_url=self._openai_compatible_base_url(base_url) if base_url else "",
-            api_key=api_key,
-            provider_name=_string(model.get("providerName") or model.get("provider_name") or provider_id),
-            chat_model=_string(model.get("chatModel") or model.get("chat_model") or "OpenAIChatModel"),
-        )
+        return {
+            "provider_id": provider_id,
+            "model": model_name,
+            "base_url": self._openai_compatible_base_url(base_url) if base_url else "",
+            "api_key": api_key,
+            "provider_name": _string(
+                model.get("providerName") or model.get("provider_name") or provider_id
+            ),
+            "chat_model": _string(
+                model.get("chatModel") or model.get("chat_model") or "OpenAIChatModel"
+            ),
+        }
 
     def _openai_compatible_base_url(self, base_url: str) -> str:
         value = base_url.rstrip("/")
@@ -1670,19 +1772,27 @@ class RuntimeUpdater:
         self._write_matrix_access_control(whitelist, blacklist)
 
     def _apply_matrix_channel(self, config: MemberRuntimeConfig) -> None:
-        desired = self._matrix_channel_desired_state(config)
-        if desired is None:
+        payload = self._matrix_channel_payload(config)
+        if payload is None:
             return
         if self.api_client is None:
             raise RuntimeError("QwenPaw API client is required for Matrix configuration")
+        self.api_client.put_channel(
+            "agentteams_matrix",
+            payload,
+            secret_fields={"access_token", "password"},
+        )
+
+    def _matrix_channel_payload(self, config: MemberRuntimeConfig) -> Optional[Dict[str, Any]]:
+        desired = self._matrix_channel_desired_state(config)
+        if desired is None:
+            return None
         groups: Dict[str, Any] = {}
         self._ensure_require_mention_group(groups, "*")
         room_id = desired["room_id"]
         if room_id:
             self._ensure_require_mention_group(groups, room_id)
-        self.api_client.put_channel(
-            "agentteams_matrix",
-            {
+        return {
             "enabled": True,
             "homeserver": desired["homeserver"],
             "user_id": desired["user_id"],
@@ -1695,9 +1805,7 @@ class RuntimeUpdater:
             "show_tool_results": True,
             "show_thinking": True,
             "groups": groups,
-            },
-            secret_fields={"access_token", "password"},
-        )
+        }
 
     def _apply_dingtalk_channel(self, config: MemberRuntimeConfig) -> None:
         desired = config.dingtalk_channel
@@ -1957,6 +2065,11 @@ class RuntimeUpdater:
         if self.api_client is None:
             raise RuntimeError("QwenPaw API client is required for Matrix ACL configuration")
         current = self.api_client.get_channel("agentteams_matrix")
+        if (
+            current.get("access_control_group") is group_enabled
+            and current.get("access_control_dm") is dm_enabled
+        ):
+            return
         try:
             self.api_client.put_channel(
                 "agentteams_matrix",

--- a/qwenpaw/src/qwenpaw_worker/update.py
+++ b/qwenpaw/src/qwenpaw_worker/update.py
@@ -1173,6 +1173,23 @@ class AgentPackageManager:
             return []
         return sorted(path.name for path in skills_dir.iterdir() if path.is_dir())
 
+    def package_skills_identity(self, package_dir: Optional[Path]) -> str:
+        if package_dir is None:
+            return ""
+        skills_dir = self._package_content_root(package_dir) / "skills"
+        if not skills_dir.is_dir():
+            return ""
+        digest = hashlib.sha256()
+        for path in sorted(skills_dir.rglob("*")):
+            relative = path.relative_to(skills_dir).as_posix()
+            digest.update(relative.encode("utf-8"))
+            if path.is_file():
+                digest.update(b"\0file\0")
+                digest.update(path.read_bytes())
+            elif path.is_dir():
+                digest.update(b"\0dir\0")
+        return digest.hexdigest()
+
     def _qwenpaw_mcp_client_payload(self, name: str, item: Dict[str, Any]) -> Dict[str, Any]:
         payload = dict(item)
         payload.pop("id", None)
@@ -1277,9 +1294,11 @@ class RuntimeUpdater:
         api_client: Optional[QwenPawApiClient] = None,
         runtime_reconcile: Optional[Callable[[MemberRuntimeConfig], None]] = None,
         skill_sync: Optional[Callable[[List[str]], None]] = None,
+        adapter_force_apply: Optional[Callable[[], None]] = None,
     ) -> None:
         self.config = config
         self.adapter_apply = adapter_apply
+        self.adapter_force_apply = adapter_force_apply
         self.runtime_config_pull = runtime_config_pull
         self.team_context_renderer = team_context_renderer
         self.api_client = api_client
@@ -1291,12 +1310,13 @@ class RuntimeUpdater:
         )
         self.current_config: Optional[MemberRuntimeConfig] = None
         self._applied_model_identity: Optional[str] = None
-        self._applied_direct_mcp_identity: Optional[str] = None
         self._applied_matrix_channel_identity: Optional[str] = None
         self._applied_dingtalk_channel_identity: Optional[str] = None
-        self._applied_channel_policy_identity: Optional[str] = None
-        self._applied_package_mcp_identity: Optional[Tuple[str, str, str, str]] = None
-        self._applied_package_skills_identity: Optional[Tuple[str, str, str, str]] = None
+        self._applied_agent_package_identity: Optional[Tuple[str, str, str, str]] = None
+        self._applied_agent_package_dir: Optional[Path] = None
+        self._package_mcp_clients: Dict[str, Dict[str, Any]] = {}
+        self._applied_mcp_client_identities: Dict[str, str] = {}
+        self._applied_package_skills_identity: Optional[str] = None
         self._applied_managed_skills_identity: Optional[str] = None
         self._applied_inline_config_identity: Optional[str] = None
 
@@ -1336,43 +1356,37 @@ class RuntimeUpdater:
         )
         model_identity = self._component_identity(self._model_desired_state(config))
         model_should_apply = force or model_identity != self._applied_model_identity
-        direct_mcp_identity = self._direct_mcp_identity(config)
-        direct_mcp_should_apply = (
-            force or direct_mcp_identity != self._applied_direct_mcp_identity
-        )
         matrix_channel_identity = self._component_identity(self._matrix_channel_payload(config))
         matrix_channel_should_apply = (
             force or matrix_channel_identity != self._applied_matrix_channel_identity
         )
-        dingtalk_channel_identity = self._component_identity(config.dingtalk_channel)
+        dingtalk_channel_identity = self._component_identity(
+            self._dingtalk_channel_desired_fields(config.dingtalk_channel)
+        )
         dingtalk_channel_should_apply = (
             force or dingtalk_channel_identity != self._applied_dingtalk_channel_identity
         )
-        channel_policy_identity = self._channel_policy_identity(config)
-        channel_policy_should_apply = (
-            force or channel_policy_identity != self._applied_channel_policy_identity
+        package_should_apply = (
+            force
+            or config.agent_package_identity != self._applied_agent_package_identity
         )
-        package_mcp_identity = config.agent_package_identity
-        package_mcp_should_apply = (
-            force or package_mcp_identity != self._applied_package_mcp_identity
-        )
-        package_skills_should_apply = (
-            force or package_mcp_identity != self._applied_package_skills_identity
-        )
-        managed_skills_identity = self._component_identity(config.skills)
+        managed_skills_identity = self._component_identity(self._managed_skill_names(config))
         managed_skills_should_apply = (
-            force or managed_skills_identity != self._applied_managed_skills_identity
+            force
+            or package_should_apply
+            or managed_skills_identity != self._applied_managed_skills_identity
         )
         inline_config_identity = self._component_identity(config.inline_config)
         inline_config_should_apply = (
-            force or inline_config_identity != self._applied_inline_config_identity
+            force
+            or package_should_apply
+            or inline_config_identity != self._applied_inline_config_identity
         )
         logger.info(
             "runtime config apply begin component=update worker=%s generation=%s team=%s member=%s role=%s "
             "force=%s reapply_adapter=%s adapter_applied=%s mcp_server_count=%s channel_names=%s "
-            "credential_binding_count=%s model_reconcile=%s direct_mcp_reconcile=%s "
-            "matrix_channel_reconcile=%s dingtalk_channel_reconcile=%s channel_policy_reconcile=%s "
-            "package_mcp_reconcile=%s duration_ms=%s",
+            "credential_binding_count=%s model_reconcile=%s matrix_channel_reconcile=%s "
+            "dingtalk_channel_reconcile=%s package_reconcile=%s duration_ms=%s",
             self.config.worker_name,
             config.generation,
             config.team_name,
@@ -1385,11 +1399,9 @@ class RuntimeUpdater:
             _named_keys(config.channels),
             len(config.credential_bindings),
             model_should_apply,
-            direct_mcp_should_apply,
             matrix_channel_should_apply,
             dingtalk_channel_should_apply,
-            channel_policy_should_apply,
-            package_mcp_should_apply,
+            package_should_apply,
             _duration_ms(started_at),
         )
         self._apply_member_identity(config)
@@ -1398,37 +1410,63 @@ class RuntimeUpdater:
         if model_should_apply:
             self._apply_model(config)
             self._applied_model_identity = model_identity
-        if direct_mcp_should_apply:
-            self._apply_mcp_servers(config)
-            self._applied_direct_mcp_identity = direct_mcp_identity
         if matrix_channel_should_apply:
             self._apply_matrix_channel(config)
             self._applied_matrix_channel_identity = matrix_channel_identity
         if dingtalk_channel_should_apply:
             self._apply_dingtalk_channel(config)
             self._applied_dingtalk_channel_identity = dingtalk_channel_identity
-        if channel_policy_should_apply:
-            self._apply_channel_policy(config)
-            self._applied_channel_policy_identity = channel_policy_identity
+        # Matrix PUT replaces the full channel object, including ACL flags.
+        # Always reconcile policy after it; the policy methods are differential.
+        self._apply_channel_policy(config)
         self._apply_team_context_prompt(config)
 
-        applied_package = self.package_manager.apply(config)
-        if package_mcp_should_apply:
-            self._apply_package_mcp_servers(applied_package)
-            self._applied_package_mcp_identity = package_mcp_identity
-        if package_skills_should_apply:
+        applied_package = self._applied_agent_package_dir
+        package_mcp_clients = self._package_mcp_clients
+        package_skills_identity = self._applied_package_skills_identity
+        if package_should_apply:
+            applied_package = self.package_manager.apply(config)
+            package_clients = getattr(self.package_manager, "package_mcp_clients", None)
+            package_mcp_clients = (
+                package_clients(applied_package)
+                if callable(package_clients)
+                else {}
+            )
+            package_skills_identity_fn = getattr(
+                self.package_manager,
+                "package_skills_identity",
+                None,
+            )
+            package_skills_identity = (
+                package_skills_identity_fn(applied_package)
+                if callable(package_skills_identity_fn)
+                else self._component_identity(config.agent_package_identity)
+            )
+        self._reconcile_mcp_clients(config, package_mcp_clients, force=force)
+        package_skills_should_apply = (
+            force
+            or package_skills_identity != self._applied_package_skills_identity
+        )
+        if package_should_apply and package_skills_should_apply:
             self._apply_package_skills(applied_package)
-            self._applied_package_skills_identity = package_mcp_identity
         if managed_skills_should_apply:
             self._apply_managed_skills(config)
             self._applied_managed_skills_identity = managed_skills_identity
         if inline_config_should_apply:
             self._apply_inline_config(config)
             self._applied_inline_config_identity = inline_config_identity
+        if package_should_apply:
+            self._applied_agent_package_dir = applied_package
+            self._package_mcp_clients = package_mcp_clients
+            self._applied_package_skills_identity = package_skills_identity
+            self._applied_agent_package_identity = config.agent_package_identity
 
         adapter_applied = False
         if adapter_should_apply:
-            self.adapter_apply()
+            if force and self.adapter_force_apply is not None:
+                self.adapter_force_apply()
+            else:
+                self.adapter_apply()
             adapter_applied = True
 
         self.current_config = config
@@ -1448,24 +1486,9 @@ class RuntimeUpdater:
         )
         return ApplyResult(runtime_config=config, changed=True, agent_package_dir=applied_package)
 
-    def _direct_mcp_identity(self, config: MemberRuntimeConfig) -> str:
-        return self._component_identity(self._mcporter_servers(config))
-
     def _component_identity(self, value: Any) -> str:
         payload = _stable_json(value).encode("utf-8")
         return hashlib.sha256(payload).hexdigest()
-
-    def _channel_policy_identity(self, config: MemberRuntimeConfig) -> str:
-        group_allow, dm_allow, group_deny, dm_deny = self._matrix_policy_ids(config)
-        return self._component_identity(
-            {
-                "groupAllow": sorted(set(group_allow)),
-                "dmAllow": sorted(set(dm_allow)),
-                "groupDeny": sorted(set(group_deny)),
-                "dmDeny": sorted(set(dm_deny)),
-                "self": _string(config.member.get("matrixUserId")),
-            }
-        )
 
     def _apply_inline_config(self, config: MemberRuntimeConfig) -> None:
         prompt_files = {
@@ -1657,28 +1680,61 @@ class RuntimeUpdater:
             return value
         return f"{value}/v1"
 
-    def _apply_mcp_servers(self, config: MemberRuntimeConfig) -> None:
-        servers = self._mcporter_servers(config)
+    def _reconcile_mcp_clients(
+        self,
+        config: MemberRuntimeConfig,
+        package_servers: Dict[str, Dict[str, Any]],
+        *,
+        force: bool,
+    ) -> None:
+        direct_servers = self._direct_mcp_clients(config)
+        builtin_conflicts = {"teamharness", "workerflow"} & (
+            direct_servers.keys() | package_servers.keys()
+        )
+        if builtin_conflicts:
+            names = ", ".join(sorted(builtin_conflicts))
+            raise ValueError(f"desired MCP client names conflict with builtin clients: {names}")
+
+        # Preserve the established precedence: AgentPackage MCP definitions
+        # override Direct definitions with the same client key.
+        desired = {**direct_servers, **package_servers}
         if self.api_client is None:
-            if servers:
+            if desired:
                 raise RuntimeError("QwenPaw API client is required for MCP configuration")
             return
+
         existing = {str(item.get("key")): item for item in self.api_client.list_mcp()}
-        ownership_path = self.config.qwenpaw_working_dir / ".agentteams-managed-mcp.json"
-        try:
-            managed = set(json.loads(ownership_path.read_text(encoding="utf-8")))
-        except (FileNotFoundError, json.JSONDecodeError, TypeError):
-            managed = set()
-        for key in sorted((managed & existing.keys()) - servers.keys()):
+        direct_ownership_path = (
+            self.config.qwenpaw_working_dir / ".agentteams-managed-mcp.json"
+        )
+        package_ownership_path = (
+            self.config.qwenpaw_working_dir / ".agentteams-managed-package-mcp.json"
+        )
+        managed = self._read_managed_mcp_keys(direct_ownership_path)
+        managed.update(self._read_managed_mcp_keys(package_ownership_path))
+        for key in sorted((managed & existing.keys()) - desired.keys()):
             self.api_client.delete_mcp(key)
-        for key, server in servers.items():
-            transport = _string(server.get("transport") or "http")
-            payload = {
+
+        next_identities: Dict[str, str] = {}
+        for key in sorted(desired):
+            payload = desired[key]
+            identity = self._component_identity(payload)
+            if key not in existing:
+                self.api_client.create_mcp(key, payload)
+            elif force or self._applied_mcp_client_identities.get(key) != identity:
+                self.api_client.update_mcp(key, payload)
+            next_identities[key] = identity
+        self._applied_mcp_client_identities = next_identities
+        self._write_managed_mcp_keys(direct_ownership_path, direct_servers)
+        self._write_managed_mcp_keys(package_ownership_path, package_servers)
+
+    def _direct_mcp_clients(self, config: MemberRuntimeConfig) -> Dict[str, Dict[str, Any]]:
+        clients: Dict[str, Dict[str, Any]] = {}
+        for key, server in self._mcporter_servers(config).items():
+            clients[key] = {
                 "name": key,
                 "enabled": True,
-                "transport": "streamable_http"
-                if transport in {"http", "streamable_http"}
-                else transport,
+                "transport": _string(server.get("transport") or "streamable_http"),
                 "url": _string(server.get("url")),
                 "headers": dict(server.get("headers") or {}),
                 "command": _string(server.get("command")),
@@ -1686,47 +1742,21 @@ class RuntimeUpdater:
                 "env": dict(server.get("env") or {}),
                 "cwd": _string(server.get("cwd")),
             }
-            if key in existing:
-                self.api_client.update_mcp(key, payload)
-            else:
-                self.api_client.create_mcp(key, payload)
-        ownership_path.parent.mkdir(parents=True, exist_ok=True)
-        ownership_path.write_text(
-            json.dumps(sorted(servers), ensure_ascii=False) + "\n",
-            encoding="utf-8",
-        )
+        return clients
 
-    def _apply_package_mcp_servers(self, package_dir: Optional[Path]) -> None:
-        package_clients = getattr(self.package_manager, "package_mcp_clients", None)
-        servers = package_clients(package_dir) if callable(package_clients) else {}
-        if self.api_client is None:
-            if servers:
-                raise RuntimeError(
-                    "QwenPaw API client is required for agent package MCP configuration",
-                )
-            return
-        existing = {str(item.get("key")): item for item in self.api_client.list_mcp()}
-        ownership_path = (
-            self.config.qwenpaw_working_dir / ".agentteams-managed-package-mcp.json"
-        )
+    def _read_managed_mcp_keys(self, path: Path) -> set[str]:
         try:
-            managed = set(json.loads(ownership_path.read_text(encoding="utf-8")))
+            value = json.loads(path.read_text(encoding="utf-8"))
         except (FileNotFoundError, json.JSONDecodeError, TypeError):
-            managed = set()
-        for key in sorted((managed & existing.keys()) - servers.keys()):
-            self.api_client.delete_mcp(key)
-        for key, server in servers.items():
-            payload = dict(server)
-            payload.setdefault("name", key)
-            if key in existing:
-                self.api_client.update_mcp(key, payload)
-            else:
-                self.api_client.create_mcp(key, payload)
-        ownership_path.parent.mkdir(parents=True, exist_ok=True)
-        ownership_path.write_text(
-            json.dumps(sorted(servers), ensure_ascii=False) + "\n",
-            encoding="utf-8",
-        )
+            return set()
+        return {_string(item) for item in value if _string(item)} if isinstance(value, list) else set()
+
+    def _write_managed_mcp_keys(self, path: Path, servers: Dict[str, Any]) -> None:
+        content = json.dumps(sorted(servers), ensure_ascii=False) + "\n"
+        if path.is_file() and path.read_text(encoding="utf-8") == content:
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
 
     def _apply_package_skills(self, package_dir: Optional[Path]) -> None:
         if package_dir is None or self.api_client is None:
@@ -1737,7 +1767,7 @@ class RuntimeUpdater:
             self.api_client.refresh_and_enable_skills(skill_names)
 
     def _apply_managed_skills(self, config: MemberRuntimeConfig) -> None:
-        skill_names = config.skills
+        skill_names = self._managed_skill_names(config)
         if not skill_names:
             return
         if self.skill_sync is None:
@@ -1754,11 +1784,16 @@ class RuntimeUpdater:
             raise RuntimeError(f"assigned skill files are missing: {', '.join(missing)}")
         self.api_client.refresh_and_enable_skills(skill_names)
 
+    def _managed_skill_names(self, config: MemberRuntimeConfig) -> List[str]:
+        return sorted(set(config.skills))
+
     def _apply_channel_policy(self, config: MemberRuntimeConfig) -> None:
         group_allow, dm_allow, group_deny, dm_deny = self._matrix_policy_ids(config)
-        if not (group_allow or dm_allow or group_deny or dm_deny):
+        if (
+            not (group_allow or dm_allow or group_deny or dm_deny)
+            and self._matrix_channel_payload(config) is None
+        ):
             return
-
         self_allow = _string(config.member.get("matrixUserId"))
         self_allowlist = [self_allow] if self_allow else []
         whitelist = self._dedupe(self_allowlist + group_allow + dm_allow)
@@ -1814,48 +1849,18 @@ class RuntimeUpdater:
         if self.api_client is None:
             raise RuntimeError("QwenPaw API client is required for DingTalk configuration")
         current = self.api_client.get_channel("dingtalk")
-        if not _bool(desired.get("enabled")):
+        desired_fields = self._dingtalk_channel_desired_fields(desired)
+        assert desired_fields is not None
+        if not desired_fields["enabled"]:
             self.api_client.put_channel(
                 "dingtalk",
-                {**current, "enabled": False},
+                {**current, **desired_fields},
                 secret_fields={"client_secret"},
             )
             return
 
-        streaming_enabled = _bool(desired.get("streaming_enabled"))
-        client_id = _string(desired.get("client_id"))
-        client_secret = _string(desired.get("client_secret"))
-        robot_code = _string(desired.get("robot_code"))
-        desired_fields = {
-            "enabled": True,
-            "client_id": client_id,
-            "client_secret": client_secret,
-            "robot_code": robot_code,
-            "show_thinking": not _bool(desired.get("filter_thinking")),
-            "show_tool_calls": not _bool(desired.get("filter_tool_messages")),
-            "show_tool_results": not _bool(desired.get("filter_tool_messages")),
-            "streaming_enabled": streaming_enabled,
-        }
-        if streaming_enabled:
-            missing = [
-                name
-                for name, value in (
-                    ("client_id", client_id),
-                    ("client_secret", client_secret),
-                    ("robot_code", robot_code),
-                    ("card_template_id", _string(desired.get("card_template_id"))),
-                )
-                if not value
-            ]
-            if missing:
-                raise ValueError(
-                    "DingTalk streaming requires client_id, client_secret, "
-                    "robot_code, and card_template_id. Create and publish the "
-                    "streaming card template in DingTalk Open Platform, select "
-                    "card mode, then set card_template_id; missing "
-                    f"{', '.join(missing)}"
-                )
-            card_template_id = _string(desired.get("card_template_id"))
+        if desired_fields["streaming_enabled"]:
+            card_template_id = desired_fields["card_template_id"]
             previous_message_type = _string(current.get("message_type"))
             previous_template_id = _string(current.get("card_template_id"))
             if (
@@ -1870,7 +1875,56 @@ class RuntimeUpdater:
                     previous_template_id,
                     card_template_id,
                 )
-            desired_fields.update(
+        self.api_client.put_channel(
+            "dingtalk",
+            {**current, **desired_fields},
+            secret_fields={"client_secret"},
+        )
+
+    def _dingtalk_channel_desired_fields(
+        self,
+        desired: Optional[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        if desired is None:
+            return None
+        if not _bool(desired.get("enabled")):
+            return {"enabled": False}
+
+        streaming_enabled = _bool(desired.get("streaming_enabled"))
+        client_id = _string(desired.get("client_id"))
+        client_secret = _string(desired.get("client_secret"))
+        robot_code = _string(desired.get("robot_code"))
+        fields: Dict[str, Any] = {
+            "enabled": True,
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "robot_code": robot_code,
+            "show_thinking": not _bool(desired.get("filter_thinking")),
+            "show_tool_calls": not _bool(desired.get("filter_tool_messages")),
+            "show_tool_results": not _bool(desired.get("filter_tool_messages")),
+            "streaming_enabled": streaming_enabled,
+        }
+        if streaming_enabled:
+            card_template_id = _string(desired.get("card_template_id"))
+            missing = [
+                name
+                for name, value in (
+                    ("client_id", client_id),
+                    ("client_secret", client_secret),
+                    ("robot_code", robot_code),
+                    ("card_template_id", card_template_id),
+                )
+                if not value
+            ]
+            if missing:
+                raise ValueError(
+                    "DingTalk streaming requires client_id, client_secret, "
+                    "robot_code, and card_template_id. Create and publish the "
+                    "streaming card template in DingTalk Open Platform, select "
+                    "card mode, then set card_template_id; missing "
+                    f"{', '.join(missing)}"
+                )
+            fields.update(
                 {
                     "message_type": "card",
                     "card_template_id": card_template_id,
@@ -1882,20 +1936,16 @@ class RuntimeUpdater:
             )
         else:
             if "message_type" in desired:
-                desired_fields["message_type"] = _string(desired.get("message_type") or "markdown")
+                fields["message_type"] = _string(desired.get("message_type") or "markdown")
             if "card_template_id" in desired:
-                desired_fields["card_template_id"] = _string(desired.get("card_template_id"))
+                fields["card_template_id"] = _string(desired.get("card_template_id"))
             if "card_template_key" in desired:
-                desired_fields["card_template_key"] = _string(
+                fields["card_template_key"] = _string(
                     desired.get("card_template_key") or "content"
                 )
             if "card_auto_layout" in desired:
-                desired_fields["card_auto_layout"] = _bool(desired.get("card_auto_layout"))
-        self.api_client.put_channel(
-            "dingtalk",
-            {**current, **desired_fields},
-            secret_fields={"client_secret"},
-        )
+                fields["card_auto_layout"] = _bool(desired.get("card_auto_layout"))
+        return fields
 
     def _matrix_channel_desired_state(self, config: MemberRuntimeConfig) -> Optional[Dict[str, str]]:
         homeserver = _string(
@@ -2051,9 +2101,14 @@ class RuntimeUpdater:
         headers = dict(headers) if isinstance(headers, dict) else {}
         if gateway_key and "Authorization" not in headers:
             headers["Authorization"] = f"Bearer {gateway_key}"
+        transport = _string(item.get("transport") or "http").lower()
         return {
             "url": url,
-            "transport": _string(item.get("transport") or "http"),
+            "transport": (
+                "streamable_http"
+                if transport in {"http", "streamable_http"}
+                else transport
+            ),
             "headers": headers,
         }
 

--- a/qwenpaw/src/qwenpaw_worker/worker.py
+++ b/qwenpaw/src/qwenpaw_worker/worker.py
@@ -76,6 +76,7 @@ class Worker:
         self.updater = RuntimeUpdater(
             config=config,
             adapter_apply=self._apply_runtime_adapter,
+            adapter_force_apply=self._force_apply_runtime_adapter,
             api_client=self.api_client,
             runtime_reconcile=self._reconcile_runtime_storage,
         )
@@ -630,11 +631,17 @@ class Worker:
                 encoding="utf-8",
             )
 
-    def _apply_runtime_adapter(self) -> None:
+    def _apply_runtime_adapter(self, force: bool = False) -> None:
         self._prepare_default_plugins()
-        self._configure_builtin_plugin_mcp_clients()
+        if force:
+            self._configure_builtin_plugin_mcp_clients(force=True)
+        else:
+            self._configure_builtin_plugin_mcp_clients()
         self._configure_builtin_plugin_mcp_policies()
         self._ensure_session_file_prompt_policy()
+
+    def _force_apply_runtime_adapter(self) -> None:
+        self._apply_runtime_adapter(force=True)
 
     def _prepare_default_plugins(self) -> None:
         builtin_root = self._builtin_qwenpaw_plugins_dir()
@@ -946,7 +953,7 @@ class Worker:
                 await asyncio.sleep(0.5)
         raise RuntimeError(f"qwenpaw API did not become ready: {last_error}")
 
-    def _configure_builtin_plugin_mcp_clients(self) -> None:
+    def _configure_builtin_plugin_mcp_clients(self, force: bool = False) -> None:
         existing = {str(item.get("key")) for item in self.api_client.list_mcp()}
         for plugin_id in ("teamharness", "workerflow"):
             plugin_dir = self.config.qwenpaw_working_dir / "plugins" / plugin_id
@@ -984,7 +991,7 @@ class Worker:
             identity = self._builtin_mcp_payload_identity(plugin_dir, payload)
             if plugin_id not in existing:
                 self.api_client.create_mcp(plugin_id, payload)
-            elif self._builtin_mcp_payload_identities.get(plugin_id) != identity:
+            elif force or self._builtin_mcp_payload_identities.get(plugin_id) != identity:
                 self.api_client.update_mcp(plugin_id, payload)
             self._builtin_mcp_payload_identities[plugin_id] = identity
 

--- a/qwenpaw/src/qwenpaw_worker/worker.py
+++ b/qwenpaw/src/qwenpaw_worker/worker.py
@@ -86,6 +86,7 @@ class Worker:
         self._stopping = False
         self._workspace_shared_dir: Optional[Path] = None
         self._initial_runtime_config: Optional[MemberRuntimeConfig] = None
+        self._builtin_mcp_payload_identities: dict[str, str] = {}
 
     async def run(self) -> None:
         if not await self.start():
@@ -980,10 +981,27 @@ class Worker:
                 },
                 "cwd": str(asset_dir),
             }
-            if plugin_id in existing:
-                self.api_client.update_mcp(plugin_id, payload)
-            else:
+            identity = self._builtin_mcp_payload_identity(plugin_dir, payload)
+            if plugin_id not in existing:
                 self.api_client.create_mcp(plugin_id, payload)
+            elif self._builtin_mcp_payload_identities.get(plugin_id) != identity:
+                self.api_client.update_mcp(plugin_id, payload)
+            self._builtin_mcp_payload_identities[plugin_id] = identity
+
+    def _builtin_mcp_payload_identity(
+        self,
+        plugin_dir: Path,
+        payload: dict[str, object],
+    ) -> str:
+        marker = plugin_dir / BUILTIN_QWENPAW_PLUGIN_MARKER
+        plugin_digest = marker.read_text(encoding="utf-8").strip() if marker.is_file() else ""
+        serialized = json.dumps(
+            {"payload": payload, "pluginDigest": plugin_digest},
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
     def _configure_builtin_plugin_mcp_policies(self) -> None:
         allow_policy = {

--- a/qwenpaw/tests/test_update.py
+++ b/qwenpaw/tests/test_update.py
@@ -54,6 +54,7 @@ class _FakeQwenPawApi:
         self.model_events = []
         self.active_model = None
         self.enabled_skills = []
+        self.skill_events = []
 
     def get_channel(self, channel):
         return dict(self.channels.get(channel, {}))
@@ -101,6 +102,7 @@ class _FakeQwenPawApi:
 
     def refresh_and_enable_skills(self, skill_names):
         self.enabled_skills = list(skill_names)
+        self.skill_events.append(list(skill_names))
         return {"results": {name: {"success": True} for name in self.enabled_skills}}
 
 
@@ -139,6 +141,40 @@ def test_runtime_updater_syncs_and_enables_assigned_skills(tmp_path: Path) -> No
     assert synced == ["competition-skill"]
     assert (config.default_workspace_dir / "skills" / "competition-skill" / "SKILL.md").is_file()
     assert updater.api_client.enabled_skills == ["competition-skill"]
+
+
+def test_runtime_updater_treats_managed_skill_order_as_equivalent(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    synced: list[list[str]] = []
+
+    def sync_skills(skill_names: list[str]) -> None:
+        synced.append(list(skill_names))
+        for name in skill_names:
+            skill_dir = config.default_workspace_dir / "skills" / name
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            (skill_dir / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+
+    updater = _runtime_updater(
+        config=config,
+        package_manager=_NoopPackageManager(),
+        skill_sync=sync_skills,
+    )
+
+    def runtime_config(skills: list[str]) -> MemberRuntimeConfig:
+        return MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "-".join(skills)},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {"skills": skills},
+            },
+        )
+
+    updater.apply_once(runtime_config=runtime_config(["beta", "alpha"]))
+    updater.apply_once(runtime_config=runtime_config(["alpha", "beta"]))
+
+    assert synced == [["alpha", "beta"]]
+    assert updater.api_client.skill_events == [["alpha", "beta"]]
 
 
 def test_runtime_updater_reconciles_model_mcp_matrix_channel_and_acl_via_api(
@@ -257,6 +293,79 @@ def test_runtime_updater_maps_dingtalk_visibility_and_preserves_empty_secret(
     assert actual["show_tool_calls"] is True
     assert actual["show_tool_results"] is True
     assert updater.api_client.channel_events == ["dingtalk"]
+
+
+def test_runtime_updater_ignores_unused_dingtalk_fields(
+    tmp_path: Path,
+) -> None:
+    updater = _runtime_updater(config=_config(tmp_path), package_manager=_NoopPackageManager())
+
+    def runtime_config(ignored: str) -> MemberRuntimeConfig:
+        return MemberRuntimeConfig(
+            path=updater.config.runtime_config_path,
+            raw={
+                "metadata": {"generation": ignored},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "channels": {
+                        "dingtalk": {
+                            "enabled": True,
+                            "client_id": "client-id",
+                            "client_secret": "secret",
+                            "robot_code": "robot",
+                            "unused": ignored,
+                        },
+                    },
+                },
+            },
+        )
+
+    updater.apply_once(runtime_config=runtime_config("one"))
+    updater.apply_once(runtime_config=runtime_config("two"))
+
+    assert updater.api_client.channel_events == ["dingtalk"]
+
+
+def test_runtime_updater_restores_matrix_policy_after_channel_update(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENTTEAMS_MATRIX_URL", "http://matrix.example.com")
+    monkeypatch.setenv("AGENTTEAMS_WORKER_MATRIX_TOKEN", "matrix-token")
+    monkeypatch.setenv("AGENTTEAMS_MATRIX_DOMAIN", "matrix.local")
+    updater = _runtime_updater(config=_config(tmp_path), package_manager=_NoopPackageManager())
+
+    def runtime_config(room_id: str) -> MemberRuntimeConfig:
+        return MemberRuntimeConfig(
+            path=updater.config.runtime_config_path,
+            raw={
+                "metadata": {"generation": room_id},
+                "team": {"teamRoomId": room_id},
+                "member": {
+                    "runtime": "qwenpaw",
+                    "matrixUserId": "@worker:matrix.local",
+                },
+                "desired": {
+                    "channelPolicy": {
+                        "groupAllowExtra": ["@human:matrix.local"],
+                        "dmAllowExtra": ["@human:matrix.local"],
+                    },
+                },
+            },
+        )
+
+    updater.apply_once(runtime_config=runtime_config("!room-one:matrix.local"))
+    updater.apply_once(runtime_config=runtime_config("!room-two:matrix.local"))
+
+    matrix = updater.api_client.channels["agentteams_matrix"]
+    assert matrix["access_control_group"] is True
+    assert matrix["access_control_dm"] is True
+    assert updater.api_client.channel_events == [
+        "agentteams_matrix",
+        "agentteams_matrix",
+        "agentteams_matrix",
+        "agentteams_matrix",
+    ]
 
 
 def test_runtime_updater_preserves_unmanaged_mcp_clients(tmp_path: Path) -> None:
@@ -393,6 +502,39 @@ def test_runtime_updater_reapplies_direct_mcp_when_effective_payload_changes(
     assert "docs" not in updater.api_client.mcp
 
 
+def test_runtime_updater_reconciles_only_changed_direct_mcp_client(
+    tmp_path: Path,
+) -> None:
+    updater = _runtime_updater(config=_config(tmp_path), package_manager=_NoopPackageManager())
+
+    def runtime_config(a_url: str, a_transport: str = "http") -> MemberRuntimeConfig:
+        return MemberRuntimeConfig(
+            path=updater.config.runtime_config_path,
+            raw={
+                "metadata": {"generation": a_url + a_transport},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "mcpServers": {
+                        "a": {"url": a_url, "transport": a_transport},
+                        "b": {"url": "https://b.example/mcp"},
+                    },
+                },
+            },
+        )
+
+    updater.apply_once(runtime_config=runtime_config("https://a-v1.example/mcp"))
+    updater.apply_once(runtime_config=runtime_config("https://a-v2.example/mcp"))
+    updater.apply_once(
+        runtime_config=runtime_config("https://a-v2.example/mcp", "streamable_http")
+    )
+
+    assert updater.api_client.mcp_events == [
+        ("create", "a"),
+        ("create", "b"),
+        ("update", "a"),
+    ]
+
+
 def test_runtime_updater_reapplies_package_mcp_only_when_package_identity_changes(
     tmp_path: Path,
 ) -> None:
@@ -452,7 +594,104 @@ def test_runtime_updater_reapplies_package_mcp_only_when_package_identity_change
     ]
 
 
-def _agent_package(tmp_path: Path, version: str, *, include_teams: bool = False) -> Path:
+def test_runtime_updater_does_not_reapply_unchanged_package_mcp_payload(
+    tmp_path: Path,
+) -> None:
+    class PackageManager:
+        def apply(self, runtime_config: MemberRuntimeConfig) -> Path:
+            return tmp_path / f"package-{runtime_config.agent_package_identity[2]}"
+
+        def package_mcp_clients(self, _package_dir: Path) -> dict[str, dict[str, object]]:
+            return {
+                "docs": {
+                    "name": "docs",
+                    "enabled": True,
+                    "transport": "streamable_http",
+                    "url": "https://package.example/mcp",
+                },
+            }
+
+        def package_skill_names(self, _package_dir: Path) -> list[str]:
+            return []
+
+    updater = _runtime_updater(config=_config(tmp_path), package_manager=PackageManager())
+
+    def runtime_config(version: str) -> MemberRuntimeConfig:
+        return MemberRuntimeConfig(
+            path=updater.config.runtime_config_path,
+            raw={
+                "metadata": {"generation": version},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "agentPackage": {
+                        "ref": f"file:///tmp/package-{version}.tar.gz",
+                        "name": "demo",
+                        "version": version,
+                        "digest": f"sha256:{version}",
+                    },
+                },
+            },
+        )
+
+    updater.apply_once(runtime_config=runtime_config("1"))
+    updater.apply_once(runtime_config=runtime_config("2"))
+
+    assert updater.api_client.mcp_events == [("create", "docs")]
+
+
+def test_runtime_updater_preserves_package_precedence_for_direct_mcp_collision(
+    tmp_path: Path,
+) -> None:
+    class PackageManager:
+        def apply(self, _runtime_config: MemberRuntimeConfig) -> Path:
+            return tmp_path / "package"
+
+        def package_mcp_clients(self, _package_dir: Path) -> dict[str, dict[str, object]]:
+            return {
+                "docs": {
+                    "name": "docs",
+                    "transport": "streamable_http",
+                    "url": "https://package.example/mcp",
+                },
+            }
+
+        def package_skill_names(self, _package_dir: Path) -> list[str]:
+            return []
+
+    updater = _runtime_updater(config=_config(tmp_path), package_manager=PackageManager())
+
+    def runtime_config(url: str) -> MemberRuntimeConfig:
+        return MemberRuntimeConfig(
+            path=updater.config.runtime_config_path,
+            raw={
+                "metadata": {"generation": url},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "agentPackage": {
+                        "ref": "file:///tmp/package.tar.gz",
+                        "name": "demo",
+                        "version": "1",
+                        "digest": "sha256:1",
+                    },
+                    "mcpServers": {"docs": {"url": url}},
+                },
+            },
+        )
+
+    updater.apply_once(runtime_config=runtime_config("https://direct-v1.example/mcp"))
+    updater.apply_once(runtime_config=runtime_config("https://direct-v2.example/mcp"))
+
+    assert updater.api_client.mcp_events == [("create", "docs")]
+    assert updater.api_client.mcp["docs"]["url"] == "https://package.example/mcp"
+
+
+def _agent_package(
+    tmp_path: Path,
+    version: str,
+    *,
+    include_teams: bool = False,
+    skill_name: str = "",
+) -> Path:
     source_dir = tmp_path / f"package-src-{version}"
     config_dir = source_dir / "config"
     config_dir.mkdir(parents=True)
@@ -460,10 +699,119 @@ def _agent_package(tmp_path: Path, version: str, *, include_teams: bool = False)
     (config_dir / "AGENTS.md").write_text(f"agent package {version}\n", encoding="utf-8")
     if include_teams:
         (config_dir / "TEAMS.md").write_text(f"package teams {version}\n", encoding="utf-8")
+    if skill_name:
+        skill_dir = source_dir / "skills" / skill_name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("package skill\n", encoding="utf-8")
     package_path = tmp_path / f"agent-package-{version}.tar.gz"
     with tarfile.open(package_path, "w:gz") as archive:
         archive.add(source_dir, arcname=".")
     return package_path
+
+
+def test_runtime_updater_preserves_inline_prompt_on_unrelated_member_change(
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path)
+    package = _agent_package(tmp_path, "1")
+    updater = _runtime_updater(config=config)
+
+    def runtime_config(member_name: str) -> MemberRuntimeConfig:
+        return MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": member_name},
+                "team": {"members": [{"name": member_name, "role": "worker"}]},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "agentPackage": {
+                        "ref": f"file://{package}",
+                        "name": "demo",
+                        "version": "1",
+                        "digest": "sha256:1",
+                    },
+                    "inlineConfig": {"agents": "inline agents"},
+                },
+            },
+        )
+
+    updater.apply_once(runtime_config=runtime_config("alice"))
+    updater.apply_once(runtime_config=runtime_config("bob"))
+
+    assert (config.default_workspace_dir / "AGENTS.md").read_text(
+        encoding="utf-8"
+    ) == "inline agents\n"
+
+
+def test_runtime_updater_preserves_managed_skill_over_package_on_member_change(
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path)
+    package = _agent_package(tmp_path, "1", skill_name="shared-skill")
+
+    def sync_skills(skill_names: list[str]) -> None:
+        for name in skill_names:
+            skill_dir = config.default_workspace_dir / "skills" / name
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            (skill_dir / "SKILL.md").write_text("managed skill\n", encoding="utf-8")
+
+    updater = _runtime_updater(config=config, skill_sync=sync_skills)
+
+    def runtime_config(member_name: str) -> MemberRuntimeConfig:
+        return MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": member_name},
+                "team": {"members": [{"name": member_name, "role": "worker"}]},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "agentPackage": {
+                        "ref": f"file://{package}",
+                        "name": "demo",
+                        "version": "1",
+                        "digest": "sha256:1",
+                    },
+                    "skills": ["shared-skill"],
+                },
+            },
+        )
+
+    updater.apply_once(runtime_config=runtime_config("alice"))
+    updater.apply_once(runtime_config=runtime_config("bob"))
+
+    skill_path = config.default_workspace_dir / "skills" / "shared-skill" / "SKILL.md"
+    assert skill_path.read_text(encoding="utf-8") == "managed skill\n"
+
+
+def test_runtime_updater_skips_package_skill_refresh_when_skill_content_is_unchanged(
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path)
+    package_v1 = _agent_package(tmp_path, "1", skill_name="shared-skill")
+    package_v2 = _agent_package(tmp_path, "2", skill_name="shared-skill")
+    updater = _runtime_updater(config=config)
+
+    def runtime_config(package: Path, version: str) -> MemberRuntimeConfig:
+        return MemberRuntimeConfig(
+            path=config.runtime_config_path,
+            raw={
+                "metadata": {"generation": version},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "agentPackage": {
+                        "ref": f"file://{package}",
+                        "name": "demo",
+                        "version": version,
+                        "digest": f"sha256:{version}",
+                    },
+                },
+            },
+        )
+
+    updater.apply_once(runtime_config=runtime_config(package_v1, "1"))
+    updater.apply_once(runtime_config=runtime_config(package_v2, "2"))
+
+    assert updater.api_client.skill_events == [["shared-skill"]]
 
 
 def test_runtime_updater_applies_changed_config_and_reapplies_adapter(tmp_path: Path) -> None:
@@ -501,10 +849,30 @@ def test_runtime_updater_applies_changed_config_and_reapplies_adapter(tmp_path: 
         )
     )
 
-    assert applied == ["1", "2"]
+    assert applied == ["1"]
     assert adapter_calls == ["adapter", "adapter"]
     assert updater.current_config is not None
     assert updater.current_config.generation == "2"
+
+
+def test_runtime_updater_propagates_force_to_adapter_reconcile(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    adapter_calls: list[str] = []
+    updater = _runtime_updater(
+        config=config,
+        adapter_apply=lambda: adapter_calls.append("normal"),
+        adapter_force_apply=lambda: adapter_calls.append("force"),
+        package_manager=_NoopPackageManager(),
+    )
+    runtime_config = MemberRuntimeConfig(
+        path=config.runtime_config_path,
+        raw={"metadata": {"generation": "1"}, "member": {"runtime": "qwenpaw"}},
+    )
+
+    updater.apply_once(runtime_config=runtime_config)
+    updater.apply_once(runtime_config=runtime_config, force=True)
+
+    assert adapter_calls == ["normal", "force"]
 
 
 def test_runtime_updater_load_and_apply_once_does_not_reapply_adapter(tmp_path: Path) -> None:

--- a/qwenpaw/tests/test_update.py
+++ b/qwenpaw/tests/test_update.py
@@ -49,6 +49,9 @@ class _FakeQwenPawApi:
         }
         self.acls = {"agentteams_matrix": {"whitelist": {}, "blacklist": {}, "pending": []}}
         self.mcp = {}
+        self.mcp_events = []
+        self.channel_events = []
+        self.model_events = []
         self.active_model = None
         self.enabled_skills = []
 
@@ -56,6 +59,7 @@ class _FakeQwenPawApi:
         return dict(self.channels.get(channel, {}))
 
     def put_channel(self, channel, desired, *, secret_fields=()):
+        self.channel_events.append(channel)
         current = self.get_channel(channel)
         payload = dict(desired)
         for field in secret_fields:
@@ -77,17 +81,21 @@ class _FakeQwenPawApi:
         return list(self.mcp.values())
 
     def create_mcp(self, key, payload):
+        self.mcp_events.append(("create", key))
         self.mcp[key] = {"key": key, **payload}
         return self.mcp[key]
 
     def update_mcp(self, key, payload):
+        self.mcp_events.append(("update", key))
         self.mcp[key] = {"key": key, **payload}
         return self.mcp[key]
 
     def delete_mcp(self, key):
+        self.mcp_events.append(("delete", key))
         self.mcp.pop(key, None)
 
     def configure_active_model(self, provider_id, model, **kwargs):
+        self.model_events.append((provider_id, model))
         self.active_model = {"provider_id": provider_id, "model": model, **kwargs}
         return {"active_llm": self.active_model}
 
@@ -220,12 +228,35 @@ def test_runtime_updater_maps_dingtalk_visibility_and_preserves_empty_secret(
             },
         ),
     )
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=updater.config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "1"},
+                "team": {"members": [{"name": "new-member", "role": "coordinator"}]},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "channels": {
+                        "dingtalk": {
+                            "enabled": True,
+                            "client_id": "client-id",
+                            "client_secret": "",
+                            "robot_code": "robot",
+                            "filter_thinking": True,
+                            "filter_tool_messages": False,
+                        },
+                    },
+                },
+            },
+        ),
+    )
 
     actual = updater.api_client.channels["dingtalk"]
     assert actual["client_secret"] == "existing-secret"
     assert actual["show_thinking"] is False
     assert actual["show_tool_calls"] is True
     assert actual["show_tool_results"] is True
+    assert updater.api_client.channel_events == ["dingtalk"]
 
 
 def test_runtime_updater_preserves_unmanaged_mcp_clients(tmp_path: Path) -> None:
@@ -240,6 +271,185 @@ def test_runtime_updater_preserves_unmanaged_mcp_clients(tmp_path: Path) -> None
     )
 
     assert "third-party" in updater.api_client.mcp
+
+
+def test_runtime_updater_does_not_reapply_mcp_for_team_member_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENTTEAMS_WORKER_GATEWAY_KEY", "gateway-secret")
+    monkeypatch.setenv("AGENTTEAMS_MATRIX_URL", "http://matrix.example.com")
+    monkeypatch.setenv("AGENTTEAMS_WORKER_MATRIX_TOKEN", "matrix-token")
+    updater = _runtime_updater(config=_config(tmp_path), package_manager=_NoopPackageManager())
+
+    def runtime_config(generation: str, members: list[dict[str, str]]) -> MemberRuntimeConfig:
+        return MemberRuntimeConfig(
+            path=updater.config.runtime_config_path,
+            raw={
+                "metadata": {"generation": generation},
+                "team": {"teamRoomId": "!team:matrix.local", "members": members},
+                "member": {
+                    "runtime": "qwenpaw",
+                    "matrixUserId": "@worker:matrix.local",
+                },
+                "credentials": {
+                    "matrixTokenEnv": "AGENTTEAMS_WORKER_MATRIX_TOKEN",
+                    "gatewayKeyEnv": "AGENTTEAMS_WORKER_GATEWAY_KEY",
+                },
+                "desired": {
+                    "model": {
+                        "providerId": "agentteams-gateway",
+                        "model": "qwen-plus",
+                        "gatewayUrl": "https://gateway.example.com",
+                    },
+                    "mcpServers": [
+                        {"name": "docs", "url": "https://gateway.example.com/mcp"},
+                    ],
+                },
+            },
+        )
+
+    first = runtime_config(
+        "1",
+        [
+            {"name": "alice", "role": "coordinator", "matrixUserId": "@alice:matrix.local"},
+            {"name": "bob", "role": "coordinator", "matrixUserId": "@bob:matrix.local"},
+        ],
+    )
+    reordered = runtime_config(
+        "1",
+        [
+            {"name": "bob", "role": "coordinator", "matrixUserId": "@bob:matrix.local"},
+            {"name": "alice", "role": "coordinator", "matrixUserId": "@alice:matrix.local"},
+        ],
+    )
+    changed = runtime_config(
+        "1",
+        [
+            {"name": "bob", "role": "coordinator", "matrixUserId": "@bob:matrix.local"},
+            {"name": "alice", "role": "coordinator", "matrixUserId": "@alice:matrix.local"},
+            {"name": "carol", "role": "coordinator", "matrixUserId": "@carol:matrix.local"},
+        ],
+    )
+
+    first_result = updater.apply_once(runtime_config=first, reapply_adapter=False)
+    reordered_result = updater.apply_once(runtime_config=reordered, reapply_adapter=False)
+    changed_result = updater.apply_once(runtime_config=changed, reapply_adapter=False)
+
+    assert first_result.changed is True
+    assert reordered_result.changed is True
+    assert changed_result.changed is True
+    assert updater.api_client.mcp_events == [("create", "docs")]
+    assert updater.api_client.model_events == [("agentteams-gateway", "qwen-plus")]
+    assert updater.api_client.channel_events == [
+        "agentteams_matrix",
+        "agentteams_matrix",
+    ]
+
+
+def test_runtime_updater_reapplies_direct_mcp_when_effective_payload_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENTTEAMS_WORKER_GATEWAY_KEY", "gateway-secret")
+    updater = _runtime_updater(config=_config(tmp_path), package_manager=_NoopPackageManager())
+
+    def runtime_config(url: str) -> MemberRuntimeConfig:
+        return MemberRuntimeConfig(
+            path=updater.config.runtime_config_path,
+            raw={
+                "metadata": {"generation": url},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {"mcpServers": [{"name": "docs", "url": url}]},
+            },
+        )
+
+    first = runtime_config("https://one.example/mcp")
+    second = runtime_config("https://two.example/mcp")
+    updater.apply_once(runtime_config=first, reapply_adapter=False)
+    updater.apply_once(runtime_config=second, reapply_adapter=False)
+    updater.apply_once(runtime_config=second, force=True, reapply_adapter=False)
+    updater.api_client.mcp.pop("docs")
+    updater.apply_once(runtime_config=second, force=True, reapply_adapter=False)
+    updater.apply_once(
+        runtime_config=MemberRuntimeConfig(
+            path=updater.config.runtime_config_path,
+            raw={
+                "metadata": {"generation": "removed"},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {"mcpServers": []},
+            },
+        ),
+        reapply_adapter=False,
+    )
+
+    assert updater.api_client.mcp_events == [
+        ("create", "docs"),
+        ("update", "docs"),
+        ("update", "docs"),
+        ("create", "docs"),
+        ("delete", "docs"),
+    ]
+    assert "docs" not in updater.api_client.mcp
+
+
+def test_runtime_updater_reapplies_package_mcp_only_when_package_identity_changes(
+    tmp_path: Path,
+) -> None:
+    class PackageManager:
+        def __init__(self) -> None:
+            self.client_reads: list[str] = []
+
+        def apply(self, runtime_config: MemberRuntimeConfig) -> Path:
+            version = runtime_config.agent_package_identity[2]
+            return tmp_path / f"package-{version}"
+
+        def package_mcp_clients(self, package_dir: Path) -> dict[str, dict[str, str]]:
+            self.client_reads.append(package_dir.name)
+            return {
+                "package-docs": {
+                    "name": "package-docs",
+                    "transport": "streamable_http",
+                    "url": f"https://{package_dir.name}.example/mcp",
+                },
+            }
+
+        def package_skill_names(self, _package_dir: Path) -> list[str]:
+            return []
+
+    package_manager = PackageManager()
+    updater = _runtime_updater(config=_config(tmp_path), package_manager=package_manager)
+
+    def runtime_config(version: str, generation: str) -> MemberRuntimeConfig:
+        return MemberRuntimeConfig(
+            path=updater.config.runtime_config_path,
+            raw={
+                "metadata": {"generation": generation},
+                "team": {"members": [{"name": generation, "role": "coordinator"}]},
+                "member": {"runtime": "qwenpaw"},
+                "desired": {
+                    "agentPackage": {
+                        "ref": f"file:///tmp/package-{version}.tar.gz",
+                        "name": "demo",
+                        "version": version,
+                        "digest": f"sha256:{version}",
+                    },
+                },
+            },
+        )
+
+    updater.apply_once(runtime_config=runtime_config("1", "1"), reapply_adapter=False)
+    updater.apply_once(runtime_config=runtime_config("1", "2"), reapply_adapter=False)
+    package_v2 = runtime_config("2", "3")
+    updater.apply_once(runtime_config=package_v2, reapply_adapter=False)
+    updater.apply_once(runtime_config=package_v2, force=True, reapply_adapter=False)
+
+    assert package_manager.client_reads == ["package-1", "package-2", "package-2"]
+    assert updater.api_client.mcp_events == [
+        ("create", "package-docs"),
+        ("update", "package-docs"),
+        ("update", "package-docs"),
+    ]
 
 
 def _agent_package(tmp_path: Path, version: str, *, include_teams: bool = False) -> Path:

--- a/qwenpaw/tests/test_worker_lifecycle.py
+++ b/qwenpaw/tests/test_worker_lifecycle.py
@@ -935,6 +935,45 @@ def test_builtin_plugin_mcp_is_reconciled_through_api(
     assert expected_storage_env.items() <= created["teamharness"]["env"].items()
 
 
+def test_builtin_plugin_mcp_skips_update_when_payload_is_unchanged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    worker = Worker(_config(tmp_path))
+    worker._prepare_env()
+
+    class Api:
+        def __init__(self) -> None:
+            self.mcp = {
+                "teamharness": {"key": "teamharness"},
+                "workerflow": {"key": "workerflow"},
+            }
+            self.updated: list[str] = []
+
+        def list_mcp(self):
+            return list(self.mcp.values())
+
+        def create_mcp(self, key, payload):
+            self.mcp[key] = {"key": key, **payload}
+
+        def update_mcp(self, key, payload):
+            self.updated.append(key)
+            self.mcp[key] = {"key": key, **payload}
+
+    api = Api()
+    worker.api_client = api
+
+    worker._configure_builtin_plugin_mcp_clients()
+    worker._configure_builtin_plugin_mcp_clients()
+
+    assert api.updated == ["teamharness", "workerflow"]
+
+    monkeypatch.setenv("AGENTTEAMS_WORKER_ROLE", "team_leader")
+    worker._configure_builtin_plugin_mcp_clients()
+
+    assert api.updated == ["teamharness", "workerflow", "teamharness", "workerflow"]
+
+
 @pytest.mark.anyio
 async def test_builtin_mcp_policy_is_persisted_before_desired_state_reload(
     tmp_path: Path,

--- a/qwenpaw/tests/test_worker_lifecycle.py
+++ b/qwenpaw/tests/test_worker_lifecycle.py
@@ -968,10 +968,26 @@ def test_builtin_plugin_mcp_skips_update_when_payload_is_unchanged(
 
     assert api.updated == ["teamharness", "workerflow"]
 
+    worker._configure_builtin_plugin_mcp_clients(force=True)
+
+    assert api.updated == [
+        "teamharness",
+        "workerflow",
+        "teamharness",
+        "workerflow",
+    ]
+
     monkeypatch.setenv("AGENTTEAMS_WORKER_ROLE", "team_leader")
     worker._configure_builtin_plugin_mcp_clients()
 
-    assert api.updated == ["teamharness", "workerflow", "teamharness", "workerflow"]
+    assert api.updated == [
+        "teamharness",
+        "workerflow",
+        "teamharness",
+        "workerflow",
+        "teamharness",
+        "workerflow",
+    ]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- add effective-payload identities for QwenPaw model, Direct/Package MCP, Matrix/DingTalk channels, Matrix policy, skills, and inline config
- only write components whose effective configuration changed, while preserving initial and forced reconciliation
- avoid rewriting unchanged Matrix access flags while continuing to reconcile actual ACL membership changes
- reconcile Builtin MCP clients from their final startup payload and builtin plugin digest
- add regression coverage for member reorder/addition, MCP changes/removal/recovery, Package MCP, and Builtin MCP

## Root cause

`RuntimeUpdater` used the whole runtime config as its apply trigger, but did not isolate side effects by component. A `team.members` change could therefore rewrite unchanged model, channel, and MCP configuration.

QwenPaw model/channel writes reload the workspace, while MCP writes reload the driver. Both paths stop and recreate MCP clients even when their effective configuration did not change.

This change keeps necessary Team context and Matrix ACL updates, but skips unrelated QwenPaw mutations and the resulting workspace/driver reloads.

Pure member-order comparison remains unchanged and can be handled separately as a no-op optimization; MCP correctness no longer depends on stable member ordering.

## Validation

- `qwenpaw/tests/test_update.py` and `qwenpaw/tests/test_worker_lifecycle.py`: `62 passed, 1 skipped`
- Python compilation and `git diff --check` passed
- rebuilt a local v1.2.2 instance with two QwenPaw Workers
- real Team member change applied the required Matrix ACL update with zero model PUTs, channel PUTs, MCP PUTs, workspace reloads, or MCP client stops
- real model-driven `repro-mcp__ping` call returned `pong` with `state=success`

Closes #1187
