### PR TITLE
fix(api): reject unknown spec fields and empty workerMembers on Team create/update

### DIFF
--- a/agentteams-controller/internal/server/resource_handler.go
+++ b/agentteams-controller/internal/server/resource_handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"time"
 
 	v1beta1 "github.com/agentscope-ai/AgentTeams/agentteams-controller/api/v1beta1"
@@ -19,6 +20,39 @@ import (
 // k8sUpdateMaxRetries is the max attempts for Get→patch spec→Update against
 // optimistic locking conflicts when the controller updates status between Get and Update.
 const k8sUpdateMaxRetries = 3
+
+// unknownFieldPattern extracts the offending field name from the error
+// produced by json.Decoder.DisallowUnknownFields.
+var unknownFieldPattern = regexp.MustCompile(`unknown field "([^"]+)"`)
+
+// legacyFieldHints maps removed or renamed spec fields to migration guidance.
+// Without strict decoding, manifests written for another controller version
+// (or with a typo) are silently stripped during decode: the resource is
+// created/updated without its members, and the membership reconciler then
+// repeatedly evicts the orphaned members from the team room ("removed from
+// desired member set").
+var legacyFieldHints = map[string]string{
+	"workers": "`workers` was removed in v1.2.0; create standalone Worker resources and reference them by name via `workerMembers`",
+}
+
+// decodeResourceRequest decodes a resource create/update request body,
+// rejecting unknown fields so that schema drift between the client manifest
+// and the controller version fails loudly instead of silently dropping spec
+// fields such as team membership.
+func decodeResourceRequest(r *http.Request, v interface{}) error {
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
+		if m := unknownFieldPattern.FindStringSubmatch(err.Error()); m != nil {
+			if hint, ok := legacyFieldHints[m[1]]; ok {
+				return fmt.Errorf("unknown field %q: %s", m[1], hint)
+			}
+			return fmt.Errorf("unknown field %q in request body; check the field name against the current resource schema", m[1])
+		}
+		return err
+	}
+	return nil
+}
 
 // ResourceHandler handles declarative CRUD operations on CRs.
 //
