### PR TITLE
fix(controller): validate replan taskId against TeamHarness _safe_id

### DIFF
--- a/agentteams-controller/internal/server/project_handler.go
+++ b/agentteams-controller/internal/server/project_handler.go
@@ -2123,6 +2123,25 @@ func (h *ProjectHandler) ReplanProject(w http.ResponseWriter, r *http.Request) {
 	httputil.WriteJSON(w, http.StatusOK, h.buildWorkflow(meta, pwc.team, false))
 }
 
+// isSafeTaskID mirrors TeamHarness _safe_id ([A-Za-z0-9][A-Za-z0-9._-]*).
+// Task ids become segments of TaskMeta object keys
+// (shared/tasks/{id}/meta.json) and are embedded in the GetTaskArtifact
+// path allowlist, so separators and traversal characters must be rejected.
+func isSafeTaskID(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case i > 0 && (r == '.' || r == '_' || r == '-'):
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 // normalizeReplanTasks converts raw plan tasks into projectTaskMeta with the
 // same field normalization as TeamHarness _normalize_task: it accepts
 // taskId/task_id, assignedTo/assigned_to, dependsOn/depends_on; status
@@ -2136,9 +2155,12 @@ func normalizeReplanTasks(raw []json.RawMessage, previous map[string]projectTask
 		if err := json.Unmarshal(item, &m); err != nil {
 			return nil, fmt.Errorf("invalid task entry: %v", err)
 		}
-		taskID := firstString(m["taskId"], m["task_id"])
+		taskID := strings.TrimSpace(firstString(m["taskId"], m["task_id"]))
 		if taskID == "" {
 			return nil, fmt.Errorf("taskId is required")
+		}
+		if !isSafeTaskID(taskID) {
+			return nil, fmt.Errorf("taskId must be a safe id: %s", taskID)
 		}
 		prev, hasPrev := previous[taskID]
 		status := firstString(m["status"])

--- a/agentteams-controller/internal/server/project_handler_test.go
+++ b/agentteams-controller/internal/server/project_handler_test.go
@@ -3245,6 +3245,56 @@ func TestReplanProject_DuplicateID400(t *testing.T) {
 	}
 }
 
+// TestReplanProject_UnsafeTaskID400 guards _safe_id parity: the TeamHarness
+// reference rejects task ids outside [A-Za-z0-9][A-Za-z0-9._-]* because ids
+// become TaskMeta object-key segments (shared/tasks/{id}/meta.json).
+func TestReplanProject_UnsafeTaskID400(t *testing.T) {
+	cases := []string{
+		"task with space",
+		"../escape",
+		"t/1",
+		"-leading-dash",
+		".leading-dot",
+		"任务一",
+	}
+	for _, tc := range cases {
+		store := ossfake.NewMemory()
+		putProject(store, "shared/projects/p1/meta.json", map[string]any{
+			"project_id": "p1", "title": "P1", "status": "active", "plan_type": "dag", "tasks": []map[string]any{},
+		})
+		h := newProjectTestHandler(t, store)
+		body := `{"tasks":[{"taskId":"` + tc + `","title":"X"}]}`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/projects/p1/replan", strings.NewReader(body))
+		req.SetPathValue("id", "p1")
+		req = withCaller(req, &authpkg.CallerIdentity{Role: authpkg.RoleAdmin, Username: "admin"})
+		rec := httptest.NewRecorder()
+		h.ReplanProject(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("taskId %q: status=%d, want 400 (unsafe id)", tc, rec.Code)
+		}
+	}
+}
+
+// TestReplanProject_SafeTaskIDAccepted guards the positive side of the
+// _safe_id rule: ids mixing letters, digits, dots, dashes and underscores
+// (with a leading alphanumeric) remain valid.
+func TestReplanProject_SafeTaskIDAccepted(t *testing.T) {
+	store := ossfake.NewMemory()
+	putProject(store, "shared/projects/p1/meta.json", map[string]any{
+		"project_id": "p1", "title": "P1", "status": "active", "plan_type": "dag", "tasks": []map[string]any{},
+	})
+	h := newProjectTestHandler(t, store)
+	body := `{"tasks":[{"taskId":"t-1.x_2","title":"X"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/projects/p1/replan", strings.NewReader(body))
+	req.SetPathValue("id", "p1")
+	req = withCaller(req, &authpkg.CallerIdentity{Role: authpkg.RoleAdmin, Username: "admin"})
+	rec := httptest.NewRecorder()
+	h.ReplanProject(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s, want 200 for safe id", rec.Code, rec.Body.String())
+	}
+}
+
 func TestReplanProject_UnknownDependency400(t *testing.T) {
 	store := ossfake.NewMemory()
 	putProject(store, "shared/projects/p1/meta.json", map[string]any{


### PR DESCRIPTION
## Summary

Fixes #1190.

`normalizeReplanTasks` (`POST /api/v1/projects/{id}/replan`) claims `_normalize_task` parity with the TeamHarness reference implementation, but the port dropped the `_safe_id` validation: any `taskId` string (spaces, `/`, `..`, non-alphanumeric leading char, Unicode) was accepted with `200` and persisted into the project DAG.

These ids flow unsanitized into:
- TaskMeta object keys (`taskMetaKeys` → `shared/tasks/{taskID}/meta.json`), producing traversal-shaped keys for ids like `t/1` or `../escape`;
- the `GetTaskArtifact` path allowlist (`strings.HasPrefix(path, "shared/tasks/"+taskID+"/")`), weakening the prefix check;
- downstream TeamHarness MCP operations, which re-apply `_safe_id` and then refuse to manage such tasks (zombie DAG nodes).

## Changes

- Add `isSafeTaskID`, mirroring the TeamHarness `_safe_id` rule `[A-Za-z0-9][A-Za-z0-9._-]*` (the same token-safety rule `CreateProject` already applies to `project_id` via `isPlainToken`).
- `normalizeReplanTasks` trims and validates `taskId`, returning `400` (`"taskId must be a safe id: ..."`) on violation — matching the reference `ValueError`.

## Verification

New tests in `project_handler_test.go`:
- `TestReplanProject_UnsafeTaskID400` — `"task with space"`, `"../escape"`, `"t/1"`, `"-leading-dash"`, `".leading-dot"`, `"任务一"` all rejected with 400 (they were all accepted before this fix; verified on `332d57a4`).
- `TestReplanProject_SafeTaskIDAccepted` — ids like `t-1.x_2` remain valid.

```
go test ./internal/server/ -run TestReplanProject -count=1   # all PASS
go test ./...                                                # full suite PASS
go vet ./internal/server/ && gofmt -l internal/server/       # clean
```

No behavior change for valid ids; existing replan tests pass unchanged.
