### PR TITLE
[codex] prepare v1.2.3 installer fallback

### DIFF
--- a/install/agentteams-install.sh
+++ b/install/agentteams-install.sh
@@ -62,7 +62,7 @@
 set -e
 
 AGENTTEAMS_VERSION="${AGENTTEAMS_VERSION:-}"
-AGENTTEAMS_KNOWN_STABLE_VERSION="v1.2.2"   # fallback if GitHub API is unreachable
+AGENTTEAMS_KNOWN_STABLE_VERSION="v1.2.3"   # fallback if GitHub API is unreachable
 
 _normalize_version() {
     local version="$1"


### PR DESCRIPTION
## Summary

- update the installer fallback stable version from `v1.2.2` to `v1.2.3`
- keep the normal GitHub latest-release lookup unchanged

## Release gate

- Build Images run `32497142212` completed successfully from `main@6c2e3fdee85778e6d62ab22ddf3fc76756ea95be`
- all nine `v1.2.3` registry manifests were verified to contain `linux/amd64` and `linux/arm64`

## Validation

- `bash -n install/agentteams-install.sh`
- `bash install/agentteams-dashboard-tests.sh` (`48/48` passed)
- `git diff --check`