@@ -70,7 +104,7 @@ func (h *ResourceHandler) stampControllerLabel(meta *metav1.ObjectMeta) {
 
 func (h *ResourceHandler) CreateWorker(w http.ResponseWriter, r *http.Request) {
 	var req CreateWorkerRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeResourceRequest(r, &req); err != nil {
 		httputil.WriteError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 		return
 	}
@@ -207,7 +241,7 @@ func (h *ResourceHandler) UpdateWorker(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req UpdateWorkerRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeResourceRequest(r, &req); err != nil {
 		httputil.WriteError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 		return
 	}
@@ -314,7 +348,7 @@ func (h *ResourceHandler) DeleteWorker(w http.ResponseWriter, r *http.Request) {
 
 func (h *ResourceHandler) CreateTeam(w http.ResponseWriter, r *http.Request) {
 	var req CreateTeamRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeResourceRequest(r, &req); err != nil {
 		httputil.WriteError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 		return
 	}
@@ -419,8 +453,13 @@ func (h *ResourceHandler) UpdateTeam(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req UpdateTeamRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeResourceRequest(r, &req); err != nil {
 		httputil.WriteError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+	if req.WorkerMembers != nil && len(req.WorkerMembers) == 0 {
+		httputil.WriteError(w, http.StatusBadRequest,
+			"workerMembers must not be empty: an empty list removes every Worker from the team and triggers eviction from the team room; omit the field to keep the current membership")
 		return
 	}
 	if req.WorkerMembers != nil {
@@ -496,7 +535,7 @@ func (h *ResourceHandler) DeleteTeam(w http.ResponseWriter, r *http.Request) {
 
 func (h *ResourceHandler) CreateHuman(w http.ResponseWriter, r *http.Request) {
 	var req CreateHumanRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeResourceRequest(r, &req); err != nil {
 		httputil.WriteError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 		return
 	}
@@ -583,7 +622,7 @@ func (h *ResourceHandler) DeleteHuman(w http.ResponseWriter, r *http.Request) {
 
 func (h *ResourceHandler) CreateManager(w http.ResponseWriter, r *http.Request) {
 	var req CreateManagerRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeResourceRequest(r, &req); err != nil {
 		httputil.WriteError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 		return
 	}
@@ -668,7 +707,7 @@ func (h *ResourceHandler) UpdateManager(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var req UpdateManagerRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := decodeResourceRequest(r, &req); err != nil {
 		httputil.WriteError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 		return
 	}

--- a/agentteams-controller/internal/server/resource_handler_test.go
+++ b/agentteams-controller/internal/server/resource_handler_test.go
@@ -1071,3 +1071,105 @@ func TestGetWorker_L2Scoped(t *testing.T) {
 		t.Fatalf("standalone worker status=%d, want 404 (W8: hide existence)", rec3.Code)
 	}
 }
+
+// Unknown spec fields must fail loudly instead of being silently dropped:
+// dropping membership fields leaves the Team spec memberless, after which
+// the membership reconciler repeatedly evicts every worker from the team
+// room ("removed from desired member set").
+func TestCreateTeamRejectsUnknownFields(t *testing.T) {
+	scheme := newServerTestScheme(t)
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	handler := NewResourceHandler(k8sClient, "default", nil, "")
+
+	cases := []struct {
+		name       string
+		body       string
+		wantSubstr []string
+	}{
+		{
+			name: "legacy workers field carries a migration hint",
+			body: `{
+				"name":"alpha-team",
+				"workerMembers":[{"name":"alpha-lead","role":"team_leader"}],
+				"workers":[{"name":"alpha-lead","role":"team_leader"}]
+			}`,
+			wantSubstr: []string{`"workers"`, "workerMembers"},
+		},
+		{
+			name: "generic unknown field names the offender",
+			body: `{
+				"name":"alpha-team",
+				"workerMembers":[{"name":"alpha-lead","role":"team_leader"}],
+				"bogusField":true
+			}`,
+			wantSubstr: []string{`"bogusField"`},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/teams", bytes.NewReader([]byte(tc.body)))
+			rec := httptest.NewRecorder()
+			handler.CreateTeam(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, rec.Code, rec.Body.String())
+			}
+			for _, sub := range tc.wantSubstr {
+				if !strings.Contains(rec.Body.String(), sub) {
+					t.Fatalf("error should contain %s, got: %s", sub, rec.Body.String())
+				}
+			}
+		})
+	}
+
+	var teams v1beta1.TeamList
+	if err := k8sClient.List(context.Background(), &teams); err != nil {
+		t.Fatalf("list teams: %v", err)
+	}
+	if len(teams.Items) != 0 {
+		t.Fatalf("no team must be created when the request contains unknown fields")
+	}
+}
+
+// An explicit empty workerMembers list would wipe the team membership and
+// trigger room evictions; it must be rejected. Unknown fields on update are
+// rejected too.
+func TestUpdateTeamRejectsEmptyWorkerMembersAndUnknownFields(t *testing.T) {
+	scheme := newServerTestScheme(t)
+	leader := &v1beta1.Worker{ObjectMeta: metav1.ObjectMeta{Name: "alpha-lead", Namespace: "default"}}
+	dev := &v1beta1.Worker{ObjectMeta: metav1.ObjectMeta{Name: "alpha-dev", Namespace: "default"}}
+	team := &v1beta1.Team{
+		ObjectMeta: metav1.ObjectMeta{Name: "alpha-team", Namespace: "default"},
+		Spec: v1beta1.TeamSpec{
+			WorkerMembers: []v1beta1.TeamWorkerRef{
+				{Name: "alpha-lead", Role: "team_leader"},
+				{Name: "alpha-dev", Role: "worker"},
+			},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(leader, dev, team).Build()
+	handler := NewResourceHandler(k8sClient, "default", nil, "")
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/teams/alpha-team", bytes.NewReader([]byte(`{"workerMembers":[]}`)))
+	req.SetPathValue("name", "alpha-team")
+	rec := httptest.NewRecorder()
+	handler.UpdateTeam(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d for empty workerMembers, got %d: %s", http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+
+	var stored v1beta1.Team
+	if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "alpha-team", Namespace: "default"}, &stored); err != nil {
+		t.Fatalf("get team: %v", err)
+	}
+	if len(stored.Spec.WorkerMembers) != 2 {
+		t.Fatalf("workerMembers wiped: got %d members, want 2", len(stored.Spec.WorkerMembers))
+	}
+
+	req2 := httptest.NewRequest(http.MethodPut, "/api/v1/teams/alpha-team", bytes.NewReader([]byte(`{"workers":[{"name":"alpha-lead"}]}`)))
+	req2.SetPathValue("name", "alpha-team")
+	rec2 := httptest.NewRecorder()
+	handler.UpdateTeam(rec2, req2)
+	if rec2.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d for unknown field on update, got %d: %s", http.StatusBadRequest, rec2.Code, rec2.Body.String())
+	}
+}


### PR DESCRIPTION
Fixes #1200

## Problem

Team create/update handlers decode request bodies with a plain \`json.Decoder\` (no \`DisallowUnknownFields\`). Spec fields that do not match the controller's schema version are silently dropped and the request still succeeds. When the dropped field carries membership, a Team with zero members is stored, and the team-room membership reconciler then repeatedly evicts every joined worker from the team room with reason \`"removed from desired member set"\` (observed 64 evictions on a clean install; see #1200 for the full reproduction).

Additionally, \`UpdateTeam\` accepts an explicit \`"workerMembers": []\` and silently wipes the whole membership — the same eviction path (the CRD marks \`workerMembers\` \`MinItems=1\`, but that is not enforced here).

## Changes

- Add \`decodeResourceRequest\`: all resource create/update request bodies (Worker/Team/Human/Manager) are now decoded with \`DisallowUnknownFields\`. Unknown fields yield HTTP 400 naming the offending field; the removed pre-1.2 \`workers\` field carries a migration hint pointing at \`workerMembers\`.
- \`UpdateTeam\` rejects an explicit empty \`workerMembers\` list; omitting the field keeps the current membership (existing behavior preserved).

## Tests

- \`TestCreateTeamRejectsUnknownFields\` — legacy \`workers\` hint + generic unknown-field rejection; no Team is persisted.
- \`TestUpdateTeamRejectsEmptyWorkerMembersAndUnknownFields\` — empty-list wipe rejected and membership preserved; unknown fields rejected on update.

Both files are gofmt-clean. Note: my local toolchain is Go 1.16 while the module requires Go 1.25, so the suite was not executed locally — relying on CI to run it. Happy to adjust per maintainer preference (e.g. scoping strict decoding to Team endpoints only).
